### PR TITLE
fix(graph): serve real layout bytes for note sync instead of empty content

### DIFF
--- a/internal/graph/note_path_content.go
+++ b/internal/graph/note_path_content.go
@@ -1,0 +1,77 @@
+package graph
+
+import (
+	"context"
+
+	"trip2g/internal/db"
+	"trip2g/internal/model"
+)
+
+// resolveNotePathContent returns the content to sync back for a note path.
+//
+// Priority:
+//  1. a registered layout (Layouts().Map) → its OriginalContent
+//  2. a cached note view (LatestNoteViews().PathMap) → its content
+//  3. the latest stored note_versions row (fetchLatest)
+//
+// Step 3 is the data-loss guard. A path is LISTED by notePaths with a real,
+// non-empty latest_content_hash but can be ABSENT from both caches when, for
+// example, it is a layout-shaped note under a subfolder ("demo/_layouts/…",
+// which noteloader only registers under the top-level "_layouts/"), or during a
+// transient note_paths.version_count vs note_versions.version divergence.
+// Layouts are also hidden from LatestNoteViews. Returning "" in that case makes
+// the sync plugin overwrite the local file with empty content, wiping it.
+func resolveNotePathContent(
+	obj *db.NotePath,
+	layouts *model.Layouts,
+	nvs *model.NoteViews,
+	fetchLatest func() (string, bool, error),
+) (string, error) {
+	for _, layout := range layouts.Map {
+		if layout.Path == obj.Value {
+			// Return original content for sync (JSON for .html.json, HTML for .html)
+			return layout.OriginalContent, nil
+		}
+	}
+
+	if nv := nvs.PathMap[obj.Value]; nv != nil {
+		return string(nv.Content), nil
+	}
+
+	content, found, err := fetchLatest()
+	if err != nil {
+		return "", err
+	}
+	if found {
+		return content, nil
+	}
+
+	// No stored version exists for this path (genuinely absent). Its advertised
+	// latest_content_hash would be empty too, so the client won't pull it.
+	return "", nil
+}
+
+// latestNoteVersionContent fetches the raw content of the latest stored version
+// for a path directly from note_versions, bypassing the Layouts/NoteViews
+// caches. It is robust to version_count divergence because it selects the row
+// with the highest version number (NoteVersionHistoryByPath orders by version
+// desc) rather than the one matching note_paths.version_count. Returns
+// (content, found, error); found is false only when no version row exists.
+func latestNoteVersionContent(ctx context.Context, env Env, path string) (string, bool, error) {
+	rows, err := env.NoteVersionHistoryByPath(ctx, db.NoteVersionHistoryByPathParams{
+		Value: path,
+		Limit: 1,
+	})
+	if err != nil {
+		return "", false, err
+	}
+	if len(rows) == 0 {
+		return "", false, nil
+	}
+
+	nv, err := env.NoteVersionByID(ctx, rows[0].ID)
+	if err != nil {
+		return "", false, err
+	}
+	return nv.Content, true, nil
+}

