### PR TITLE
feat(kanban): light/dark theme toggle via $mol_lights + data-theme

### DIFF
--- a/templates/kanban/_layouts/kanban.html
+++ b/templates/kanban/_layouts/kanban.html
@@ -10,8 +10,18 @@
     /* The fixed sign-in corner lives top-right; reserve room so the board's own
        header status badge doesn't slide under it. */
     .kanban-header-right { margin-right: 184px !important; }
-    .kanban-byline { position: fixed; bottom: 10px; right: 14px; z-index: 50; font-size: 12px; color: #6b7280; background: rgba(255,255,255,.82); padding: 4px 10px; border-radius: 999px; box-shadow: 0 1px 4px rgba(0,0,0,.08); }
+    .kanban-byline { position: fixed; bottom: 10px; right: 14px; z-index: 50; font-size: 12px; color: hsl(var(--muted-foreground)); background: hsl(var(--background)); padding: 4px 10px; border-radius: 999px; box-shadow: 0 1px 4px rgba(0,0,0,.08); }
   </style>
+
+  <!-- Theme bootstrap: set data-theme before any paint to avoid flash-of-wrong-theme.
+       Reads $mol_lights from localStorage (set by the Options menu toggle); falls
+       back to prefers-color-scheme. Must run before the kanban stylesheet is injected
+       by the bundle. -->
+  <script>try{var v=localStorage.getItem('$mol_lights'),
+ dark=v===null?!matchMedia('(prefers-color-scheme: light)').matches:v!=='true',
+ r=document.documentElement;
+ r.classList.toggle('dark',dark);r.classList.toggle('light',!dark);
+ r.setAttribute('data-theme',dark?'dark':'light')}catch(e){}</script>
 
   <!-- Standard trip2g sign-in / search chrome: emits window.__trip2g_settings and
        the user-space bundle scripts so the login widget below can boot. -->

--- a/templates/kanban/dist/kanban.js
+++ b/templates/kanban/dist/kanban.js
@@ -75,7 +75,7 @@ Error generating stack: `+i.message+`
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme="light"]) {
     --background: 240 10% 3.9%;
     --foreground: 0 0% 98%;
     --card: 240 10% 3.9%;
@@ -96,6 +96,27 @@ Error generating stack: `+i.message+`
     --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.4), 0 2px 4px -2px rgb(0 0 0 / 0.3);
     --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.5), 0 4px 6px -4px rgb(0 0 0 / 0.3);
   }
+}
+:root[data-theme="dark"] {
+  --background: 240 10% 3.9%;
+  --foreground: 0 0% 98%;
+  --card: 240 10% 3.9%;
+  --card-foreground: 0 0% 98%;
+  --muted: 240 3.7% 15.9%;
+  --muted-foreground: 240 5% 64.9%;
+  --border: 240 3.7% 15.9%;
+  --input: 240 3.7% 15.9%;
+  --primary: 0 0% 98%;
+  --primary-foreground: 240 5.9% 10%;
+  --accent: 240 3.7% 15.9%;
+  --accent-foreground: 0 0% 98%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 0 0% 98%;
+  --ring: 240 4.9% 83.9%;
+
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.3);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.4), 0 2px 4px -2px rgb(0 0 0 / 0.3);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.5), 0 4px 6px -4px rgb(0 0 0 / 0.3);
 }
 
 /* \u2500\u2500 base reset \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 */

--- a/templates/kanban/src/styles.css
+++ b/templates/kanban/src/styles.css
@@ -30,7 +30,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme="light"]) {
     --background: 240 10% 3.9%;
     --foreground: 0 0% 98%;
     --card: 240 10% 3.9%;
@@ -51,6 +51,27 @@
     --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.4), 0 2px 4px -2px rgb(0 0 0 / 0.3);
     --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.5), 0 4px 6px -4px rgb(0 0 0 / 0.3);
   }
+}
+:root[data-theme="dark"] {
+  --background: 240 10% 3.9%;
+  --foreground: 0 0% 98%;
+  --card: 240 10% 3.9%;
+  --card-foreground: 0 0% 98%;
+  --muted: 240 3.7% 15.9%;
+  --muted-foreground: 240 5% 64.9%;
+  --border: 240 3.7% 15.9%;
+  --input: 240 3.7% 15.9%;
+  --primary: 0 0% 98%;
+  --primary-foreground: 240 5.9% 10%;
+  --accent: 240 3.7% 15.9%;
+  --accent-foreground: 0 0% 98%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 0 0% 98%;
+  --ring: 240 4.9% 83.9%;
+
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.3);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.4), 0 2px 4px -2px rgb(0 0 0 / 0.3);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.5), 0 4px 6px -4px rgb(0 0 0 / 0.3);
 }
 
 /* ── base reset ──────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

- **styles.css**: restructured the dark-token block from `@media (prefers-color-scheme: dark) { :root { … } }` into a three-state form: `@media … { :root:not([data-theme="light"]) { … } }` + `root[data-theme="dark"] { … }` — same 18 token values, manual choice beats the system default
- **kanban.html**: added an inline bootstrap `<script>` in `<head>` (before bundle load) that reads `localStorage['$mol_lights']` then falls back to `prefers-color-scheme`, setting `data-theme`/`classList` on `<html>` at first paint — eliminates flash-of-wrong-theme
- **kanban.html**: retokenized `.kanban-byline` hard-coded colors (`rgba(255,255,255,.82)` / `#6b7280`) to `hsl(var(--background))` / `hsl(var(--muted-foreground))`
- **dist/kanban.js**: rebuilt bundle (styles.css is inlined as text via esbuild loader)

No new toggle UI — the existing `$mol_lights_toggle` in the Options menu drives it.

## Test plan

- [ ] `npm test` — 99 tests pass (43 unit + 56 integration)
- [ ] `tsc --noEmit` — clean
- [ ] `grep 'data-theme="dark"' dist/kanban.js` — present (confirmed 1 match)
- [ ] Manual: open board in dark system mode → board is dark; toggle via Options → board switches to light; reload → stays light (localStorage persists)