### PR TITLE
fix(kanban): close two LOW follow-ups from the live-sync data-loss review

### DIFF
--- a/cmd/server/notes.go
+++ b/cmd/server/notes.go
@@ -105,6 +105,16 @@ func (a *app) HideNotePaths(ctx context.Context, paths []string) error {
 }
 
 func (a *app) InsertNote(ctx context.Context, note model.RawNote) (int64, error) {
+	pathID, _, err := insertnote.Resolve(ctx, a, note)
+	return pathID, err
+}
+
+// InsertNoteWithVersion is InsertNote that also returns the id of the
+// note_versions row it inserted (0 when content was unchanged). updateNotes uses
+// it to report each save's OWN version id, race-free, instead of re-deriving it
+// from a post-write reload (which under concurrent same-board editing can be a
+// peer's newer version).
+func (a *app) InsertNoteWithVersion(ctx context.Context, note model.RawNote) (int64, int64, error) {
 	return insertnote.Resolve(ctx, a, note)
 }
 

--- a/internal/case/insertnote/actor_test.go
+++ b/internal/case/insertnote/actor_test.go
@@ -77,7 +77,7 @@ func TestInsertNoteRecordsUserActor(t *testing.T) {
 
 	env := &actorEnv{WriteQueries: wq, userID: &user.ID}
 
-	pathID, err := insertnote.Resolve(ctx, env, model.RawNote{Path: "user-note.md", Content: "hello"})
+	pathID, _, err := insertnote.Resolve(ctx, env, model.RawNote{Path: "user-note.md", Content: "hello"})
 	require.NoError(t, err)
 
 	version := latestVersion(t, rq, pathID)
@@ -121,7 +121,7 @@ func TestInsertNoteRecordsAPIKeyActor(t *testing.T) {
 
 	env := &actorEnv{WriteQueries: wq, apiKeyID: &apiKey.ID}
 
-	pathID, err := insertnote.Resolve(ctx, env, model.RawNote{Path: "synced-note.md", Content: "from sync"})
+	pathID, _, err := insertnote.Resolve(ctx, env, model.RawNote{Path: "synced-note.md", Content: "from sync"})
 	require.NoError(t, err)
 
 	version := latestVersion(t, rq, pathID)
@@ -149,7 +149,7 @@ func TestInsertNoteRecordsNoActorAsNull(t *testing.T) {
 
 	env := &actorEnv{WriteQueries: wq} // userID and apiKeyID both nil
 
-	pathID, err := insertnote.Resolve(ctx, env, model.RawNote{Path: "anon-note.md", Content: "no actor"})
+	pathID, _, err := insertnote.Resolve(ctx, env, model.RawNote{Path: "anon-note.md", Content: "no actor"})
 	require.NoError(t, err)
 
 	version := latestVersion(t, rq, pathID)
@@ -175,7 +175,7 @@ func TestInsertNoteRecordsClientHeader(t *testing.T) {
 	clientVal := "obsidian-plugin/4.2.1"
 	env := &actorEnv{WriteQueries: wq, client: &clientVal}
 
-	pathID, err := insertnote.Resolve(ctx, env, model.RawNote{Path: "client-note.md", Content: "from client"})
+	pathID, _, err := insertnote.Resolve(ctx, env, model.RawNote{Path: "client-note.md", Content: "from client"})
 	require.NoError(t, err)
 
 	version := latestVersion(t, rq, pathID)

--- a/internal/case/insertnote/mocks_test.go
+++ b/internal/case/insertnote/mocks_test.go
@@ -27,7 +27,7 @@ var _ insertnote.Env = &EnvMock{}
 //			InsertNotePathFunc: func(ctx context.Context, arg db.InsertNotePathParams) (db.InsertNotePathRow, error) {
 //				panic("mock out the InsertNotePath method")
 //			},
-//			InsertNoteVersionFunc: func(ctx context.Context, arg db.InsertNoteVersionParams) error {
+//			InsertNoteVersionFunc: func(ctx context.Context, arg db.InsertNoteVersionParams) (int64, error) {
 //				panic("mock out the InsertNoteVersion method")
 //			},
 //			NoteVersionActorFunc: func(ctx context.Context) model.NoteActor {
@@ -50,7 +50,7 @@ type EnvMock struct {
 	InsertNotePathFunc func(ctx context.Context, arg db.InsertNotePathParams) (db.InsertNotePathRow, error)
 
 	// InsertNoteVersionFunc mocks the InsertNoteVersion method.
-	InsertNoteVersionFunc func(ctx context.Context, arg db.InsertNoteVersionParams) error
+	InsertNoteVersionFunc func(ctx context.Context, arg db.InsertNoteVersionParams) (int64, error)
 
 	// NoteVersionActorFunc mocks the NoteVersionActor method.
 	NoteVersionActorFunc func(ctx context.Context) model.NoteActor
@@ -174,7 +174,7 @@ func (mock *EnvMock) InsertNotePathCalls() []struct {
 }
 
 // InsertNoteVersion calls InsertNoteVersionFunc.
-func (mock *EnvMock) InsertNoteVersion(ctx context.Context, arg db.InsertNoteVersionParams) error {
+func (mock *EnvMock) InsertNoteVersion(ctx context.Context, arg db.InsertNoteVersionParams) (int64, error) {
 	if mock.InsertNoteVersionFunc == nil {
 		panic("EnvMock.InsertNoteVersionFunc: method is nil but Env.InsertNoteVersion was just called")
 	}

--- a/internal/case/insertnote/resolve.go
+++ b/internal/case/insertnote/resolve.go
@@ -19,7 +19,7 @@ var ErrNoteVersionAlreadyExists = errors.New("note version already exists")
 type Env interface {
 	InsertNotePath(ctx context.Context, arg db.InsertNotePathParams) (db.InsertNotePathRow, error)
 	IncrementNoteVersionCount(ctx context.Context, arg db.IncrementNoteVersionCountParams) (int64, error)
-	InsertNoteVersion(ctx context.Context, arg db.InsertNoteVersionParams) error
+	InsertNoteVersion(ctx context.Context, arg db.InsertNoteVersionParams) (int64, error)
 	UnhideNotePath(ctx context.Context, value string) error
 	// NoteVersionActor returns who is pushing this version: the acting user id,
 	// the authenticating API key id, and the client identifier from the
@@ -27,7 +27,11 @@ type Env interface {
 	NoteVersionActor(ctx context.Context) model.NoteActor
 }
 
-func Resolve(ctx context.Context, env Env, arg model.RawNote) (int64, error) {
+// Resolve writes the note and returns its note_paths id and the id of the
+// note_versions row it inserted. The version id is 0 when no new version was
+// created (content unchanged) — callers that need a version id should fall back
+// to the current latest in that case.
+func Resolve(ctx context.Context, env Env, arg model.RawNote) (int64, int64, error) {
 	sha := sha256.New()
 
 	sha.Write([]byte(arg.Path))
@@ -54,7 +58,7 @@ func Resolve(ctx context.Context, env Env, arg model.RawNote) (int64, error) {
 				continue
 			}
 
-			return 0, fmt.Errorf("failed to InsertNotePath: %w", insertErr)
+			return 0, 0, fmt.Errorf("failed to InsertNotePath: %w", insertErr)
 		}
 
 		notePath = &insertedRow
@@ -63,18 +67,18 @@ func Resolve(ctx context.Context, env Env, arg model.RawNote) (int64, error) {
 	}
 
 	if notePath == nil {
-		return 0, ErrNotePathHashUnresolvedCollision
+		return 0, 0, ErrNotePathHashUnresolvedCollision
 	}
 
 	// Always unhide note when pushed (even if content hasn't changed)
 	err := env.UnhideNotePath(ctx, arg.Path)
 	if err != nil {
-		return 0, fmt.Errorf("failed to unhide note path: %w", err)
+		return 0, 0, fmt.Errorf("failed to unhide note path: %w", err)
 	}
 
 	if notePath.VersionCount > 0 && notePath.LatestContentHash == contentHash {
-		// Content hasn't changed, no need to create new version
-		return notePath.ID, nil
+		// Content hasn't changed, no new version created (version id 0).
+		return notePath.ID, 0, nil
 	}
 
 	increaseParams := db.IncrementNoteVersionCountParams{
@@ -85,7 +89,7 @@ func Resolve(ctx context.Context, env Env, arg model.RawNote) (int64, error) {
 
 	version, err := env.IncrementNoteVersionCount(ctx, increaseParams)
 	if err != nil {
-		return 0, fmt.Errorf("failed to IncrementNoteVersionCount: %w", err)
+		return 0, 0, fmt.Errorf("failed to IncrementNoteVersionCount: %w", err)
 	}
 
 	actor := env.NoteVersionActor(ctx)
@@ -99,10 +103,10 @@ func Resolve(ctx context.Context, env Env, arg model.RawNote) (int64, error) {
 		CreatedByClient:   actor.Client,
 	}
 
-	err = env.InsertNoteVersion(ctx, noteVersion)
+	versionID, err := env.InsertNoteVersion(ctx, noteVersion)
 	if err != nil {
-		return 0, fmt.Errorf("failed to InsertNoteVersion: %w", err)
+		return 0, 0, fmt.Errorf("failed to InsertNoteVersion: %w", err)
 	}
 
-	return notePath.ID, nil
+	return notePath.ID, versionID, nil
 }

--- a/internal/case/insertnote/resolve_test.go
+++ b/internal/case/insertnote/resolve_test.go
@@ -39,9 +39,9 @@ func TestUnhideCalledEvenWhenContentUnchanged(t *testing.T) {
 			t.Error("IncrementNoteVersionCount should not be called when content is unchanged")
 			return 0, nil
 		},
-		InsertNoteVersionFunc: func(ctx context.Context, arg db.InsertNoteVersionParams) error {
+		InsertNoteVersionFunc: func(ctx context.Context, arg db.InsertNoteVersionParams) (int64, error) {
 			t.Error("InsertNoteVersion should not be called when content is unchanged")
-			return nil
+			return 0, nil
 		},
 	}
 
@@ -50,9 +50,11 @@ func TestUnhideCalledEvenWhenContentUnchanged(t *testing.T) {
 		Content: "test content",
 	}
 
-	pathID, err := insertnote.Resolve(ctx, env, note)
+	pathID, versionID, err := insertnote.Resolve(ctx, env, note)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), pathID)
+	// No new version is created when content is unchanged.
+	require.Equal(t, int64(0), versionID)
 
 	// UnhideNotePath MUST be called even when content hasn't changed
 	require.True(t, unhideCalled, "UnhideNotePath should be called even when content is unchanged")
@@ -83,9 +85,9 @@ func TestUnhideCalledWhenContentChanged(t *testing.T) {
 		IncrementNoteVersionCountFunc: func(ctx context.Context, arg db.IncrementNoteVersionCountParams) (int64, error) {
 			return 2, nil
 		},
-		InsertNoteVersionFunc: func(ctx context.Context, arg db.InsertNoteVersionParams) error {
+		InsertNoteVersionFunc: func(ctx context.Context, arg db.InsertNoteVersionParams) (int64, error) {
 			versionCreated = true
-			return nil
+			return 42, nil
 		},
 		NoteVersionActorFunc: func(ctx context.Context) model.NoteActor {
 			return model.NoteActor{}
@@ -97,9 +99,11 @@ func TestUnhideCalledWhenContentChanged(t *testing.T) {
 		Content: "new content",
 	}
 
-	pathID, err := insertnote.Resolve(ctx, env, note)
+	pathID, versionID, err := insertnote.Resolve(ctx, env, note)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), pathID)
+	// Resolve returns the id of the note_versions row it inserted.
+	require.Equal(t, int64(42), versionID)
 
 	require.True(t, unhideCalled, "UnhideNotePath should be called")
 	require.True(t, versionCreated, "New version should be created when content changed")
@@ -129,9 +133,9 @@ func TestNewNoteUnhideAndVersionCreated(t *testing.T) {
 		IncrementNoteVersionCountFunc: func(ctx context.Context, arg db.IncrementNoteVersionCountParams) (int64, error) {
 			return 1, nil
 		},
-		InsertNoteVersionFunc: func(ctx context.Context, arg db.InsertNoteVersionParams) error {
+		InsertNoteVersionFunc: func(ctx context.Context, arg db.InsertNoteVersionParams) (int64, error) {
 			versionCreated = true
-			return nil
+			return 7, nil
 		},
 		NoteVersionActorFunc: func(ctx context.Context) model.NoteActor {
 			return model.NoteActor{}
@@ -143,9 +147,10 @@ func TestNewNoteUnhideAndVersionCreated(t *testing.T) {
 		Content: "brand new content",
 	}
 
-	pathID, err := insertnote.Resolve(ctx, env, note)
+	pathID, versionID, err := insertnote.Resolve(ctx, env, note)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), pathID)
+	require.Equal(t, int64(7), versionID)
 
 	require.True(t, unhideCalled, "UnhideNotePath should be called for new note")
 	require.True(t, versionCreated, "Version should be created for new note")

--- a/internal/case/updatenotes/mocks_test.go
+++ b/internal/case/updatenotes/mocks_test.go
@@ -26,8 +26,8 @@ var _ Env = &EnvMock{}
 //			HideNotePathFunc: func(ctx context.Context, params db.HideNotePathParams) error {
 //				panic("mock out the HideNotePath method")
 //			},
-//			InsertNoteFunc: func(ctx context.Context, note appmodel.RawNote) (int64, error) {
-//				panic("mock out the InsertNote method")
+//			InsertNoteWithVersionFunc: func(ctx context.Context, note appmodel.RawNote) (int64, int64, error) {
+//				panic("mock out the InsertNoteWithVersion method")
 //			},
 //			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 //				panic("mock out the LatestNoteViews method")
@@ -48,8 +48,8 @@ type EnvMock struct {
 	// HideNotePathFunc mocks the HideNotePath method.
 	HideNotePathFunc func(ctx context.Context, params db.HideNotePathParams) error
 
-	// InsertNoteFunc mocks the InsertNote method.
-	InsertNoteFunc func(ctx context.Context, note appmodel.RawNote) (int64, error)
+	// InsertNoteWithVersionFunc mocks the InsertNoteWithVersion method.
+	InsertNoteWithVersionFunc func(ctx context.Context, note appmodel.RawNote) (int64, int64, error)
 
 	// LatestNoteViewsFunc mocks the LatestNoteViews method.
 	LatestNoteViewsFunc func() *appmodel.NoteViews
@@ -73,8 +73,8 @@ type EnvMock struct {
 			// Params is the params argument value.
 			Params db.HideNotePathParams
 		}
-		// InsertNote holds details about calls to the InsertNote method.
-		InsertNote []struct {
+		// InsertNoteWithVersion holds details about calls to the InsertNoteWithVersion method.
+		InsertNoteWithVersion []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// Note is the note argument value.
@@ -93,7 +93,7 @@ type EnvMock struct {
 	}
 	lockHandleLatestNotesAfterSave sync.RWMutex
 	lockHideNotePath               sync.RWMutex
-	lockInsertNote                 sync.RWMutex
+	lockInsertNoteWithVersion      sync.RWMutex
 	lockLatestNoteViews            sync.RWMutex
 	lockPrepareLatestNotes         sync.RWMutex
 }
@@ -170,10 +170,10 @@ func (mock *EnvMock) HideNotePathCalls() []struct {
 	return calls
 }
 
-// InsertNote calls InsertNoteFunc.
-func (mock *EnvMock) InsertNote(ctx context.Context, note appmodel.RawNote) (int64, error) {
-	if mock.InsertNoteFunc == nil {
-		panic("EnvMock.InsertNoteFunc: method is nil but Env.InsertNote was just called")
+// InsertNoteWithVersion calls InsertNoteWithVersionFunc.
+func (mock *EnvMock) InsertNoteWithVersion(ctx context.Context, note appmodel.RawNote) (int64, int64, error) {
+	if mock.InsertNoteWithVersionFunc == nil {
+		panic("EnvMock.InsertNoteWithVersionFunc: method is nil but Env.InsertNoteWithVersion was just called")
 	}
 	callInfo := struct {
 		Ctx  context.Context
@@ -182,17 +182,17 @@ func (mock *EnvMock) InsertNote(ctx context.Context, note appmodel.RawNote) (int
 		Ctx:  ctx,
 		Note: note,
 	}
-	mock.lockInsertNote.Lock()
-	mock.calls.InsertNote = append(mock.calls.InsertNote, callInfo)
-	mock.lockInsertNote.Unlock()
-	return mock.InsertNoteFunc(ctx, note)
+	mock.lockInsertNoteWithVersion.Lock()
+	mock.calls.InsertNoteWithVersion = append(mock.calls.InsertNoteWithVersion, callInfo)
+	mock.lockInsertNoteWithVersion.Unlock()
+	return mock.InsertNoteWithVersionFunc(ctx, note)
 }
 
-// InsertNoteCalls gets all the calls that were made to InsertNote.
+// InsertNoteWithVersionCalls gets all the calls that were made to InsertNoteWithVersion.
 // Check the length with:
 //
-//	len(mockedEnv.InsertNoteCalls())
-func (mock *EnvMock) InsertNoteCalls() []struct {
+//	len(mockedEnv.InsertNoteWithVersionCalls())
+func (mock *EnvMock) InsertNoteWithVersionCalls() []struct {
 	Ctx  context.Context
 	Note appmodel.RawNote
 } {
@@ -200,9 +200,9 @@ func (mock *EnvMock) InsertNoteCalls() []struct {
 		Ctx  context.Context
 		Note appmodel.RawNote
 	}
-	mock.lockInsertNote.RLock()
-	calls = mock.calls.InsertNote
-	mock.lockInsertNote.RUnlock()
+	mock.lockInsertNoteWithVersion.RLock()
+	calls = mock.calls.InsertNoteWithVersion
+	mock.lockInsertNoteWithVersion.RUnlock()
 	return calls
 }
 

--- a/internal/case/updatenotes/resolve.go
+++ b/internal/case/updatenotes/resolve.go
@@ -16,7 +16,12 @@ import (
 
 type Env interface {
 	LatestNoteViews() *appmodel.NoteViews
-	InsertNote(ctx context.Context, note appmodel.RawNote) (int64, error)
+	// InsertNoteWithVersion writes the note and returns its path id and the id of
+	// the note_versions row it inserted (0 when content was unchanged). The own
+	// version id lets us report each save's OWN version (race-free) rather than
+	// re-deriving it from the post-write reload, which under concurrent same-board
+	// editing can be a peer's newer version.
+	InsertNoteWithVersion(ctx context.Context, note appmodel.RawNote) (int64, int64, error)
 	HideNotePath(ctx context.Context, params db.HideNotePathParams) error
 	PrepareLatestNotes(ctx context.Context, partial bool) (*appmodel.NoteViews, error)
 	HandleLatestNotesAfterSave(ctx context.Context, pathIDs []int64) error
@@ -33,6 +38,9 @@ func Resolve(ctx context.Context, env Env, input model.UpdateNotesInput) (model.
 	nvs := env.LatestNoteViews()
 	var paths []string
 	var pathIDs []int64
+	// versionIDs is aligned with pathIDs: each entry is the write's OWN inserted
+	// version id (0 when content was unchanged).
+	var versionIDs []int64
 	hid := false
 
 	// nvs.PathMap is keyed by note.Path (filesystem path, e.g. "todo.md").
@@ -63,11 +71,12 @@ func Resolve(ctx context.Context, env Env, input model.UpdateNotesInput) (model.
 					}, nil
 				}
 			}
-			pathID, err := env.InsertNote(ctx, appmodel.RawNote{Path: upsert.Path, Content: upsert.Content})
+			pathID, versionID, err := env.InsertNoteWithVersion(ctx, appmodel.RawNote{Path: upsert.Path, Content: upsert.Content})
 			if err != nil {
 				return nil, fmt.Errorf("updatenotes: insert upsert %s: %w", upsert.Path, err)
 			}
 			pathIDs = append(pathIDs, pathID)
+			versionIDs = append(versionIDs, versionID)
 			paths = append(paths, upsert.Path)
 		case change.Patch != nil:
 			patch := change.Patch
@@ -94,11 +103,12 @@ func Resolve(ctx context.Context, env Env, input model.UpdateNotesInput) (model.
 				return model.UpdateNotesPatchNotFoundPayload{Path: patch.Path, Find: patch.Find}, nil
 			}
 			newContent := content[:idx] + patch.Replace + content[idx+len(patch.Find):]
-			pathID, err := env.InsertNote(ctx, appmodel.RawNote{Path: patch.Path, Content: newContent})
+			pathID, versionID, err := env.InsertNoteWithVersion(ctx, appmodel.RawNote{Path: patch.Path, Content: newContent})
 			if err != nil {
 				return nil, fmt.Errorf("updatenotes: insert patch %s: %w", patch.Path, err)
 			}
 			pathIDs = append(pathIDs, pathID)
+			versionIDs = append(versionIDs, versionID)
 			paths = append(paths, patch.Path)
 		case change.Hide != nil:
 			// Hide is a metadata operation. Unlike the standalone hideNotes mutation,
@@ -133,7 +143,7 @@ func Resolve(ctx context.Context, env Env, input model.UpdateNotesInput) (model.
 		}
 		// Surface each saved note's new version id (mirrors pushNotes' updated[].id) so a
 		// client can advance its self-echo baseline to its OWN save's version.
-		updated = collectUpdated(reloaded, pathIDs)
+		updated = collectUpdated(reloaded, pathIDs, versionIDs)
 	} else if hid {
 		if _, err := env.PrepareLatestNotes(ctx, false); err != nil {
 			return nil, fmt.Errorf("updatenotes: prepare latest notes after hide: %w", err)
@@ -143,16 +153,26 @@ func Resolve(ctx context.Context, env Env, input model.UpdateNotesInput) (model.
 	return model.UpdateNotesSuccessPayload{Paths: paths, Updated: updated}, nil
 }
 
-// collectUpdated maps each saved path id to its new version id from the reloaded
-// NoteViews. Notes not found (e.g. hidden) are skipped.
-func collectUpdated(nvs *appmodel.NoteViews, pathIDs []int64) []model.NoteWriteResult {
+// collectUpdated reports each saved note with the version id the WRITE itself
+// inserted (versionIDs[i], aligned with pathIDs[i]). Reporting the write's own
+// version — rather than re-deriving it from the reloaded NoteViews — is race-free:
+// under concurrent same-board editing the reload's latest version can be a peer's,
+// which would briefly suppress a genuine peer event on the saving client. The
+// reload is still consulted for the note's Path and to skip notes no longer present
+// (e.g. hidden). When the write created no new version (versionID 0, content
+// unchanged) the reload's current version is used as a fallback.
+func collectUpdated(nvs *appmodel.NoteViews, pathIDs, versionIDs []int64) []model.NoteWriteResult {
 	updated := make([]model.NoteWriteResult, 0, len(pathIDs))
-	for _, id := range pathIDs {
+	for i, id := range pathIDs {
 		nv := nvs.GetByPathID(id)
 		if nv == nil {
 			continue
 		}
-		updated = append(updated, model.NoteWriteResult{Path: nv.Path, VersionID: nv.VersionID})
+		versionID := versionIDs[i]
+		if versionID == 0 {
+			versionID = nv.VersionID
+		}
+		updated = append(updated, model.NoteWriteResult{Path: nv.Path, VersionID: versionID})
 	}
 	return updated
 }

--- a/internal/case/updatenotes/resolve_test.go
+++ b/internal/case/updatenotes/resolve_test.go
@@ -17,7 +17,7 @@ import (
 // mockEnv is a hand-written mock implementing updatenotes.Env.
 type mockEnv struct {
 	latestNoteViews            func() *appmodel.NoteViews
-	insertNote                 func(ctx context.Context, note appmodel.RawNote) (int64, error)
+	insertNoteWithVersion      func(ctx context.Context, note appmodel.RawNote) (int64, int64, error)
 	hideNotePath               func(ctx context.Context, params db.HideNotePathParams) error
 	prepareLatestNotes         func(ctx context.Context, partial bool) (*appmodel.NoteViews, error)
 	handleLatestNotesAfterSave func(ctx context.Context, pathIDs []int64) error
@@ -27,11 +27,11 @@ func (m *mockEnv) LatestNoteViews() *appmodel.NoteViews {
 	return m.latestNoteViews()
 }
 
-func (m *mockEnv) InsertNote(ctx context.Context, note appmodel.RawNote) (int64, error) {
-	if m.insertNote == nil {
-		panic("unexpected call to InsertNote")
+func (m *mockEnv) InsertNoteWithVersion(ctx context.Context, note appmodel.RawNote) (int64, int64, error) {
+	if m.insertNoteWithVersion == nil {
+		panic("unexpected call to InsertNoteWithVersion")
 	}
-	return m.insertNote(ctx, note)
+	return m.insertNoteWithVersion(ctx, note)
 }
 
 func (m *mockEnv) HideNotePath(ctx context.Context, params db.HideNotePathParams) error {
@@ -80,9 +80,9 @@ func TestResolve_UpsertBasic(t *testing.T) {
 	handleCalled := false
 	env := &mockEnv{
 		latestNoteViews: appmodel.NewNoteViews,
-		insertNote: func(_ context.Context, note appmodel.RawNote) (int64, error) {
+		insertNoteWithVersion: func(_ context.Context, note appmodel.RawNote) (int64, int64, error) {
 			insertedNote = note
-			return 10, nil
+			return 10, 110, nil
 		},
 		prepareLatestNotes: noopPrepare,
 		handleLatestNotesAfterSave: func(_ context.Context, ids []int64) error {
@@ -108,6 +108,103 @@ func TestResolve_UpsertBasic(t *testing.T) {
 	require.True(t, handleCalled, "HandleLatestNotesAfterSave must be called after successful writes")
 }
 
+// TestResolve_UpsertReportsOwnVersion pins the race-free fix: updated[].versionId
+// must be the version the WRITE itself inserted, not the latest version visible in
+// the post-write reload. Under concurrent same-board editing the reload can already
+// carry a peer's newer version for the same note; reporting that as "ours" would
+// briefly suppress a genuine peer event on the saving client. Here the reload reports
+// a peer's version (999) for the saved note, but the resolver must surface our own
+// inserted version (42).
+func TestResolve_UpsertReportsOwnVersion(t *testing.T) {
+	ctx := context.Background()
+
+	const pathID int64 = 7
+	const ownVersion int64 = 42
+	const peerVersion int64 = 999
+
+	// The post-write reload sees a peer's newer version for the same note.
+	reloaded := appmodel.NewNoteViews()
+	reloaded.RegisterNote(&appmodel.NoteView{
+		PathID:    pathID,
+		Path:      "note.md",
+		Permalink: "note.md",
+		VersionID: peerVersion,
+		Content:   []byte("peer content"),
+	})
+
+	env := &mockEnv{
+		latestNoteViews: appmodel.NewNoteViews,
+		insertNoteWithVersion: func(_ context.Context, _ appmodel.RawNote) (int64, int64, error) {
+			return pathID, ownVersion, nil
+		},
+		prepareLatestNotes: func(_ context.Context, _ bool) (*appmodel.NoteViews, error) {
+			return reloaded, nil
+		},
+		handleLatestNotesAfterSave: noopHandle,
+	}
+
+	input := model.UpdateNotesInput{
+		Changes: []model.NoteChangeInput{
+			{Upsert: &model.NoteChangeUpsertInput{Path: "note.md", Content: "my content"}},
+		},
+	}
+
+	result, err := updatenotes.Resolve(ctx, env, input)
+	require.NoError(t, err)
+
+	payload, ok := result.(model.UpdateNotesSuccessPayload)
+	require.True(t, ok, "expected UpdateNotesSuccessPayload, got %T", result)
+	require.Len(t, payload.Updated, 1)
+	require.Equal(t, "note.md", payload.Updated[0].Path)
+	require.Equal(t, ownVersion, payload.Updated[0].VersionID,
+		"must report the write's OWN inserted version, not the peer's reload version")
+}
+
+// TestResolve_UpsertFallsBackToReloadVersionWhenUnchanged pins the unchanged-content
+// path: InsertNoteWithVersion returns version id 0 (no new version created), so the
+// resolver falls back to the note's current version in the reload.
+func TestResolve_UpsertFallsBackToReloadVersionWhenUnchanged(t *testing.T) {
+	ctx := context.Background()
+
+	const pathID int64 = 8
+	const currentVersion int64 = 500
+
+	reloaded := appmodel.NewNoteViews()
+	reloaded.RegisterNote(&appmodel.NoteView{
+		PathID:    pathID,
+		Path:      "note.md",
+		Permalink: "note.md",
+		VersionID: currentVersion,
+		Content:   []byte("same content"),
+	})
+
+	env := &mockEnv{
+		latestNoteViews: appmodel.NewNoteViews,
+		insertNoteWithVersion: func(_ context.Context, _ appmodel.RawNote) (int64, int64, error) {
+			return pathID, 0, nil // content unchanged → no new version
+		},
+		prepareLatestNotes: func(_ context.Context, _ bool) (*appmodel.NoteViews, error) {
+			return reloaded, nil
+		},
+		handleLatestNotesAfterSave: noopHandle,
+	}
+
+	input := model.UpdateNotesInput{
+		Changes: []model.NoteChangeInput{
+			{Upsert: &model.NoteChangeUpsertInput{Path: "note.md", Content: "same content"}},
+		},
+	}
+
+	result, err := updatenotes.Resolve(ctx, env, input)
+	require.NoError(t, err)
+
+	payload, ok := result.(model.UpdateNotesSuccessPayload)
+	require.True(t, ok, "expected UpdateNotesSuccessPayload, got %T", result)
+	require.Len(t, payload.Updated, 1)
+	require.Equal(t, currentVersion, payload.Updated[0].VersionID,
+		"version 0 from the write means unchanged content → fall back to the reload's current version")
+}
+
 func TestResolve_UpsertWithCorrectHash(t *testing.T) {
 	ctx := context.Background()
 	existingContent := "existing content"
@@ -117,8 +214,8 @@ func TestResolve_UpsertWithCorrectHash(t *testing.T) {
 
 	env := &mockEnv{
 		latestNoteViews: func() *appmodel.NoteViews { return nvs },
-		insertNote: func(_ context.Context, _ appmodel.RawNote) (int64, error) {
-			return 11, nil
+		insertNoteWithVersion: func(_ context.Context, _ appmodel.RawNote) (int64, int64, error) {
+			return 11, 111, nil
 		},
 		prepareLatestNotes:         noopPrepare,
 		handleLatestNotesAfterSave: noopHandle,
@@ -148,9 +245,9 @@ func TestResolve_UpsertWithWrongHash(t *testing.T) {
 
 	env := &mockEnv{
 		latestNoteViews: func() *appmodel.NoteViews { return nvs },
-		insertNote: func(_ context.Context, _ appmodel.RawNote) (int64, error) {
+		insertNoteWithVersion: func(_ context.Context, _ appmodel.RawNote) (int64, int64, error) {
 			t.Fatal("InsertNote should not be called on hash mismatch")
-			return 0, nil
+			return 0, 0, nil
 		},
 		prepareLatestNotes:         noopPrepare,
 		handleLatestNotesAfterSave: noopHandle,
@@ -224,12 +321,12 @@ func TestResolve_UpsertCreateOnly(t *testing.T) {
 			var insertedNote appmodel.RawNote
 			env := &mockEnv{
 				latestNoteViews: func() *appmodel.NoteViews { return nvs },
-				insertNote: func(_ context.Context, note appmodel.RawNote) (int64, error) {
+				insertNoteWithVersion: func(_ context.Context, note appmodel.RawNote) (int64, int64, error) {
 					if !tt.wantCreated {
 						t.Fatal("InsertNote must not be called when an existing note blocks the create")
 					}
 					insertedNote = note
-					return 100, nil
+					return 100, 200, nil
 				},
 				prepareLatestNotes:         noopPrepare,
 				handleLatestNotesAfterSave: noopHandle,
@@ -272,9 +369,9 @@ func TestResolve_PatchFound(t *testing.T) {
 	var insertedNote appmodel.RawNote
 	env := &mockEnv{
 		latestNoteViews: func() *appmodel.NoteViews { return nvs },
-		insertNote: func(_ context.Context, note appmodel.RawNote) (int64, error) {
+		insertNoteWithVersion: func(_ context.Context, note appmodel.RawNote) (int64, int64, error) {
 			insertedNote = note
-			return 12, nil
+			return 12, 112, nil
 		},
 		prepareLatestNotes:         noopPrepare,
 		handleLatestNotesAfterSave: noopHandle,
@@ -301,9 +398,9 @@ func TestResolve_PatchNotFound(t *testing.T) {
 
 	env := &mockEnv{
 		latestNoteViews: func() *appmodel.NoteViews { return nvs },
-		insertNote: func(_ context.Context, _ appmodel.RawNote) (int64, error) {
+		insertNoteWithVersion: func(_ context.Context, _ appmodel.RawNote) (int64, int64, error) {
 			t.Fatal("InsertNote should not be called when find string is absent")
-			return 0, nil
+			return 0, 0, nil
 		},
 		prepareLatestNotes:         noopPrepare,
 		handleLatestNotesAfterSave: noopHandle,
@@ -330,9 +427,9 @@ func TestResolve_PatchMultipleOccurrences(t *testing.T) {
 
 	env := &mockEnv{
 		latestNoteViews: func() *appmodel.NoteViews { return nvs },
-		insertNote: func(_ context.Context, _ appmodel.RawNote) (int64, error) {
+		insertNoteWithVersion: func(_ context.Context, _ appmodel.RawNote) (int64, int64, error) {
 			t.Fatal("InsertNote should not be called on ambiguous patch")
-			return 0, nil
+			return 0, 0, nil
 		},
 		prepareLatestNotes:         noopPrepare,
 		handleLatestNotesAfterSave: noopHandle,
@@ -359,9 +456,9 @@ func TestResolve_PatchNoteMissing(t *testing.T) {
 
 	env := &mockEnv{
 		latestNoteViews: appmodel.NewNoteViews,
-		insertNote: func(_ context.Context, _ appmodel.RawNote) (int64, error) {
+		insertNoteWithVersion: func(_ context.Context, _ appmodel.RawNote) (int64, int64, error) {
 			t.Fatal("InsertNote should not be called when note is missing")
-			return 0, nil
+			return 0, 0, nil
 		},
 		prepareLatestNotes:         noopPrepare,
 		handleLatestNotesAfterSave: noopHandle,
@@ -390,9 +487,9 @@ func TestResolve_PatchWithWrongHash(t *testing.T) {
 
 	env := &mockEnv{
 		latestNoteViews: func() *appmodel.NoteViews { return nvs },
-		insertNote: func(_ context.Context, _ appmodel.RawNote) (int64, error) {
+		insertNoteWithVersion: func(_ context.Context, _ appmodel.RawNote) (int64, int64, error) {
 			t.Fatal("InsertNote should not be called on hash mismatch")
-			return 0, nil
+			return 0, 0, nil
 		},
 		prepareLatestNotes:         noopPrepare,
 		handleLatestNotesAfterSave: noopHandle,
@@ -420,9 +517,9 @@ func TestResolve_Hide(t *testing.T) {
 	prepareCount := 0
 	env := &mockEnv{
 		latestNoteViews: appmodel.NewNoteViews,
-		insertNote: func(_ context.Context, _ appmodel.RawNote) (int64, error) {
+		insertNoteWithVersion: func(_ context.Context, _ appmodel.RawNote) (int64, int64, error) {
 			t.Fatal("InsertNote should not be called for hide")
-			return 0, nil
+			return 0, 0, nil
 		},
 		hideNotePath: func(_ context.Context, params db.HideNotePathParams) error {
 			hiddenPath = params.Value
@@ -461,9 +558,9 @@ func TestResolve_EmptyChangeSkipped(t *testing.T) {
 
 	env := &mockEnv{
 		latestNoteViews: appmodel.NewNoteViews,
-		insertNote: func(_ context.Context, _ appmodel.RawNote) (int64, error) {
+		insertNoteWithVersion: func(_ context.Context, _ appmodel.RawNote) (int64, int64, error) {
 			t.Fatal("InsertNote should not be called for empty change")
-			return 0, nil
+			return 0, 0, nil
 		},
 		hideNotePath: func(_ context.Context, _ db.HideNotePathParams) error {
 			t.Fatal("HideNotePath should not be called for empty change")
@@ -497,9 +594,9 @@ func TestResolve_MixedBatch(t *testing.T) {
 
 	env := &mockEnv{
 		latestNoteViews: func() *appmodel.NoteViews { return nvs },
-		insertNote: func(_ context.Context, _ appmodel.RawNote) (int64, error) {
+		insertNoteWithVersion: func(_ context.Context, _ appmodel.RawNote) (int64, int64, error) {
 			insertCallCount++
-			return int64(100 + insertCallCount), nil
+			return int64(100 + insertCallCount), int64(200 + insertCallCount), nil
 		},
 		hideNotePath: func(_ context.Context, _ db.HideNotePathParams) error {
 			hideCallCount++

--- a/internal/db/queries.write.sql.go
+++ b/internal/db/queries.write.sql.go
@@ -1588,9 +1588,10 @@ func (q *WriteQueries) InsertNotePath(ctx context.Context, arg InsertNotePathPar
 	return i, err
 }
 
-const insertNoteVersion = `-- name: InsertNoteVersion :exec
+const insertNoteVersion = `-- name: InsertNoteVersion :one
 insert into note_versions (path_id, version, content, created_by_user_id, created_by_api_key_id, created_by_client)
 values (?, ?, ?, ?, ?, ?)
+returning id
 `
 
 type InsertNoteVersionParams struct {
@@ -1602,8 +1603,8 @@ type InsertNoteVersionParams struct {
 	CreatedByClient   *string `json:"created_by_client"`
 }
 
-func (q *WriteQueries) InsertNoteVersion(ctx context.Context, arg InsertNoteVersionParams) error {
-	_, err := q.db.ExecContext(ctx, insertNoteVersion,
+func (q *WriteQueries) InsertNoteVersion(ctx context.Context, arg InsertNoteVersionParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, insertNoteVersion,
 		arg.PathID,
 		arg.Version,
 		arg.Content,
@@ -1611,7 +1612,9 @@ func (q *WriteQueries) InsertNoteVersion(ctx context.Context, arg InsertNoteVers
 		arg.CreatedByApiKeyID,
 		arg.CreatedByClient,
 	)
-	return err
+	var id int64
+	err := row.Scan(&id)
+	return id, err
 }
 
 const insertOIDCCredentials = `-- name: InsertOIDCCredentials :one

--- a/internal/graph/resolver.go
+++ b/internal/graph/resolver.go
@@ -262,6 +262,9 @@ type Env interface {
 	revokeusertoken.Env
 	toggleuserfavoritenote.Env
 	pushnotes.Env
+	// InsertNoteWithVersion is InsertNote that also returns the inserted version id;
+	// updateNotes (updatenotes.Env) reports each save's own version race-free with it.
+	InsertNoteWithVersion(ctx context.Context, note model.RawNote) (int64, int64, error)
 	commitnotes.Env
 	rendernotepage.Env
 	uploadnoteasset.Env

--- a/queries.write.sql
+++ b/queries.write.sql
@@ -24,9 +24,10 @@ update note_paths
  where id = ?
 returning version_count;
 
--- name: InsertNoteVersion :exec
+-- name: InsertNoteVersion :one
 insert into note_versions (path_id, version, content, created_by_user_id, created_by_api_key_id, created_by_client)
-values (?, ?, ?, ?, ?, ?);
+values (?, ?, ?, ?, ?, ?)
+returning id;
 
 -- name: InsertUserWithEmail :one
 insert into users (email, created_via) values (lower(sqlc.arg(email)), sqlc.arg(created_via))

--- a/templates/kanban/src/ops.ts
+++ b/templates/kanban/src/ops.ts
@@ -238,8 +238,10 @@ function cardEqualAt(a: KanbanCard[], ai: number, b: KanbanCard[], bi: number): 
  * on only one side survives; a base card edited differently on BOTH sides is a real
  * conflict → null. When both sides only ADD cards into the same (possibly empty)
  * region, both sets are kept (a remote add that repeats a local add by text is dropped).
+ *
+ * Exported for direct unit testing of the positional card merge.
  */
-function mergeCards(
+export function mergeCards(
   base: KanbanCard[],
   local: KanbanCard[],
   remote: KanbanCard[],
@@ -283,8 +285,10 @@ function mergeCards(
  * merge of its cards plus a reconcile of its `complete` flag. Returns null when the
  * cards genuinely conflict (the same base card edited differently on each side) or the
  * complete flag was toggled differently on each side.
+ *
+ * Exported for direct unit testing of the card-level column merge.
  */
-function mergeChangedColumn(b: KanbanList, l: KanbanList, r: KanbanList): KanbanList | null {
+export function mergeChangedColumn(b: KanbanList, l: KanbanList, r: KanbanList): KanbanList | null {
   const localCompleteChanged = l.complete !== b.complete
   const remoteCompleteChanged = r.complete !== b.complete
   if (localCompleteChanged && remoteCompleteChanged && l.complete !== r.complete) return null

--- a/templates/kanban/src/smoke.test.ts
+++ b/templates/kanban/src/smoke.test.ts
@@ -3,8 +3,8 @@ import assert from 'node:assert/strict'
 import { createHash } from 'node:crypto'
 import { sha256Base64 } from './api'
 import { parseBoard, serializeBoard } from './format'
-import { moveCard, addCard, editCard, deleteCard, toggleCard, cardLine, applyBoardToBaseline, addList, renameList, deleteList, moveList, applyStructuralChange, mergeColumns } from './ops'
-import type { KanbanList } from './format'
+import { moveCard, addCard, editCard, deleteCard, toggleCard, cardLine, applyBoardToBaseline, addList, renameList, deleteList, moveList, applyStructuralChange, mergeColumns, mergeCards, mergeChangedColumn } from './ops'
+import type { KanbanCard, KanbanList } from './format'
 
 const SAMPLE = `---
 kanban-plugin: basic
@@ -375,4 +375,82 @@ test('mergeColumns: local delete vs remote edit of same column → conflict (nul
   const local = [col('A', ['x'])]                 // deleted B
   const remote = [col('A', ['x']), col('B', ['y', 'y2'])] // remote edited B
   assert.equal(mergeColumns(base, local, remote), null)
+})
+
+// ── mergeCards / mergeChangedColumn: direct positional card-level 3-way merge ──
+// These exercise the card merge in isolation — the exact cases the PR #46 reviewer
+// traced by hand. Every assertion pins the full resulting card list, so any silent
+// drop or duplicate fails the test.
+
+const cards = (texts: string[]): KanbanCard[] => texts.map(text => ({ text, checked: false }))
+const cardTexts = (cs: KanbanCard[] | null) => (cs ? cs.map(c => c.text) : null)
+
+test('mergeCards: local moves a card within the column, remote untouched → move kept', () => {
+  // base a,b,c → local moves a to the end
+  const merged = mergeCards(cards(['a', 'b', 'c']), cards(['b', 'c', 'a']), cards(['a', 'b', 'c']))
+  assert.deepEqual(cardTexts(merged), ['b', 'c', 'a'])
+})
+
+test('mergeCards: local deletes a card, remote untouched → delete kept (no resurrection)', () => {
+  const merged = mergeCards(cards(['a', 'b', 'c']), cards(['a', 'c']), cards(['a', 'b', 'c']))
+  assert.deepEqual(cardTexts(merged), ['a', 'c'])
+})
+
+test('mergeCards: local reorders (swap), remote untouched → reorder kept', () => {
+  const merged = mergeCards(cards(['a', 'b']), cards(['b', 'a']), cards(['a', 'b']))
+  assert.deepEqual(cardTexts(merged), ['b', 'a'])
+})
+
+test('mergeCards: duplicate card text preserved when a local add keeps both originals', () => {
+  const merged = mergeCards(cards(['dup', 'dup']), cards(['dup', 'dup', 'new']), cards(['dup', 'dup']))
+  assert.deepEqual(cardTexts(merged), ['dup', 'dup', 'new'], 'both duplicates and the new card survive')
+})
+
+test('mergeCards: deleting one of two identical cards leaves exactly one', () => {
+  const merged = mergeCards(cards(['dup', 'dup']), cards(['dup']), cards(['dup', 'dup']))
+  assert.deepEqual(cardTexts(merged), ['dup'], 'exactly one duplicate remains — no over-delete, no resurrection')
+})
+
+test('mergeCards: both sides add distinct cards into the same region → both survive', () => {
+  const merged = mergeCards(cards(['c']), cards(['c', 'A']), cards(['c', 'B']))
+  assert.deepEqual(cardTexts(merged), ['c', 'A', 'B'])
+})
+
+test('mergeCards: both sides add the same-text card → deduped to one', () => {
+  const merged = mergeCards(cards(['c']), cards(['c', 'A']), cards(['c', 'A']))
+  assert.deepEqual(cardTexts(merged), ['c', 'A'], 'identical add on both sides is not duplicated')
+})
+
+test('mergeCards: both add into an empty column → both kept, local-first order', () => {
+  const merged = mergeCards(cards([]), cards(['X']), cards(['Y']))
+  assert.deepEqual(cardTexts(merged), ['X', 'Y'])
+})
+
+test('mergeCards: position-shift conflict (remote delete shifts across a local edit) → null', () => {
+  // local edits b→B; remote deletes a, shifting every index. The positional
+  // prefix/suffix reduction cannot isolate the two changes → genuine conflict.
+  const merged = mergeCards(cards(['a', 'b', 'c']), cards(['a', 'B', 'c']), cards(['b', 'c']))
+  assert.equal(merged, null)
+})
+
+test('mergeCards: same base card edited differently on each side → null', () => {
+  const merged = mergeCards(cards(['x']), cards(['x LOCAL']), cards(['x REMOTE']))
+  assert.equal(merged, null)
+})
+
+test('mergeChangedColumn: local toggles complete, remote adds a card → both survive', () => {
+  const base: KanbanList = { title: 'A', complete: false, cards: cards(['a']) }
+  const local: KanbanList = { title: 'A', complete: true, cards: cards(['a']) }
+  const remote: KanbanList = { title: 'A', complete: false, cards: cards(['a', 'b']) }
+  const merged = mergeChangedColumn(base, local, remote)
+  assert.ok(merged)
+  assert.equal(merged!.complete, true, 'local complete-toggle preserved')
+  assert.deepEqual(cardTexts(merged!.cards), ['a', 'b'], 'remote card-add preserved')
+})
+
+test('mergeChangedColumn: conflicting card edits on each side → null', () => {
+  const base: KanbanList = { title: 'A', complete: false, cards: cards(['x']) }
+  const local: KanbanList = { title: 'A', complete: false, cards: cards(['x LOCAL']) }
+  const remote: KanbanList = { title: 'A', complete: false, cards: cards(['x REMOTE']) }
+  assert.equal(mergeChangedColumn(base, local, remote), null)
 })


### PR DESCRIPTION
Two LOW follow-ups from the PR #46 adversarial review (kanban live-sync data-loss fix).

## LOW #1 — race-free own-save version id (backend)
`updatenotes` previously derived each saved note's `versionId` from the post-write reload (`PrepareLatestNotes` → `GetByPathID` = the latest version at reload time). Under concurrent same-board editing that can return a peer's newer version, so `updated[].versionId` could briefly report a peer's version as "ours" and the client's self-echo baseline could momentarily suppress a genuine peer event (narrow, self-healing — never permanent loss).

Fix: report the version the write itself inserted.
- `InsertNoteVersion` query now `:one … returning id`; `WriteQueries.InsertNoteVersion` returns the new `note_versions.id` (which is exactly `NoteView.VersionID`).
- `insertnote.Resolve` now returns `(pathID, versionID, error)` (versionID `0` when content was unchanged → no new version).
- Added `app.InsertNoteWithVersion` (sibling of `InsertNote`) so only `updatenotes.Env` changes — `pushnotes` and the webhook backjobs keep the unchanged `InsertNote` signature.
- `updatenotes` tracks each write's own version id and reports it; the reload is still used for the note's `Path` and to skip hidden notes, with a fallback to the reload's current version when the write created none (unchanged content).
- GraphQL payload is byte-for-byte identical (`updated[{ path, versionId }]`).

Verify: `go build ./internal/case/updatenotes/...` ✓ · `go test ./internal/case/updatenotes/... ./internal/case/insertnote/... ./internal/case/pushnotes/... ./internal/db/...` ✓ · golangci-lint on changed packages = 0 issues.

## LOW #2 — direct unit tests for the positional card merge (frontend)
`mergeCards` / `mergeChangedColumn` were covered only end-to-end + via the column-level smoke tests. Exported both and added direct `tsx --test` units covering exactly the cases the reviewer traced by hand: card MOVE within a column, DELETE, REORDER/swap, duplicate card text (preserve + delete-one), both-add (distinct survive + same-text dedup), position-shift-conflict → null, and same-base-card-edited-differently → null. Every assertion pins the full resulting card list, so any silent drop/dup fails.

The production bundle (`dist/kanban.js`) is unchanged (the functions were already reachable via `mergeColumns`; exporting an internally-used function from an IIFE bundle does not alter the minified output — verified byte-identical), so no dist rebuild.

Verify: `npm test` → 43 unit (was 31) + 56 integration, all green · `tsc --noEmit` clean.