### PR TITLE
feat(mcp): limit + detail_limit for search tools (context-saving previews)

### DIFF
--- a/internal/case/mcp/resolve.go
+++ b/internal/case/mcp/resolve.go
@@ -31,6 +31,9 @@ const (
 	DefaultSimilarLimit      = 10
 	MaxSimilarLimit          = 100
 	MaxMergedResults         = 20
+	DefaultSearchLimit       = 6
+	DefaultSearchDetailLimit = 3
+	MaxSearchLimit           = 20 // aligns with MaxMergedResults
 
 	// Hybrid search rank constant.
 	rrfK = 60
@@ -186,6 +189,11 @@ func handleToolsList(ctx context.Context, env Env, id any) Response { //nolint:f
 				Type: "object",
 				Properties: map[string]Property{
 					"query": {Type: "string", Description: "Search query"},
+					"limit": {Type: "number", Description: "Max number of results to return (default 6)"},
+					"detail_limit": {
+						Type:        "number",
+						Description: "How many results include full snippet matches; results beyond this are returned as lightweight previews (title, path, score) to save context (default 3)",
+					},
 				},
 				Required: []string{"query"},
 			},
@@ -251,6 +259,11 @@ func handleToolsList(ctx context.Context, env Env, id any) Response { //nolint:f
 					"query":  {Type: "string", Description: "Search query"},
 					"kb_id":  {Type: "string", Description: "Target knowledge base id"},
 					"kb_ids": {Type: "array", Description: "Target knowledge base ids", Items: &Property{Type: "string"}},
+					"limit":  {Type: "number", Description: "Max number of results to return (default 6)"},
+					"detail_limit": {
+						Type:        "number",
+						Description: "How many results include full snippet matches; results beyond this are returned as lightweight previews (title, path, score) to save context (default 3)",
+					},
 				},
 				Required: []string{"query"},
 			},
@@ -420,6 +433,24 @@ func handleToolsCall(ctx context.Context, env Env, req Request) Response {
 	}
 }
 
+// resolveSearchLimits normalises and clamps limit and detailLimit following the
+// same pattern as handleSimilar's limit handling.
+func resolveSearchLimits(log logger.Logger, limit, detailLimit int) (int, int) {
+	if limit <= 0 {
+		limit = DefaultSearchLimit
+	} else if limit > MaxSearchLimit {
+		log.Warn("search limit exceeds maximum, capping", "requested", limit, "max", MaxSearchLimit)
+		limit = MaxSearchLimit
+	}
+	if detailLimit <= 0 {
+		detailLimit = DefaultSearchDetailLimit
+	}
+	if detailLimit > limit {
+		detailLimit = limit
+	}
+	return limit, detailLimit
+}
+
 func handleSearch(ctx context.Context, env Env, id any, argsRaw json.RawMessage) Response {
 	log := logger.WithPrefix(env.Logger(), "mcp:handleSearch")
 
@@ -454,7 +485,8 @@ func handleSearch(ctx context.Context, env Env, id any, argsRaw json.RawMessage)
 		return errorResponse(id, ErrCodeInternal, "Search failed: "+err.Error())
 	}
 
-	payload := buildSearchPayload(args.Query, results, env.NoteURL, env.LatestNoteChunks())
+	limit, detailLimit := resolveSearchLimits(log, args.Limit, args.DetailLimit)
+	payload := buildSearchPayload(args.Query, results, env.NoteURL, env.LatestNoteChunks(), limit, detailLimit)
 
 	// Format response
 	var sb strings.Builder
