### PR TITLE
fix(simplebackup): restore a stale local DB when the S3 backup is newer (generation counter)

### DIFF
--- a/internal/simplebackup/backup.go
+++ b/internal/simplebackup/backup.go
@@ -18,6 +18,9 @@ import (
 const (
 	retentionCount = 3
 	backupPrefix   = "db-backup-"
+	// genMarker separates the generation counter from the unix timestamp in the
+	// object name, e.g. "db-backup-gen7-1700000000.db.gz".
+	genMarker = "gen"
 )
 
 // PerformBackup executes: VACUUM INTO -> gzip -> Upload -> Retention Cleanup.
@@ -40,7 +43,27 @@ func (m *Manager) PerformBackup(ctx context.Context) error {
 		return errors.New("database connection is nil")
 	}
 
-	_, err := m.env.DB().ExecContext(ctx, fmt.Sprintf("VACUUM INTO '%s'", tempBackupPath))
+	// Compute the next generation from the existing S3 backups so the counter is
+	// globally monotonic, independent of the (possibly stale) local generation and
+	// of wall clocks. The new generation is written into the source DB header
+	// (PRAGMA user_version) BEFORE the VACUUM INTO so the snapshot carries it.
+	//
+	// Caveat: this assumes a single writer at a time (the writer-slot /
+	// Deployment replicas=1 model). Two concurrent writers on separate DB files
+	// could read the same max generation and both compute the same gen+1; true
+	// safety would require an S3 conditional put (compare-and-set on the object
+	// name). That is intentionally not implemented here.
+	newGen, err := m.nextGeneration(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to compute backup generation: %w", err)
+	}
+
+	_, err = m.env.DB().ExecContext(ctx, fmt.Sprintf("PRAGMA user_version = %d", newGen))
+	if err != nil {
+		return fmt.Errorf("failed to set user_version: %w", err)
+	}
+
+	_, err = m.env.DB().ExecContext(ctx, fmt.Sprintf("VACUUM INTO '%s'", tempBackupPath))
 	if err != nil {
 		return fmt.Errorf("VACUUM INTO failed: %w", err)
 	}
@@ -63,7 +86,7 @@ func (m *Manager) PerformBackup(ctx context.Context) error {
 		pw.CloseWithError(copyErr)
 	}()
 
-	objectName := fmt.Sprintf("%s%d.db.gz", backupPrefix, startTime.Unix())
+	objectName := fmt.Sprintf("%s%s%d-%d.db.gz", backupPrefix, genMarker, newGen, startTime.Unix())
 
 	err = m.env.PutPrivateObject(ctx, pr, objectName)
 	if err != nil {
@@ -78,6 +101,29 @@ func (m *Manager) PerformBackup(ctx context.Context) error {
 
 	log.Info("backup completed", "duration", time.Since(startTime))
 	return nil
+}
+
+// nextGeneration returns (max generation across existing S3 backups) + 1.
+// Legacy backups without a generation are treated as generation 0, so the first
+// gen'd backup after a legacy history is generation 1.
+func (m *Manager) nextGeneration(ctx context.Context) (int, error) {
+	objects, err := m.env.ListPrivateObjects(ctx, miniostorage.ListOptions{
+		Prefix: backupPrefix,
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	maxGen := 0
+	for _, obj := range objects {
+		if !strings.HasPrefix(obj.Key, backupPrefix) || !strings.HasSuffix(obj.Key, ".db.gz") {
+			continue
+		}
+		if g := backupGeneration(obj.Key); g > maxGen {
+			maxGen = g
+		}
+	}
+	return maxGen + 1, nil
 }
 
 func (m *Manager) enforceRetention(ctx context.Context) error {
@@ -103,8 +149,11 @@ func (m *Manager) enforceRetention(ctx context.Context) error {
 	return nil
 }
 
-// filterAndSortBackups filters objects to valid backup files and sorts newest-first by filename timestamp.
-// Unparseable filenames sort to the end (treated as oldest, deleted by retention first).
+// filterAndSortBackups filters objects to valid backup files and sorts newest-first.
+// Ordering is by generation descending, with the unix timestamp as a tiebreaker.
+// Legacy names (db-backup-<unixtime>.db.gz) have generation 0, so any gen'd backup
+// is always considered newer; legacy names remain parseable so retention can delete
+// them. Fully unparseable names sort to the end (treated as oldest).
 func filterAndSortBackups(objects []model.PrivateObject) []model.PrivateObject {
 	var backups []model.PrivateObject
 	for _, obj := range objects {
@@ -114,14 +163,38 @@ func filterAndSortBackups(objects []model.PrivateObject) []model.PrivateObject {
 	}
 
 	sort.Slice(backups, func(i, j int) bool {
-		var ti, tj int64
-		ni, _ := fmt.Sscanf(backups[i].Key, backupPrefix+"%d.db.gz", &ti)
-		nj, _ := fmt.Sscanf(backups[j].Key, backupPrefix+"%d.db.gz", &tj)
-		if ni == 0 || nj == 0 {
-			return ni > nj
+		gi, gj := backupGeneration(backups[i].Key), backupGeneration(backups[j].Key)
+		if gi != gj {
+			return gi > gj
 		}
-		return ti > tj
+		return backupUnixtime(backups[i].Key) > backupUnixtime(backups[j].Key)
 	})
 
 	return backups
+}
+
+// backupGeneration extracts the generation counter from a backup object name.
+// New names look like "db-backup-gen<gen>-<unixtime>.db.gz" and return <gen>.
+// Legacy names "db-backup-<unixtime>.db.gz" (no gen) and unparseable names return 0.
+func backupGeneration(key string) int {
+	var gen int
+	var unix int64
+	if n, _ := fmt.Sscanf(key, backupPrefix+genMarker+"%d-%d.db.gz", &gen, &unix); n == 2 {
+		return gen
+	}
+	return 0
+}
+
+// backupUnixtime extracts the unix timestamp from a backup object name, handling
+// both the new gen'd format and the legacy format. Returns 0 if unparseable.
+func backupUnixtime(key string) int64 {
+	var gen int
+	var unix int64
+	if n, _ := fmt.Sscanf(key, backupPrefix+genMarker+"%d-%d.db.gz", &gen, &unix); n == 2 {
+		return unix
+	}
+	if n, _ := fmt.Sscanf(key, backupPrefix+"%d.db.gz", &unix); n == 1 {
+		return unix
+	}
+	return 0
 }

--- a/internal/simplebackup/backup_test.go
+++ b/internal/simplebackup/backup_test.go
@@ -52,6 +52,35 @@ func createTestDB(t *testing.T) string {
 	return dbPath
 }
 
+// createTestDBWithGen creates a real SQLite database whose PRAGMA user_version
+// (the backup generation counter) is set to gen, and returns its path.
+func createTestDBWithGen(t *testing.T, gen int) string {
+	t.Helper()
+	dbPath := createTestDB(t)
+
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	_, err = db.Exec(fmt.Sprintf("PRAGMA user_version = %d", gen))
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	return dbPath
+}
+
+// gzipFile reads the file at path and returns its gzipped bytes.
+func gzipFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, err = gw.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, gw.Close())
+	return buf.Bytes()
+}
+
 // openTestDB opens a SQLite DB and returns it (caller must close).
 func openTestDB(t *testing.T, path string) *sql.DB {
 	t.Helper()
@@ -110,8 +139,10 @@ func TestPerformBackup_Success(t *testing.T) {
 	// Verify PutPrivateObject called once with correct name pattern.
 	calls := env.PutPrivateObjectCalls()
 	require.Len(t, calls, 1)
-	require.True(t, strings.HasPrefix(calls[0].ObjectID, "db-backup-"), "object name should start with db-backup-")
+	require.True(t, strings.HasPrefix(calls[0].ObjectID, "db-backup-gen"), "object name should start with db-backup-gen")
 	require.True(t, strings.HasSuffix(calls[0].ObjectID, ".db.gz"), "object name should end with .db.gz")
+	// No existing backups → first generation is 1.
+	require.True(t, strings.HasPrefix(calls[0].ObjectID, "db-backup-gen1-"), "first backup should be generation 1, got %s", calls[0].ObjectID)
 
 	// Verify uploaded data is valid gzip containing valid SQLite.
 	gr, err := gzip.NewReader(&uploaded)
@@ -122,6 +153,54 @@ func TestPerformBackup_Success(t *testing.T) {
 	require.NoError(t, gr.Close())
 	// SQLite files start with "SQLite format 3".
 	require.True(t, bytes.HasPrefix(sqliteData.Bytes(), []byte("SQLite format 3")), "decompressed data should be SQLite")
+}
+
+// TestPerformBackup_GenerationIsMaxPlusOne verifies the new generation is
+// (max generation across existing S3 backups) + 1, that legacy names count as
+// gen 0, and that the snapshot carries the new generation in PRAGMA user_version.
+func TestPerformBackup_GenerationIsMaxPlusOne(t *testing.T) {
+	dbPath := createTestDB(t)
+	db := openTestDB(t, dbPath)
+	t.Cleanup(func() { db.Close() })
+
+	existing := []model.PrivateObject{
+		{Key: "db-backup-1650000000.db.gz", Size: 100},      // legacy → gen 0
+		{Key: "db-backup-gen5-1690000000.db.gz", Size: 100}, // gen 5 (max)
+		{Key: "db-backup-gen2-1680000000.db.gz", Size: 100}, // gen 2
+	}
+
+	var uploaded bytes.Buffer
+	env := newEnv(db)
+	env.ListPrivateObjectsFunc = func(ctx context.Context, opts miniostorage.ListOptions) ([]model.PrivateObject, error) {
+		return existing, nil
+	}
+	env.PutPrivateObjectFunc = func(ctx context.Context, r io.Reader, objectID string) error {
+		_, err := io.Copy(&uploaded, r)
+		return err
+	}
+	env.DeletePrivateObjectFunc = func(ctx context.Context, objectID string) error { return nil }
+
+	mgr := simplebackup.New(env, dbPath)
+	require.NoError(t, mgr.PerformBackup(context.Background()))
+
+	calls := env.PutPrivateObjectCalls()
+	require.Len(t, calls, 1)
+	require.True(t, strings.HasPrefix(calls[0].ObjectID, "db-backup-gen6-"),
+		"new generation should be max(5)+1=6, got %s", calls[0].ObjectID)
+
+	// The uploaded snapshot must carry user_version = 6.
+	gr, err := gzip.NewReader(&uploaded)
+	require.NoError(t, err)
+	var raw bytes.Buffer
+	_, err = io.Copy(&raw, gr)
+	require.NoError(t, err)
+	require.NoError(t, gr.Close())
+
+	snapPath := t.TempDir() + "/snapshot.db"
+	require.NoError(t, os.WriteFile(snapPath, raw.Bytes(), 0600))
+	gen, err := readUserVersionForTest(t, snapPath)
+	require.NoError(t, err)
+	require.Equal(t, 6, gen, "snapshot should carry the new generation in user_version")
 }
 
 // TestPerformBackup_ConcurrentBlocked verifies that a second backup returns "already in progress".
@@ -270,19 +349,24 @@ func TestPerformBackup_RetentionNoDeleteWhenUnderLimit(t *testing.T) {
 	require.Empty(t, env.DeletePrivateObjectCalls(), "should not delete when under retention limit")
 }
 
-// TestRestoreOnStartup_SkipsWhenDBExists verifies restore is skipped when DB file already exists.
-func TestRestoreOnStartup_SkipsWhenDBExists(t *testing.T) {
+// TestRestoreOnStartup_SkipsWhenLocalNotOlder verifies restore is skipped when the
+// local DB generation is >= the latest backup's generation (no download happens).
+func TestRestoreOnStartup_SkipsWhenLocalNotOlder(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := dir + "/existing.db"
-	require.NoError(t, os.WriteFile(dbPath, []byte("existing content"), 0644))
+	// Local DB at generation 5; latest backup is gen 5 → not newer → skip.
+	localPath := createTestDBWithGen(t, 5)
+	require.NoError(t, os.Rename(localPath, dbPath))
 
 	env := newEnv(nil)
 	env.ListPrivateObjectsFunc = func(ctx context.Context, opts miniostorage.ListOptions) ([]model.PrivateObject, error) {
-		t.Fatal("ListPrivateObjects should not be called when DB exists")
-		return nil, nil
+		return []model.PrivateObject{
+			{Key: "db-backup-gen5-1700000000.db.gz", Size: 100},
+			{Key: "db-backup-gen4-1690000000.db.gz", Size: 100},
+		}, nil
 	}
 	env.GetPrivateObjectFunc = func(ctx context.Context, objectID string) (io.ReadCloser, error) {
-		t.Fatal("GetPrivateObject should not be called when DB exists")
+		t.Fatal("GetPrivateObject should not be called when local DB is not older")
 		return nil, nil
 	}
 
@@ -290,7 +374,55 @@ func TestRestoreOnStartup_SkipsWhenDBExists(t *testing.T) {
 	err := mgr.RestoreOnStartup(context.Background())
 	require.NoError(t, err)
 
-	require.Empty(t, env.ListPrivateObjectsCalls(), "ListPrivateObjects should not be called when DB exists")
+	require.Empty(t, env.GetPrivateObjectCalls(), "no download when local DB is not older")
+}
+
+// TestRestoreOnStartup_RestoresWhenBackupNewer verifies restore fires (overwriting
+// the existing local DB) when the latest backup carries a newer generation.
+func TestRestoreOnStartup_RestoresWhenBackupNewer(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := dir + "/existing.db"
+	// Local DB at generation 3 (stale).
+	localPath := createTestDBWithGen(t, 3)
+	require.NoError(t, os.Rename(localPath, dbPath))
+
+	// Backup snapshot at generation 7.
+	backupSrc := createTestDBWithGen(t, 7)
+	gzipped := gzipFile(t, backupSrc)
+
+	env := newEnv(nil)
+	env.ListPrivateObjectsFunc = func(ctx context.Context, opts miniostorage.ListOptions) ([]model.PrivateObject, error) {
+		return []model.PrivateObject{
+			{Key: "db-backup-gen7-1700000000.db.gz", Size: int64(len(gzipped))},
+			{Key: "db-backup-gen3-1690000000.db.gz", Size: 100},
+		}, nil
+	}
+	env.GetPrivateObjectFunc = func(ctx context.Context, objectID string) (io.ReadCloser, error) {
+		require.Equal(t, "db-backup-gen7-1700000000.db.gz", objectID)
+		return io.NopCloser(bytes.NewReader(gzipped)), nil
+	}
+
+	mgr := simplebackup.New(env, dbPath)
+	err := mgr.RestoreOnStartup(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, env.GetPrivateObjectCalls(), 1, "should download the newer backup")
+
+	// The restored DB should carry generation 7.
+	gen, err := readUserVersionForTest(t, dbPath)
+	require.NoError(t, err)
+	require.Equal(t, 7, gen, "local DB should be overwritten with the newer generation")
+}
+
+// readUserVersionForTest reads PRAGMA user_version from a SQLite file.
+func readUserVersionForTest(t *testing.T, path string) (int, error) {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	require.NoError(t, err)
+	defer db.Close()
+	var gen int
+	err = db.QueryRow("PRAGMA user_version").Scan(&gen)
+	return gen, err
 }
 
 // TestRestoreOnStartup_NoBackups verifies a clean start when no backup files exist.

--- a/internal/simplebackup/restore.go
+++ b/internal/simplebackup/restore.go
@@ -14,20 +14,36 @@ import (
 	_ "modernc.org/sqlite" // driver for integrity check
 )
 
-// RestoreOnStartup restores the DB from S3 storage if local file is missing.
+// RestoreOnStartup restores the DB from S3 storage when there is no local DB, or
+// when the latest S3 backup carries a newer generation than the local DB. The
+// generation is stored in the SQLite header via PRAGMA user_version and travels
+// inside every snapshot, so the latest backup's generation can be read from its
+// object name without downloading it.
 // #nosec G110 - Decompression bomb risk is acceptable for trusted backup source.
 func (m *Manager) RestoreOnStartup(ctx context.Context) error {
 	log := m.env.Logger()
 
-	// 1. Check if local DB exists
+	// 1. Determine whether a local DB already exists.
+	localExists := true
+	localGen := 0
 	if _, err := os.Stat(m.databasePath); err == nil {
-		log.Debug("local database exists, skipping restore")
-		return nil
-	} else if !os.IsNotExist(err) {
+		// Read the local generation from its own short-lived read-only connection.
+		// This runs pre-DB-init, so we must not rely on m.env.DB(); the connection
+		// is closed before any potential overwrite of the file.
+		gen, genErr := readUserVersion(m.databasePath)
+		if genErr != nil {
+			return fmt.Errorf("failed to read local generation: %w", genErr)
+		}
+		localGen = gen
+	} else if os.IsNotExist(err) {
+		localExists = false
+	} else {
 		return fmt.Errorf("failed to check database existence: %w", err)
 	}
 
-	log.Info("local database not found, attempting restore")
+	if !localExists {
+		log.Info("local database not found, attempting restore")
+	}
 
 	// 2. Find latest backup
 	objects, err := m.env.ListPrivateObjects(ctx, miniostorage.ListOptions{
@@ -39,11 +55,28 @@ func (m *Manager) RestoreOnStartup(ctx context.Context) error {
 
 	backups := filterAndSortBackups(objects)
 	if len(backups) == 0 {
+		if localExists {
+			log.Debug("no backups found, keeping existing local database")
+			return nil
+		}
 		log.Warn("no valid backup files found, starting with fresh database")
 		return nil
 	}
 
 	latest := backups[0]
+
+	// 3. If a local DB exists, only restore when the latest backup is newer.
+	if localExists {
+		latestGen := backupGeneration(latest.Key)
+		if latestGen <= localGen {
+			log.Debug("local database is up to date, skipping restore",
+				"localGeneration", localGen, "latestBackupGeneration", latestGen, "key", latest.Key)
+			return nil
+		}
+		log.Info("newer backup available, restoring",
+			"localGeneration", localGen, "latestBackupGeneration", latestGen)
+	}
+
 	log.Info("restoring backup", "key", latest.Key, "size", latest.Size, "modified", latest.LastModified)
 
 	// 3. Download & Decompress
@@ -98,6 +131,23 @@ func (m *Manager) RestoreOnStartup(ctx context.Context) error {
 
 	log.Info("restore successful")
 	return nil
+}
+
+// readUserVersion opens the SQLite file read-only on a short-lived connection,
+// reads PRAGMA user_version (the backup generation counter), and closes the
+// connection so the file can safely be overwritten afterwards.
+func readUserVersion(path string) (int, error) {
+	db, err := sql.Open("sqlite", "file:"+path+"?mode=ro")
+	if err != nil {
+		return 0, err
+	}
+	defer db.Close()
+
+	var gen int
+	if err := db.QueryRow("PRAGMA user_version").Scan(&gen); err != nil {
+		return 0, err
+	}
+	return gen, nil
 }
 
 func verifyIntegrity(path string) error {

--- a/internal/simplebackup/sort_internal_test.go
+++ b/internal/simplebackup/sort_internal_test.go
@@ -1,0 +1,95 @@
+package simplebackup
+
+import (
+	"testing"
+
+	"trip2g/internal/model"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestBackupGeneration covers parsing the generation counter out of object names,
+// including the legacy (no-gen) and unparseable cases.
+func TestBackupGeneration(t *testing.T) {
+	cases := []struct {
+		key  string
+		want int
+	}{
+		{"db-backup-gen7-1700000000.db.gz", 7},
+		{"db-backup-gen1-1690000000.db.gz", 1},
+		{"db-backup-gen42-0.db.gz", 42},
+		{"db-backup-1700000000.db.gz", 0}, // legacy, no gen
+		{"db-backup-garbage.db.gz", 0},    // unparseable
+		{"unrelated-object.txt", 0},       // not a backup
+	}
+	for _, c := range cases {
+		require.Equal(t, c.want, backupGeneration(c.key), "key=%s", c.key)
+	}
+}
+
+// TestBackupUnixtime covers parsing the unix timestamp out of both name formats.
+func TestBackupUnixtime(t *testing.T) {
+	cases := []struct {
+		key  string
+		want int64
+	}{
+		{"db-backup-gen7-1700000000.db.gz", 1700000000},
+		{"db-backup-1690000000.db.gz", 1690000000}, // legacy
+		{"db-backup-garbage.db.gz", 0},             // unparseable
+	}
+	for _, c := range cases {
+		require.Equal(t, c.want, backupUnixtime(c.key), "key=%s", c.key)
+	}
+}
+
+// TestFilterAndSortBackups verifies ordering with a mix of gen'd and legacy names:
+// gen'd backups are always newer than legacy (gen 0); within the same generation
+// the higher unixtime wins; legacy names are kept (parseable) so retention can
+// still delete them; non-backup objects are filtered out.
+func TestFilterAndSortBackups(t *testing.T) {
+	input := []model.PrivateObject{
+		{Key: "db-backup-1650000000.db.gz"},      // legacy, gen 0
+		{Key: "db-backup-gen2-1700000000.db.gz"}, // gen 2
+		{Key: "not-a-backup.txt"},                // filtered out
+		{Key: "db-backup-gen1-1695000000.db.gz"}, // gen 1
+		{Key: "db-backup-1660000000.db.gz"},      // legacy, gen 0, newer ts than the other legacy
+		{Key: "db-backup-gen2-1699000000.db.gz"}, // gen 2, older ts than the other gen2
+	}
+
+	got := filterAndSortBackups(input)
+
+	gotKeys := make([]string, len(got))
+	for i, o := range got {
+		gotKeys[i] = o.Key
+	}
+
+	want := []string{
+		"db-backup-gen2-1700000000.db.gz", // gen 2, newest ts
+		"db-backup-gen2-1699000000.db.gz", // gen 2, older ts
+		"db-backup-gen1-1695000000.db.gz", // gen 1
+		"db-backup-1660000000.db.gz",      // legacy gen 0, newer ts
+		"db-backup-1650000000.db.gz",      // legacy gen 0, older ts
+	}
+	require.Equal(t, want, gotKeys)
+}
+
+// TestFilterAndSortBackups_LegacyOnly verifies legacy-only history still sorts
+// newest-first by unix timestamp (backward compatibility with pre-gen backups).
+func TestFilterAndSortBackups_LegacyOnly(t *testing.T) {
+	input := []model.PrivateObject{
+		{Key: "db-backup-1000.db.gz"},
+		{Key: "db-backup-3000.db.gz"},
+		{Key: "db-backup-2000.db.gz"},
+	}
+
+	got := filterAndSortBackups(input)
+	gotKeys := make([]string, len(got))
+	for i, o := range got {
+		gotKeys[i] = o.Key
+	}
+	require.Equal(t, []string{
+		"db-backup-3000.db.gz",
+		"db-backup-2000.db.gz",
+		"db-backup-1000.db.gz",
+	}, gotKeys)
+}


### PR DESCRIPTION
## Problem
`RestoreOnStartup` only restored when the local DB file was **missing** (`os.Stat`). An instance landing on a node with a STALE local DB skipped restore and served stale content, even when S3 had a newer backup.

## Fix
A monotonic **generation counter** in `PRAGMA user_version` (no schema migration; travels inside every `VACUUM INTO` snapshot). On backup: `gen = max(S3 gens)+1`, stamped into the DB and the object name `db-backup-gen<N>-<ts>.db.gz`. On startup: if a local DB exists, compare its generation to the latest backup's (parsed from the name, no download) and restore only when the backup is newer. Legacy names (no gen) = generation 0. Single-writer caveat documented.

## Validation
Unit tests (`go test ./internal/simplebackup/...` green) + an end-to-end stand on a fresh node (DEV=false, MinIO): boot→backup gen1, save stale DB, boot→backup gen2, put the stale gen1 DB back, reboot → logs `newer backup available, restoring (local 1, latest 2)` and the local `user_version` ends at 2. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)