### PR TITLE
feat(mdloader): strip Obsidian %% comments from rendered output

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -484,6 +484,9 @@ linters:
       - path: 'internal/mdloader/highlight/'
         linters:
           - gochecknoglobals  # Package-level variables needed for goldmark extension registration
+      - path: 'internal/mdloader/obsidiancomments/'
+        linters:
+          - gochecknoglobals  # Package-level variables needed for goldmark extension registration
       - path: 'cmd/testgoqite/'
         linters:
           - cyclop       # Test code can be complex

--- a/docs/demo/obsidian-comments.md
+++ b/docs/demo/obsidian-comments.md
@@ -1,0 +1,29 @@
+---
+free: true
+title: Obsidian Comments Test
+---
+
+This page tests Obsidian-style `%%` comment stripping.
+
+## Inline comment
+
+The word BEFORE%%this comment must not appear%%AFTER is visible on both sides.
+
+## Block comment
+
+Text before the block comment.
+
+%%
+This entire block comment must not appear in output.
+Multiple lines are hidden.
+%%
+
+Text after the block comment.
+
+## Code block preservation
+
+Content inside fenced code blocks must not be stripped:
+
+```
+%% this literal percent-percent inside a code block must be preserved %%
+```

--- a/e2e/obsidian-comments.spec.js
+++ b/e2e/obsidian-comments.spec.js
@@ -1,0 +1,37 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+
+test.describe('Obsidian %% comment stripping', () => {
+  test('inline comment: surrounding text is visible, comment text is absent', async ({ page }) => {
+    await page.goto('/obsidian-comments');
+
+    // The text on both sides of the inline comment must be present
+    await expect(page.locator('body')).toContainText('BEFORE');
+    await expect(page.locator('body')).toContainText('AFTER');
+
+    // The comment content itself must not appear in the rendered page
+    const bodyText = await page.locator('body').textContent();
+    expect(bodyText).not.toContain('this comment must not appear');
+  });
+
+  test('block comment: surrounding paragraphs are visible, block content is absent', async ({ page }) => {
+    await page.goto('/obsidian-comments');
+
+    // Paragraphs surrounding the block comment must be present
+    await expect(page.locator('body')).toContainText('Text before the block comment.');
+    await expect(page.locator('body')).toContainText('Text after the block comment.');
+
+    // The block comment content must not appear
+    const bodyText = await page.locator('body').textContent();
+    expect(bodyText).not.toContain('This entire block comment must not appear in output.');
+    expect(bodyText).not.toContain('Multiple lines are hidden.');
+  });
+
+  test('code block: literal %% inside fenced code is preserved', async ({ page }) => {
+    await page.goto('/obsidian-comments');
+
+    // The literal %% inside a fenced code block must survive
+    await expect(page.locator('pre code')).toContainText('%%');
+    await expect(page.locator('pre code')).toContainText('this literal percent-percent inside a code block must be preserved');
+  });
+});

--- a/internal/mdloader/loader.go
+++ b/internal/mdloader/loader.go
@@ -14,6 +14,7 @@ import (
 	"trip2g/internal/image"
 	"trip2g/internal/logger"
 	"trip2g/internal/mdloader/highlight"
+	"trip2g/internal/mdloader/obsidiancomments"
 	"trip2g/internal/model"
 	"trip2g/internal/obsidiancanvas"
 
@@ -135,6 +136,7 @@ func Load(options Options) (*model.NoteViews, error) {
 			extension.GFM,
 			enclavefix.New(&enclavecore.Config{}),
 			meta.Meta,
+			obsidiancomments.ObsidianComments,
 		),
 	)
 

--- a/internal/mdloader/obsidiancomments/obsidiancomments.go
+++ b/internal/mdloader/obsidiancomments/obsidiancomments.go
@@ -16,8 +16,6 @@ import (
 	"github.com/yuin/goldmark/util"
 )
 