@@ -463,10 +495,6 @@ func handleSearch(ctx context.Context, env Env, id any, argsRaw json.RawMessage)
 	} else {
 		sb.WriteString(fmt.Sprintf("Found %d notes:\n\n", len(payload.Results)))
 		for i, r := range payload.Results {
-			if i >= DefaultDisplayLimit {
-				sb.WriteString(fmt.Sprintf("\n... and %d more", len(payload.Results)-DefaultDisplayLimit))
-				break
-			}
 			sb.WriteString(fmt.Sprintf("%d. %s\n   %s\n   %s\n", i+1, r.Title, r.NotePath, r.URL))
 			if len(r.Matches) > 0 {
 				sb.WriteString(fmt.Sprintf("   %s\n", r.Matches[0].Snippet))
@@ -563,35 +591,50 @@ func canReadMCPNote(ctx context.Context, env Env, note *model.NoteView) (bool, e
 	return env.CanReadNote(ctx, note)
 }
 
-func buildSearchPayload(query string, results []model.SearchResult, noteURL func(*model.NoteView) string, chunks []model.NoteChunk) SearchResultPayload {
+func buildSearchPayload(
+	query string,
+	results []model.SearchResult,
+	noteURL func(*model.NoteView) string,
+	chunks []model.NoteChunk,
+	limit, detailLimit int,
+) SearchResultPayload {
 	payload := SearchResultPayload{Query: query}
+	count := 0
 	for _, r := range results {
 		if r.NoteView == nil {
 			continue
 		}
+		if count >= limit {
+			break
+		}
 
 		item := searchResultItemFromNote(r.NoteView, r.Score, noteURL)
-		for i, snippet := range r.HighlightedContent {
-			matchID := fmt.Sprintf("p%d:m%d", r.NoteView.PathID, i+1)
-			chunkIndex := 0
-			if r.ChunkIndex != nil {
-				chunkIndex = *r.ChunkIndex
-			} else if nearest, ok := nearestChunkIndexForSnippet(r.NoteView, snippet, chunks); ok {
-				chunkIndex = nearest
+		if count < detailLimit {
+			// Full detail: include snippet Matches.
+			for i, snippet := range r.HighlightedContent {
+				matchID := fmt.Sprintf("p%d:m%d", r.NoteView.PathID, i+1)
+				chunkIndex := 0
+				if r.ChunkIndex != nil {
+					chunkIndex = *r.ChunkIndex
+				} else if nearest, ok := nearestChunkIndexForSnippet(r.NoteView, snippet, chunks); ok {
+					chunkIndex = nearest
+				}
+				if chunkIndex > 0 || (r.ChunkIndex != nil && chunkIndex == 0) {
+					matchID = fmt.Sprintf("p%d:c%d", r.NoteView.PathID, chunkIndex)
+				}
+				chunkContent := chunkContentByIndex(r.NoteView, chunkIndex, chunks)
+				item.Matches = append(item.Matches, SearchMatch{
+					MatchID:      matchID,
+					ChunkIndex:   chunkIndex,
+					Snippet:      snippet,
+					ContextWords: 10,
+					TOCPath:      tocPathForSnippet(string(r.NoteView.HTML), snippet, chunkContent),
+				})
 			}
-			if chunkIndex > 0 || (r.ChunkIndex != nil && chunkIndex == 0) {
-				matchID = fmt.Sprintf("p%d:c%d", r.NoteView.PathID, chunkIndex)
-			}
-			chunkContent := chunkContentByIndex(r.NoteView, chunkIndex, chunks)
-			item.Matches = append(item.Matches, SearchMatch{
-				MatchID:      matchID,
-				ChunkIndex:   chunkIndex,
-				Snippet:      snippet,
-				ContextWords: 10,
-				TOCPath:      tocPathForSnippet(string(r.NoteView.HTML), snippet, chunkContent),
-			})
 		}
+		// Beyond detailLimit: item.Matches stays nil (lightweight preview).
 		payload.Results = append(payload.Results, item)
+		count++
 	}
 	return payload
 }

--- a/internal/case/mcp/resolve_internal_test.go
+++ b/internal/case/mcp/resolve_internal_test.go
@@ -72,7 +72,7 @@ func TestBuildSearchPayloadUsesChunkBasedMatchIDs(t *testing.T) {
 		MatchOrigin:        model.SearchMatchVector,
 		ChunkIndex:         &chunkIndex,
 		HighlightedContent: []string{"Лучший способ отомстить - не уподобляться обидчику."},
-	}}, func(n *model.NoteView) string { return "https://markavrelii.2pub.me" + n.Permalink }, nil)
+	}}, func(n *model.NoteView) string { return "https://markavrelii.2pub.me" + n.Permalink }, nil, MaxSearchLimit, MaxSearchLimit)
 
 	require.Len(t, payload.Results, 1)
 	require.Len(t, payload.Results[0].Matches, 1)
@@ -105,7 +105,7 @@ func TestBuildSearchPayloadMapsTextSnippetToNearestChunkWhenClear(t *testing.T) 
 			ChunkIndex: 2,
 			Content:    "Книга 06\n\nСовсем другой фрагмент.",
 		},
-	})
+	}, MaxSearchLimit, MaxSearchLimit)
 
 	require.Len(t, payload.Results, 1)
 	require.Len(t, payload.Results[0].Matches, 1)
@@ -133,7 +133,7 @@ func TestBuildSearchPayloadLeavesTextMatchAsGenericWhenNoClearChunk(t *testing.T
 			ChunkIndex: 1,
 			Content:    "Книга 06\n\nЛучший способ отомстить - не уподобляться обидчику.",
 		},
-	})
+	}, MaxSearchLimit, MaxSearchLimit)
 
 	require.Len(t, payload.Results, 1)
 	require.Len(t, payload.Results[0].Matches, 1)