--- a/internal/graph/note_path_content_test.go
+++ b/internal/graph/note_path_content_test.go
@@ -1,0 +1,70 @@
+package graph
+
+import (
+	"errors"
+	"testing"
+
+	"trip2g/internal/db"
+	"trip2g/internal/model"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveNotePathContent_FallsBackToStoredBytesOnMapMiss reproduces the
+// data-loss bug: a path listed in notePaths with a non-empty latest_content_hash
+// but absent from both Layouts().Map and LatestNoteViews().PathMap must still
+// return its real stored bytes, never "". Returning "" makes the sync plugin
+// wipe the local file.
+func TestResolveNotePathContent_FallsBackToStoredBytesOnMapMiss(t *testing.T) {
+	const path = "demo/_layouts/json-test.html.json"
+	const realContent = `{"meta":{},"body":[{"type":"html","html":"<h1>real</h1>"}]}`
+
+	obj := &db.NotePath{Value: path, LatestContentHash: "nonempty-hash"}
+	layouts := &model.Layouts{Map: map[string]model.Layout{}}
+	nvs := &model.NoteViews{PathMap: map[string]*model.NoteView{}}
+
+	got, err := resolveNotePathContent(obj, layouts, nvs, func() (string, bool, error) {
+		return realContent, true, nil
+	})
+
+	require.NoError(t, err)
+	require.NotEmpty(t, got, "must never return empty content for a path with a non-empty latest_content_hash")
+	require.JSONEq(t, realContent, got)
+}
+
+// TestResolveNotePathContent_RegisteredLayoutWins keeps the fast path: a path
+// present in Layouts().Map returns its OriginalContent without hitting the DB.
+func TestResolveNotePathContent_RegisteredLayoutWins(t *testing.T) {
+	const path = "_layouts/index.html"
+	const original = "<html>{{ yield body() }}</html>"
+
+	obj := &db.NotePath{Value: path}
+	layouts := &model.Layouts{Map: map[string]model.Layout{
+		"index": {Path: path, OriginalContent: original},
+	}}
+	nvs := &model.NoteViews{PathMap: map[string]*model.NoteView{}}
+
+	got, err := resolveNotePathContent(obj, layouts, nvs, func() (string, bool, error) {
+		t.Fatal("fetchLatest must not be called when the layout is registered")
+		return "", false, nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, original, got)
+}
+
+// TestResolveNotePathContent_FetchErrorPropagates ensures a DB error surfaces as
+// an error (plugin skips on error) rather than being swallowed into "".
+func TestResolveNotePathContent_FetchErrorPropagates(t *testing.T) {
+	obj := &db.NotePath{Value: "demo/_layouts/json-test.html.json"}
+	layouts := &model.Layouts{Map: map[string]model.Layout{}}
+	nvs := &model.NoteViews{PathMap: map[string]*model.NoteView{}}
+
+	wantErr := errors.New("db down")
+	got, err := resolveNotePathContent(obj, layouts, nvs, func() (string, bool, error) {
+		return "", false, wantErr
+	})
+
+	require.ErrorIs(t, err, wantErr)
+	require.Empty(t, got)
+}

--- a/internal/graph/schema.resolvers.go
+++ b/internal/graph/schema.resolvers.go
@@ -2808,26 +2808,10 @@ func (r *notePathResolver) LatestNoteView(ctx context.Context, obj *db.NotePath)
 
 // Content is the resolver for the content field.
 func (r *notePathResolver) Content(ctx context.Context, obj *db.NotePath) (string, error) {
-	// TODO: optimize - add PathMap to Layouts for O(1) lookup
-	layouts := r.env(ctx).Layouts()
-	for _, layout := range layouts.Map {
-		if layout.Path == obj.Value {
-			// Return original content for sync (JSON for .html.json, HTML for .html)
-			return layout.OriginalContent, nil
-		}
-	}
-
-	nvs := r.env(ctx).LatestNoteViews()
-	nv := nvs.PathMap[obj.Value]
-
-	if nv != nil {
-		return string(nv.Content), nil
-	}
-
-	// if the client push html files outside of _layouts folder,
-	// we may not have content for them
-	// TODO: fix this
-	return "", nil // errors.New("note content not found")
+	env := r.env(ctx)
+	return resolveNotePathContent(obj, env.Layouts(), env.LatestNoteViews(), func() (string, bool, error) {
+		return latestNoteVersionContent(ctx, env, obj.Value)
+	})
 }
 
 // AssetReplaces is the resolver for the assetReplaces field.


### PR DESCRIPTION
## Problem

Confirmed data-loss bug: the obsidian-sync plugin wipes local `_layouts/*.html.json` (and `.html`) layout files to EMPTY content during sync.

Server side: `notePathResolver.Content` looped `Layouts().Map` and, on a miss, fell through to `return "", nil` (the old `// TODO: fix this`). A `_layouts/*` path is LISTED by `notePaths` with a real, non-empty `latestContentHash` (so the plugin pulls it) but can be ABSENT from the in-memory `Layouts().Map`:
- a layout-shaped note under a subfolder, e.g. `demo/_layouts/json-test.html.json` — noteloader only registers layouts under the top-level `_layouts/`;
- transient `note_paths.version_count` vs `note_versions.version` divergence.

`_layouts/*` notes are also hidden from `LatestNoteViews`, so the `nvs.PathMap` fallback was nil too → the resolver returned `""`. The plugin then overwrote the local file with empty content.

## Fix

`notePathResolver.Content` now falls back to the raw latest `note_versions.content` for the path when it is absent from both caches, via existing Env methods `NoteVersionHistoryByPath` (latest version id — robust to `version_count` divergence because it selects by `version desc`, not by `version_count`) + `NoteVersionByID` (content). It returns the real stored bytes, never `""`. A DB error now propagates as an error instead of being swallowed into `""`.

Logic extracted into a testable `resolveNotePathContent` helper (`internal/graph/note_path_content.go`).

## Tests

`internal/graph/note_path_content_test.go`:
- map-miss → returns real stored bytes (the bug repro), never empty;
- registered layout still wins (no DB hit);
- fetch error propagates (plugin skips on error rather than wiping).

## Verify

- `go build ./...` clean
- `go test ./internal/graph/... ./internal/noteloader/...` green
- `golangci-lint run ./internal/graph/...` → 0 issues

Note: `noteloader.go:214` is intentionally NOT changed — `demo/_layouts/` is a plain folder, not a layout root; loading it as a layout would produce a garbage layout ID. Serving the note's raw bytes is the correct fix. The plugin-side defense-in-depth guard is in a separate PR against trip2g/obsidian-sync.