### PR TITLE
perf(mdloader): cache frontmatter-patch results across reloads

### DIFF
--- a/internal/frontmatterpatch/cache.go
+++ b/internal/frontmatterpatch/cache.go
@@ -1,0 +1,236 @@
+package frontmatterpatch
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"strconv"
+	"sync"
+
+	jsonnet "github.com/google/go-jsonnet"
+)
+
+// ResultCache memoizes ApplyPatches results across note-loader reloads.
+//
+// ApplyPatches is a pure, deterministic function of (patches, path, pre-patch
+// rawMeta): it only calls MatchPath (a pure glob match) and Evaluate (Jsonnet on
+// a sandboxed VM with no importer, native funcs, time, or randomness — only the
+// meta+path extVars) followed by a shallow merge. So its result can be safely
+// memoized: re-running the Jsonnet VM per note on every reload is pure waste.
+//
+// The cache stores one entry per note path, validated by two hashes:
+//
+//   - patchSetHash: a hash of the whole compiled patch set. When ANY patch
+//     changes (admin- OR note-defined → the compiled set changes) the hash
+//     changes and the entire cache is dropped, so every note recomputes once.
+//     This is the cheap, correct invalidation: no need to track which note is
+//     affected by which patch.
+//   - preMetaHash: a hash of the note's pre-patch rawMeta. Changes only when the
+//     note's own frontmatter changes, invalidating just that one entry.
+//
+// Keeping a single entry per path bounds memory to the note count and
+// auto-evicts the stale meta of edited notes.
+//
+// ResultCache is safe for concurrent use.
+type ResultCache struct {
+	mu           sync.Mutex
+	patchSetHash string
+	entries      map[string]cacheEntry
+
+	hits   uint64
+	misses uint64
+}
+
+type cacheEntry struct {
+	preMetaHash string
+	result      ApplyResult
+}
+
+// NewResultCache returns an empty result cache.
+func NewResultCache() *ResultCache {
+	return &ResultCache{entries: map[string]cacheEntry{}}
+}
+
+// CachedApply returns the patched result for (path, rawMeta) under the compiled
+// patch set identified by patchSetHash, memoizing the result across calls. On a
+// cache hit it does NOT invoke the Jsonnet VM.
+//
+// rawMeta must be the PRE-patch frontmatter. On a miss it is passed straight to
+// ApplyPatches, which mutates it in place and returns it as the result — matching
+// the uncached behavior exactly. On a hit, a private deep copy is returned, so the
+// caller may freely mutate the result without corrupting the cache.
+func (c *ResultCache) CachedApply(
+	vm *jsonnet.VM,
+	patches []CompiledPatch,
+	patchSetHash, path string,
+	rawMeta map[string]interface{},
+) ApplyResult {
+	return c.cachedApply(patchSetHash, path, rawMeta, func() ApplyResult {
+		return ApplyPatches(vm, patches, path, rawMeta)
+	})
+}
+
+// cachedApply is the cache core with the (Jsonnet-running) compute step injected
+// so tests can spy on whether the compute path is taken on a hit.
+func (c *ResultCache) cachedApply(
+	patchSetHash, path string,
+	rawMeta map[string]interface{},
+	compute func() ApplyResult,
+) ApplyResult {
+	preMetaHash := hashMeta(rawMeta)
+
+	c.mu.Lock()
+	if c.patchSetHash != patchSetHash {
+		// The patch set changed → the whole cache is invalid.
+		c.patchSetHash = patchSetHash
+		c.entries = make(map[string]cacheEntry, len(c.entries))
+	}
+	if e, ok := c.entries[path]; ok && e.preMetaHash == preMetaHash {
+		hit := cloneResult(e.result)
+		c.hits++
+		c.mu.Unlock()
+		return hit
+	}
+	c.misses++
+	c.mu.Unlock()
+
+	// Compute outside the lock: ApplyPatches uses the shared VM and is the
+	// expensive part. A concurrent miss for the same path may compute twice,
+	// which is wasteful but harmless (the function is pure).
+	result := compute()
+
+	c.mu.Lock()
+	// Re-check: a concurrent reload may have reset the cache for a new patch set.
+	if c.patchSetHash == patchSetHash {
+		c.entries[path] = cacheEntry{preMetaHash: preMetaHash, result: cloneResult(result)}
+	}
+	c.mu.Unlock()
+
+	return result
+}
+
+// Hits returns the number of cache hits served so far. For observability/tests.
+func (c *ResultCache) Hits() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.hits
+}
+
+// Misses returns the number of cache misses (Jsonnet recomputes) so far.
+func (c *ResultCache) Misses() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.misses
+}
+
+// PatchSetHash returns a stable hash identifying a compiled patch set. Two sets
+// hash equal iff they would apply identically: same patches in the same order,
+// with the same match patterns, priority, source, and description (every field
+// that can influence an ApplyResult). Compute once per Load.
+func PatchSetHash(patches []CompiledPatch) string {
+	h := sha256.New()
+	var num [8]byte
+	writeStr := func(s string) {
+		binary.BigEndian.PutUint64(num[:], uint64(len(s)))
+		_, _ = h.Write(num[:])
+		_, _ = h.Write([]byte(s))
+	}
+	writeStrings := func(ss []string) {
+		writeStr(strconv.Itoa(len(ss)))
+		for _, s := range ss {
+			writeStr(s)
+		}
+	}
+
+	writeStr(strconv.Itoa(len(patches)))
+	for _, p := range patches {
+		writeStr(strconv.Itoa(p.ID))
+		writeStr(strconv.Itoa(p.Priority))
+		writeStrings(p.IncludePatterns)
+		writeStrings(p.ExcludePatterns)
+		writeStr(p.WrappedSource)
+		writeStr(p.Description)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// hashMeta returns a deterministic hash of pre-patch frontmatter. It reuses the
+// canonical JSON form that Evaluate marshals (encoding/json sorts map keys), so
+// two maps with equal content hash equal regardless of iteration order.
+func hashMeta(rawMeta map[string]interface{}) string {
+	b, err := json.Marshal(normalizeYAML(rawMeta))
+	if err != nil {
+		// Unmarshalable meta: return a value that never matches a stored entry,
+		// forcing a correct (uncached) recompute. Practically unreachable, since
+		// normalizeYAML produces JSON-marshalable values.
+		return "\x00unhashable"
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// cloneResult returns a deep copy of an ApplyResult that shares no mutable state
+// with the original, so a cached snapshot can never be corrupted by a caller.
+func cloneResult(r ApplyResult) ApplyResult {
+	return ApplyResult{
+		RawMeta:        deepCopyMeta(r.RawMeta),
+		AppliedPatches: cloneAppliedPatches(r.AppliedPatches),
+		Warnings:       cloneStrings(r.Warnings),
+	}
+}
+
+func cloneAppliedPatches(s []AppliedPatch) []AppliedPatch {
+	if s == nil {
+		return nil
+	}
+	out := make([]AppliedPatch, len(s))
+	copy(out, s)
+	return out
+}
+
+func cloneStrings(s []string) []string {
+	if s == nil {
+		return nil
+	}
+	out := make([]string, len(s))
+	copy(out, s)
+	return out
+}
+
+// deepCopyMeta returns an independent deep copy of a frontmatter map, preserving
+// the original Go value types (unlike a JSON round-trip, which would coerce e.g.
+// int to float64). Handles the nested map[interface{}]interface{} /
+// map[string]interface{} / []interface{} shapes produced by goldmark-meta.
+func deepCopyMeta(m map[string]interface{}) map[string]interface{} {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		out[k] = deepCopyValue(v)
+	}
+	return out
+}
+
+func deepCopyValue(v interface{}) interface{} {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		return deepCopyMeta(val)
+	case map[interface{}]interface{}:
+		out := make(map[interface{}]interface{}, len(val))
+		for k, item := range val {
+			out[k] = deepCopyValue(item)
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, len(val))
+		for i, item := range val {
+			out[i] = deepCopyValue(item)
+		}
+		return out
+	default:
+		// Scalars (string, bool, int, float64, nil, time.Time, …) are immutable.
+		return v
+	}
+}

--- a/internal/frontmatterpatch/cache_test.go
+++ b/internal/frontmatterpatch/cache_test.go
@@ -1,0 +1,311 @@
+package frontmatterpatch
+
+import (
+	"testing"
+
+	jsonnet "github.com/google/go-jsonnet"
+	"github.com/stretchr/testify/require"
+)
+
+// load simulates one note-loader Load: it builds a fresh pre-patch meta copy
+// (as each Load does) and runs the patch set through the cache, counting how
+// many times the Jsonnet-running compute path is taken. ApplyPatches mutates its
+// input in place, so each load must start from a fresh copy.
+func load(
+	c *ResultCache,
+	vm *jsonnet.VM,
+	patches []CompiledPatch,
+	patchSetHash, path string,
+	base map[string]interface{},
+	computeCalls *int,
+) ApplyResult {
+	m := deepCopyMeta(base)
+	return c.cachedApply(patchSetHash, path, m, func() ApplyResult {
+		*computeCalls++
+		return ApplyPatches(vm, patches, path, m)
+	})
+}
+
+func TestResultCache_HitSkipsJsonnet(t *testing.T) {
+	vm := NewVM()
+	patches := []CompiledPatch{Compile(1, []string{"*.md"}, nil, `meta + { free: true }`, 0, "free")}
+	psh := PatchSetHash(patches)
+	base := map[string]interface{}{"title": "Test"}
+
+	var calls int
+	c := NewResultCache()
+
+	r1 := load(c, vm, patches, psh, "a.md", base, &calls)
+	r2 := load(c, vm, patches, psh, "a.md", base, &calls)
+
+	require.Equal(t, 1, calls, "second call must hit the cache and skip the Jsonnet VM")
+	require.Equal(t, true, r1.RawMeta["free"])
+	require.Equal(t, r1.RawMeta, r2.RawMeta, "hit must return an identical result")
+	require.Equal(t, uint64(1), c.Hits())
+	require.Equal(t, uint64(1), c.Misses())
+}
+
+func TestResultCache_InvalidatePatchSet(t *testing.T) {
+	vm := NewVM()
+	patchesA := []CompiledPatch{Compile(1, []string{"*.md"}, nil, `meta + { free: true }`, 0, "free")}
+	patchesB := []CompiledPatch{Compile(1, []string{"*.md"}, nil, `meta + { free: false }`, 0, "free")}
+	pshA := PatchSetHash(patchesA)
+	pshB := PatchSetHash(patchesB)
+	base := map[string]interface{}{"title": "Test"}
+
+	var calls int
+	c := NewResultCache()
+
+	_ = load(c, vm, patchesA, pshA, "a.md", base, &calls)
+	require.Equal(t, 1, calls)
+
+	// Same note + same content, but the patch set changed → recompute.
+	rB := load(c, vm, patchesB, pshB, "a.md", base, &calls)
+	require.Equal(t, 2, calls, "changing the patch set must invalidate the whole cache")
+	require.Equal(t, false, rB.RawMeta["free"])
+
+	// New patch set is now cached → a repeat is a hit.
+	_ = load(c, vm, patchesB, pshB, "a.md", base, &calls)
+	require.Equal(t, 2, calls, "stable patch set must hit again")
+}
+
+func TestResultCache_InvalidatePreMeta(t *testing.T) {
+	vm := NewVM()
+	patches := []CompiledPatch{Compile(1, []string{"*.md"}, nil, `meta + { free: true }`, 0, "free")}
+	psh := PatchSetHash(patches)
+
+	var calls int
+	c := NewResultCache()
+
+	_ = load(c, vm, patches, psh, "a.md", map[string]interface{}{"title": "One"}, &calls)
+	require.Equal(t, 1, calls)
+
+	// Same path, different pre-patch frontmatter → recompute.
+	_ = load(c, vm, patches, psh, "a.md", map[string]interface{}{"title": "Two"}, &calls)
+	require.Equal(t, 2, calls, "changing the note's frontmatter must invalidate its entry")
+
+	// The latest meta is cached (one entry per path) → repeat is a hit.
+	_ = load(c, vm, patches, psh, "a.md", map[string]interface{}{"title": "Two"}, &calls)
+	require.Equal(t, 2, calls)
+}
+
+func TestResultCache_DifferentPathSeparateEntry(t *testing.T) {
+	vm := NewVM()
+	patches := []CompiledPatch{Compile(1, []string{"**/*.md"}, nil, `{ filepath: path }`, 0, "path")}
+	psh := PatchSetHash(patches)
+	base := map[string]interface{}{"title": "Test"}
+
+	var calls int
+	c := NewResultCache()
+
+	rA := load(c, vm, patches, psh, "a.md", base, &calls)
+	rB := load(c, vm, patches, psh, "b.md", base, &calls)
+	require.Equal(t, 2, calls, "distinct paths are distinct entries")
+	require.Equal(t, "a.md", rA.RawMeta["filepath"])
+	require.Equal(t, "b.md", rB.RawMeta["filepath"])
+
+	// Both paths are cached independently → both hit.
+	_ = load(c, vm, patches, psh, "a.md", base, &calls)
+	_ = load(c, vm, patches, psh, "b.md", base, &calls)
+	require.Equal(t, 2, calls, "both paths must hit on reload")
+}
+
+// TestResultCache_HitDeepCopyPreventsCorruption is the no-mutation-corruption
+// guarantee: a caller that mutates a returned result (including nested values and
+// the applied-patch slice) must not corrupt a subsequent cache hit.
+func TestResultCache_HitDeepCopyPreventsCorruption(t *testing.T) {
+	vm := NewVM()
+	patches := []CompiledPatch{
+		Compile(1, []string{"*.md"}, nil, `meta + { nested: { a: "one" }, free: true }`, 0, "nested"),
+	}
+	psh := PatchSetHash(patches)
+	base := map[string]interface{}{"title": "Test"}
+
+	var calls int
+	c := NewResultCache()
+
+	r1 := load(c, vm, patches, psh, "a.md", base, &calls)
+
+	// Aggressively corrupt the first result.
+	r1.RawMeta["title"] = "HACKED"
+	r1.RawMeta["injected"] = true
+	if nested, ok := r1.RawMeta["nested"].(map[string]interface{}); ok {
+		nested["a"] = "HACKED"
+	}
+	if len(r1.AppliedPatches) > 0 {
+		r1.AppliedPatches[0].Description = "HACKED"
+	}
+
+	r2 := load(c, vm, patches, psh, "a.md", base, &calls)
+
+	require.Equal(t, 1, calls, "second call must be a cache hit")
+	require.Equal(t, "Test", r2.RawMeta["title"], "cache must not be corrupted")
+	require.NotContains(t, r2.RawMeta, "injected")
+	require.Equal(t, true, r2.RawMeta["free"])
+	nested, ok := r2.RawMeta["nested"].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, "one", nested["a"], "nested value must survive caller mutation")
+	require.Equal(t, "nested", r2.AppliedPatches[0].Description)
+}
+
+// TestCachedApply_MatchesUncached proves the cached path (both miss and hit) is
+// byte-identical to a direct, uncached ApplyPatches across a range of scenarios.
+func TestCachedApply_MatchesUncached(t *testing.T) {
+	cases := []struct {
+		name    string
+		patches []CompiledPatch
+		path    string
+		meta    map[string]interface{}
+	}{
+		{
+			name:    "simple set",
+			patches: []CompiledPatch{Compile(1, []string{"*.md"}, nil, `{ free: true }`, 0, "free")},
+			path:    "a.md",
+			meta:    map[string]interface{}{"title": "Test"},
+		},
+		{
+			name: "priority chaining",
+			patches: []CompiledPatch{
+				Compile(1, []string{"*.md"}, nil, `{ category: "blog" }`, 100, "cat"),
+				Compile(2, []string{"*.md"}, nil, `meta + { tags: ["general"] }`, 200, "tags"),
+			},
+			path: "post.md",
+			meta: map[string]interface{}{"title": "Test"},
+		},
+		{
+			name:    "no match",
+			patches: []CompiledPatch{Compile(1, []string{"blog/**"}, nil, `{ x: 1 }`, 0, "x")},
+			path:    "docs/guide.md",
+			meta:    map[string]interface{}{"title": "Test"},
+		},
+		{
+			name:    "runtime error warning",
+			patches: []CompiledPatch{Compile(1, []string{"*.md"}, nil, `meta.nonexistent.field`, 0, "boom")},
+			path:    "a.md",
+			meta:    map[string]interface{}{"title": "Test"},
+		},
+		{
+			name:    "nested yaml.v2 map",
+			patches: []CompiledPatch{Compile(1, []string{"*.md"}, nil, `meta + { free: true }`, 0, "free")},
+			path:    "a.md",
+			meta: map[string]interface{}{
+				"title": "Test",
+				"form": map[interface{}]interface{}{
+					"fields": []interface{}{
+						map[interface{}]interface{}{"name": "email", "required": true},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			vm := NewVM()
+			psh := PatchSetHash(tc.patches)
+
+			uncached := ApplyPatches(vm, tc.patches, tc.path, deepCopyMeta(tc.meta))
+
+			c := NewResultCache()
+			miss := c.CachedApply(vm, tc.patches, psh, tc.path, deepCopyMeta(tc.meta))
+			hit := c.CachedApply(vm, tc.patches, psh, tc.path, deepCopyMeta(tc.meta))
+
+			require.Equal(t, uint64(1), c.Hits())
+			require.Equal(t, uncached.RawMeta, miss.RawMeta, "miss must match uncached")
+			require.Equal(t, uncached.AppliedPatches, miss.AppliedPatches)
+			require.Equal(t, uncached.Warnings, miss.Warnings)
+			require.Equal(t, uncached.RawMeta, hit.RawMeta, "hit must match uncached")
+			require.Equal(t, uncached.AppliedPatches, hit.AppliedPatches)
+			require.Equal(t, uncached.Warnings, hit.Warnings)
+		})
+	}
+}
+
+func TestResultCache_EmptyPatchesUnchanged(t *testing.T) {
+	vm := NewVM()
+	psh := PatchSetHash(nil)
+	base := map[string]interface{}{"title": "Test", "free": true}
+	c := NewResultCache()
+
+	r1 := c.CachedApply(vm, nil, psh, "a.md", deepCopyMeta(base))
+	r2 := c.CachedApply(vm, nil, psh, "a.md", deepCopyMeta(base))
+
+	require.Empty(t, r1.AppliedPatches)
+	require.Equal(t, base, r1.RawMeta, "no patches → meta unchanged")
+	require.Equal(t, base, r2.RawMeta)
+}
+
+func TestPatchSetHash(t *testing.T) {
+	p := func() []CompiledPatch {
+		return []CompiledPatch{
+			Compile(1, []string{"*.md"}, nil, `{ a: 1 }`, 0, "a"),
+			Compile(2, []string{"blog/**"}, []string{"blog/drafts/**"}, `{ b: 2 }`, 10, "b"),
+		}
+	}
+
+	h1 := PatchSetHash(p())
+	h2 := PatchSetHash(p())
+	require.Equal(t, h1, h2, "identical sets hash equal")
+	require.NotEqual(t, PatchSetHash(p()), PatchSetHash(p()[:1]), "fewer patches → different hash")
+
+	reordered := []CompiledPatch{p()[1], p()[0]}
+	require.NotEqual(t, PatchSetHash(p()), PatchSetHash(reordered), "order matters")
+
+	srcChanged := p()
+	srcChanged[0] = Compile(1, []string{"*.md"}, nil, `{ a: 2 }`, 0, "a")
+	require.NotEqual(t, PatchSetHash(p()), PatchSetHash(srcChanged), "source change → different hash")
+
+	descChanged := p()
+	descChanged[0] = Compile(1, []string{"*.md"}, nil, `{ a: 1 }`, 0, "different")
+	require.NotEqual(t, PatchSetHash(p()), PatchSetHash(descChanged), "description change → different hash")
+
+	patternChanged := p()
+	patternChanged[0] = Compile(1, []string{"docs/**"}, nil, `{ a: 1 }`, 0, "a")
+	require.NotEqual(t, PatchSetHash(p()), PatchSetHash(patternChanged), "include change → different hash")
+
+	require.NotEmpty(t, PatchSetHash(nil), "nil set still hashes")
+}
+
+func benchPatches() []CompiledPatch {
+	return []CompiledPatch{
+		Compile(1, []string{"**/*.md"}, nil, `meta + { layout: "post" }`, 0, "layout"),
+		Compile(2, []string{"blog/**"}, nil, `meta + { section: "blog", free: true }`, 10, "blog section"),
+		Compile(3, []string{"**/*.md"}, nil,
+			`if std.objectHas(meta, "draft") && meta.draft then { status: "draft" } else { status: "published" }`,
+			20, "status"),
+	}
+}
+
+func benchMeta() map[string]interface{} {
+	return map[string]interface{}{
+		"title":  "A Realistic Post Title",
+		"tags":   []interface{}{"go", "perf", "caching"},
+		"date":   "2026-06-29",
+		"author": "alexes",
+	}
+}
+
+func BenchmarkApplyFrontmatterPatches_Cold(b *testing.B) {
+	vm := NewVM()
+	patches := benchPatches()
+	meta := benchMeta()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = ApplyPatches(vm, patches, "blog/2026/post.md", deepCopyMeta(meta))
+	}
+}
+
+func BenchmarkApplyFrontmatterPatches_CacheHit(b *testing.B) {
+	vm := NewVM()
+	patches := benchPatches()
+	psh := PatchSetHash(patches)
+	meta := benchMeta()
+	c := NewResultCache()
+	_ = c.CachedApply(vm, patches, psh, "blog/2026/post.md", deepCopyMeta(meta)) // warm
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = c.CachedApply(vm, patches, psh, "blog/2026/post.md", meta)
+	}
+}

--- a/internal/mdloader/loader.go
+++ b/internal/mdloader/loader.go
@@ -66,6 +66,12 @@ type loader struct {
 
 	frontmatterPatches []frontmatterpatch.CompiledPatch
 	jsonnetVM          *jsonnet.VM
+
+	// patchCache memoizes frontmatter-patch results across reloads (optional).
+	// patchSetHash identifies the merged patch set for this Load and is the
+	// cache's coarse invalidation key.
+	patchCache   *frontmatterpatch.ResultCache
+	patchSetHash string
 }
 
 type Config struct {
@@ -94,6 +100,11 @@ type Options struct {
 	// ChartData supplies cached rows for url/internal datachart sources. Nil is
 	// fine — those charts then render a loader.
 	ChartData ChartDataProvider
+
+	// PatchCache memoizes frontmatter-patch results across Load calls. Optional;
+	// when nil, patches are applied directly (uncached). Reuse the same instance
+	// across reloads for the cache to help (it persists alongside the note cache).
+	PatchCache *frontmatterpatch.ResultCache
 }
 
 // Load transforms markdown files into pages.
@@ -115,6 +126,7 @@ func Load(options Options) (*model.NoteViews, error) {
 	ldr.linkResolver.chartData = options.ChartData
 
 	ldr.frontmatterPatches = options.FrontmatterPatches
+	ldr.patchCache = options.PatchCache
 
 	renderOptions := []renderer.Option{
 		renderer.WithNodeRenderers(util.Prioritized(&chartRenderer{resolver: ldr.linkResolver}, 197)),
@@ -160,48 +172,8 @@ func Load(options Options) (*model.NoteViews, error) {
 		parsed = append(parsed, ps)
 	}
 
-	// Step 2: collect vault patches from sources with type: frontmatter-patch.
-	var vaultPatches []frontmatterpatch.CompiledPatch
-	for _, ps := range parsed {
-		typ, _ := ps.rawMeta["type"].(string)
-		if typ != "frontmatter-patch" {
-			continue
-		}
-
-		bodies, err := extractJsonnetBlocks(ps.doc, ps.src.Content)
-		if err != nil {
-			ps.patchError = err.Error()
-			continue
-		}
-
-		patches, err := frontmatterpatch.CompileVaultPatches(
-			ps.src.Path,
-			toStringSlice(ps.rawMeta["include"]),
-			toStringSlice(ps.rawMeta["exclude"]),
-			bodies,
-			toInt(ps.rawMeta["priority"]),
-		)
-		if err != nil {
-			ps.patchError = err.Error()
-			continue
-		}
-
-		vaultPatches = append(vaultPatches, patches...)
-	}
-
-	// Sort vault patches by priority, then description (path).
-	sort.Slice(vaultPatches, func(i, j int) bool {
-		if vaultPatches[i].Priority != vaultPatches[j].Priority {
-			return vaultPatches[i].Priority < vaultPatches[j].Priority
-		}
-		return vaultPatches[i].Description < vaultPatches[j].Description
-	})
-
-	// Merge: DB patches first, then vault patches.
-	ldr.frontmatterPatches = append(ldr.frontmatterPatches, vaultPatches...)
-	if len(ldr.frontmatterPatches) > 0 {
-		ldr.jsonnetVM = frontmatterpatch.NewVM()
-	}
+	// Step 2: collect vault patches, merge with DB patches, prepare the VM + hash.
+	ldr.collectAndMergePatches(parsed)
 
 	// Step 2b: collect layout section files (header/footer/sidebar with glob patterns).
 	for _, ps := range parsed {
@@ -714,6 +686,56 @@ func (ldr *loader) parseSource(src SourceFile) *parsedSource {
 	return &parsedSource{src: src, doc: doc, rawMeta: rawMeta}
 }
 
+// collectAndMergePatches gathers vault patches from sources with
+// type: frontmatter-patch, merges them after the DB patches, and prepares the
+// shared Jsonnet VM plus the patch-set hash used by the result cache.
+func (ldr *loader) collectAndMergePatches(parsed []*parsedSource) {
+	var vaultPatches []frontmatterpatch.CompiledPatch
+	for _, ps := range parsed {
+		typ, _ := ps.rawMeta["type"].(string)
+		if typ != "frontmatter-patch" {
+			continue
+		}
+
+		bodies, err := extractJsonnetBlocks(ps.doc, ps.src.Content)
+		if err != nil {
+			ps.patchError = err.Error()
+			continue
+		}
+
+		patches, err := frontmatterpatch.CompileVaultPatches(
+			ps.src.Path,
+			toStringSlice(ps.rawMeta["include"]),
+			toStringSlice(ps.rawMeta["exclude"]),
+			bodies,
+			toInt(ps.rawMeta["priority"]),
+		)
+		if err != nil {
+			ps.patchError = err.Error()
+			continue
+		}
+
+		vaultPatches = append(vaultPatches, patches...)
+	}
+
+	// Sort vault patches by priority, then description (path).
+	sort.Slice(vaultPatches, func(i, j int) bool {
+		if vaultPatches[i].Priority != vaultPatches[j].Priority {
+			return vaultPatches[i].Priority < vaultPatches[j].Priority
+		}
+		return vaultPatches[i].Description < vaultPatches[j].Description
+	})
+
+	// Merge: DB patches first, then vault patches.
+	ldr.frontmatterPatches = append(ldr.frontmatterPatches, vaultPatches...)
+	if len(ldr.frontmatterPatches) > 0 {
+		ldr.jsonnetVM = frontmatterpatch.NewVM()
+		// Hash the full merged set (DB + vault) once. Any patch change — admin or
+		// note-defined — flips this and invalidates the whole result cache.
+		ldr.patchSetHash = frontmatterpatch.PatchSetHash(ldr.frontmatterPatches)
+	}
+}
+
 // finishPage applies frontmatter patches, extracts metadata, and prepares
 // the NoteView for rendering. This is the second phase of note loading.
 func (ldr *loader) finishPage(ps *parsedSource) (*model.NoteView, error) {
@@ -797,7 +819,16 @@ func (ldr *loader) applyFrontmatterPatches(
 		return rawMeta, nil
 	}
 
-	result := frontmatterpatch.ApplyPatches(ldr.jsonnetVM, ldr.frontmatterPatches, path, rawMeta)
+	var result frontmatterpatch.ApplyResult
+	if ldr.patchCache != nil {
+		// Cache hit returns a private deep copy; cache miss applies patches and
+		// stores a snapshot. Either way the result is byte-identical to the
+		// direct ApplyPatches below.
+		result = ldr.patchCache.CachedApply(
+			ldr.jsonnetVM, ldr.frontmatterPatches, ldr.patchSetHash, path, rawMeta)
+	} else {
+		result = frontmatterpatch.ApplyPatches(ldr.jsonnetVM, ldr.frontmatterPatches, path, rawMeta)
+	}
 
 	// Convert AppliedPatch to model.AppliedFrontmatterPatch.
 	applied := make([]model.AppliedFrontmatterPatch, len(result.AppliedPatches))

--- a/internal/mdloader/loader_test.go
+++ b/internal/mdloader/loader_test.go
@@ -1852,6 +1852,101 @@ func TestFrontmatterPatchNotDoubledOnCacheHit(t *testing.T) {
 		"patch must NOT accumulate on third cached reload")
 }
 
+// TestFrontmatterPatchResultCacheAcrossReloads verifies that a persistent
+// ResultCache reused across reloads (1) keeps patched RawMeta byte-identical to
+// the uncached path, (2) actually serves cache hits when content and patch set
+// are unchanged, and (3) recomputes when a note's content changes.
+func TestFrontmatterPatchResultCacheAcrossReloads(t *testing.T) {
+	log := logger.TestLogger{}
+
+	patch := frontmatterpatch.Compile(1, []string{"*"}, nil,
+		`meta + { title: meta.title + " — Site", patched: true }`, 0, "title suffix")
+
+	srcA := mdloader.SourceFile{Path: "a.md", Content: []byte("---\ntitle: A\nfree: true\n---\nBody A")}
+	srcB := mdloader.SourceFile{Path: "b.md", Content: []byte("---\ntitle: B\n---\nBody B")}
+
+	// Reference: uncached load (no PatchCache).
+	ref, err := mdloader.Load(mdloader.Options{
+		Sources:            []mdloader.SourceFile{srcA, srcB},
+		Log:                &log,
+		FrontmatterPatches: []frontmatterpatch.CompiledPatch{patch},
+	})
+	require.NoError(t, err)
+
+	cache := frontmatterpatch.NewResultCache()
+
+	// Load 1 with the cache — all misses (cold).
+	pages1, err := mdloader.Load(mdloader.Options{
+		Sources:            []mdloader.SourceFile{srcA, srcB},
+		Log:                &log,
+		FrontmatterPatches: []frontmatterpatch.CompiledPatch{patch},
+		PatchCache:         cache,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), cache.Hits(), "cold load has no hits")
+	require.Equal(t, uint64(2), cache.Misses(), "cold load computes both notes")
+
+	makeNoteCache := func(prev *model.NoteViews) func(mdloader.SourceFile) *model.NoteView {
+		return func(src mdloader.SourceFile) *model.NoteView {
+			old, ok := prev.PathMap[src.Path]
+			if !ok || string(old.Content) != string(src.Content) {
+				return nil
+			}
+			return old
+		}
+	}
+
+	// Load 2 — same content + same patch set → both notes served from cache.
+	pages2, err := mdloader.Load(mdloader.Options{
+		Sources:            []mdloader.SourceFile{srcA, srcB},
+		Log:                &log,
+		FrontmatterPatches: []frontmatterpatch.CompiledPatch{patch},
+		PatchCache:         cache,
+		NoteCache:          makeNoteCache(pages1),
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), cache.Hits(), "warm reload must hit the cache for both notes")
+	require.Equal(t, uint64(2), cache.Misses(), "no new computes on a warm reload")
+
+	// Cached result must be byte-identical to the uncached reference.
+	require.Equal(t, ref.PathMap["a.md"].RawMeta, pages2.PathMap["a.md"].RawMeta)
+	require.Equal(t, ref.PathMap["b.md"].RawMeta, pages2.PathMap["b.md"].RawMeta)
+	require.Equal(t, "A — Site", pages2.PathMap["a.md"].Title, "patch applied exactly once via cache")
+	require.Equal(t, true, pages2.PathMap["a.md"].RawMeta["patched"])
+
+	// Load 3 — a.md content changes, b.md unchanged.
+	srcA2 := mdloader.SourceFile{Path: "a.md", Content: []byte("---\ntitle: A2\nfree: true\n---\nBody A2")}
+	pages3, err := mdloader.Load(mdloader.Options{
+		Sources:            []mdloader.SourceFile{srcA2, srcB},
+		Log:                &log,
+		FrontmatterPatches: []frontmatterpatch.CompiledPatch{patch},
+		PatchCache:         cache,
+		NoteCache:          makeNoteCache(pages2),
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), cache.Hits(), "unchanged b.md still hits")
+	require.Equal(t, uint64(3), cache.Misses(), "changed a.md recomputes once")
+	require.Equal(t, "A2 — Site", pages3.PathMap["a.md"].Title)
+}
+
+// TestFrontmatterPatchCacheNoPatchesBypassed verifies the empty-patch fast path
+// is preserved: with no patches the cache is never touched.
+func TestFrontmatterPatchCacheNoPatchesBypassed(t *testing.T) {
+	log := logger.TestLogger{}
+	cache := frontmatterpatch.NewResultCache()
+
+	src := mdloader.SourceFile{Path: "a.md", Content: []byte("---\ntitle: A\nfree: true\n---\nBody")}
+	pages, err := mdloader.Load(mdloader.Options{
+		Sources:    []mdloader.SourceFile{src},
+		Log:        &log,
+		PatchCache: cache,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "A", pages.PathMap["a.md"].Title)
+	require.Equal(t, uint64(0), cache.Hits())
+	require.Equal(t, uint64(0), cache.Misses(), "no patches → cache must not be consulted")
+}
+
 // TestVaultPatchApplies verifies that a vault patch file (type: frontmatter-patch)
 // with a matching include pattern applies its jsonnet block to target notes.
 func TestVaultPatchApplies(t *testing.T) {

--- a/internal/noteloader/loader.go
+++ b/internal/noteloader/loader.go
@@ -92,6 +92,11 @@ type Loader struct {
 	config             mdloader.Config
 	frontmatterPatches []frontmatterpatch.CompiledPatch
 	chartData          mdloader.ChartDataProvider
+
+	// patchCache persists frontmatter-patch results across reloads, alongside the
+	// note (AST) cache held in l.nvs. It skips re-running the Jsonnet VM per note
+	// when neither the note's frontmatter nor the patch set changed.
+	patchCache *frontmatterpatch.ResultCache
 }
 
 func New(version string, env Env, config mdloader.Config) *Loader {
@@ -99,8 +104,9 @@ func New(version string, env Env, config mdloader.Config) *Loader {
 		env: env,
 		log: logger.WithPrefix(env.Logger(), version+" noteloader:"),
 
-		version: version,
-		config:  config,
+		version:    version,
+		config:     config,
+		patchCache: frontmatterpatch.NewResultCache(),
 	}
 }
 
@@ -269,6 +275,7 @@ func (l *Loader) Load(ctx context.Context, options LoadOptions) error {
 		},
 		FrontmatterPatches: l.frontmatterPatches,
 		ChartData:          l.chartData,
+		PatchCache:         l.patchCache,
 	}
 
 	nvs, err := mdloader.Load(mdOptions)


### PR DESCRIPTION
## Problem

Every `pushNotes` triggers a full `noteloader.Load` → `mdloader.Load`. The AST is already cached per note (`noteCache` reuses the parsed doc + `OriginalRawMeta` across reloads). But `finishPage` still called `applyFrontmatterPatches` → `frontmatterpatch.ApplyPatches` **unconditionally for every note on every reload**, re-running the Jsonnet VM per note even when the note's AST came from cache. In a vault with frontmatter patches this was ~15% of CPU under push load, plus heavy GC pressure from Jsonnet allocations.

## Why it's safe to cache

`frontmatterpatch.ApplyPatches(vm, patches, path, rawMeta)` is a **pure, deterministic** function of `(patches, path, rawMeta)`: only `MatchPath` (pure glob) + `Evaluate` (Jsonnet on a sandboxed `MakeVM()` with no importer, native funcs, time, randomness, or extVars beyond the `meta`/`path` inputs) + a shallow merge. No I/O or cross-note state. Confirmed by reading `evaluate.go`, `Evaluate`, `NewVM`, and that all downstream `RawMeta` access is read-only.

## The fix — a persistent result cache

New `frontmatterpatch.ResultCache` (`internal/frontmatterpatch/cache.go`), memoizing `ApplyResult` per note:

- **patchSetHash** — hash of the whole compiled patch set (DB + vault), computed once per Load. Any patch change (admin- **or** note-defined → the merged set changes) flips it and drops the whole cache → recompute once.
- **preMetaHash** — hash of the note's pre-patch `rawMeta` (canonical sorted-key JSON). Changes only when the note's frontmatter changes → invalidates that one entry.
- Keyed per **path** (one entry per note) → memory bounded to note count, stale meta auto-evicted.

The cache instance lives on `noteloader.Loader` (created in `New()`), the same persistent home and lifecycle as the existing AST/note cache (`l.nvs`), and is threaded through `mdloader.Options.PatchCache`. On a hit it returns a **deep copy** (preserving original Go types — no JSON-coercion) so callers can't corrupt the snapshot; on a miss it stores a deep-copied snapshot and returns the direct `ApplyPatches` output (byte-identical to the uncached path). The `len(patches)==0` fast path is untouched.

## Benchmark (3 matching patches, realistic meta)

```
BenchmarkApplyFrontmatterPatches_Cold-12        10000   211860 ns/op   264413 B/op   3825 allocs/op
BenchmarkApplyFrontmatterPatches_CacheHit-12   1805716     1310 ns/op     1424 B/op     21 allocs/op
```

~**162x faster** per note on a cache hit; allocs drop 3825 → 21 (~182x). This eliminates per-note Jsonnet on the steady-state push path; the win scales linearly with (notes × patches matched).

## Tests

- `TestResultCache_HitSkipsJsonnet` — spy/counter on the compute path proves a hit **skips the Jsonnet VM**.
- `TestResultCache_InvalidatePatchSet` / `_InvalidatePreMeta` / `_DifferentPathSeparateEntry` — invalidation matrix.
- `TestResultCache_HitDeepCopyPreventsCorruption` — caller mutating returned RawMeta (incl. nested) and AppliedPatches cannot corrupt a later hit.
- `TestCachedApply_MatchesUncached` — cached miss **and** hit are byte-identical to direct `ApplyPatches` across 5 scenarios (incl. nested yaml.v2 maps, runtime-error warnings, no-match).
- `TestPatchSetHash` — order/source/description/pattern sensitivity.
- `TestFrontmatterPatchResultCacheAcrossReloads` — end-to-end across 3 `mdloader.Load` cycles: cold (2 misses) → warm reload (2 hits, identical RawMeta) → content change (1 recompute + 1 hit).
- `TestFrontmatterPatchCacheNoPatchesBypassed` — empty patch set never touches the cache.

## End-to-end syncperf

`scripts/syncperf/gen-vault.mjs` seeds notes with `publish:true` frontmatter but **no** frontmatter-patch files, so its noop/small-change bench hits the `len==0` early return and would not move regardless of this cache. To measure the real-world delta, add a patch note to the generated vault before pushing, e.g. `_perf_patch.md`:

```
---
type: frontmatter-patch
include:
  - "**/*.md"
priority: 10
---
\`\`\`jsonnet
meta + { perf_cached: true }
\`\`\`
```

then run `bench.mjs --label before/after`. The full stack was too heavy to spin up in the worktree (disk-constrained box); the Go micro-benchmark + N× scaling is the reliable signal.

## Verification

- `go build ./internal/frontmatterpatch/... ./internal/mdloader/... ./internal/noteloader/...` → exit 0; `go vet` clean.
- `go test ./internal/mdloader/... ./internal/frontmatterpatch/... ./internal/noteloader/...` → all green (new + existing; patch behavior byte-identical on miss and hit).
- `golangci-lint run` on changed packages → 0 new issues (2 remaining are pre-existing in unmodified `validate.go`/`link_renderer.go`).