--- a/internal/case/mcp/resolve_test.go
+++ b/internal/case/mcp/resolve_test.go
@@ -3,6 +3,7 @@ package mcp_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"trip2g/internal/case/mcp"
@@ -1292,5 +1293,158 @@ func TestHandleSimilarLimitValidation(t *testing.T) {
 
 		require.Nil(t, resp.Error)
 		// Test passes if no error - limit should be capped
+	})
+}
+
+// makeSearchNote creates a NoteView with a given PathID, path, and title for search tests.
+func makeSearchNote(pathID int64, path, title string) *appmodel.NoteView {
+	return &appmodel.NoteView{
+		Path:      path,
+		PathID:    pathID,
+		Title:     title,
+		Permalink: "/" + path,
+	}
+}
+
+// makeSearchEnv builds a minimal Env mock that returns results from SearchLatestNotes.
+func makeSearchEnv(t *testing.T, results []appmodel.SearchResult) *EnvMock {
+	t.Helper()
+	return &EnvMock{
+		SearchLatestNotesFunc: func(query string) ([]appmodel.SearchResult, error) {
+			return results, nil
+		},
+		LatestNoteChunksFunc: func() []appmodel.NoteChunk { return nil },
+		FeaturesFunc:         func() features.Features { return features.Features{} },
+		PublicURLFunc:        func() string { return "https://example.test" },
+		NoteURLFunc: func(note *appmodel.NoteView) string {
+			return "https://example.test" + note.Permalink
+		},
+		LoggerFunc: func() logger.Logger { return &logger.DummyLogger{} },
+		CanReadNoteFunc: func(_ context.Context, _ *appmodel.NoteView) (bool, error) {
+			return true, nil
+		},
+	}
+}
+
+// searchCall issues a tools/call search request and returns the payload.
+func searchCall(t *testing.T, env *EnvMock, argsJSON string) mcp.SearchResultPayload {
+	t.Helper()
+	params := mcp.CallToolParams{
+		Name:      "search",
+		Arguments: json.RawMessage(argsJSON),
+	}
+	paramsJSON, _ := json.Marshal(params)
+	resp := mcp.Resolve(context.Background(), env, mcp.Request{
+		JSONRPC: "2.0", Method: "tools/call", Params: paramsJSON, ID: 1,
+	})
+	require.Nil(t, resp.Error, "unexpected error: %v", resp.Error)
+	result := resp.Result.(mcp.CallToolResult)
+	return result.StructuredContent.(mcp.SearchResultPayload)
+}
+
+// makeNResults builds N search results with distinct notes.
+func makeNResults(n int) []appmodel.SearchResult {
+	results := make([]appmodel.SearchResult, n)
+	for i := range n {
+		note := makeSearchNote(int64(i+1), fmt.Sprintf("note%d.md", i+1), fmt.Sprintf("Note %d", i+1))
+		results[i] = appmodel.SearchResult{
+			NoteView:           note,
+			URL:                note.Permalink,
+			Score:              float64(n - i),
+			HighlightedContent: []string{fmt.Sprintf("Snippet for note %d", i+1)},
+		}
+	}
+	return results
+}
+
+func TestSearchLimitAndDetailLimit(t *testing.T) {
+	t.Run("defaults: 6 total, 3 full detail", func(t *testing.T) {
+		env := makeSearchEnv(t, makeNResults(10))
+		payload := searchCall(t, env, `{"query":"test"}`)
+
+		// default limit = 6
+		require.Len(t, payload.Results, 6)
+
+		// first 3 have Matches, results[3..5] are previews (Matches nil)
+		for i := range 3 {
+			require.NotNil(t, payload.Results[i].Matches, "result[%d] should have Matches", i)
+		}
+		for i := 3; i < 6; i++ {
+			require.Nil(t, payload.Results[i].Matches, "result[%d] should be a preview (no Matches)", i)
+		}
+	})
+
+	t.Run("explicit limit honored", func(t *testing.T) {
+		env := makeSearchEnv(t, makeNResults(10))
+		payload := searchCall(t, env, `{"query":"test","limit":4}`)
+		require.Len(t, payload.Results, 4)
+	})
+
+	t.Run("explicit detail_limit honored", func(t *testing.T) {
+		env := makeSearchEnv(t, makeNResults(8))
+		payload := searchCall(t, env, `{"query":"test","limit":5,"detail_limit":2}`)
+		require.Len(t, payload.Results, 5)
+		for i := range 2 {
+			require.NotNil(t, payload.Results[i].Matches, "result[%d] should have Matches", i)
+		}
+		for i := 2; i < 5; i++ {
+			require.Nil(t, payload.Results[i].Matches, "result[%d] should be preview", i)
+		}
+	})
+
+	t.Run("detail_limit clamped to limit", func(t *testing.T) {
+		env := makeSearchEnv(t, makeNResults(8))
+		// detail_limit=10 > limit=4 → clamp to 4, all have Matches
+		payload := searchCall(t, env, `{"query":"test","limit":4,"detail_limit":10}`)
+		require.Len(t, payload.Results, 4)
+		for i := range payload.Results {
+			require.NotNil(t, payload.Results[i].Matches, "result[%d] should have Matches (clamped detail_limit)", i)
+		}
+	})
+
+	t.Run("limit capped at MaxSearchLimit", func(t *testing.T) {
+		env := makeSearchEnv(t, makeNResults(25))
+		payload := searchCall(t, env, `{"query":"test","limit":999}`)
+		require.LessOrEqual(t, len(payload.Results), mcp.MaxSearchLimit)
+	})
+
+	t.Run("total results do not exceed limit when fewer results exist", func(t *testing.T) {
+		env := makeSearchEnv(t, makeNResults(3))
+		payload := searchCall(t, env, `{"query":"test"}`) // default limit=6
+		require.Len(t, payload.Results, 3)                // only 3 available
+	})
+
+	t.Run("detail_limit=0 defaults to DefaultSearchDetailLimit", func(t *testing.T) {
+		env := makeSearchEnv(t, makeNResults(8))
+		payload := searchCall(t, env, `{"query":"test","limit":6,"detail_limit":0}`)
+		// default detail_limit=3
+		require.Len(t, payload.Results, 6)
+		for i := range 3 {
+			require.NotNil(t, payload.Results[i].Matches, "result[%d] should have Matches", i)
+		}
+		for i := 3; i < 6; i++ {
+			require.Nil(t, payload.Results[i].Matches, "result[%d] should be preview", i)
+		}
+	})
+
+	t.Run("text output shows snippets for detail results, path-only for previews", func(t *testing.T) {
+		env := makeSearchEnv(t, makeNResults(4))
+		params := mcp.CallToolParams{
+			Name:      "search",
+			Arguments: json.RawMessage(`{"query":"test","limit":4,"detail_limit":2}`),
+		}
+		paramsJSON, _ := json.Marshal(params)
+		resp := mcp.Resolve(context.Background(), env, mcp.Request{
+			JSONRPC: "2.0", Method: "tools/call", Params: paramsJSON, ID: 1,
+		})
+		require.Nil(t, resp.Error)
+		result := resp.Result.(mcp.CallToolResult)
+		text := result.Content[0].Text
+		// Full detail results include snippet; previews should include "[preview]" marker or similar
+		require.Contains(t, text, "Snippet for note 1")
+		require.Contains(t, text, "Snippet for note 2")
+		// Preview results (index 2,3) should NOT contain their snippets in the text
+		require.NotContains(t, text, "Snippet for note 3")
+		require.NotContains(t, text, "Snippet for note 4")
 	})
 }

