### PR TITLE
feat(layouts): default-template chrome accessors (Header/Footer/Styles) + camelCase namespaces

### DIFF
--- a/internal/case/rendernotepage/endpoint.go
+++ b/internal/case/rendernotepage/endpoint.go
@@ -331,11 +331,17 @@ func renderLayout(
 	vars["htmlInjectionsBodyEnd"] = reflect.ValueOf(bodyEndInjections)
 
 	// Build the shared helper and expose two Jet namespaces:
-	//   default_template — template chrome: {{ default_template.user_space_scripts() }}
-	//   current_user     — viewer role:     {{ current_user.is_admin() }}
+	//   defaultTemplate — template chrome: {{ defaultTemplate.UserSpaceScripts() }}
+	//   currentUser     — viewer role:     {{ currentUser.IsAdmin() }}
+	// The snake_case keys are kept as deprecated aliases (the released kanban
+	// template still calls default_template.user_space_scripts()).
 	usHelper := buildUserSpaceHelper(ctx, env, resp)
-	vars["default_template"] = reflect.ValueOf(usHelper.jetMap())
-	vars["current_user"] = reflect.ValueOf(usHelper.currentUserJetMap())
+	defaultTemplateNS := reflect.ValueOf(usHelper.jetMap())
+	currentUserNS := reflect.ValueOf(usHelper.currentUserJetMap())
+	vars["defaultTemplate"] = defaultTemplateNS
+	vars["currentUser"] = currentUserNS
+	vars["default_template"] = defaultTemplateNS // deprecated alias
+	vars["current_user"] = currentUserNS         // deprecated alias
 
 	viewErr := layout.View.Execute(ctx, vars, resp)
 	if viewErr != nil {

--- a/internal/case/rendernotepage/userspace.go
+++ b/internal/case/rendernotepage/userspace.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 
 	"trip2g/internal/case/renderlayout"
+	"trip2g/internal/defaulttemplate"
 	"trip2g/internal/langdetect"
+	"trip2g/internal/model"
 	"trip2g/internal/templateviews"
 
 	"github.com/valyala/fasthttp"
@@ -22,12 +24,15 @@ import (
 // once in <head> without duplicating the inline settings object.
 type userSpaceHelper struct {
 	jsURLs          []string
+	cssURLs         []string
 	localeHashes    map[string]string
 	uiLang          string
 	devMode         bool
 	isAdmin         bool
 	title           string
 	note            *templateviews.Note
+	nvs             *templateviews.NVS
+	layoutSections  []model.LayoutSectionEntry
 	settingsEmitted bool
 }
 
@@ -133,24 +138,68 @@ func (h *userSpaceHelper) scripts() string {
 }
 
 // admin returns true when the current viewer is the site owner/admin.
-// Jet calls this via reflection for {{ current_user.is_admin() }}.
+// Jet calls this via reflection for {{ currentUser.IsAdmin() }}.
 func (h *userSpaceHelper) admin() bool {
 	return h.isAdmin
 }
 
-// jetMap returns the map stored in vars["default_template"].
-// Contains only template-chrome helpers (script injection).
-func (h *userSpaceHelper) jetMap() map[string]interface{} {
-	return map[string]interface{}{
-		"user_space_scripts": h.scripts,
+// dtCtx builds the minimal default-template Ctx needed to resolve and render
+// the site header/footer chrome for a custom layout.
+func (h *userSpaceHelper) dtCtx() *defaulttemplate.Ctx {
+	return &defaulttemplate.Ctx{
+		Note:           h.note,
+		Notes:          h.nvs,
+		LayoutSections: h.layoutSections,
 	}
 }
 
-// currentUserJetMap returns the map stored in vars["current_user"].
-// Layouts call {{ current_user.is_admin() }} to gate edit affordances.
+// header returns the standard site-header HTML (or "" when the page has no
+// header). Jet calls this for {{ defaultTemplate.Header() }}.
+func (h *userSpaceHelper) header() string {
+	return defaulttemplate.Header(h.dtCtx())
+}
+
+// footer returns the standard site-footer HTML (or "" when the page has no
+// footer). Jet calls this for {{ defaultTemplate.Footer() }}.
+func (h *userSpaceHelper) footer() string {
+	return defaulttemplate.Footer(h.dtCtx())
+}
+
+// styles returns <link> tags for the default-template stylesheet so a custom
+// layout embedding the standard chrome isn't unstyled. Reuses the existing
+// hashed served URL (renderlayout.Env.UserCSSURLs) — never a hardcoded hash.
+// Jet calls this for {{ defaultTemplate.Styles() }}.
+func (h *userSpaceHelper) styles() string {
+	var sb strings.Builder
+	for _, u := range h.cssURLs {
+		sb.WriteString(`<link rel="stylesheet" href="`)
+		sb.WriteString(html.EscapeString(u))
+		sb.WriteString(`">`)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+// jetMap returns the map stored in vars["defaultTemplate"] (and its deprecated
+// vars["default_template"] alias). Holds template-chrome helpers: script
+// injection plus the standard header/footer/styles.
+func (h *userSpaceHelper) jetMap() map[string]interface{} {
+	return map[string]interface{}{
+		"UserSpaceScripts":   h.scripts,
+		"user_space_scripts": h.scripts, // deprecated alias
+		"Header":             h.header,
+		"Footer":             h.footer,
+		"Styles":             h.styles,
+	}
+}
+
+// currentUserJetMap returns the map stored in vars["currentUser"] (and its
+// deprecated vars["current_user"] alias). Layouts call IsAdmin() to gate edit
+// affordances.
 func (h *userSpaceHelper) currentUserJetMap() map[string]interface{} {
 	return map[string]interface{}{
-		"is_admin": h.admin,
+		"IsAdmin":  h.admin,
+		"is_admin": h.admin, // deprecated alias
 	}
 }
 
@@ -168,12 +217,14 @@ func buildUserSpaceHelper(
 ) *userSpaceHelper {
 	var (
 		jsURLs       []string
+		cssURLs      []string
 		localeHashes map[string]string
 		devMode      bool
 	)
 
 	if rlEnv, ok := env.(renderlayout.Env); ok {
 		jsURLs = rlEnv.UserJSURLs()
+		cssURLs = rlEnv.UserCSSURLs()
 		localeHashes = rlEnv.UserLocaleHashes()
 		devMode = rlEnv.IsDevMode()
 	}
@@ -183,5 +234,11 @@ func buildUserSpaceHelper(
 		string(ctx.Request.Header.Peek("Accept-Language")),
 	)
 
-	return newUserSpaceHelper(jsURLs, localeHashes, uiLang, devMode, resp.UserToken.IsAdmin(), resp.Title, resp.NoteView)
+	h := newUserSpaceHelper(jsURLs, localeHashes, uiLang, devMode, resp.UserToken.IsAdmin(), resp.Title, resp.NoteView)
+	h.cssURLs = cssURLs
+	h.nvs = templateviews.NewNVS(resp.Notes, resp.DefaultVersion)
+	if resp.Notes != nil {
+		h.layoutSections = resp.Notes.LayoutSections
+	}
+	return h
 }

--- a/internal/case/rendernotepage/userspace_test.go
+++ b/internal/case/rendernotepage/userspace_test.go
@@ -284,3 +284,121 @@ func TestJetBinding_IsAdmin_False(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "false", buf.String())
 }
+
+// stubPartialRenderer is a no-op model.NoteViewPartialRenderer so SiteFooter can
+// render its chrome wrapper without a full markdown pipeline in tests.
+type stubPartialRenderer struct{}
+
+func (stubPartialRenderer) Sections(int) []model.NoteViewSection      { return nil }
+func (stubPartialRenderer) Section(string) *model.NoteViewSection     { return nil }
+func (stubPartialRenderer) Introduce() model.NoteViewSection          { return model.NoteViewSection{} }
+func (stubPartialRenderer) HeadingBlocks(int) []model.NoteViewSection { return nil }
+func (stubPartialRenderer) FirstList() *model.NoteViewList            { return nil }
+func (stubPartialRenderer) Lists() []model.NoteViewList               { return nil }
+func (stubPartialRenderer) FirstImageURL() string                    { return "" }
+
+// chromeHelper builds a userSpaceHelper whose Notes resolve _header/_footer so
+// that Header()/Footer()/Styles() produce the standard chrome HTML.
+func chromeHelper() *userSpaceHelper {
+	mainNV := &model.NoteView{Path: "blog/post1.md", Permalink: "/blog/post1"}
+	headerNV := &model.NoteView{Path: "_header.md", Permalink: "/_header"}
+	footerNV := &model.NoteView{Path: "_footer.md", Permalink: "/_footer", PartialRenderer: stubPartialRenderer{}}
+
+	nvs := model.NewNoteViews()
+	for _, nv := range []*model.NoteView{mainNV, headerNV, footerNV} {
+		nvs.PathMap[nv.Path] = nv
+		nvs.Map[nv.Permalink] = nv
+	}
+	tv := templateviews.NewNVS(nvs, "live")
+
+	h := newUserSpaceHelper(nil, nil, "en", false, false, "Title", tv.ByPath("blog/post1.md"))
+	h.nvs = tv
+	h.cssURLs = []string{"/assets/defaulttemplate.css?h=abc123"}
+	return h
+}
+
+// TestJetBinding_DefaultTemplateChrome_CamelCase verifies the new camelCase
+// namespace + PascalCase methods resolve and render raw (WithSafeWriter(nil)):
+// UserSpaceScripts(), Header(), Footer(), Styles().
+func TestJetBinding_DefaultTemplateChrome_CamelCase(t *testing.T) {
+	const tmplKey = "/chrome.html"
+	loader := &testStringLoader{
+		templates: map[string]string{
+			tmplKey: `[s]{{ defaultTemplate.UserSpaceScripts() }}[h]{{ defaultTemplate.Header() }}` +
+				`[f]{{ defaultTemplate.Footer() }}[c]{{ defaultTemplate.Styles() }}`,
+		},
+	}
+	views := jet.NewSet(loader, jet.DevelopmentMode(true), jet.WithSafeWriter(nil))
+	tmpl, err := views.GetTemplate(tmplKey)
+	require.NoError(t, err)
+
+	h := chromeHelper()
+	vars := make(jet.VarMap)
+	vars["defaultTemplate"] = reflect.ValueOf(h.jetMap())
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, vars, nil)
+	require.NoError(t, err)
+	out := buf.String()
+
+	require.Contains(t, out, "window.__trip2g_settings")    // UserSpaceScripts()
+	require.Contains(t, out, `<header class="site-header">`) // Header()
+	require.Contains(t, out, `<footer class="site-footer">`) // Footer()
+	require.Contains(t, out, `<link rel="stylesheet" href="/assets/defaulttemplate.css?h=abc123">`) // Styles()
+
+	// Chrome HTML is written raw, not entity-escaped.
+	require.NotContains(t, out, "&lt;header")
+	require.NotContains(t, out, "&lt;footer")
+	require.NotContains(t, out, "&lt;link")
+}
+
+// TestJetBinding_IsAdmin_CamelCase verifies {{ currentUser.IsAdmin() }} resolves.
+func TestJetBinding_IsAdmin_CamelCase(t *testing.T) {
+	const tmplKey = "/current-user.html"
+	loader := &testStringLoader{
+		templates: map[string]string{
+			tmplKey: `{{ currentUser.IsAdmin() }}`,
+		},
+	}
+	views := jet.NewSet(loader, jet.DevelopmentMode(true), jet.WithSafeWriter(nil))
+	tmpl, err := views.GetTemplate(tmplKey)
+	require.NoError(t, err)
+
+	h := newUserSpaceHelper(nil, nil, "en", false, true, "Title", nil)
+	vars := make(jet.VarMap)
+	vars["currentUser"] = reflect.ValueOf(h.currentUserJetMap())
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, vars, nil)
+	require.NoError(t, err)
+	require.Equal(t, "true", buf.String())
+}
+
+// TestJetBinding_DeprecatedAliasesStillResolve verifies the old snake_case
+// names kept as aliases still resolve — the released kanban template calls
+// default_template.user_space_scripts() and current_user.is_admin().
+func TestJetBinding_DeprecatedAliasesStillResolve(t *testing.T) {
+	const tmplKey = "/aliases.html"
+	loader := &testStringLoader{
+		templates: map[string]string{
+			tmplKey: `[s]{{ default_template.user_space_scripts() }}[a]{{ current_user.is_admin() }}`,
+		},
+	}
+	views := jet.NewSet(loader, jet.DevelopmentMode(true), jet.WithSafeWriter(nil))
+	tmpl, err := views.GetTemplate(tmplKey)
+	require.NoError(t, err)
+
+	h := newUserSpaceHelper([]string{"/assets/bundle.js"}, nil, "en", false, true, "Title", sampleNote())
+	vars := make(jet.VarMap)
+	vars["default_template"] = reflect.ValueOf(h.jetMap())
+	vars["current_user"] = reflect.ValueOf(h.currentUserJetMap())
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, vars, nil)
+	require.NoError(t, err)
+	out := buf.String()
+
+	require.Contains(t, out, "window.__trip2g_settings")                       // user_space_scripts()
+	require.Contains(t, out, `<script src="/assets/bundle.js" defer></script>`)
+	require.Contains(t, out, "[a]true")                                        // is_admin()
+}

--- a/internal/defaulttemplate/chrome.go
+++ b/internal/defaulttemplate/chrome.go
@@ -1,0 +1,32 @@
+package defaulttemplate
+
+// Header resolves the page header note (per the same precedence as NotePage:
+// per-note `header:` frontmatter, glob-matched layout section, `_header`
+// fallback) and returns its rendered site-header HTML, or "" when the page has
+// no header. Exposed so custom Jet layouts can embed the standard chrome via
+// {{ defaultTemplate.Header() }} without re-implementing resolution.
+func Header(ctx *Ctx) string {
+	ref := ctx.HeaderRef()
+	if ref.Kind == ContentRefNone {
+		return ""
+	}
+	note := ctx.resolveNoteRef(ref)
+	if note == nil {
+		return ""
+	}
+	return SiteHeader(ctx, note, false, false)
+}
+
+// Footer resolves the page footer note and returns its rendered site-footer
+// HTML, or "" when the page has no footer.
+func Footer(ctx *Ctx) string {
+	ref := ctx.FooterRef()
+	if ref.Kind == ContentRefNone {
+		return ""
+	}
+	note := ctx.resolveNoteRef(ref)
+	if note == nil {
+		return ""
+	}
+	return SiteFooter(ctx, note)
+}


### PR DESCRIPTION
## What

Builds on the user-space chrome work (`feat/layout-user-space`). Two changes:

### 1. Homogenize Jet namespace naming (camelCase namespaces + PascalCase methods)
- `renderLayout` now injects **`defaultTemplate`** and **`currentUser`** as the primary VarMap keys.
- The old **`default_template`** / **`current_user`** keys are kept as **deprecated aliases** (same values) — the released kanban template still calls the snake names, so they keep working.
- `jetMap()` exposes `UserSpaceScripts` (+ `user_space_scripts` alias), `Header`, `Footer`, `Styles`.
- `currentUserJetMap()` exposes `IsAdmin` (+ `is_admin` alias).

### 2. Default-template chrome accessors (Design A — ready-to-inject HTML)
- New `defaulttemplate.Header(ctx)` / `Footer(ctx)`: resolve the header/footer note (per-note frontmatter → glob layout section → `_header`/`_footer` fallback) and return the generated `SiteHeader`/`SiteFooter` HTML, or `""`.
- `userSpaceHelper.header()` / `footer()` build a minimal `*defaulttemplate.Ctx` from the resolve response (`Note`, `Notes` NVS, `LayoutSections`) and call those.
- `userSpaceHelper.styles()` returns `<link rel="stylesheet">` tags reusing the existing hashed served URL (`renderlayout.Env.UserCSSURLs()`) — no hardcoded hash.

All chrome strings are written raw (the Jet set uses `WithSafeWriter(nil)`).

## Accessors a layout author writes

```jet
{{ defaultTemplate.UserSpaceScripts() }}   {# login/search bundle + settings #}
{{ defaultTemplate.Header() }}             {# standard site header HTML #}
{{ defaultTemplate.Footer() }}             {# standard site footer HTML #}
{{ defaultTemplate.Styles() }}             {# default-template stylesheet <link> #}
{{ currentUser.IsAdmin() }}                {# bool, gate edit affordances #}
```

Deprecated (still work): `default_template.user_space_scripts()`, `current_user.is_admin()`.

## Tests

Extended `internal/case/rendernotepage/userspace_test.go` (table-style, in-memory Jet loader matching the real `WithSafeWriter(nil)` set):
- `TestJetBinding_DefaultTemplateChrome_CamelCase` — resolves `UserSpaceScripts()`, `Header()`, `Footer()`, `Styles()` and asserts raw (unescaped) chrome HTML.
- `TestJetBinding_IsAdmin_CamelCase` — `currentUser.IsAdmin()`.
- `TestJetBinding_DeprecatedAliasesStillResolve` — `default_template.user_space_scripts()` + `current_user.is_admin()`.

`go build ./internal/... ` and `go test ./internal/case/rendernotepage/... ./internal/defaulttemplate/...` green.