### PR TITLE
perf(layout): cache compiled Jet layouts in production (DevMode from config)

### DIFF
--- a/internal/layoutloader/auto_import.go
+++ b/internal/layoutloader/auto_import.go
@@ -54,8 +54,10 @@ func injectAfterLeadingImports(content, preamble string) string {
 // IMPORTANT: callers must already hold jl.mu — this function reads jl.templates.
 func (jl *jetLoader) buildAutoImportPreamble(pageSourceID string) string {
 	// Use a separate jet.Set to parse the page and component templates without
-	// polluting the page's real Set.
-	tmpViews := jet.NewSet(jl, jet.DevelopmentMode(true))
+	// polluting the page's real Set. This runs on every reload (not per render),
+	// but follows jl.devMode for consistency: with caching on, the repeated
+	// GetTemplate calls in buildBlockRegistry/resolveNeededFiles reuse parses.
+	tmpViews := jet.NewSet(jl, jet.DevelopmentMode(jl.devMode))
 	// `arg_type` and `yield_blocks` are referenced inside component bodies; provide
 	// no-op implementations so that GetTemplate parses successfully.
 	tmpViews.AddGlobalFunc("arg_type", func(a jet.Arguments) reflect.Value {

--- a/internal/layoutloader/devmode_test.go
+++ b/internal/layoutloader/devmode_test.go
@@ -1,0 +1,121 @@
+package layoutloader
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+	"trip2g/internal/logger"
+	"trip2g/internal/model"
+
+	"github.com/CloudyKit/jet/v6"
+	"github.com/stretchr/testify/require"
+)
+
+// countingLoader counts Open calls. In Jet, each Open corresponds to one
+// template read (io.ReadAll) followed by a parse — exactly the work that
+// DevelopmentMode=true repeats on every render.
+type countingLoader struct {
+	templates map[string]string
+	opens     map[string]int
+}
+
+func (l *countingLoader) Exists(p string) bool {
+	_, ok := l.templates[p]
+	return ok
+}
+
+func (l *countingLoader) Open(p string) (io.ReadCloser, error) {
+	l.opens[p]++
+	return io.NopCloser(strings.NewReader(l.templates[p])), nil
+}
+
+// TestDevMode_CachesParsedIncludeAcrossRenders is the core perf assertion.
+//
+// `{{ include }}` is resolved at RUNTIME (jet eval.go executeInclude ->
+// getSiblingTemplate). With DevelopmentMode(false) the parsed include is cached
+// in the Set after the first render and reused; with DevelopmentMode(true) the
+// Set skips its cache and re-reads + re-parses the include on EVERY render.
+//
+// The jet.NewSet construction here mirrors loader.go's NewSet call exactly.
+func TestDevMode_CachesParsedIncludeAcrossRenders(t *testing.T) {
+	templates := map[string]string{
+		"/main": `<main>{{ include "/part" }}</main>`,
+		"/part": `<p>shared</p>`,
+	}
+
+	renderNTimes := func(devMode bool, n int) int {
+		loader := &countingLoader{templates: templates, opens: map[string]int{}}
+		set := jet.NewSet(loader, jet.DevelopmentMode(devMode), jet.WithSafeWriter(nil))
+		tmpl, err := set.GetTemplate("/main")
+		require.NoError(t, err)
+		for range n {
+			var buf bytes.Buffer
+			require.NoError(t, tmpl.Execute(&buf, nil, nil))
+			require.Equal(t, "<main><p>shared</p></main>", buf.String())
+		}
+		return loader.opens["/part"]
+	}
+
+	// Production behavior: the include is parsed once, then served from cache.
+	require.Equal(t, 1, renderNTimes(false, 5),
+		"DevMode=false must parse the included template exactly once across renders")
+
+	// Dev behavior (live reload): re-read + re-parse on every render.
+	require.Equal(t, 5, renderNTimes(true, 5),
+		"DevMode=true re-parses the included template on every render")
+}
+
+// TestLoadDevModeFalse_LayoutEditsPropagateAcrossReloads is the correctness
+// guard: turning caching ON (DevMode=false) must NOT pin stale layouts.
+//
+// layoutloader.Load builds a fresh jet.Set per reload from the CURRENT
+// sourceFiles, so an edited layout (a new Load) renders the new content even
+// though DevelopmentMode is off — the cache lives only for one Set's lifetime.
+func TestLoadDevModeFalse_LayoutEditsPropagateAcrossReloads(t *testing.T) {
+	env := &testEnv{logger: &logger.TestLogger{}}
+	mk := func(body string) []model.LayoutSourceFile {
+		return []model.LayoutSourceFile{{
+			ID:      "/page",
+			Path:    "_layouts/page.html",
+			Content: body,
+		}}
+	}
+
+	render := func(sources []model.LayoutSourceFile) string {
+		layouts, err := Load(env, sources, Options{DevMode: false})
+		require.NoError(t, err)
+		var buf bytes.Buffer
+		require.NoError(t, layouts.Map["/page"].View.Execute(&buf, nil, nil))
+		return buf.String()
+	}
+
+	require.Equal(t, "<h1>v1</h1>", render(mk(`<h1>v1</h1>`)))
+	// Edited layout pushed -> new Load -> new Set: edit must take effect.
+	require.Equal(t, "<h1>v2-edited</h1>", render(mk(`<h1>v2-edited</h1>`)),
+		"layout edits must propagate across reloads even with DevMode=false")
+}
+
+// TestLoadDevMode_OutputIdenticalAcrossModes proves the DevMode flag changes
+// only parse caching, never rendered output, through the public Load API with a
+// runtime {{ include }} (the path that re-parses in dev mode).
+func TestLoadDevMode_OutputIdenticalAcrossModes(t *testing.T) {
+	env := &testEnv{logger: &logger.TestLogger{}}
+	sources := []model.LayoutSourceFile{
+		{ID: "/page", Path: "_layouts/page.html", Content: `<main>{{ include "/part" }}</main>`},
+		{ID: "/part", Path: "_layouts/part.html", Content: `<p>shared</p>`},
+	}
+
+	out := func(dev bool) string {
+		layouts, err := Load(env, sources, Options{DevMode: dev})
+		require.NoError(t, err)
+		// Render twice to exercise the include cache/no-cache path.
+		require.NoError(t, layouts.Map["/page"].View.Execute(io.Discard, nil, nil))
+		var buf bytes.Buffer
+		require.NoError(t, layouts.Map["/page"].View.Execute(&buf, nil, nil))
+		return buf.String()
+	}
+
+	require.Equal(t, out(true), out(false), "DevMode must not change rendered output")
+	require.Contains(t, out(false), "<main><p>shared</p></main>")
+}

--- a/internal/layoutloader/devmode_test.go
+++ b/internal/layoutloader/devmode_test.go
@@ -73,7 +73,8 @@ func TestDevMode_CachesParsedIncludeAcrossRenders(t *testing.T) {
 // sourceFiles, so an edited layout (a new Load) renders the new content even
 // though DevelopmentMode is off — the cache lives only for one Set's lifetime.
 func TestLoadDevModeFalse_LayoutEditsPropagateAcrossReloads(t *testing.T) {
-	env := &testEnv{logger: &logger.TestLogger{}}
+	// devMode=false: production caching ON (IsDevMode returns false).
+	env := &testEnv{logger: &logger.TestLogger{}, devMode: false}
 	mk := func(body string) []model.LayoutSourceFile {
 		return []model.LayoutSourceFile{{
 			ID:      "/page",
@@ -83,7 +84,7 @@ func TestLoadDevModeFalse_LayoutEditsPropagateAcrossReloads(t *testing.T) {
 	}
 
 	render := func(sources []model.LayoutSourceFile) string {
-		layouts, err := Load(env, sources, Options{DevMode: false})
+		layouts, err := Load(env, sources, Options{})
 		require.NoError(t, err)
 		var buf bytes.Buffer
 		require.NoError(t, layouts.Map["/page"].View.Execute(&buf, nil, nil))
@@ -100,14 +101,15 @@ func TestLoadDevModeFalse_LayoutEditsPropagateAcrossReloads(t *testing.T) {
 // only parse caching, never rendered output, through the public Load API with a
 // runtime {{ include }} (the path that re-parses in dev mode).
 func TestLoadDevMode_OutputIdenticalAcrossModes(t *testing.T) {
-	env := &testEnv{logger: &logger.TestLogger{}}
 	sources := []model.LayoutSourceFile{
 		{ID: "/page", Path: "_layouts/page.html", Content: `<main>{{ include "/part" }}</main>`},
 		{ID: "/part", Path: "_layouts/part.html", Content: `<p>shared</p>`},
 	}
 
 	out := func(dev bool) string {
-		layouts, err := Load(env, sources, Options{DevMode: dev})
+		// env.IsDevMode() drives jet.DevelopmentMode via the Env interface.
+		env := &testEnv{logger: &logger.TestLogger{}, devMode: dev}
+		layouts, err := Load(env, sources, Options{})
 		require.NoError(t, err)
 		// Render twice to exercise the include cache/no-cache path.
 		require.NoError(t, layouts.Map["/page"].View.Execute(io.Discard, nil, nil))

--- a/internal/layoutloader/loader.go
+++ b/internal/layoutloader/loader.go
@@ -30,6 +30,11 @@ type jetLoader struct {
 	sourceIDs []string
 	log       logger.Logger
 
+	// devMode controls jet.DevelopmentMode for every Set this loader builds.
+	// false (production) caches the parsed template within the Set's lifetime;
+	// true (dev) re-reads + re-parses on every render for live layout reload.
+	devMode bool
+
 	layouts model.Layouts
 
 	pendingWarnings map[string][]model.NoteWarning
@@ -57,6 +62,13 @@ func (jl *jetLoader) Open(templatePath string) (io.ReadCloser, error) {
 
 type Options struct {
 	BasePath string
+
+	// DevMode toggles jet.DevelopmentMode. Production must be false so each
+	// layout's compiled template is cached (parsed once per reload) instead of
+	// re-read + re-parsed on every render. Set true only for dev instances that
+	// want live layout reload. Layout edits still propagate when false because
+	// Load rebuilds the jet.Set fresh from the current sourceFiles each reload.
+	DevMode bool
 }
 
 func Load(env Env, sourceFiles []model.LayoutSourceFile, options Options) (*model.Layouts, error) {
@@ -65,6 +77,7 @@ func Load(env Env, sourceFiles []model.LayoutSourceFile, options Options) (*mode
 	jl := &jetLoader{
 		templates:            make(map[string]string),
 		log:                  log,
+		devMode:              options.DevMode,
 		pendingWarnings:      make(map[string][]model.NoteWarning),
 		sets:                 make(map[string]*jet.Set),
 		yieldBlocksSlices:    make(map[string]*[]string),
@@ -154,6 +167,7 @@ func Load(env Env, sourceFiles []model.LayoutSourceFile, options Options) (*mode
 				templates:            snap,
 				sourceIDs:            sourceIDs,
 				log:                  jl.log,
+				devMode:              jl.devMode,
 				layouts:              model.Layouts{Map: make(map[string]model.Layout)},
 				pendingWarnings:      make(map[string][]model.NoteWarning),
 				sets:                 make(map[string]*jet.Set),
@@ -413,7 +427,7 @@ func (jl *jetLoader) load(source model.LayoutSourceFile) (*jet.Template, string)
 	// WithSafeWriter(nil) disables HTML auto-escaping. Layouts contain trusted,
 	// pre-rendered content (not user input), so escaping breaks presigned URLs
 	// in CSS url() — & becomes &amp;, which corrupts AWS signature params.
-	views := jet.NewSet(jl, jet.DevelopmentMode(true), jet.WithSafeWriter(nil))
+	views := jet.NewSet(jl, jet.DevelopmentMode(jl.devMode), jet.WithSafeWriter(nil))
 
 	sourceDir := filepath.Dir(source.Path)
 

--- a/internal/layoutloader/loader.go
+++ b/internal/layoutloader/loader.go
@@ -19,6 +19,14 @@ type Loader struct {
 
 type Env interface {
 	Logger() logger.Logger
+
+	// IsDevMode reports whether this is a development instance. When false
+	// (production), the compiled layout is cached within the jet.Set's lifetime
+	// so each template is parsed once per reload, not once per render. When true
+	// (dev), jet.DevelopmentMode re-reads + re-parses every render for live layout
+	// reload. Layout edits still propagate when false because Load rebuilds the
+	// jet.Set fresh from the current sourceFiles on every reload.
+	IsDevMode() bool
 }
 
 // func New(env Env) *Loader {
@@ -62,13 +70,6 @@ func (jl *jetLoader) Open(templatePath string) (io.ReadCloser, error) {
 
 type Options struct {
 	BasePath string
-
-	// DevMode toggles jet.DevelopmentMode. Production must be false so each
-	// layout's compiled template is cached (parsed once per reload) instead of
-	// re-read + re-parsed on every render. Set true only for dev instances that
-	// want live layout reload. Layout edits still propagate when false because
-	// Load rebuilds the jet.Set fresh from the current sourceFiles each reload.
-	DevMode bool
 }
 
 func Load(env Env, sourceFiles []model.LayoutSourceFile, options Options) (*model.Layouts, error) {
@@ -77,7 +78,7 @@ func Load(env Env, sourceFiles []model.LayoutSourceFile, options Options) (*mode
 	jl := &jetLoader{
 		templates:            make(map[string]string),
 		log:                  log,
-		devMode:              options.DevMode,
+		devMode:              env.IsDevMode(),
 		pendingWarnings:      make(map[string][]model.NoteWarning),
 		sets:                 make(map[string]*jet.Set),
 		yieldBlocksSlices:    make(map[string]*[]string),

--- a/internal/layoutloader/loader_test.go
+++ b/internal/layoutloader/loader_test.go
@@ -19,11 +19,16 @@ import (
 )
 
 type testEnv struct {
-	logger logger.Logger
+	logger  logger.Logger
+	devMode bool
 }
 
 func (t *testEnv) Logger() logger.Logger {
 	return t.logger
+}
+
+func (t *testEnv) IsDevMode() bool {
+	return t.devMode
 }
 
 func TestResolveAssets(t *testing.T) {

--- a/internal/noteloader/loader.go
+++ b/internal/noteloader/loader.go
@@ -304,7 +304,6 @@ func (l *Loader) Load(ctx context.Context, options LoadOptions) error {
 
 	layoutOptions := layoutloader.Options{
 		BasePath: layoutBasePath,
-		DevMode:  l.env.IsDevMode(),
 	}
 
 	layouts, err := layoutloader.Load(l.env, templateSources, layoutOptions)

--- a/internal/noteloader/loader.go
+++ b/internal/noteloader/loader.go
@@ -59,6 +59,11 @@ type Env interface {
 	Logger() logger.Logger
 	Now() time.Time
 
+	// IsDevMode reports whether this is a development instance. It drives
+	// jet.DevelopmentMode for layout templates: false (production) caches the
+	// compiled layout per reload, true re-parses every render for live reload.
+	IsDevMode() bool
+
 	// LoadFrontmatterPatches loads and compiles frontmatter patches from database
 	LoadFrontmatterPatches(ctx context.Context) ([]frontmatterpatch.CompiledPatch, error)
 
@@ -299,6 +304,7 @@ func (l *Loader) Load(ctx context.Context, options LoadOptions) error {
 
 	layoutOptions := layoutloader.Options{
 		BasePath: layoutBasePath,
+		DevMode:  l.env.IsDevMode(),
 	}
 
 	layouts, err := layoutloader.Load(l.env, templateSources, layoutOptions)

--- a/internal/noteloader/loader_test.go
+++ b/internal/noteloader/loader_test.go
@@ -31,6 +31,7 @@ func makeMinimalEnv(notes []noteloader.RawNote, requireSignin func() bool) *EnvM
 		PublicURLFunc:     func() string { return "https://example.com" },
 		LoggerFunc:        func() logger.Logger { return &logger.TestLogger{} },
 		NowFunc:           time.Now,
+		IsDevModeFunc:     func() bool { return false },
 		LoadFrontmatterPatchesFunc: func(_ context.Context) ([]frontmatterpatch.CompiledPatch, error) {
 			return nil, nil
 		},

--- a/internal/noteloader/mocks_test.go
+++ b/internal/noteloader/mocks_test.go
@@ -24,6 +24,9 @@ var _ noteloader.Env = &EnvMock{}
 //
 //		// make and configure a mocked noteloader.Env
 //		mockedEnv := &EnvMock{
+//			IsDevModeFunc: func() bool {
+//				panic("mock out the IsDevMode method")
+//			},
 //			ListAllSubgraphsFunc: func(ctx context.Context) ([]db.Subgraph, error) {
 //				panic("mock out the ListAllSubgraphs method")
 //			},
@@ -67,6 +70,9 @@ var _ noteloader.Env = &EnvMock{}
 //
 //	}
 type EnvMock struct {
+	// IsDevModeFunc mocks the IsDevMode method.
+	IsDevModeFunc func() bool
+
 	// ListAllSubgraphsFunc mocks the ListAllSubgraphs method.
 	ListAllSubgraphsFunc func(ctx context.Context) ([]db.Subgraph, error)
 
@@ -105,6 +111,9 @@ type EnvMock struct {
 
 	// calls tracks calls to the methods.
 	calls struct {
+		// IsDevMode holds details about calls to the IsDevMode method.
+		IsDevMode []struct {
+		}
 		// ListAllSubgraphs holds details about calls to the ListAllSubgraphs method.
 		ListAllSubgraphs []struct {
 			// Ctx is the ctx argument value.
@@ -164,6 +173,7 @@ type EnvMock struct {
 			Ctx context.Context
 		}
 	}
+	lockIsDevMode              sync.RWMutex
 	lockListAllSubgraphs       sync.RWMutex
 	lockLoadFrontmatterPatches sync.RWMutex
 	lockLoadSiteConfig         sync.RWMutex
@@ -176,6 +186,33 @@ type EnvMock struct {
 	lockRawAssets              sync.RWMutex
 	lockRawNoteChunks          sync.RWMutex
 	lockRawNotes               sync.RWMutex
+}
+
+// IsDevMode calls IsDevModeFunc.
+func (mock *EnvMock) IsDevMode() bool {
+	if mock.IsDevModeFunc == nil {
+		panic("EnvMock.IsDevModeFunc: method is nil but Env.IsDevMode was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockIsDevMode.Lock()
+	mock.calls.IsDevMode = append(mock.calls.IsDevMode, callInfo)
+	mock.lockIsDevMode.Unlock()
+	return mock.IsDevModeFunc()
+}
+
+// IsDevModeCalls gets all the calls that were made to IsDevMode.
+// Check the length with:
+//
+//	len(mockedEnv.IsDevModeCalls())
+func (mock *EnvMock) IsDevModeCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockIsDevMode.RLock()
+	calls = mock.calls.IsDevMode
+	mock.lockIsDevMode.RUnlock()
+	return calls
 }
 
 // ListAllSubgraphs calls ListAllSubgraphsFunc.

--- a/internal/noteloader/smoke_render_test.go
+++ b/internal/noteloader/smoke_render_test.go
@@ -13,6 +13,7 @@ import (
 type smokeTestEnv struct{ log logger.Logger }
 
 func (e *smokeTestEnv) Logger() logger.Logger { return e.log }
+func (e *smokeTestEnv) IsDevMode() bool       { return false }
 
 func smokeLoadLayouts(t *testing.T, sources []model.LayoutSourceFile) *model.Layouts {
 	t.Helper()


### PR DESCRIPTION
## Problem

The Jet layout `Set` was created with `jet.DevelopmentMode(true)` **hardcoded** in
`internal/layoutloader`. In dev mode Jet skips its parsed-template cache, so every
runtime `{{ include }}` (resolved in `eval.go` `executeInclude` → `getSiblingTemplate` →
`getTemplate`) re-reads + re-parses the included layout on **every render**
(`jet.Set.loadFromFile` → `io.ReadAll` + `Set.parse`). Under sustained push load this
re-parse was ~29% of all allocations and a big chunk of the ~45%-CPU-in-GC.

## Fix

Make `DevelopmentMode` follow the app's dev flag instead of being hardcoded.

- `internal/layoutloader`: add `Options.DevMode` (+ `jetLoader.devMode`); the two
  `jet.NewSet(...)` calls (`loader.go` render path and `auto_import.go` preview path)
  now use `jet.DevelopmentMode(jl.devMode)`. Preview loader inherits the flag.
- `internal/noteloader`: add `IsDevMode() bool` to the `Env` interface and set
  `layoutOptions.DevMode = l.env.IsDevMode()` in `Load`. The `app` already exposes
  `IsDevMode()` (returns `config.DevMode`, the `-dev` flag), and all note-loader env
  wrappers embed `*app`, so the flag reaches the loader unchanged. **Default: production
  = false (caching ON), dev = true (live reload preserved).**

## Correctness (edits still propagate with caching ON)

`layoutloader.Load` builds a **fresh** `jet.Set` per reload from the current
`sourceFiles`, and `noteloader.Load` runs on every reload (every pushNotes). The Jet
cache lives only for one `Set`'s lifetime, so `DevelopmentMode(false)` turns a
parse-per-render into a parse-once-per-reload **within** a reload — a pushed layout edit
still takes effect because the next reload rebuilds the Set. There is **no** cross-reload
Set caching. Verified against `jet/v6` `set.go` (`getTemplate` only consults the cache
when `!developmentMode`).

## Tests

`internal/layoutloader/devmode_test.go`:
- `TestDevMode_CachesParsedIncludeAcrossRenders` — counts template reads via a counting
  loader, mirroring the production `NewSet`. **DevMode=false parses the include once
  across 5 renders; DevMode=true parses it 5x** (linear in render count). This is the win.
- `TestLoadDevModeFalse_LayoutEditsPropagateAcrossReloads` — with `DevMode=false`, a
  changed layout (new `Load`) renders the updated content (no stale pinning).
- `TestLoadDevMode_OutputIdenticalAcrossModes` — rendered output is byte-identical between
  modes; only caching changes.

All existing `layoutloader`/`noteloader` tests still pass (rendering output unchanged).
`noteloader` mock regenerated via moq for the new `Env.IsDevMode`.

## Verification

- `go build ./...` → exit 0
- `go test ./internal/layoutloader/... ./internal/noteloader/...` → green
- `golangci-lint run` on both packages → 0 issues

A live allocation profile against the running dev server was skipped: the bench script
mutates that instance's data (pushes notes) and the running binary can't be re-symbolized
here. The deterministic parse-count test is used instead (the sanctioned fallback), which
shows the per-render re-parse — the ~29% alloc source — collapses to once per reload.