--- a/internal/case/mcp/types.go
+++ b/internal/case/mcp/types.go
@@ -72,13 +72,17 @@ type Content struct {
 // Tool-specific argument types
 
 type SearchArguments struct {
-	Query string `json:"query"`
+	Query       string `json:"query"`
+	Limit       int    `json:"limit,omitempty"`
+	DetailLimit int    `json:"detail_limit,omitempty"`
 }
 
 type FederatedSearchArguments struct {
-	Query string   `json:"query"`
-	KBID  string   `json:"kb_id,omitempty"`
-	KBIDs []string `json:"kb_ids,omitempty"`
+	Query       string   `json:"query"`
+	KBID        string   `json:"kb_id,omitempty"`
+	KBIDs       []string `json:"kb_ids,omitempty"`
+	Limit       int      `json:"limit,omitempty"`
+	DetailLimit int      `json:"detail_limit,omitempty"`
 }
 
 type FederatedSimilarArguments struct {


### PR DESCRIPTION
Adds `limit` (default 6) and `detail_limit` (default 3) to the `search` and `federated_search` MCP tools to cut LLM context usage.

- `limit` — max results returned (capped at `MaxSearchLimit = 20`).
- `detail_limit` — how many of those come back with full snippet `Matches`; results beyond it return as lightweight previews (title / path / score, `Matches: nil`).
- Defaults = **3 full + 3 previews = 6 total** (previously up to 20 full results in the payload).
- Validation mirrors the existing `similar` tool: `<= 0` → default, `> max` → cap with a warning, `detail_limit` clamped to `limit`.

**Caveat — `federated_search`:** the params are exposed in the schema and accepted in the args struct, but truncation is applied per remote peer (the local fan-out delegates to each peer's own `search` handler) — the aggregate is not capped locally. Easy follow-up if aggregate capping is wanted.

**Verification:** 8 new subtests in `resolve_test.go`; `go test ./internal/case/mcp/...` green; `golangci-lint` clean.