-// ── AST nodes ────────────────────────────────────────────────────────────────
-
 // ObsidianInlineComment is an inline AST node for %%...%%.
 type ObsidianInlineComment struct {
 	gast.BaseInline
@@ -54,8 +52,6 @@ func (n *ObsidianBlockComment) Kind() gast.NodeKind {
 	return KindObsidianBlockComment
 }
 
-// ── Inline parser ─────────────────────────────────────────────────────────────
-
 type inlineCommentParser struct{}
 
 var defaultInlineCommentParser = &inlineCommentParser{}
@@ -68,7 +64,7 @@ func (p *inlineCommentParser) Trigger() []byte {
 // Parse tries to parse %%...%% at the current position.
 // Returns nil if not a valid comment (e.g. lone %%).
 func (p *inlineCommentParser) Parse(parent gast.Node, block text.Reader, pc parser.Context) gast.Node {
-	line, segment := block.PeekLine()
+	line, _ := block.PeekLine()
 
 	// Need at least %%%% (4 bytes: open %%, close %%)
 	if len(line) < 4 || line[0] != '%' || line[1] != '%' {
@@ -85,7 +81,6 @@ func (p *inlineCommentParser) Parse(parent gast.Node, block text.Reader, pc pars
 	// Advance past the entire %%...%% span
 	advance := 2 + idx + 2
 	block.Advance(advance)
-	_ = segment // suppress unused warning
 
 	return &ObsidianInlineComment{}
 }
@@ -93,8 +88,6 @@ func (p *inlineCommentParser) Parse(parent gast.Node, block text.Reader, pc pars
 func (p *inlineCommentParser) CloseBlock(parent gast.Node, pc parser.Context) {
 	// nothing to do
 }
-
-// ── Block parser ──────────────────────────────────────────────────────────────
 
 type blockCommentParser struct{}
 
@@ -142,8 +135,6 @@ func (p *blockCommentParser) CanAcceptIndentedLine() bool { return false }
 // IsRaw returns true to prevent child parsing.
 func (p *blockCommentParser) IsRaw() bool { return true }
 
-// ── Renderer ──────────────────────────────────────────────────────────────────
-
 type commentRenderer struct{}
 
 // RegisterFuncs registers render functions that produce no output.
@@ -157,8 +148,6 @@ func (r *commentRenderer) renderNothing(
 ) (gast.WalkStatus, error) {
 	return gast.WalkSkipChildren, nil
 }
-
-// ── Extension ─────────────────────────────────────────────────────────────────
 
 type obsidianComments struct{}
 

--- a/internal/mdloader/obsidiancomments/obsidiancomments.go
+++ b/internal/mdloader/obsidiancomments/obsidiancomments.go
@@ -1,0 +1,182 @@
+// Package obsidiancomments strips Obsidian-style %% comments %% from rendered output.
+//
+// Inline comments (%%text%%) are removed while surrounding text is preserved.
+// Block comments (%% on its own line, content, %% on its own line) produce no output.
+// Content inside fenced code blocks and inline code spans is left untouched.
+package obsidiancomments
+
+import (
+	"bytes"
+
+	"github.com/yuin/goldmark"
+	gast "github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
+)
+
+// ── AST nodes ────────────────────────────────────────────────────────────────
+
+// ObsidianInlineComment is an inline AST node for %%...%%.
+type ObsidianInlineComment struct {
+	gast.BaseInline
+}
+
+// Dump implements gast.Node.Dump.
+func (n *ObsidianInlineComment) Dump(source []byte, level int) {
+	gast.DumpHelper(n, source, level, nil, nil)
+}
+
+// KindObsidianInlineComment is the NodeKind for ObsidianInlineComment.
+var KindObsidianInlineComment = gast.NewNodeKind("ObsidianInlineComment")
+
+// Kind implements gast.Node.Kind.
+func (n *ObsidianInlineComment) Kind() gast.NodeKind {
+	return KindObsidianInlineComment
+}
+
+// ObsidianBlockComment is a block-level AST node for %%\n...\n%%.
+type ObsidianBlockComment struct {
+	gast.BaseBlock
+}
+
+// Dump implements gast.Node.Dump.
+func (n *ObsidianBlockComment) Dump(source []byte, level int) {
+	gast.DumpHelper(n, source, level, nil, nil)
+}
+
+// KindObsidianBlockComment is the NodeKind for ObsidianBlockComment.
+var KindObsidianBlockComment = gast.NewNodeKind("ObsidianBlockComment")
+
+// Kind implements gast.Node.Kind.
+func (n *ObsidianBlockComment) Kind() gast.NodeKind {
+	return KindObsidianBlockComment
+}
+
+// ── Inline parser ─────────────────────────────────────────────────────────────
+
+type inlineCommentParser struct{}
+
+var defaultInlineCommentParser = &inlineCommentParser{}
+
+// Trigger returns the trigger byte for the inline parser.
+func (p *inlineCommentParser) Trigger() []byte {
+	return []byte{'%'}
+}
+
+// Parse tries to parse %%...%% at the current position.
+// Returns nil if not a valid comment (e.g. lone %%).
+func (p *inlineCommentParser) Parse(parent gast.Node, block text.Reader, pc parser.Context) gast.Node {
+	line, segment := block.PeekLine()
+
+	// Need at least %%%% (4 bytes: open %%, close %%)
+	if len(line) < 4 || line[0] != '%' || line[1] != '%' {
+		return nil
+	}
+
+	// Find closing %% within the same line (no multi-line inline comments)
+	rest := line[2:]
+	idx := bytes.Index(rest, []byte("%%"))
+	if idx < 0 {
+		return nil
+	}
+
+	// Advance past the entire %%...%% span
+	advance := 2 + idx + 2
+	block.Advance(advance)
+	_ = segment // suppress unused warning
+
+	return &ObsidianInlineComment{}
+}
+
+func (p *inlineCommentParser) CloseBlock(parent gast.Node, pc parser.Context) {
+	// nothing to do
+}
+
+// ── Block parser ──────────────────────────────────────────────────────────────
+
+type blockCommentParser struct{}
+
+var defaultBlockCommentParser = &blockCommentParser{}
+
+func (p *blockCommentParser) Trigger() []byte {
+	return []byte{'%'}
+}
+
+// Open checks whether the current line is a standalone %%.
+func (p *blockCommentParser) Open(parent gast.Node, reader text.Reader, pc parser.Context) (gast.Node, parser.State) {
+	line, _ := reader.PeekLine()
+	trimmed := bytes.TrimRight(line, "\r\n")
+	if string(trimmed) != "%%" {
+		return nil, parser.NoChildren
+	}
+	// Consume up to EOL; the parser loop advances past the newline.
+	reader.AdvanceToEOL()
+	return &ObsidianBlockComment{}, parser.NoChildren
+}
+
+// Continue consumes lines until a closing standalone %% or EOF.
+func (p *blockCommentParser) Continue(node gast.Node, reader text.Reader, pc parser.Context) parser.State {
+	line, _ := reader.PeekLine()
+	trimmed := bytes.TrimRight(line, "\r\n")
+	if string(trimmed) == "%%" {
+		// Consume closing %% line and stop.
+		reader.AdvanceToEOL()
+		return parser.Close
+	}
+	// Consume the content line.
+	reader.AdvanceToEOL()
+	return parser.Continue | parser.NoChildren
+}
+
+// Close is called when the block closes.
+func (p *blockCommentParser) Close(node gast.Node, reader text.Reader, pc parser.Context) {}
+
+// CanInterruptParagraph returns true so a block comment can start mid-document.
+func (p *blockCommentParser) CanInterruptParagraph() bool { return true }
+
+// CanAcceptIndentedLine returns false (block comment must start at column 0).
+func (p *blockCommentParser) CanAcceptIndentedLine() bool { return false }
+
+// IsRaw returns true to prevent child parsing.
+func (p *blockCommentParser) IsRaw() bool { return true }
+
+// ── Renderer ──────────────────────────────────────────────────────────────────
+
+type commentRenderer struct{}
+
+// RegisterFuncs registers render functions that produce no output.
+func (r *commentRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(KindObsidianInlineComment, r.renderNothing)
+	reg.Register(KindObsidianBlockComment, r.renderNothing)
+}
+
+func (r *commentRenderer) renderNothing(
+	w util.BufWriter, source []byte, n gast.Node, entering bool,
+) (gast.WalkStatus, error) {
+	return gast.WalkSkipChildren, nil
+}
+
+// ── Extension ─────────────────────────────────────────────────────────────────
+
+type obsidianComments struct{}
+
+// ObsidianComments is the goldmark extension that strips Obsidian %% comments.
+var ObsidianComments = &obsidianComments{}
+
+func (e *obsidianComments) Extend(m goldmark.Markdown) {
+	m.Parser().AddOptions(
+		parser.WithInlineParsers(
+			util.Prioritized(defaultInlineCommentParser, 300),
+		),
+		parser.WithBlockParsers(
+			util.Prioritized(defaultBlockCommentParser, 400),
+		),
+	)
+	m.Renderer().AddOptions(
+		renderer.WithNodeRenderers(
+			util.Prioritized(&commentRenderer{}, 300),
+		),
+	)
+}

--- a/internal/mdloader/obsidiancomments/obsidiancomments_test.go
+++ b/internal/mdloader/obsidiancomments/obsidiancomments_test.go
@@ -1,0 +1,90 @@
+package obsidiancomments_test
+
+import (
+	"bytes"
+	"testing"
+	"trip2g/internal/mdloader/obsidiancomments"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark"
+)
+
+func newMD() goldmark.Markdown {
+	return goldmark.New(
+		goldmark.WithExtensions(obsidiancomments.ObsidianComments),
+	)
+}
+
+func convert(t *testing.T, src string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	err := newMD().Convert([]byte(src), &buf)
+	require.NoError(t, err)
+	return buf.String()
+}
+
+func TestObsidianComments(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "inline comment stripped",
+			in:   "This is an %%invisible%% comment.",
+			want: "<p>This is an  comment.</p>\n",
+		},
+		{
+			name: "inline comment at start of line",
+			in:   "%%hidden%% visible",
+			want: "<p> visible</p>\n",
+		},
+		{
+			name: "inline comment at end of line",
+			in:   "visible %%hidden%%",
+			want: "<p>visible </p>\n",
+		},
+		{
+			name: "block comment produces no output",
+			in:   "before\n%%\nthis is\na block comment\n%%\nafter",
+			want: "<p>before</p>\n<p>after</p>\n",
+		},
+		{
+			name: "multiple inline comments in one line",
+			in:   "a %%b%% c %%d%% e",
+			want: "<p>a  c  e</p>\n",
+		},
+		{
+			name: "multiple comments in one document",
+			in:   "%%first%% text %%second%%\n\n%%\nblock\n%%\n\nend",
+			want: "<p> text </p>\n<p>end</p>\n",
+		},
+		{
+			name: "unmatched lone %% left alone",
+			in:   "text %% more text",
+			want: "<p>text %% more text</p>\n",
+		},
+		{
+			name: "percent percent inside fenced code block untouched",
+			in:   "```\n%%comment%%\n```",
+			want: "<pre><code>%%comment%%\n</code></pre>\n",
+		},
+		{
+			name: "percent percent inside inline code untouched",
+			in:   "`%%not a comment%%`",
+			want: "<p><code>%%not a comment%%</code></p>\n",
+		},
+		{
+			name: "empty comment",
+			in:   "text %%%% more",
+			want: "<p>text  more</p>\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convert(t, tt.in)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `internal/mdloader/obsidiancomments` goldmark extension that strips Obsidian `%%comment%%` syntax from rendered HTML
- Inline comments (`%%text%%`) are removed while surrounding text is preserved
- Block comments (standalone `%%` on its own line, content, closing `%%`) produce no output
- Content inside fenced code blocks and inline code spans is untouched

## Approach

**Goldmark extension (inline parser + block parser + renderer)** — consistent with the existing `highlight` and `enclavefix` neighbors.

Two parsers, both rendering to nothing:
- `inlineCommentParser` (triggered by `%`): scans for `%%...%%` on the same line; if no closing `%%` found, returns `nil` (lone `%%` left as-is — satisfies the "unmatched lone %% left alone" requirement)
- `blockCommentParser` (triggered by `%`): `Open` fires when a line is exactly `%%`; `Continue` consumes content lines and closes on the next standalone `%%`

A pre-parse byte-level stripper was considered but rejected: it can't reliably detect fenced code fence context across multi-line blocks without reimplementing large parts of the CommonMark spec. The goldmark parser naturally handles code spans (inline code parser runs at higher priority) and fenced code blocks (block parser lifecycle excludes inline parsers inside code blocks).

Key detail: both `Open` and `Continue` use `reader.AdvanceToEOL()` (not `Advance(len(line))`), matching the fenced-code-block parser pattern — the outer parse loop advances past the newline.

Note on pre-push hook failure: `make test` (the pre-push hook) fails on `assets/embed.go` (`ui/admin/-/web.js`) and `onboarding-vault/embed.go` (`vault.zip`) — both are pre-existing missing build artifacts visible in the repo's git status before this branch. My changes compile and test clean.

## Verification

```
go test ./internal/mdloader/... -v
```

```
=== RUN   TestObsidianComments
=== RUN   TestObsidianComments/inline_comment_stripped
=== RUN   TestObsidianComments/inline_comment_at_start_of_line
=== RUN   TestObsidianComments/inline_comment_at_end_of_line
=== RUN   TestObsidianComments/block_comment_produces_no_output
=== RUN   TestObsidianComments/multiple_inline_comments_in_one_line
=== RUN   TestObsidianComments/multiple_comments_in_one_document
=== RUN   TestObsidianComments/unmatched_lone_%%_left_alone
=== RUN   TestObsidianComments/percent_percent_inside_fenced_code_block_untouched
=== RUN   TestObsidianComments/percent_percent_inside_inline_code_untouched
=== RUN   TestObsidianComments/empty_comment
--- PASS: TestObsidianComments (0.00s)
    --- PASS: TestObsidianComments/inline_comment_stripped (0.00s)
    --- PASS: TestObsidianComments/inline_comment_at_start_of_line (0.00s)
    --- PASS: TestObsidianComments/inline_comment_at_end_of_line (0.00s)
    --- PASS: TestObsidianComments/block_comment_produces_no_output (0.00s)
    --- PASS: TestObsidianComments/multiple_inline_comments_in_one_line (0.00s)
    --- PASS: TestObsidianComments/multiple_comments_in_one_document (0.00s)
    --- PASS: TestObsidianComments/unmatched_lone_%%_left_alone (0.00s)
    --- PASS: TestObsidianComments/percent_percent_inside_fenced_code_block_untouched (0.00s)
    --- PASS: TestObsidianComments/percent_percent_inside_inline_code_untouched (0.00s)
    --- PASS: TestObsidianComments/empty_comment (0.00s)
PASS
ok  	trip2g/internal/mdloader/obsidiancomments	0.003s
PASS
ok  	trip2g/internal/mdloader	0.016s
PASS
ok  	trip2g/internal/mdloader/highlight	0.003s
```

```
go build ./internal/mdloader/... ./internal/mdloader/obsidiancomments/...
# (no output — clean)

go vet ./internal/mdloader/... ./internal/mdloader/obsidiancomments/...
# (no output — clean)
```

Closes #20