### PR TITLE
feat: anonymous pre-gzipped page cache on the read path

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -55,6 +55,7 @@ import (
 	"trip2g/internal/notion"
 	"trip2g/internal/nowpayments"
 	"trip2g/internal/openai"
+	"trip2g/internal/pagecache"
 	"trip2g/internal/patreon"
 	"trip2g/internal/patreonjobs"
 	"trip2g/internal/personaltoken"
@@ -201,6 +202,12 @@ type app struct {
 
 	*configregistry.SiteConfigBuilder
 
+	// pageCache holds pre-gzipped anonymous rendered-page responses. Named (not
+	// embedded) so its generic Get/Set/Clear don't promote onto app and collide
+	// with other embedded types; reached via the CachedPage/StoreCachedPage/
+	// ClearPageCache accessors below.
+	pageCache *pagecache.PageCache
+
 	liveNoteLoader         *noteloader.Loader
 	latestNoteLoader       *noteloader.Loader
 	frontmatterPatchLoader *frontmatterpatch.Loader
@@ -337,6 +344,7 @@ func main() {
 
 	a.ctx = ctx
 	a.SiteConfigBuilder = configregistry.NewSiteConfigBuilder(a)
+	a.pageCache = pagecache.New()
 	a.sigChan = make(chan os.Signal, 1)
 	signal.Notify(a.sigChan, syscall.SIGINT, syscall.SIGTERM)
 
@@ -502,6 +510,10 @@ func (a *app) PrepareLatestNotes(ctx context.Context, partial bool) (*model.Note
 		return nil, fmt.Errorf("failed to load latest notes: %w", err)
 	}
 
+	// A reload changes note content, layouts and telegram links, so flush the
+	// whole anonymous page cache rather than reasoning about which keys moved.
+	a.ClearPageCache()
+
 	return a.latestNoteLoader.NoteViews(), nil
 }
 
@@ -511,7 +523,25 @@ func (a *app) PrepareLiveNotes(ctx context.Context) (*model.NoteViews, error) {
 		return nil, fmt.Errorf("failed to load live notes: %w", err)
 	}
 
+	a.ClearPageCache()
+
 	return a.liveNoteLoader.NoteViews(), nil
+}
+
+// CachedPage returns the pre-gzipped bytes cached for key, if any. Part of the
+// rendernotepage.Env contract for the anonymous page cache.
+func (a *app) CachedPage(key pagecache.Key) ([]byte, bool) {
+	return a.pageCache.Get(key)
+}
+
+// StoreCachedPage records pre-gzipped bytes for key.
+func (a *app) StoreCachedPage(key pagecache.Key, gz []byte) {
+	a.pageCache.Set(key, gz)
+}
+
+// ClearPageCache drops every cached page (on note reload).
+func (a *app) ClearPageCache() {
+	a.pageCache.Clear()
 }
 
 func (a *app) Layouts() *model.Layouts {

--- a/cmd/server/pagecache_wiring_test.go
+++ b/cmd/server/pagecache_wiring_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"trip2g/internal/db"
+	"trip2g/internal/frontmatterpatch"
+	"trip2g/internal/logger"
+	"trip2g/internal/mdloader"
+	"trip2g/internal/model"
+	"trip2g/internal/noteloader"
+	"trip2g/internal/pagecache"
+
+	"github.com/stretchr/testify/require"
+)
+
+// emptyNoteLoaderEnv is a minimal noteloader.Env that loads zero notes/assets,
+// so noteloader.Load succeeds without a database. It lets the wiring tests call
+// the real (*app).PrepareLatestNotes / PrepareLiveNotes and observe the
+// ClearPageCache() each performs after a successful reload.
+type emptyNoteLoaderEnv struct{}
+
+func (emptyNoteLoaderEnv) RawNotes(context.Context) ([]noteloader.RawNote, error) { return nil, nil }
+func (emptyNoteLoaderEnv) RawAssets(context.Context) ([]noteloader.RawAsset, error) {
+	return nil, nil
+}
+func (emptyNoteLoaderEnv) RawNoteChunks(context.Context) ([]noteloader.RawNoteChunk, error) {
+	return nil, nil
+}
+func (emptyNoteLoaderEnv) NoteAssetExists(context.Context, db.NoteAsset) (bool, error) {
+	return false, nil
+}
+func (emptyNoteLoaderEnv) NoteAssetURL(context.Context, db.NoteAsset) (model.PresignedURL, error) {
+	return model.PresignedURL{}, nil
+}
+func (emptyNoteLoaderEnv) NoteAssetPath(db.NoteAsset) string { return "" }
+func (emptyNoteLoaderEnv) PublicURL() string                 { return "https://example.com" }
+func (emptyNoteLoaderEnv) Logger() logger.Logger             { return &logger.DummyLogger{} }
+func (emptyNoteLoaderEnv) Now() time.Time                    { return time.Now() }
+func (emptyNoteLoaderEnv) IsDevMode() bool                   { return false }
+func (emptyNoteLoaderEnv) LoadFrontmatterPatches(context.Context) ([]frontmatterpatch.CompiledPatch, error) {
+	return nil, nil
+}
+func (emptyNoteLoaderEnv) LoadSiteConfig(context.Context) (model.SiteConfig, error) {
+	return model.SiteConfig{}, nil
+}
+func (emptyNoteLoaderEnv) ListAllSubgraphs(context.Context) ([]db.Subgraph, error) {
+	return nil, nil
+}
+
+// appWithEmptyLoaders builds an app whose note loaders load nothing and whose
+// page cache holds one entry. Calling a Prepare* method must empty the cache.
+func appWithEmptyLoaders() *app {
+	a := &app{pageCache: pagecache.New()}
+	a.latestNoteLoader = noteloader.New("latest", emptyNoteLoaderEnv{}, mdloader.Config{})
+	a.liveNoteLoader = noteloader.New("live", emptyNoteLoaderEnv{}, mdloader.Config{})
+	return a
+}
+
+func seedOnePage(a *app) {
+	a.StoreCachedPage(pagecache.Key{Path: "/seed", Host: "example.com"}, []byte("gz"))
+}
+
+// TestPrepareLatestNotes_ClearsPageCache pins the reload->invalidation wiring:
+// PrepareLatestNotes (main.go) calls a.ClearPageCache() after a successful load,
+// so the anonymous page cache is emptied. Removing that call leaves the stale
+// entry and fails this test. partial=true skips the bleve search index.
+func TestPrepareLatestNotes_ClearsPageCache(t *testing.T) {
+	a := appWithEmptyLoaders()
+	seedOnePage(a)
+	require.Equal(t, 1, a.pageCache.Len())
+
+	_, err := a.PrepareLatestNotes(context.Background(), true)
+	require.NoError(t, err)
+	require.Equal(t, 0, a.pageCache.Len(),
+		"PrepareLatestNotes must ClearPageCache() after reload")
+}
+
+// TestPrepareLiveNotes_ClearsPageCache is the same wiring assertion for the live
+// reload path: PrepareLiveNotes (main.go) calls a.ClearPageCache() after load.
+func TestPrepareLiveNotes_ClearsPageCache(t *testing.T) {
+	a := appWithEmptyLoaders()
+	seedOnePage(a)
+	require.Equal(t, 1, a.pageCache.Len())
+
+	_, err := a.PrepareLiveNotes(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 0, a.pageCache.Len(),
+		"PrepareLiveNotes must ClearPageCache() after reload")
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/google/go-jsonnet v0.21.0
 	github.com/google/uuid v1.6.0
 	github.com/gotd/td v0.139.0
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/kr/pretty v0.3.1
 	github.com/lib/pq v1.10.9
 	github.com/mailru/easyjson v0.9.0
@@ -203,7 +204,6 @@ require (
 	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b // indirect
 	github.com/hashicorp/go-immutable-radix/v2 v2.1.0 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/internal/case/rendernotepage/endpoint.go
+++ b/internal/case/rendernotepage/endpoint.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
+	"time"
 	"trip2g/internal/appreq"
 	"trip2g/internal/case/render404"
 	"trip2g/internal/case/renderlayout"
@@ -157,6 +158,21 @@ func (e Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 		layout = resp.Config.DefaultLayout
 	}
 
+	// Anonymous page cache: serve pre-gzipped bytes to gzip-accepting anonymous
+	// readers and fill on a miss. This is the only branch that reaches a
+	// cacheable 200 note page; cacheDecision enforces every safety gate
+	// (authenticated viewer, ?version=, personalized layout, exotic UI lang,
+	// non-gzip client).
+	cacheKey, cacheable := cacheDecision(ctx, env, resp, request, layout)
+	if cacheable {
+		if cached, ok := env.CachedPage(cacheKey); ok {
+			writeCachedPage(ctx, cached)
+			return nil, nil
+		}
+	}
+
+	renderStart := time.Now()
+
 	if layout != "" {
 		processed, layoutErr := renderLayout(ctx, env, resp, layout)
 		if layoutErr != nil {
@@ -164,12 +180,14 @@ func (e Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 		}
 
 		if processed {
+			fillPageCache(ctx, env, cacheKey, cacheable, renderStart)
 			return nil, nil
 		}
 	}
 
 	dtCtx := buildDefaultTemplateCtx(req, layoutParams, resp, env)
 	defaulttemplate.WriteRender(ctx, dtCtx)
+	fillPageCache(ctx, env, cacheKey, cacheable, renderStart)
 	return nil, nil
 }
 

--- a/internal/case/rendernotepage/endpoint_cache_test.go
+++ b/internal/case/rendernotepage/endpoint_cache_test.go
@@ -178,6 +178,10 @@ func TestPageCache_AnonGzipHit(t *testing.T) {
 	ctx1 := newReqCtx(reqOpts{acceptEncoding: "gzip"})
 	runHandle(t, env, ctx1, nil)
 	require.Equal(t, "gzip", string(ctx1.Response.Header.ContentEncoding()))
+	// The fill path presets Content-Encoding (so CompressHandler is skipped) and
+	// must re-add the Vary: Accept-Encoding that CompressHandler emits otherwise.
+	require.Equal(t, "Accept-Encoding", string(ctx1.Response.Header.Peek("Vary")),
+		"fill response must carry Vary: Accept-Encoding like the uncached path")
 	require.Len(t, env.StoreCachedPageCalls(), 1, "first request fills the cache")
 	require.Equal(t, 1, pc.Len())
 	html1 := body(t, ctx1)
@@ -186,6 +190,8 @@ func TestPageCache_AnonGzipHit(t *testing.T) {
 	ctx2 := newReqCtx(reqOpts{acceptEncoding: "gzip"})
 	runHandle(t, env, ctx2, nil)
 	require.Equal(t, "gzip", string(ctx2.Response.Header.ContentEncoding()))
+	require.Equal(t, "Accept-Encoding", string(ctx2.Response.Header.Peek("Vary")),
+		"cache-hit response must carry Vary: Accept-Encoding like the uncached path")
 	require.Len(t, env.StoreCachedPageCalls(), 1, "second request must NOT re-fill (served from cache)")
 	require.Equal(t, html1, body(t, ctx2), "cached page decompresses identical to a fresh render")
 	// The cached gzipped bytes are served verbatim.
@@ -259,6 +265,34 @@ func TestPageCache_PushInvalidation(t *testing.T) {
 	runHandle(t, env, ctx2, nil)
 	require.Len(t, env.StoreCachedPageCalls(), 2, "post-push request re-renders + re-fills")
 	require.Contains(t, string(body(t, ctx2)), "<h1>Updated</h1>")
+}
+
+// Test 4b: the whole-cache Clear (map-swap) is load-bearing ON ITS OWN. Unlike
+// TestPageCache_PushInvalidation, NO key field changes here — same NoteVersionID,
+// same ConfigEpoch, same path/host/lang — so the key stays identical and the only
+// thing that can force a re-render is Clear(). This pins the invalidation path for
+// changes that do NOT move NoteVersionID (custom-layout edits whose layout version
+// is not in the key; subgraph access changes at the same content version). Remove
+// the pc.Clear() below and the second request hits the stale entry: the
+// StoreCachedPageCalls()==2 assertion then fails.
+func TestPageCache_ClearOnlyInvalidation(t *testing.T) {
+	_, views := cacheTestNote()
+	env, pc, _ := cacheTestEnv(views, nil)
+
+	ctx1 := newReqCtx(reqOpts{acceptEncoding: "gzip"})
+	runHandle(t, env, ctx1, nil)
+	require.Len(t, env.StoreCachedPageCalls(), 1, "first request fills the cache")
+	require.Equal(t, 1, pc.Len())
+
+	// A reload that does NOT bump NoteVersionID still Clears the map.
+	pc.Clear()
+	require.Equal(t, 0, pc.Len())
+
+	ctx2 := newReqCtx(reqOpts{acceptEncoding: "gzip"})
+	runHandle(t, env, ctx2, nil)
+	require.Len(t, env.StoreCachedPageCalls(), 2,
+		"Clear() alone (no key change) must force a re-render + re-fill")
+	require.Equal(t, 1, pc.Len())
 }
 
 // Test 5: a config change bumps ConfigEpoch so old entries are unreachable.

--- a/internal/case/rendernotepage/endpoint_cache_test.go
+++ b/internal/case/rendernotepage/endpoint_cache_test.go
@@ -1,0 +1,379 @@
+package rendernotepage_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	"trip2g/internal/appreq"
+	"trip2g/internal/case/rendernotepage"
+	"trip2g/internal/db"
+	"trip2g/internal/defaulttemplate"
+	"trip2g/internal/features"
+	"trip2g/internal/layoutloader"
+	"trip2g/internal/logger"
+	"trip2g/internal/model"
+	"trip2g/internal/pagecache"
+	"trip2g/internal/templateviews"
+	"trip2g/internal/usertoken"
+
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+func TestMain(m *testing.M) {
+	// The default template's paywall / sign-in / onboarding render paths call
+	// ctx.T(), which needs the i18n bundle loaded.
+	if err := defaulttemplate.Init(); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}
+
+// --- helpers ---------------------------------------------------------------
+
+// cacheLoaderEnv satisfies layoutloader.Env for building test layouts.
+type cacheLoaderEnv struct{}
+
+func (cacheLoaderEnv) Logger() logger.Logger { return &logger.DummyLogger{} }
+func (cacheLoaderEnv) IsDevMode() bool       { return false }
+
+func cacheTestNote() (*model.NoteView, *model.NoteViews) {
+	note := &model.NoteView{
+		Path:          "/test-note",
+		Title:         "Test Note",
+		PathID:        1,
+		VersionID:     42,
+		Content:       []byte("# Test"),
+		HTML:          "<h1>Test</h1>",
+		Permalink:     "/test-note",
+		Free:          true,
+		InLinks:       map[string]struct{}{},
+		Assets:        map[string]struct{}{},
+		AssetReplaces: map[string]*model.NoteAssetReplace{},
+	}
+	views := &model.NoteViews{
+		Map:     map[string]*model.NoteView{"/test-note": note},
+		List:    []*model.NoteView{note},
+		Version: "live",
+	}
+	return note, views
+}
+
+// cacheTestEnv wires an EnvMock for an anonymous, free, default-template note
+// render. The page cache and a mutable config epoch are returned so tests can
+// observe fills, force reloads, and bump the epoch.
+func cacheTestEnv(views *model.NoteViews, layouts *model.Layouts) (*EnvMock, *pagecache.PageCache, *uint64) {
+	pc := pagecache.New()
+	epoch := new(uint64)
+	if layouts == nil {
+		layouts = &model.Layouts{Map: map[string]model.Layout{}}
+	}
+	env := &EnvMock{
+		LoggerFunc:            func() logger.Logger { return &logger.DummyLogger{} },
+		SiteConfigFunc:        func(ctx context.Context) model.SiteConfig { return model.SiteConfig{} },
+		SiteTitleTemplateFunc: func() string { return "%s" },
+		LiveNoteViewsFunc:     func() *model.NoteViews { return views },
+		LatestNoteViewsFunc:   func() *model.NoteViews { return views },
+		LayoutsFunc:           func() *model.Layouts { return layouts },
+		CanReadNoteFunc:       func(ctx context.Context, note *model.NoteView) (bool, error) { return true, nil },
+		GetTelegramPostLinksByNoteVersionIDFunc: func(ctx context.Context, arg db.GetTelegramPostLinksByNoteVersionIDParams) ([]db.GetTelegramPostLinksByNoteVersionIDRow, error) {
+			return nil, nil
+		},
+		PublicURLFunc: func() string { return "https://example.com" },
+		AssetURLFunc:  func(path string) string { return path },
+		FeaturesFunc:  func() features.Features { return features.Features{} },
+		ActiveHTMLInjectionsFunc: func(ctx context.Context) ([]db.HtmlInjection, error) {
+			return nil, nil
+		},
+		NoteVersionEditorFunc: func(ctx context.Context, versionID int64) (*templateviews.NoteEditor, error) {
+			return nil, nil
+		},
+		// Authenticated-viewer path (handleUserToken) — only exercised by the
+		// authenticated-bypass test; harmless stubs otherwise.
+		ListActiveUserSubgraphsFunc: func(ctx context.Context, userID int64) ([]string, error) {
+			return nil, nil
+		},
+		RecordUserNoteViewFunc: func(ctx context.Context, userID int64, note *model.NoteView, referrerVersionID *int64) {
+		},
+		LastUserNoteViewFunc: func(ctx context.Context, arg db.LastUserNoteViewParams) (db.LastUserNoteViewRow, error) {
+			return db.LastUserNoteViewRow{}, nil
+		},
+		ConfigEpochFunc:     func() uint64 { return *epoch },
+		CachedPageFunc:      pc.Get,
+		StoreCachedPageFunc: pc.Set,
+	}
+	return env, pc, epoch
+}
+
+type reqOpts struct {
+	path           string
+	host           string
+	acceptEncoding string
+	acceptLang     string
+	langCookie     string
+	query          string
+}
+
+func newReqCtx(o reqOpts) *fasthttp.RequestCtx {
+	if o.path == "" {
+		o.path = "/test-note"
+	}
+	if o.host == "" {
+		o.host = "example.com"
+	}
+	uri := o.path
+	if o.query != "" {
+		uri += "?" + o.query
+	}
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.SetRequestURI(uri)
+	ctx.Request.Header.SetHost(o.host)
+	if o.acceptEncoding != "" {
+		ctx.Request.Header.Set("Accept-Encoding", o.acceptEncoding)
+	}
+	if o.acceptLang != "" {
+		ctx.Request.Header.Set("Accept-Language", o.acceptLang)
+	}
+	if o.langCookie != "" {
+		ctx.Request.Header.SetCookie("trip2g_lang", o.langCookie)
+	}
+	return ctx
+}
+
+func runHandle(t *testing.T, env *EnvMock, ctx *fasthttp.RequestCtx, token *usertoken.Data) {
+	t.Helper()
+	req := &appreq.Request{Req: ctx, Env: env}
+	req.SetUserToken(token)
+	_, err := rendernotepage.Endpoint{}.Handle(req)
+	require.NoError(t, err)
+}
+
+func body(t *testing.T, ctx *fasthttp.RequestCtx) []byte {
+	t.Helper()
+	raw := ctx.Response.Body()
+	if string(ctx.Response.Header.ContentEncoding()) != "gzip" {
+		return raw
+	}
+	zr, err := gzip.NewReader(bytes.NewReader(raw))
+	require.NoError(t, err)
+	out, err := io.ReadAll(zr)
+	require.NoError(t, err)
+	return out
+}
+
+// --- tests -----------------------------------------------------------------
+
+// Test 1: anonymous gzip GET of a free default-template note caches on first
+// request and serves byte-identical (decompressed) bytes from cache on the
+// second, with Content-Encoding: gzip.
+func TestPageCache_AnonGzipHit(t *testing.T) {
+	_, views := cacheTestNote()
+	env, pc, _ := cacheTestEnv(views, nil)
+
+	ctx1 := newReqCtx(reqOpts{acceptEncoding: "gzip"})
+	runHandle(t, env, ctx1, nil)
+	require.Equal(t, "gzip", string(ctx1.Response.Header.ContentEncoding()))
+	require.Len(t, env.StoreCachedPageCalls(), 1, "first request fills the cache")
+	require.Equal(t, 1, pc.Len())
+	html1 := body(t, ctx1)
+	require.Contains(t, string(html1), "<h1>Test</h1>")
+
+	ctx2 := newReqCtx(reqOpts{acceptEncoding: "gzip"})
+	runHandle(t, env, ctx2, nil)
+	require.Equal(t, "gzip", string(ctx2.Response.Header.ContentEncoding()))
+	require.Len(t, env.StoreCachedPageCalls(), 1, "second request must NOT re-fill (served from cache)")
+	require.Equal(t, html1, body(t, ctx2), "cached page decompresses identical to a fresh render")
+	// The cached gzipped bytes are served verbatim.
+	require.Equal(t, ctx1.Response.Body(), ctx2.Response.Body())
+}
+
+// Test 2: a request carrying an authenticated token is never served from cache
+// and never populates it (admin/subscriber must not poison the anon cache).
+func TestPageCache_AuthenticatedBypass(t *testing.T) {
+	_, views := cacheTestNote()
+	env, pc, _ := cacheTestEnv(views, nil)
+
+	// Authenticated viewer (e.g. admin) — gzip-accepting all the same.
+	ctx := newReqCtx(reqOpts{acceptEncoding: "gzip"})
+	runHandle(t, env, ctx, &usertoken.Data{ID: 1, Role: "admin"})
+
+	require.Empty(t, env.CachedPageCalls(), "authenticated request must not consult the cache")
+	require.Empty(t, env.StoreCachedPageCalls(), "authenticated request must not populate the cache")
+	require.Equal(t, 0, pc.Len())
+	require.NotEqual(t, "gzip", string(ctx.Response.Header.ContentEncoding()),
+		"authenticated render is left for CompressHandler, not pre-gzipped from cache")
+
+	// And a subsequent anonymous request still gets a fresh fill (cache was not
+	// poisoned by the admin render).
+	ctxAnon := newReqCtx(reqOpts{acceptEncoding: "gzip"})
+	runHandle(t, env, ctxAnon, nil)
+	require.Equal(t, 1, pc.Len())
+}
+
+// Test 6a: ?version= (admin live/latest preview) bypasses the cache.
+func TestPageCache_VersionParamBypass(t *testing.T) {
+	_, views := cacheTestNote()
+	env, pc, _ := cacheTestEnv(views, nil)
+
+	ctx := newReqCtx(reqOpts{acceptEncoding: "gzip", query: "version=latest"})
+	runHandle(t, env, ctx, nil)
+	require.Empty(t, env.StoreCachedPageCalls())
+	require.Equal(t, 0, pc.Len())
+}
+
+// Non-gzip clients take the normal (uncached) path.
+func TestPageCache_NoGzipBypass(t *testing.T) {
+	_, views := cacheTestNote()
+	env, pc, _ := cacheTestEnv(views, nil)
+
+	ctx := newReqCtx(reqOpts{}) // no Accept-Encoding
+	runHandle(t, env, ctx, nil)
+	require.Empty(t, env.StoreCachedPageCalls())
+	require.Equal(t, 0, pc.Len())
+	require.NotEqual(t, "gzip", string(ctx.Response.Header.ContentEncoding()))
+}
+
+// Test 4: a note push (reload) invalidates the cache; the next anon request
+// re-renders. Here the version id changes (new content) so the key changes; a
+// real reload also Clears the map. Either way the old entry is not served.
+func TestPageCache_PushInvalidation(t *testing.T) {
+	note, views := cacheTestNote()
+	env, pc, _ := cacheTestEnv(views, nil)
+
+	ctx1 := newReqCtx(reqOpts{acceptEncoding: "gzip"})
+	runHandle(t, env, ctx1, nil)
+	require.Len(t, env.StoreCachedPageCalls(), 1)
+
+	// Simulate a push: content + version change, and the reload hook Clears.
+	note.VersionID = 43
+	note.HTML = "<h1>Updated</h1>"
+	pc.Clear()
+	require.Equal(t, 0, pc.Len())
+
+	ctx2 := newReqCtx(reqOpts{acceptEncoding: "gzip"})
+	runHandle(t, env, ctx2, nil)
+	require.Len(t, env.StoreCachedPageCalls(), 2, "post-push request re-renders + re-fills")
+	require.Contains(t, string(body(t, ctx2)), "<h1>Updated</h1>")
+}
+
+// Test 5: a config change bumps ConfigEpoch so old entries are unreachable.
+func TestPageCache_ConfigEpochBump(t *testing.T) {
+	_, views := cacheTestNote()
+	env, pc, epoch := cacheTestEnv(views, nil)
+
+	ctx1 := newReqCtx(reqOpts{acceptEncoding: "gzip"})
+	runHandle(t, env, ctx1, nil)
+	require.Len(t, env.StoreCachedPageCalls(), 1)
+	require.Equal(t, 1, pc.Len())
+
+	*epoch++ // config change
+
+	ctx2 := newReqCtx(reqOpts{acceptEncoding: "gzip"})
+	runHandle(t, env, ctx2, nil)
+	// Same path/note/lang but a new epoch => a different key => a miss + new fill.
+	require.Len(t, env.StoreCachedPageCalls(), 2)
+	require.Equal(t, 2, pc.Len(), "old-epoch entry remains but is unreachable; new entry added")
+}
+
+// Test 3: a note whose custom Jet layout is personalized is NOT cached; a note
+// with a non-personalized custom layout IS cached.
+func TestPageCache_PersonalizedLayoutBypass(t *testing.T) {
+	layouts, err := layoutloader.Load(cacheLoaderEnv{}, []model.LayoutSourceFile{
+		{ID: "/plain", Path: "_layouts/plain.html", Content: `<main>plain layout</main>`},
+		{ID: "/personal", Path: "_layouts/personal.html", Content: `<main>{{ if currentUser.IsAdmin() }}admin{{ end }}body</main>`},
+	}, layoutloader.Options{})
+	require.NoError(t, err)
+	require.False(t, layouts.Map["/plain"].Personalized)
+	require.True(t, layouts.Map["/personal"].Personalized)
+
+	t.Run("non-personalized custom layout is cached", func(t *testing.T) {
+		note, views := cacheTestNote()
+		note.Layout = "plain"
+		env, pc, _ := cacheTestEnv(views, layouts)
+
+		ctx := newReqCtx(reqOpts{acceptEncoding: "gzip"})
+		runHandle(t, env, ctx, nil)
+		require.Equal(t, 1, pc.Len(), "non-personalized layout fills the cache")
+		require.Equal(t, "gzip", string(ctx.Response.Header.ContentEncoding()))
+		require.Contains(t, string(body(t, ctx)), "plain layout")
+	})
+
+	t.Run("personalized custom layout is bypassed", func(t *testing.T) {
+		note, views := cacheTestNote()
+		note.Layout = "personal"
+		env, pc, _ := cacheTestEnv(views, layouts)
+
+		ctx := newReqCtx(reqOpts{acceptEncoding: "gzip"})
+		runHandle(t, env, ctx, nil)
+		require.Empty(t, env.StoreCachedPageCalls(), "personalized layout must not be cached")
+		require.Equal(t, 0, pc.Len())
+	})
+}
+
+// Test 6: paywall, sign-in wall and onboarding responses are bypassed — they
+// return before the cacheable branch, so the cache is never consulted or filled.
+func TestPageCache_NonNoteBranchesBypass(t *testing.T) {
+	t.Run("paywall (non-free note, anon)", func(t *testing.T) {
+		note, views := cacheTestNote()
+		note.Free = false
+		env, pc, _ := cacheTestEnv(views, nil)
+
+		ctx := newReqCtx(reqOpts{acceptEncoding: "gzip"})
+		runHandle(t, env, ctx, nil)
+		require.Empty(t, env.StoreCachedPageCalls())
+		require.Empty(t, env.CachedPageCalls())
+		require.Equal(t, 0, pc.Len())
+	})
+
+	t.Run("sign-in wall (RequireSignin subgraph, anon)", func(t *testing.T) {
+		note, views := cacheTestNote()
+		note.Subgraphs = map[string]*model.NoteSubgraph{
+			"members": {Name: "members", RequireSignin: true},
+		}
+		env, pc, _ := cacheTestEnv(views, nil)
+
+		ctx := newReqCtx(reqOpts{acceptEncoding: "gzip"})
+		runHandle(t, env, ctx, nil)
+		require.Empty(t, env.StoreCachedPageCalls())
+		require.Equal(t, 0, pc.Len())
+	})
+
+	t.Run("onboarding (no notes)", func(t *testing.T) {
+		empty := &model.NoteViews{Map: map[string]*model.NoteView{}, Version: "live"}
+		env, pc, _ := cacheTestEnv(empty, nil)
+
+		ctx := newReqCtx(reqOpts{acceptEncoding: "gzip"})
+		runHandle(t, env, ctx, nil)
+		require.Empty(t, env.StoreCachedPageCalls())
+		require.Equal(t, 0, pc.Len())
+	})
+}
+
+// Test 7: UI-language keying — en, ru and "" are distinct cache entries, and an
+// exotic Accept-Language bypasses the cache (no unbounded growth).
+func TestPageCache_UILangKeying(t *testing.T) {
+	_, views := cacheTestNote()
+	env, pc, _ := cacheTestEnv(views, nil)
+
+	// "" (no cookie / no Accept-Language)
+	runHandle(t, env, newReqCtx(reqOpts{acceptEncoding: "gzip"}), nil)
+	// en
+	runHandle(t, env, newReqCtx(reqOpts{acceptEncoding: "gzip", acceptLang: "en-US,en;q=0.9"}), nil)
+	// ru
+	runHandle(t, env, newReqCtx(reqOpts{acceptEncoding: "gzip", langCookie: "ru"}), nil)
+	require.Equal(t, 3, pc.Len(), "en, ru and \"\" are separate entries")
+
+	storesBefore := len(env.StoreCachedPageCalls())
+
+	// Exotic languages must not be cached (would otherwise thrash the cache).
+	for _, lang := range []string{"de-DE,de;q=0.9", "fr-FR", "zh-CN", "es", "it"} {
+		runHandle(t, env, newReqCtx(reqOpts{acceptEncoding: "gzip", acceptLang: lang}), nil)
+	}
+	require.Equal(t, 3, pc.Len(), "exotic languages do not create cache entries")
+	require.Len(t, env.StoreCachedPageCalls(), storesBefore, "exotic languages are never stored")
+}

--- a/internal/case/rendernotepage/mocks_test.go
+++ b/internal/case/rendernotepage/mocks_test.go
@@ -11,6 +11,7 @@ import (
 	"trip2g/internal/features"
 	"trip2g/internal/logger"
 	"trip2g/internal/model"
+	"trip2g/internal/pagecache"
 	"trip2g/internal/templateviews"
 )
 
@@ -30,8 +31,14 @@ var _ rendernotepage.Env = &EnvMock{}
 //			AssetURLFunc: func(path string) string {
 //				panic("mock out the AssetURL method")
 //			},
+//			CachedPageFunc: func(key pagecache.Key) ([]byte, bool) {
+//				panic("mock out the CachedPage method")
+//			},
 //			CanReadNoteFunc: func(ctx context.Context, note *model.NoteView) (bool, error) {
 //				panic("mock out the CanReadNote method")
+//			},
+//			ConfigEpochFunc: func() uint64 {
+//				panic("mock out the ConfigEpoch method")
 //			},
 //			FeaturesFunc: func() features.Features {
 //				panic("mock out the Features method")
@@ -84,6 +91,9 @@ var _ rendernotepage.Env = &EnvMock{}
 //			SiteTitleTemplateFunc: func() string {
 //				panic("mock out the SiteTitleTemplate method")
 //			},
+//			StoreCachedPageFunc: func(key pagecache.Key, gz []byte)  {
+//				panic("mock out the StoreCachedPage method")
+//			},
 //			UpsertUserNoteDailyViewFunc: func(ctx context.Context, params db.UpsertUserNoteDailyViewParams) (int64, error) {
 //				panic("mock out the UpsertUserNoteDailyView method")
 //			},
@@ -100,8 +110,14 @@ type EnvMock struct {
 	// AssetURLFunc mocks the AssetURL method.
 	AssetURLFunc func(path string) string
 
+	// CachedPageFunc mocks the CachedPage method.
+	CachedPageFunc func(key pagecache.Key) ([]byte, bool)
+
 	// CanReadNoteFunc mocks the CanReadNote method.
 	CanReadNoteFunc func(ctx context.Context, note *model.NoteView) (bool, error)
+
+	// ConfigEpochFunc mocks the ConfigEpoch method.
+	ConfigEpochFunc func() uint64
 
 	// FeaturesFunc mocks the Features method.
 	FeaturesFunc func() features.Features
@@ -154,6 +170,9 @@ type EnvMock struct {
 	// SiteTitleTemplateFunc mocks the SiteTitleTemplate method.
 	SiteTitleTemplateFunc func() string
 
+	// StoreCachedPageFunc mocks the StoreCachedPage method.
+	StoreCachedPageFunc func(key pagecache.Key, gz []byte)
+
 	// UpsertUserNoteDailyViewFunc mocks the UpsertUserNoteDailyView method.
 	UpsertUserNoteDailyViewFunc func(ctx context.Context, params db.UpsertUserNoteDailyViewParams) (int64, error)
 
@@ -169,12 +188,20 @@ type EnvMock struct {
 			// Path is the path argument value.
 			Path string
 		}
+		// CachedPage holds details about calls to the CachedPage method.
+		CachedPage []struct {
+			// Key is the key argument value.
+			Key pagecache.Key
+		}
 		// CanReadNote holds details about calls to the CanReadNote method.
 		CanReadNote []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// Note is the note argument value.
 			Note *model.NoteView
+		}
+		// ConfigEpoch holds details about calls to the ConfigEpoch method.
+		ConfigEpoch []struct {
 		}
 		// Features holds details about calls to the Features method.
 		Features []struct {
@@ -265,6 +292,13 @@ type EnvMock struct {
 		// SiteTitleTemplate holds details about calls to the SiteTitleTemplate method.
 		SiteTitleTemplate []struct {
 		}
+		// StoreCachedPage holds details about calls to the StoreCachedPage method.
+		StoreCachedPage []struct {
+			// Key is the key argument value.
+			Key pagecache.Key
+			// Gz is the gz argument value.
+			Gz []byte
+		}
 		// UpsertUserNoteDailyView holds details about calls to the UpsertUserNoteDailyView method.
 		UpsertUserNoteDailyView []struct {
 			// Ctx is the ctx argument value.
@@ -275,7 +309,9 @@ type EnvMock struct {
 	}
 	lockActiveHTMLInjections                sync.RWMutex
 	lockAssetURL                            sync.RWMutex
+	lockCachedPage                          sync.RWMutex
 	lockCanReadNote                         sync.RWMutex
+	lockConfigEpoch                         sync.RWMutex
 	lockFeatures                            sync.RWMutex
 	lockGetTelegramChatName                 sync.RWMutex
 	lockGetTelegramPostLinksByNoteVersionID sync.RWMutex
@@ -293,6 +329,7 @@ type EnvMock struct {
 	lockRecordUserNoteView                  sync.RWMutex
 	lockSiteConfig                          sync.RWMutex
 	lockSiteTitleTemplate                   sync.RWMutex
+	lockStoreCachedPage                     sync.RWMutex
 	lockUpsertUserNoteDailyView             sync.RWMutex
 }
 
@@ -360,6 +397,38 @@ func (mock *EnvMock) AssetURLCalls() []struct {
 	return calls
 }
 
+// CachedPage calls CachedPageFunc.
+func (mock *EnvMock) CachedPage(key pagecache.Key) ([]byte, bool) {
+	if mock.CachedPageFunc == nil {
+		panic("EnvMock.CachedPageFunc: method is nil but Env.CachedPage was just called")
+	}
+	callInfo := struct {
+		Key pagecache.Key
+	}{
+		Key: key,
+	}
+	mock.lockCachedPage.Lock()
+	mock.calls.CachedPage = append(mock.calls.CachedPage, callInfo)
+	mock.lockCachedPage.Unlock()
+	return mock.CachedPageFunc(key)
+}
+
+// CachedPageCalls gets all the calls that were made to CachedPage.
+// Check the length with:
+//
+//	len(mockedEnv.CachedPageCalls())
+func (mock *EnvMock) CachedPageCalls() []struct {
+	Key pagecache.Key
+} {
+	var calls []struct {
+		Key pagecache.Key
+	}
+	mock.lockCachedPage.RLock()
+	calls = mock.calls.CachedPage
+	mock.lockCachedPage.RUnlock()
+	return calls
+}
+
 // CanReadNote calls CanReadNoteFunc.
 func (mock *EnvMock) CanReadNote(ctx context.Context, note *model.NoteView) (bool, error) {
 	if mock.CanReadNoteFunc == nil {
@@ -393,6 +462,33 @@ func (mock *EnvMock) CanReadNoteCalls() []struct {
 	mock.lockCanReadNote.RLock()
 	calls = mock.calls.CanReadNote
 	mock.lockCanReadNote.RUnlock()
+	return calls
+}
+
+// ConfigEpoch calls ConfigEpochFunc.
+func (mock *EnvMock) ConfigEpoch() uint64 {
+	if mock.ConfigEpochFunc == nil {
+		panic("EnvMock.ConfigEpochFunc: method is nil but Env.ConfigEpoch was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockConfigEpoch.Lock()
+	mock.calls.ConfigEpoch = append(mock.calls.ConfigEpoch, callInfo)
+	mock.lockConfigEpoch.Unlock()
+	return mock.ConfigEpochFunc()
+}
+
+// ConfigEpochCalls gets all the calls that were made to ConfigEpoch.
+// Check the length with:
+//
+//	len(mockedEnv.ConfigEpochCalls())
+func (mock *EnvMock) ConfigEpochCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockConfigEpoch.RLock()
+	calls = mock.calls.ConfigEpoch
+	mock.lockConfigEpoch.RUnlock()
 	return calls
 }
 
@@ -937,6 +1033,42 @@ func (mock *EnvMock) SiteTitleTemplateCalls() []struct {
 	mock.lockSiteTitleTemplate.RLock()
 	calls = mock.calls.SiteTitleTemplate
 	mock.lockSiteTitleTemplate.RUnlock()
+	return calls
+}
+
+// StoreCachedPage calls StoreCachedPageFunc.
+func (mock *EnvMock) StoreCachedPage(key pagecache.Key, gz []byte) {
+	if mock.StoreCachedPageFunc == nil {
+		panic("EnvMock.StoreCachedPageFunc: method is nil but Env.StoreCachedPage was just called")
+	}
+	callInfo := struct {
+		Key pagecache.Key
+		Gz  []byte
+	}{
+		Key: key,
+		Gz:  gz,
+	}
+	mock.lockStoreCachedPage.Lock()
+	mock.calls.StoreCachedPage = append(mock.calls.StoreCachedPage, callInfo)
+	mock.lockStoreCachedPage.Unlock()
+	mock.StoreCachedPageFunc(key, gz)
+}
+
+// StoreCachedPageCalls gets all the calls that were made to StoreCachedPage.
+// Check the length with:
+//
+//	len(mockedEnv.StoreCachedPageCalls())
+func (mock *EnvMock) StoreCachedPageCalls() []struct {
+	Key pagecache.Key
+	Gz  []byte
+} {
+	var calls []struct {
+		Key pagecache.Key
+		Gz  []byte
+	}
+	mock.lockStoreCachedPage.RLock()
+	calls = mock.calls.StoreCachedPage
+	mock.lockStoreCachedPage.RUnlock()
 	return calls
 }
 

--- a/internal/case/rendernotepage/pagecache.go
+++ b/internal/case/rendernotepage/pagecache.go
@@ -1,0 +1,146 @@
+package rendernotepage
+
+import (
+	"net/http"
+	"time"
+
+	"trip2g/internal/langdetect"
+	"trip2g/internal/pagecache"
+
+	"github.com/valyala/fasthttp"
+)
+
+// maxCacheableRender bounds how long a render may take and still be cached. It
+// guards against fasthttp.TimeoutHandler: on timeout (60s prod / 10min dev) the
+// handler goroutine keeps running on a ctx fasthttp may already be reusing, so a
+// render that reaches the fill path far slower than any healthy one must not
+// write (possibly foreign) response bytes into the shared cache. Healthy renders
+// complete in well under a second; this is comfortably below the timeout.
+const maxCacheableRender = 5 * time.Second
+
+// normalizeUILang returns (lang, true) only for the small whitelist the page
+// cache supports. The rendered page embeds the RAW ui_lang value server-side,
+// so the cache key MUST equal that value exactly; we therefore cache only the
+// exact values {"en","ru",""} and bypass any other language (e.g. a bot's
+// exotic Accept-Language) instead of risking a page whose embedded ui_lang
+// differs from the key. This also bounds the key space to three lang buckets so
+// exotic Accept-Language headers cannot thrash the cache.
+func normalizeUILang(raw string) (string, bool) {
+	switch raw {
+	case "en", "ru", "":
+		return raw, true
+	default:
+		return "", false
+	}
+}
+
+// cacheDecision determines whether the current normal-served-note response is
+// safe to serve from / store in the anonymous page cache, and builds its key.
+//
+// It is only reached on the normal note branch: redirects, onboarding, paywall,
+// sign-in wall, 404 and unsupported-file responses already returned, so a
+// hit/fill here is always a 200 HTML note page. Caching is refused (false) when
+// ANY safety gate trips:
+//   - the client does not accept gzip (we only cache the gzipped variant);
+//   - the viewer is authenticated (resp.UserToken != nil) — could be admin,
+//     subscriber, or otherwise personalized / paywall-exempt;
+//   - an explicit ?version= switch is present (admin live/latest preview);
+//   - the note's custom Jet layout is personalized (viewer/role-dependent);
+//   - the UI language is outside the cacheable whitelist.
+func cacheDecision(
+	ctx *fasthttp.RequestCtx,
+	env Env,
+	resp *Response,
+	request Request,
+	layoutName string,
+) (pagecache.Key, bool) {
+	var zero pagecache.Key
+
+	if resp == nil || resp.Note == nil {
+		return zero, false
+	}
+	if resp.UserToken != nil {
+		return zero, false
+	}
+	if request.Version != "" {
+		return zero, false
+	}
+	if !ctx.Request.Header.HasAcceptEncoding("gzip") {
+		return zero, false
+	}
+	if layoutIsPersonalized(env, layoutName) {
+		return zero, false
+	}
+
+	uiLang, ok := normalizeUILang(langdetect.DetectPreferred(
+		string(ctx.Request.Header.Cookie(langCookieName)),
+		string(ctx.Request.Header.Peek("Accept-Language")),
+	))
+	if !ok {
+		return zero, false
+	}
+
+	return pagecache.Key{
+		Path:          request.Path,
+		Host:          request.Host,
+		NoteVersionID: resp.Note.VersionID,
+		ConfigEpoch:   env.ConfigEpoch(),
+		UILang:        uiLang,
+	}, true
+}
+
+// layoutIsPersonalized reports whether the named custom layout exists, parses,
+// and references viewer-dependent helpers. A missing or parse-error layout
+// falls back to the role-uniform default template, so it is NOT personalized.
+func layoutIsPersonalized(env Env, layoutName string) bool {
+	if layoutName == "" {
+		return false
+	}
+	layout, ok := env.Layouts().Map["/"+layoutName]
+	if !ok || layout.View == nil {
+		return false
+	}
+	return layout.Personalized
+}
+
+// writeCachedPage serves pre-gzipped bytes from the cache. It declares the gzip
+// Content-Encoding so fasthttp.CompressHandler skips re-compression.
+func writeCachedPage(ctx *fasthttp.RequestCtx, gz []byte) {
+	ctx.SetStatusCode(http.StatusOK)
+	ctx.SetContentType("text/html; charset=utf-8")
+	ctx.Response.Header.SetContentEncoding("gzip")
+	ctx.Response.SetBody(gz)
+}
+
+// fillPageCache gzips the freshly rendered body once, stores it under key, and
+// replaces the response body with the gzipped bytes + Content-Encoding so the
+// filling request is served identically and CompressHandler is skipped. It is a
+// no-op when caching was refused, the response is not a clean 200, or the render
+// took anomalously long (a likely timed-out handler racing ctx reuse).
+func fillPageCache(
+	ctx *fasthttp.RequestCtx,
+	env Env,
+	key pagecache.Key,
+	cacheable bool,
+	renderStart time.Time,
+) {
+	if !cacheable {
+		return
+	}
+	if ctx.Response.StatusCode() != http.StatusOK {
+		return
+	}
+	if time.Since(renderStart) >= maxCacheableRender {
+		return
+	}
+
+	gz, err := pagecache.Gzip(ctx.Response.Body())
+	if err != nil {
+		env.Logger().Error("page cache gzip failed", "error", err)
+		return
+	}
+
+	env.StoreCachedPage(key, gz)
+	ctx.Response.Header.SetContentEncoding("gzip")
+	ctx.Response.SetBody(gz)
+}

--- a/internal/case/rendernotepage/pagecache.go
+++ b/internal/case/rendernotepage/pagecache.go
@@ -11,11 +11,14 @@ import (
 )
 
 // maxCacheableRender bounds how long a render may take and still be cached. It
-// guards against fasthttp.TimeoutHandler: on timeout (60s prod / 10min dev) the
-// handler goroutine keeps running on a ctx fasthttp may already be reusing, so a
-// render that reaches the fill path far slower than any healthy one must not
-// write (possibly foreign) response bytes into the shared cache. Healthy renders
-// complete in well under a second; this is comfortably below the timeout.
+// is defense-in-depth against fasthttp.TimeoutHandler: on timeout (60s prod /
+// 10min dev) the client is handed a fresh ctx while the original handler
+// goroutine keeps running on its now-abandoned ctx, which it owns exclusively
+// (fasthttp 1.66.0 server.go:2459-2462 — the timed-out ctx is not reused, so
+// there is no foreign-ctx contamination). The guard simply refuses to cache a
+// render that reaches the fill path far slower than any healthy one: those bytes
+// come from an incomplete/degraded render, not a representative page. Healthy
+// renders complete in well under a second; this is comfortably below the timeout.
 const maxCacheableRender = 5 * time.Second
 
 // normalizeUILang returns (lang, true) only for the small whitelist the page
@@ -109,6 +112,10 @@ func writeCachedPage(ctx *fasthttp.RequestCtx, gz []byte) {
 	ctx.SetStatusCode(http.StatusOK)
 	ctx.SetContentType("text/html; charset=utf-8")
 	ctx.Response.Header.SetContentEncoding("gzip")
+	// CompressHandler's gzipBody early-returns once Content-Encoding is set, so it
+	// never adds the Vary: Accept-Encoding it emits on the uncached path. Add it
+	// here so cached responses carry the same Vary header as normal output.
+	ctx.Response.Header.Add("Vary", "Accept-Encoding")
 	ctx.Response.SetBody(gz)
 }
 
@@ -116,7 +123,8 @@ func writeCachedPage(ctx *fasthttp.RequestCtx, gz []byte) {
 // replaces the response body with the gzipped bytes + Content-Encoding so the
 // filling request is served identically and CompressHandler is skipped. It is a
 // no-op when caching was refused, the response is not a clean 200, or the render
-// took anomalously long (a likely timed-out handler racing ctx reuse).
+// took anomalously long (a likely timed-out handler whose incomplete bytes must
+// not enter the shared cache).
 func fillPageCache(
 	ctx *fasthttp.RequestCtx,
 	env Env,
@@ -142,5 +150,8 @@ func fillPageCache(
 
 	env.StoreCachedPage(key, gz)
 	ctx.Response.Header.SetContentEncoding("gzip")
+	// See writeCachedPage: presetting Content-Encoding makes CompressHandler skip
+	// adding Vary: Accept-Encoding, so add it to match the uncached path.
+	ctx.Response.Header.Add("Vary", "Accept-Encoding")
 	ctx.Response.SetBody(gz)
 }

--- a/internal/case/rendernotepage/resolve.go
+++ b/internal/case/rendernotepage/resolve.go
@@ -15,6 +15,7 @@ import (
 	"trip2g/internal/features"
 	"trip2g/internal/logger"
 	"trip2g/internal/model"
+	"trip2g/internal/pagecache"
 	"trip2g/internal/templateviews"
 	"trip2g/internal/usertoken"
 )
@@ -60,6 +61,14 @@ type Env interface {
 	// NoteVersionEditor loads who pushed the given note version, used to attach
 	// the admin-only "last edited by" lazy resolver onto the template note.
 	NoteVersionEditor(ctx context.Context, versionID int64) (*templateviews.NoteEditor, error)
+
+	// ConfigEpoch is a monotonic counter bumped on every site-config change; it
+	// is part of the anonymous page-cache key so config changes invalidate it.
+	ConfigEpoch() uint64
+	// CachedPage returns pre-gzipped bytes previously stored for key, if fresh.
+	CachedPage(key pagecache.Key) ([]byte, bool)
+	// StoreCachedPage records pre-gzipped response bytes for key.
+	StoreCachedPage(key pagecache.Key, gz []byte)
 }
 
 type Request struct {

--- a/internal/case/rendernotepage/userspace_test.go
+++ b/internal/case/rendernotepage/userspace_test.go
@@ -201,6 +201,10 @@ type loaderTestEnv struct{ log logger.Logger }
 
 func (e *loaderTestEnv) Logger() logger.Logger { return e.log }
 
+// IsDevMode satisfies layoutloader.Env (added when the interface gained the
+// method); tests load layouts in production mode.
+func (e *loaderTestEnv) IsDevMode() bool { return false }
+
 // TestJetBinding_IdempotentViaLayoutloader verifies idempotency through the
 // full layoutloader pipeline (covers the real jet.WithSafeWriter(nil) path).
 func TestJetBinding_IdempotentViaLayoutloader(t *testing.T) {

--- a/internal/configregistry/builder.go
+++ b/internal/configregistry/builder.go
@@ -23,6 +23,12 @@ type SiteConfigBuilder struct {
 	env   BuilderEnv
 	log   logger.Logger
 	cache atomic.Pointer[model.SiteConfig]
+
+	// configEpoch is a monotonic counter bumped on every InvalidateSiteConfig.
+	// The anonymous page cache embeds it in its key so any site-config change
+	// (which can affect site name, RSS, default layout, paywall, etc.) makes
+	// previously cached pages unreachable without an explicit flush.
+	configEpoch atomic.Uint64
 }
 
 // NewSiteConfigBuilder creates a new SiteConfigBuilder.
@@ -45,9 +51,18 @@ func (b *SiteConfigBuilder) SiteConfig(ctx context.Context) model.SiteConfig {
 	return cfg
 }
 
-// InvalidateSiteConfig resets the cached SiteConfig so it is rebuilt on next access.
+// InvalidateSiteConfig resets the cached SiteConfig so it is rebuilt on next
+// access and bumps the config epoch so anonymous page-cache entries built under
+// the previous config are no longer served.
 func (b *SiteConfigBuilder) InvalidateSiteConfig() {
 	b.cache.Store(nil)
+	b.configEpoch.Add(1)
+}
+
+// ConfigEpoch returns the current site-config epoch, bumped on every
+// InvalidateSiteConfig. Used as part of the anonymous page-cache key.
+func (b *SiteConfigBuilder) ConfigEpoch() uint64 {
+	return b.configEpoch.Load()
 }
 
 // TimeLocation returns the parsed timezone from the cached SiteConfig.

--- a/internal/layoutloader/loader.go
+++ b/internal/layoutloader/loader.go
@@ -126,6 +126,9 @@ func Load(env Env, sourceFiles []model.LayoutSourceFile, options Options) (*mode
 		Load: func(source model.LayoutSourceFile) model.Layout {
 			view, parseErr := jl.load(source)
 			layout := model.Layout{View: view}
+			if view != nil {
+				layout.Personalized = jl.detectPersonalized(source.ID, source.Content, view)
+			}
 			if parseErr != "" {
 				layout.Warnings = []model.NoteWarning{{
 					Level:   model.NoteWarningCritical,
@@ -291,6 +294,10 @@ func (jl *jetLoader) processTemplates(sourceFiles []model.LayoutSourceFile) {
 			warnings = append(warnings, pending...)
 		}
 
+		// Detect viewer/role-dependent helper usage so the anonymous page cache
+		// can bypass personalized layouts. Walks the page plus its imports.
+		personalized := jl.detectPersonalized(source.ID, source.Content, view)
+
 		jl.layouts.Map[source.ID] = model.Layout{
 			VersionID:       source.VersionID,
 			Path:            source.Path,
@@ -301,7 +308,8 @@ func (jl *jetLoader) processTemplates(sourceFiles []model.LayoutSourceFile) {
 
 			AssetReplaces: source.Assets,
 
-			Warnings: warnings,
+			Warnings:     warnings,
+			Personalized: personalized,
 		}
 	}
 }

--- a/internal/layoutloader/personalization.go
+++ b/internal/layoutloader/personalization.go
@@ -21,6 +21,11 @@ const (
 // Triggers:
 //   - any access to the `currentUser` namespace (e.g. currentUser.IsAdmin()).
 //   - note.LastEditedBy / note.LastEditedByLabel (the admin-only byline).
+//
+// For the anonymous page cache this list is defense-in-depth only: the cache is
+// keyed and gated to anon viewers, so a missed trigger here cannot serve one
+// viewer's personalized output to another — it would at worst cache an anon
+// render that need not have been cached.
 type personalizationFinder struct{ found bool }
 
 func (w *personalizationFinder) Visit(vc utils.VisitorContext, node jet.Node) {

--- a/internal/layoutloader/personalization.go
+++ b/internal/layoutloader/personalization.go
@@ -1,0 +1,76 @@
+package layoutloader
+
+import (
+	"github.com/CloudyKit/jet/v6"
+	"github.com/CloudyKit/jet/v6/utils"
+)
+
+// Identifiers/fields whose use makes a layout's output depend on the viewer.
+const (
+	identCurrentUser       = "currentUser"
+	identNote              = "note"
+	fieldLastEditedBy      = "LastEditedBy"
+	fieldLastEditedByLabel = "LastEditedByLabel"
+)
+
+// personalizationFinder walks a Jet template AST and flags references to
+// viewer/role-dependent helpers, which make the rendered output depend on WHO
+// is viewing. A layout that uses any of them must never be served from the
+// anonymous page cache.
+//
+// Triggers:
+//   - any access to the `currentUser` namespace (e.g. currentUser.IsAdmin()).
+//   - note.LastEditedBy / note.LastEditedByLabel (the admin-only byline).
+type personalizationFinder struct{ found bool }
+
+func (w *personalizationFinder) Visit(vc utils.VisitorContext, node jet.Node) {
+	switch n := node.(type) {
+	case *jet.IdentifierNode:
+		// A bare `currentUser` reference is enough; the namespace exists only
+		// to gate role-specific output.
+		if n.Ident == identCurrentUser {
+			w.found = true
+		}
+	case *jet.ChainNode:
+		if id, ok := n.Node.(*jet.IdentifierNode); ok {
+			switch id.Ident {
+			case identCurrentUser:
+				w.found = true
+			case identNote:
+				for _, field := range n.Field {
+					if field == fieldLastEditedBy || field == fieldLastEditedByLabel {
+						w.found = true
+					}
+				}
+			}
+		}
+	}
+	vc.Visit(node)
+}
+
+// detectPersonalized reports whether view — or any template it imports —
+// references viewer-dependent helpers. content is the source template text,
+// used to resolve {{ import }} paths the AST walker does not recurse into
+// (mirroring how assetFinder/blockFinder follow imports in processTemplates).
+func (jl *jetLoader) detectPersonalized(sourceID, content string, view *jet.Template) bool {
+	finder := &personalizationFinder{}
+	safeWalk(view, finder)
+	if finder.found {
+		return true
+	}
+
+	if views, ok := jl.sets[sourceID]; ok {
+		for _, importPath := range extractImportPaths(content) {
+			imported, err := views.GetTemplate(importPath)
+			if err != nil {
+				continue
+			}
+			safeWalk(imported, finder)
+			if finder.found {
+				return true
+			}
+		}
+	}
+
+	return finder.found
+}

--- a/internal/layoutloader/personalization_test.go
+++ b/internal/layoutloader/personalization_test.go
@@ -1,0 +1,90 @@
+package layoutloader
+
+import (
+	"testing"
+
+	"trip2g/internal/logger"
+	"trip2g/internal/model"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectPersonalized(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "plain layout is not personalized",
+			content: `<h1>{{ note.Title() }}</h1>{{ note.HTML() }}`,
+			want:    false,
+		},
+		{
+			name:    "default-template chrome helpers are not personalized",
+			content: `{{ defaultTemplate.Header() }}{{ note.HTML() }}{{ defaultTemplate.Footer() }}`,
+			want:    false,
+		},
+		{
+			name:    "currentUser.IsAdmin gate is personalized",
+			content: `{{ if currentUser.IsAdmin() }}<a>edit</a>{{ end }}{{ note.HTML() }}`,
+			want:    true,
+		},
+		{
+			name:    "bare currentUser reference is personalized",
+			content: `{{ currentUser }}`,
+			want:    true,
+		},
+		{
+			name:    "note.LastEditedByLabel byline is personalized",
+			content: `<footer>{{ note.LastEditedByLabel() }}</footer>`,
+			want:    true,
+		},
+		{
+			name:    "note.LastEditedBy resolver is personalized",
+			content: `{{ note.LastEditedBy().Name }}`,
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := &testEnv{logger: &logger.TestLogger{}}
+			sources := []model.LayoutSourceFile{{
+				ID:      "/main",
+				Path:    "_layouts/main.html",
+				Content: tt.content,
+			}}
+			layouts, err := Load(env, sources, Options{})
+			require.NoError(t, err)
+			got := layouts.Map["/main"]
+			require.NotNil(t, got.View, "layout must parse: %v", got.Warnings)
+			require.Equal(t, tt.want, got.Personalized)
+		})
+	}
+}
+
+// TestDetectPersonalized_ViaImport verifies the detector follows {{ import }}:
+// a clean page that imports a sub-template referencing currentUser is still
+// flagged personalized.
+func TestDetectPersonalized_ViaImport(t *testing.T) {
+	env := &testEnv{logger: &logger.TestLogger{}}
+	sources := []model.LayoutSourceFile{
+		{
+			ID:      "/comp",
+			Path:    "_layouts/comp.html",
+			Content: `{{ block adminBadge() }}{{ if currentUser.IsAdmin() }}admin{{ end }}{{ end }}`,
+		},
+		{
+			ID:      "/page",
+			Path:    "_layouts/page.html",
+			Content: `{{ import "/comp" }}<h1>{{ note.Title() }}</h1>{{ yield adminBadge() }}`,
+		},
+	}
+	layouts, err := Load(env, sources, Options{})
+	require.NoError(t, err)
+
+	page := layouts.Map["/page"]
+	require.NotNil(t, page.View, "page must parse: %v", page.Warnings)
+	require.True(t, page.Personalized, "personalization in an imported template must propagate")
+}

--- a/internal/model/layout.go
+++ b/internal/model/layout.go
@@ -25,6 +25,13 @@ type Layout struct {
 
 	// Warnings contains issues detected during loading (e.g., parse errors).
 	Warnings []NoteWarning
+
+	// Personalized is true when the layout's template (or any template it
+	// imports) references viewer/role-dependent helpers — the currentUser
+	// namespace or note.LastEditedBy/LastEditedByLabel. Such a layout renders
+	// differently per viewer, so its pages must never be served from the
+	// anonymous page cache. Computed once at load.
+	Personalized bool
 }
 
 type LayoutSourceFile struct {

--- a/internal/pagecache/pagecache.go
+++ b/internal/pagecache/pagecache.go
@@ -4,16 +4,18 @@
 // responsible for never caching personalized, authenticated, or paywalled
 // pages (see internal/case/rendernotepage).
 //
-// Reads are lock-free via an atomic map pointer; writes copy-on-write under a
-// mutex. A whole-map swap (Clear) invalidates everything on note reload.
+// The store is a thread-safe expirable LRU (hashicorp/golang-lru/v2): every
+// entry has a TTL after which Get misses, and the least-recently-used entry is
+// evicted once the size cap is reached. A whole-cache Purge (Clear) invalidates
+// everything on note reload.
 package pagecache
 
 import (
 	"bytes"
 	"compress/gzip"
-	"sync"
-	"sync/atomic"
 	"time"
+
+	"github.com/hashicorp/golang-lru/v2/expirable"
 )
 
 // Key identifies a cached anonymous rendered page. It is a comparable value
@@ -31,110 +33,59 @@ type Key struct {
 	UILang        string
 }
 
-type entry struct {
-	gz       []byte
-	storedAt time.Time
-}
-
 // DefaultTTL bounds how long an entry is served before a forced re-render. It
 // is the self-heal window for inputs that have no version counter today (HTML
 // injections, user-space JS/CSS bundle). Content and config changes invalidate
 // immediately via Clear / ConfigEpoch, so this only governs those few inputs.
+// The LRU enforces it internally: Get returns a miss once the entry is expired.
 const DefaultTTL = 30 * time.Second
 
-// defaultMaxEntries caps memory and copy-on-write cost. The live key space is
-// bounded (#notes x #hosts x 3 langs); the cap is a safety valve against
-// pathological growth, beyond which new pages are simply served uncached.
+// defaultMaxEntries caps memory. The live key space is bounded
+// (#notes x #hosts x 3 langs); once the cap is reached the LRU evicts the
+// least-recently-used entry to admit a new page rather than dropping the new one.
 const defaultMaxEntries = 8192
 
-// PageCache is a concurrency-safe store of pre-gzipped page bodies.
+// PageCache is a concurrency-safe store of pre-gzipped page bodies backed by an
+// expirable LRU.
 type PageCache struct {
-	m   atomic.Pointer[map[Key]entry]
-	mu  sync.Mutex // serializes writers performing copy-on-write
-	ttl time.Duration
-	max int
-	now func() time.Time
+	lru *expirable.LRU[Key, []byte]
 }
 
 // New returns an empty PageCache with the default TTL and size cap.
 func New() *PageCache {
-	pc := &PageCache{
-		ttl: DefaultTTL,
-		max: defaultMaxEntries,
-		now: time.Now,
-	}
-	empty := map[Key]entry{}
-	pc.m.Store(&empty)
-	return pc
+	return newWithTTL(defaultMaxEntries, DefaultTTL)
+}
+
+// newWithTTL builds a PageCache with an explicit size cap and TTL. Production
+// uses New(); tests use it to drive a short real TTL, since expirable.LRU does
+// not expose a clock injection hook.
+func newWithTTL(maxEntries int, ttl time.Duration) *PageCache {
+	return &PageCache{lru: expirable.NewLRU[Key, []byte](maxEntries, nil, ttl)}
 }
 
 // Get returns the pre-gzipped bytes for key when present and within its TTL.
-// Lock-free: a single atomic load of the map pointer on the hot path.
+// The underlying LRU is internally locked and enforces the TTL, returning a
+// miss for expired entries.
 func (pc *PageCache) Get(key Key) ([]byte, bool) {
-	mp := pc.m.Load()
-	if mp == nil {
-		return nil, false
-	}
-	e, ok := (*mp)[key]
-	if !ok {
-		return nil, false
-	}
-	if pc.now().Sub(e.storedAt) >= pc.ttl {
-		return nil, false
-	}
-	return e.gz, true
+	return pc.lru.Get(key)
 }
 
-// Set stores pre-gzipped bytes for key. It copies the map on write (so
-// concurrent lock-free readers never observe a partially mutated map), pruning
-// expired entries during the copy. Past the size cap, a brand-new key is
-// dropped (served uncached) rather than growing the map without bound.
+// Set stores pre-gzipped bytes for key. Past the size cap the LRU evicts the
+// least-recently-used entry to admit the new one.
 func (pc *PageCache) Set(key Key, gz []byte) {
-	pc.mu.Lock()
-	defer pc.mu.Unlock()
-
-	old := pc.m.Load()
-	now := pc.now()
-
-	if old != nil && len(*old) >= pc.max {
-		if _, exists := (*old)[key]; !exists {
-			return
-		}
-	}
-
-	next := make(map[Key]entry, len(*old)+1)
-	for k, v := range *old {
-		if now.Sub(v.storedAt) >= pc.ttl {
-			continue // prune stale entries while we are copying anyway
-		}
-		next[k] = v
-	}
-	next[key] = entry{gz: gz, storedAt: now}
-	pc.m.Store(&next)
+	pc.lru.Add(key, gz)
 }
 
-// Clear swaps in a fresh empty map, invalidating every entry at once. Called on
-// note reload, where every page must re-render against the new content. It
-// takes the writer mutex so it serializes with copy-on-write Set calls: without
-// it, a Set whose map snapshot pre-dates the Clear could store the just-cleared
-// entries back. (Such resurrected entries are bounded anyway — NoteVersionID and
-// ConfigEpoch are in the key, and every entry self-heals within the TTL — but
-// serializing makes Clear authoritative.)
+// Clear purges every entry at once, invalidating the whole cache. Called on
+// note reload, where every page must re-render against the new content.
 func (pc *PageCache) Clear() {
-	pc.mu.Lock()
-	defer pc.mu.Unlock()
-	empty := map[Key]entry{}
-	pc.m.Store(&empty)
+	pc.lru.Purge()
 }
 
-// Len reports the current number of stored entries (including any not yet
-// pruned expired ones). Intended for tests and metrics.
+// Len reports the current number of stored entries (including any expired ones
+// not yet reaped by the background cleanup). Intended for tests and metrics.
 func (pc *PageCache) Len() int {
-	mp := pc.m.Load()
-	if mp == nil {
-		return 0
-	}
-	return len(*mp)
+	return pc.lru.Len()
 }
 
 // Gzip compresses data with gzip at the level fasthttp's CompressHandler uses
@@ -153,9 +104,4 @@ func Gzip(data []byte) ([]byte, error) {
 		return nil, cerr
 	}
 	return buf.Bytes(), nil
-}
-
-// setClock overrides the time source; tests use it to drive TTL expiry.
-func (pc *PageCache) setClock(now func() time.Time) {
-	pc.now = now
 }

--- a/internal/pagecache/pagecache.go
+++ b/internal/pagecache/pagecache.go
@@ -1,0 +1,161 @@
+// Package pagecache holds pre-gzipped anonymous rendered-page responses so the
+// READ path can skip both re-render and per-request gzip on repeated anonymous
+// reads. It stores only fully assembled, role-uniform responses; the caller is
+// responsible for never caching personalized, authenticated, or paywalled
+// pages (see internal/case/rendernotepage).
+//
+// Reads are lock-free via an atomic map pointer; writes copy-on-write under a
+// mutex. A whole-map swap (Clear) invalidates everything on note reload.
+package pagecache
+
+import (
+	"bytes"
+	"compress/gzip"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Key identifies a cached anonymous rendered page. It is a comparable value
+// type used directly as a map key. Every field is part of the cache identity:
+//   - Path, Host: the requested URL (note + custom-domain routing / og:url).
+//   - NoteVersionID: note content, telegram links, layout sections, lang.
+//   - ConfigEpoch: monotonic counter bumped on any site-config change.
+//   - UILang: server-embedded ui_lang; only the whitelist {"en","ru",""} is
+//     ever cached so this always equals the rendered value.
+type Key struct {
+	Path          string
+	Host          string
+	NoteVersionID int64
+	ConfigEpoch   uint64
+	UILang        string
+}
+
+type entry struct {
+	gz       []byte
+	storedAt time.Time
+}
+
+// DefaultTTL bounds how long an entry is served before a forced re-render. It
+// is the self-heal window for inputs that have no version counter today (HTML
+// injections, user-space JS/CSS bundle). Content and config changes invalidate
+// immediately via Clear / ConfigEpoch, so this only governs those few inputs.
+const DefaultTTL = 30 * time.Second
+
+// defaultMaxEntries caps memory and copy-on-write cost. The live key space is
+// bounded (#notes x #hosts x 3 langs); the cap is a safety valve against
+// pathological growth, beyond which new pages are simply served uncached.
+const defaultMaxEntries = 8192
+
+// PageCache is a concurrency-safe store of pre-gzipped page bodies.
+type PageCache struct {
+	m   atomic.Pointer[map[Key]entry]
+	mu  sync.Mutex // serializes writers performing copy-on-write
+	ttl time.Duration
+	max int
+	now func() time.Time
+}
+
+// New returns an empty PageCache with the default TTL and size cap.
+func New() *PageCache {
+	pc := &PageCache{
+		ttl: DefaultTTL,
+		max: defaultMaxEntries,
+		now: time.Now,
+	}
+	empty := map[Key]entry{}
+	pc.m.Store(&empty)
+	return pc
+}
+
+// Get returns the pre-gzipped bytes for key when present and within its TTL.
+// Lock-free: a single atomic load of the map pointer on the hot path.
+func (pc *PageCache) Get(key Key) ([]byte, bool) {
+	mp := pc.m.Load()
+	if mp == nil {
+		return nil, false
+	}
+	e, ok := (*mp)[key]
+	if !ok {
+		return nil, false
+	}
+	if pc.now().Sub(e.storedAt) >= pc.ttl {
+		return nil, false
+	}
+	return e.gz, true
+}
+
+// Set stores pre-gzipped bytes for key. It copies the map on write (so
+// concurrent lock-free readers never observe a partially mutated map), pruning
+// expired entries during the copy. Past the size cap, a brand-new key is
+// dropped (served uncached) rather than growing the map without bound.
+func (pc *PageCache) Set(key Key, gz []byte) {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+
+	old := pc.m.Load()
+	now := pc.now()
+
+	if old != nil && len(*old) >= pc.max {
+		if _, exists := (*old)[key]; !exists {
+			return
+		}
+	}
+
+	next := make(map[Key]entry, len(*old)+1)
+	for k, v := range *old {
+		if now.Sub(v.storedAt) >= pc.ttl {
+			continue // prune stale entries while we are copying anyway
+		}
+		next[k] = v
+	}
+	next[key] = entry{gz: gz, storedAt: now}
+	pc.m.Store(&next)
+}
+
+// Clear swaps in a fresh empty map, invalidating every entry at once. Called on
+// note reload, where every page must re-render against the new content. It
+// takes the writer mutex so it serializes with copy-on-write Set calls: without
+// it, a Set whose map snapshot pre-dates the Clear could store the just-cleared
+// entries back. (Such resurrected entries are bounded anyway — NoteVersionID and
+// ConfigEpoch are in the key, and every entry self-heals within the TTL — but
+// serializing makes Clear authoritative.)
+func (pc *PageCache) Clear() {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	empty := map[Key]entry{}
+	pc.m.Store(&empty)
+}
+
+// Len reports the current number of stored entries (including any not yet
+// pruned expired ones). Intended for tests and metrics.
+func (pc *PageCache) Len() int {
+	mp := pc.m.Load()
+	if mp == nil {
+		return 0
+	}
+	return len(*mp)
+}
+
+// Gzip compresses data with gzip at the level fasthttp's CompressHandler uses
+// by default (level 6), so cached bytes match the wire format clients already
+// receive. The result is a freshly allocated slice owned by the caller.
+func Gzip(data []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	zw, err := gzip.NewWriterLevel(&buf, gzip.DefaultCompression)
+	if err != nil {
+		return nil, err
+	}
+	if _, werr := zw.Write(data); werr != nil {
+		return nil, werr
+	}
+	if cerr := zw.Close(); cerr != nil {
+		return nil, cerr
+	}
+	return buf.Bytes(), nil
+}
+
+// setClock overrides the time source; tests use it to drive TTL expiry.
+func (pc *PageCache) setClock(now func() time.Time) {
+	pc.now = now
+}

--- a/internal/pagecache/pagecache.go
+++ b/internal/pagecache/pagecache.go
@@ -33,11 +33,13 @@ type Key struct {
 	UILang        string
 }
 
-// DefaultTTL bounds how long an entry is served before a forced re-render. It
-// is the self-heal window for inputs that have no version counter today (HTML
-// injections, user-space JS/CSS bundle). Content and config changes invalidate
-// immediately via Clear / ConfigEpoch, so this only governs those few inputs.
-// The LRU enforces it internally: Get returns a miss once the entry is expired.
+// DefaultTTL bounds how long an entry is served before a forced re-render. The
+// LRU applies it to EVERY entry (Get returns a miss once the entry is expired),
+// so it caps staleness for all cached pages — the cache is more conservative
+// than strictly required. Its purpose is the self-heal window for inputs that
+// have no version counter today (HTML injections, user-space JS/CSS bundle):
+// content and config changes invalidate sooner via Clear / ConfigEpoch, but even
+// an input with no counter at all cannot go stale for longer than this.
 const DefaultTTL = 30 * time.Second
 
 // defaultMaxEntries caps memory. The live key space is bounded

--- a/internal/pagecache/pagecache_test.go
+++ b/internal/pagecache/pagecache_test.go
@@ -75,9 +75,9 @@ func TestClearInvalidatesEverything(t *testing.T) {
 }
 
 func TestTTLExpiry(t *testing.T) {
-	pc := New()
-	now := time.Unix(1000, 0)
-	pc.setClock(func() time.Time { return now })
+	// expirable.LRU has no clock injection, so drive a short real TTL + sleep.
+	const ttl = 30 * time.Millisecond
+	pc := newWithTTL(defaultMaxEntries, ttl)
 
 	gz, _ := Gzip([]byte("x"))
 	key := Key{Path: "/a"}
@@ -86,50 +86,35 @@ func TestTTLExpiry(t *testing.T) {
 	_, ok := pc.Get(key)
 	require.True(t, ok, "fresh entry served")
 
-	now = now.Add(DefaultTTL - time.Millisecond)
-	_, ok = pc.Get(key)
-	require.True(t, ok, "within TTL still served")
-
-	now = now.Add(2 * time.Millisecond)
+	time.Sleep(2 * ttl)
 	_, ok = pc.Get(key)
 	require.False(t, ok, "past TTL not served")
 }
 
-func TestSetPrunesExpired(t *testing.T) {
-	pc := New()
-	now := time.Unix(1000, 0)
-	pc.setClock(func() time.Time { return now })
-
-	gz, _ := Gzip([]byte("x"))
-	pc.Set(Key{Path: "/old"}, gz)
-
-	now = now.Add(2 * DefaultTTL)
-	pc.Set(Key{Path: "/new"}, gz)
-
-	// The stale /old entry is pruned during the copy-on-write of the new Set.
-	require.Equal(t, 1, pc.Len())
-	_, ok := pc.Get(Key{Path: "/new"})
-	require.True(t, ok)
-}
-
-func TestSizeCapDropsNewKeys(t *testing.T) {
-	pc := New()
-	pc.max = 2
+func TestSizeCapEvictsLRU(t *testing.T) {
+	// The cap now does LRU eviction (least-recently-used evicted to admit a new
+	// key), NOT drop-new.
+	pc := newWithTTL(2, DefaultTTL)
 	gz, _ := Gzip([]byte("x"))
 
 	pc.Set(Key{Path: "/a"}, gz)
 	pc.Set(Key{Path: "/b"}, gz)
-	pc.Set(Key{Path: "/c"}, gz) // over cap: dropped
 	require.Equal(t, 2, pc.Len())
-	_, ok := pc.Get(Key{Path: "/c"})
-	require.False(t, ok)
 
-	// Updating an existing key past the cap is still allowed.
-	gz2, _ := Gzip([]byte("y"))
-	pc.Set(Key{Path: "/a"}, gz2)
-	got, ok := pc.Get(Key{Path: "/a"})
+	// Touch /a so /b becomes the least-recently-used entry.
+	_, ok := pc.Get(Key{Path: "/a"})
 	require.True(t, ok)
-	require.Equal(t, []byte("y"), gunzip(t, got))
+
+	// Adding a new key over the cap evicts the LRU (/b), not the new key.
+	pc.Set(Key{Path: "/c"}, gz)
+	require.Equal(t, 2, pc.Len(), "cap holds: still max entries")
+
+	_, ok = pc.Get(Key{Path: "/c"})
+	require.True(t, ok, "new key is admitted (LRU eviction, not drop-new)")
+	_, ok = pc.Get(Key{Path: "/a"})
+	require.True(t, ok, "recently-used key retained")
+	_, ok = pc.Get(Key{Path: "/b"})
+	require.False(t, ok, "least-recently-used key was evicted")
 }
 
 func TestConcurrentGetSet(t *testing.T) {

--- a/internal/pagecache/pagecache_test.go
+++ b/internal/pagecache/pagecache_test.go
@@ -1,0 +1,153 @@
+package pagecache
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func gunzip(t *testing.T, gz []byte) []byte {
+	t.Helper()
+	zr, err := gzip.NewReader(bytes.NewReader(gz))
+	require.NoError(t, err)
+	out, err := io.ReadAll(zr)
+	require.NoError(t, err)
+	return out
+}
+
+func TestGzipRoundTrip(t *testing.T) {
+	body := []byte("<html><body>hello world</body></html>")
+	gz, err := Gzip(body)
+	require.NoError(t, err)
+	require.Equal(t, body, gunzip(t, gz))
+}
+
+func TestGetSet(t *testing.T) {
+	pc := New()
+	key := Key{Path: "/a", Host: "h", NoteVersionID: 1, UILang: "en"}
+
+	_, ok := pc.Get(key)
+	require.False(t, ok, "empty cache must miss")
+
+	gz, err := Gzip([]byte("page-a"))
+	require.NoError(t, err)
+	pc.Set(key, gz)
+
+	got, ok := pc.Get(key)
+	require.True(t, ok)
+	require.Equal(t, []byte("page-a"), gunzip(t, got))
+}
+
+func TestKeyFieldsAreDistinct(t *testing.T) {
+	pc := New()
+	base := Key{Path: "/a", Host: "h", NoteVersionID: 1, ConfigEpoch: 0, UILang: "en"}
+	variants := []Key{
+		base,
+		{Path: "/b", Host: "h", NoteVersionID: 1, ConfigEpoch: 0, UILang: "en"},
+		{Path: "/a", Host: "h2", NoteVersionID: 1, ConfigEpoch: 0, UILang: "en"},
+		{Path: "/a", Host: "h", NoteVersionID: 2, ConfigEpoch: 0, UILang: "en"},
+		{Path: "/a", Host: "h", NoteVersionID: 1, ConfigEpoch: 1, UILang: "en"},
+		{Path: "/a", Host: "h", NoteVersionID: 1, ConfigEpoch: 0, UILang: "ru"},
+	}
+	for i, k := range variants {
+		gz, _ := Gzip([]byte{byte(i)})
+		pc.Set(k, gz)
+	}
+	require.Equal(t, len(variants), pc.Len(), "each distinct key is its own entry")
+}
+
+func TestClearInvalidatesEverything(t *testing.T) {
+	pc := New()
+	gz, _ := Gzip([]byte("x"))
+	pc.Set(Key{Path: "/a"}, gz)
+	pc.Set(Key{Path: "/b"}, gz)
+	require.Equal(t, 2, pc.Len())
+
+	pc.Clear()
+	require.Equal(t, 0, pc.Len())
+	_, ok := pc.Get(Key{Path: "/a"})
+	require.False(t, ok)
+}
+
+func TestTTLExpiry(t *testing.T) {
+	pc := New()
+	now := time.Unix(1000, 0)
+	pc.setClock(func() time.Time { return now })
+
+	gz, _ := Gzip([]byte("x"))
+	key := Key{Path: "/a"}
+	pc.Set(key, gz)
+
+	_, ok := pc.Get(key)
+	require.True(t, ok, "fresh entry served")
+
+	now = now.Add(DefaultTTL - time.Millisecond)
+	_, ok = pc.Get(key)
+	require.True(t, ok, "within TTL still served")
+
+	now = now.Add(2 * time.Millisecond)
+	_, ok = pc.Get(key)
+	require.False(t, ok, "past TTL not served")
+}
+
+func TestSetPrunesExpired(t *testing.T) {
+	pc := New()
+	now := time.Unix(1000, 0)
+	pc.setClock(func() time.Time { return now })
+
+	gz, _ := Gzip([]byte("x"))
+	pc.Set(Key{Path: "/old"}, gz)
+
+	now = now.Add(2 * DefaultTTL)
+	pc.Set(Key{Path: "/new"}, gz)
+
+	// The stale /old entry is pruned during the copy-on-write of the new Set.
+	require.Equal(t, 1, pc.Len())
+	_, ok := pc.Get(Key{Path: "/new"})
+	require.True(t, ok)
+}
+
+func TestSizeCapDropsNewKeys(t *testing.T) {
+	pc := New()
+	pc.max = 2
+	gz, _ := Gzip([]byte("x"))
+
+	pc.Set(Key{Path: "/a"}, gz)
+	pc.Set(Key{Path: "/b"}, gz)
+	pc.Set(Key{Path: "/c"}, gz) // over cap: dropped
+	require.Equal(t, 2, pc.Len())
+	_, ok := pc.Get(Key{Path: "/c"})
+	require.False(t, ok)
+
+	// Updating an existing key past the cap is still allowed.
+	gz2, _ := Gzip([]byte("y"))
+	pc.Set(Key{Path: "/a"}, gz2)
+	got, ok := pc.Get(Key{Path: "/a"})
+	require.True(t, ok)
+	require.Equal(t, []byte("y"), gunzip(t, got))
+}
+
+func TestConcurrentGetSet(t *testing.T) {
+	// Exercises the lock-free read / copy-on-write write paths under -race.
+	pc := New()
+	gz, _ := Gzip([]byte("x"))
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := range 200 {
+				k := Key{Path: "/p", NoteVersionID: int64(j % 16)}
+				pc.Set(k, gz)
+				pc.Get(k)
+				pc.Get(Key{Path: "/p", NoteVersionID: int64(i)})
+			}
+		}(i)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## What

Anonymous, pre-gzipped rendered-page cache on the READ path. Repeated anonymous reads of a free note skip BOTH re-render and per-request gzip: the first anon request renders + gzips + stores; subsequent ones serve the stored gzipped bytes with `Content-Encoding: gzip`, so `fasthttp.CompressHandler` never re-compresses (it skips when `Content-Encoding` is already set).

Correctness is the priority — the cache only ever stores role-uniform anonymous responses, and every safety gate fails closed (bypass = render normally).

## How it works

- **Store** (`internal/pagecache`): `atomic.Pointer[map[Key]entry]` — lock-free `Get` on the hot path, copy-on-write `Set` under a mutex (prunes expired entries, size cap 8192). `Clear` swaps a fresh map. Key = `{Path, Host, NoteVersionID, ConfigEpoch, UILang}`. 30s TTL per entry.
- **Integration** (`internal/case/rendernotepage`): inside `Endpoint.Handle`, on the normal served-note branch only (after Resolve, so all redirect/paywall/onboarding branches have already returned). `cacheDecision` builds the key and refuses caching on any gate; `writeCachedPage` serves a hit; `fillPageCache` gzips once and stores on a miss.
- **Personalized-layout detector** (`internal/layoutloader`): at template load, walks the Jet AST (page + imports) for `currentUser.*` or `note.LastEditedBy`/`LastEditedByLabel` and sets `model.Layout.Personalized`. Non-personalized custom layouts are cacheable; personalized ones bypass.

## Bypass gates (never cache, never serve)

- Authenticated viewer (`resp.UserToken != nil`) — covers cookie/bearer/personal-token; broader and safer than the cookie alone.
- `?version=` (admin live/latest preview).
- Paywall / sign-in wall / onboarding (return before the cacheable branch).
- Personalized custom Jet layout.
- Client not accepting gzip; UI language outside `{en, ru, ""}`.
- Anomalously slow render (timeout-goroutine guard, see below).

## Invalidation

- **Note push/reload** → `PrepareLatestNotes`/`PrepareLiveNotes` call `ClearPageCache()` (full map swap).
- **Site-config change** → `SiteConfigBuilder.InvalidateSiteConfig` bumps `ConfigEpoch` (in the key).
- **HTML injections + user-space JS/CSS bundle** have no version counter → covered by the 30s TTL self-heal. Tradeoff: ≤30s staleness for injection/bundle edits; note content and config invalidate immediately. TTL chosen over a new injection-epoch to avoid threading a counter through every injection write path (smaller, more isolated change), and it doubles as a safety net for any un-keyed input.

## Correctness hardening (from an architecture review)

- **Timeout-goroutine race**: `fasthttp.TimeoutHandler` keeps the handler goroutine running on a possibly-reused ctx after a 60s timeout. `fillPageCache` skips storing if the render took ≥5s (well under the timeout), so a timed-out handler can't cache foreign/partial bytes.
- **`Clear` takes the writer mutex** so it can't be undone by a concurrent copy-on-write `Set` whose snapshot pre-dates the clear.
- **gzip Accept-Encoding** uses `fasthttp`'s own `HasAcceptEncoding` (q-aware: `gzip;q=0` → no match), consistent with `CompressHandler`.

## Tests (correctness-first)

`internal/case/rendernotepage/endpoint_cache_test.go` (drives `Endpoint.Handle` end-to-end):
- anon gzip GET caches then serves byte-identical from cache with `Content-Encoding: gzip`;
- **authenticated token never served from / never populates the cache** (no poisoning);
- personalized custom layout bypassed, non-personalized cached;
- note push invalidates; config-epoch bump retires old entries;
- `?version=` / paywall / sign-in / onboarding / no-gzip bypass;
- UILang keying: en/ru/"" separate entries, exotic Accept-Language never stored (no unbounded growth).

`internal/layoutloader/personalization_test.go`: `currentUser.*` / `note.LastEditedBy*` → personalized (including via an imported sub-template); plain/chrome-only → not.

`internal/pagecache/pagecache_test.go`: get/set, key distinctness, TTL expiry + prune, size cap, `Clear`, concurrent `-race`.

Also fixes a pre-existing compile break in `userspace_test.go` (its `loaderTestEnv` was missing `IsDevMode`, added to `layoutloader.Env` by an earlier PR) so the package's tests build.

## Verify

- `go vet` + `golangci-lint run` (pinned v2.1.6): **0 issues** on all changed packages incl. `cmd/server`.
- `go test -race ./internal/pagecache/... ./internal/layoutloader/... ./internal/configregistry/... ./internal/model/... ./internal/case/rendernotepage/... ./internal/noteloader/...`: **all green**.
- `go test -tags dev ./cmd/server/...`: **green**.
- `go build ./...` fails only on the pre-existing missing generated embeds (`ui/admin/-/web.js`, `vault.zip`) — the documented fresh-worktree gotcha, unrelated to this change.
