### PR TITLE
perf(rendernotepage): check page cache before Resolve to skip DB on hits

### DIFF
--- a/internal/case/rendernotepage/endpoint.go
+++ b/internal/case/rendernotepage/endpoint.go
@@ -53,6 +53,14 @@ func (e Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 
 	env := req.Env.(Env)
 
+	// Anonymous page-cache fast path: serve a pre-gzipped HIT BEFORE Resolve so
+	// the hot read path skips Resolve's per-request DB enrichment (telegram
+	// links). Any unmet gate or cache miss falls through to the unchanged full
+	// path below; cacheDecision + fillPageCache there remain the only writer.
+	if serveCachedPageEarly(ctx, env, request) {
+		return nil, nil
+	}
+
 	resp, err := Resolve(ctx, env, request)
 	if resp != nil && resp.Note != nil {
 		layoutParams.Title = resp.Title

--- a/internal/case/rendernotepage/endpoint_cache_reorder_test.go
+++ b/internal/case/rendernotepage/endpoint_cache_reorder_test.go
@@ -188,3 +188,98 @@ func TestPageCache_EarlyAccessEnforced(t *testing.T) {
 	require.NotContains(t, string(body(t, ctx)), "PRIMED-SHOULD-NOT-BE-SERVED",
 		"early path must enforce CanReadNote before serving a cache hit")
 }
+
+// sentinel marks page-cache bytes that must never reach a client via the early
+// fast-path for a request that the full path handles with a redirect/placeholder.
+const sentinel = "PRIMED-SHOULD-NOT-BE-SERVED"
+
+// primeSentinel stores sentinel bytes under the exact key serveCachedPageEarly
+// builds for the default anon request, so the regression tests prove the early
+// path bails BEFORE consulting (and serving) the cache for these notes.
+func primeSentinel(t *testing.T, pc *pagecache.PageCache, key pagecache.Key) {
+	t.Helper()
+	gz, err := pagecache.Gzip([]byte(sentinel))
+	require.NoError(t, err)
+	pc.Set(key, gz)
+	require.Equal(t, 1, pc.Len())
+}
+
+// Test (M1): the early fast-path must NEVER serve a primed cache entry for a
+// request that a special Handle branch resolves to a redirect / placeholder —
+// alt-permalink 301, note.Redirect 302, lang-redirect 302, unsupported-file
+// placeholder. These pages are never stored by the full path (they return before
+// fillPageCache), so today's safety is structural; these tests pin it by priming
+// an entry under the exact key and proving the early path still bails and the
+// full-path outcome (redirect / placeholder) wins.
+func TestPageCache_EarlyNeverServesRedirectGates(t *testing.T) {
+	// All cases use the default request key (path /test-note, host example.com,
+	// version 42, epoch 0, ui_lang "" — except lang-redirect which keys on "en").
+	defaultKey := pagecache.Key{Path: "/test-note", Host: "example.com", NoteVersionID: 42, ConfigEpoch: 0, UILang: ""}
+
+	t.Run("alt-permalink 301", func(t *testing.T) {
+		note, views := cacheTestNote()
+		// Non-canonical request path: note is reachable at /test-note but its
+		// canonical permalink differs and it has alternate permalinks → 301.
+		note.Permalink = "/canonical-note"
+		note.AlternatePermalinks = map[model.URLNormalizationMethod]string{
+			model.URLNormSimpleTranslit: "/test-note",
+		}
+		env, pc, _ := cacheTestEnv(views, nil)
+		primeSentinel(t, pc, defaultKey)
+
+		ctx := newReqCtx(reqOpts{acceptEncoding: "gzip"})
+		runHandle(t, env, ctx, nil)
+		require.NotContains(t, string(body(t, ctx)), sentinel,
+			"alt-permalink request must not be served from the early cache")
+		require.Equal(t, http.StatusMovedPermanently, ctx.Response.StatusCode())
+		require.NotEmpty(t, string(ctx.Response.Header.Peek("Location")), "301 must set Location")
+	})
+
+	t.Run("note.Redirect 302", func(t *testing.T) {
+		note, views := cacheTestNote()
+		target := "https://example.com/elsewhere"
+		note.Redirect = &target
+		env, pc, _ := cacheTestEnv(views, nil)
+		primeSentinel(t, pc, defaultKey)
+
+		ctx := newReqCtx(reqOpts{acceptEncoding: "gzip"})
+		runHandle(t, env, ctx, nil)
+		require.NotContains(t, string(body(t, ctx)), sentinel,
+			"note.Redirect request must not be served from the early cache")
+		require.Equal(t, http.StatusFound, ctx.Response.StatusCode())
+		require.Equal(t, target, string(ctx.Response.Header.Peek("Location")))
+	})
+
+	t.Run("unsupported-file-ext placeholder", func(t *testing.T) {
+		note, views := cacheTestNote()
+		note.Path = "/board.canvas" // .canvas → unsupported-file placeholder
+		env, pc, _ := cacheTestEnv(views, nil)
+		primeSentinel(t, pc, defaultKey)
+
+		ctx := newReqCtx(reqOpts{acceptEncoding: "gzip"})
+		runHandle(t, env, ctx, nil)
+		require.NotContains(t, string(body(t, ctx)), sentinel,
+			"unsupported-file request must not be served from the early cache")
+		require.Equal(t, http.StatusOK, ctx.Response.StatusCode(), "placeholder renders 200")
+	})
+
+	t.Run("lang-redirect 302", func(t *testing.T) {
+		note, views := cacheTestNote()
+		// Hub note (no own lang) with an en alternative: an en-preferring anon
+		// request is redirected to the en version before the cacheable branch.
+		note.Lang = ""
+		other := &model.NoteView{Path: "/note-en", Permalink: "/note-en", Lang: "en"}
+		note.LangRedirects = []model.LangRedirect{{Lang: "en", URL: "/note-en", Note: other}}
+		env, pc, _ := cacheTestEnv(views, nil)
+		// en-preferring request keys on ui_lang "en".
+		enKey := pagecache.Key{Path: "/test-note", Host: "example.com", NoteVersionID: 42, ConfigEpoch: 0, UILang: "en"}
+		primeSentinel(t, pc, enKey)
+
+		ctx := newReqCtx(reqOpts{acceptEncoding: "gzip", acceptLang: "en-US,en;q=0.9"})
+		runHandle(t, env, ctx, nil)
+		require.NotContains(t, string(body(t, ctx)), sentinel,
+			"lang-redirect request must not be served from the early cache")
+		require.Equal(t, http.StatusFound, ctx.Response.StatusCode())
+		require.Equal(t, "/note-en", string(ctx.Response.Header.Peek("Location")))
+	})
+}

--- a/internal/case/rendernotepage/endpoint_cache_reorder_test.go
+++ b/internal/case/rendernotepage/endpoint_cache_reorder_test.go
@@ -1,0 +1,190 @@
+package rendernotepage_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"trip2g/internal/appreq"
+	"trip2g/internal/case/rendernotepage"
+	"trip2g/internal/layoutloader"
+	"trip2g/internal/model"
+	"trip2g/internal/pagecache"
+	"trip2g/internal/usertoken"
+
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+// These tests pin the "check page cache before Resolve" reorder: on an anonymous,
+// gzip-accepting, cacheable request the page-cache HIT must be served BEFORE
+// Resolve runs, skipping Resolve's per-request DB enrichment (telegram links).
+// They reuse the helpers in endpoint_cache_test.go (cacheTestNote, cacheTestEnv,
+// newReqCtx, runHandle, body, reqOpts, cacheLoaderEnv).
+
+// Test a (the RED test): a cache HIT must NOT re-run Resolve's DB enrichment.
+// GetTelegramPostLinksByNoteVersionID is the proxy for "Resolve ran": today the
+// cache is consulted only AFTER Resolve, so the hit still pays that query — this
+// assertion fails until the early fast-path short-circuits before Resolve.
+func TestPageCache_EarlyHitSkipsResolveDBWork(t *testing.T) {
+	_, views := cacheTestNote()
+	env, pc, _ := cacheTestEnv(views, nil)
+
+	// Prime the cache via the full path (Resolve runs, telegram links queried).
+	runHandle(t, env, newReqCtx(reqOpts{acceptEncoding: "gzip"}), nil)
+	require.Equal(t, 1, pc.Len())
+	tgBefore := len(env.GetTelegramPostLinksByNoteVersionIDCalls())
+	require.Equal(t, 1, tgBefore, "priming request runs full Resolve incl. telegram links")
+
+	// Cache HIT: serve cached bytes WITHOUT re-running Resolve's DB enrichment.
+	ctx := newReqCtx(reqOpts{acceptEncoding: "gzip"})
+	runHandle(t, env, ctx, nil)
+	require.Equal(t, "gzip", string(ctx.Response.Header.ContentEncoding()))
+	require.Len(t, env.StoreCachedPageCalls(), 1, "hit must not re-fill the cache")
+	require.Equal(t, tgBefore, len(env.GetTelegramPostLinksByNoteVersionIDCalls()),
+		"cache HIT must skip GetTelegramPostLinksByNoteVersionID (Resolve DB enrichment)")
+}
+
+// Test b: the early-served bytes are byte-identical to the filling render.
+func TestPageCache_EarlyHitBytesMatchRender(t *testing.T) {
+	_, views := cacheTestNote()
+	env, pc, _ := cacheTestEnv(views, nil)
+
+	ctx1 := newReqCtx(reqOpts{acceptEncoding: "gzip"})
+	runHandle(t, env, ctx1, nil) // fill
+	ctx2 := newReqCtx(reqOpts{acceptEncoding: "gzip"})
+	runHandle(t, env, ctx2, nil) // early hit
+
+	require.Equal(t, ctx1.Response.Body(), ctx2.Response.Body(),
+		"early cache hit serves byte-identical gzip to the filling render")
+	require.Equal(t, body(t, ctx1), body(t, ctx2),
+		"decompressed early-hit body equals the filling render")
+	require.Equal(t, 1, pc.Len())
+}
+
+// Test c: a cache miss falls through to the full path (Resolve runs, telegram
+// links queried, page rendered and cache filled).
+func TestPageCache_MissFallsThrough(t *testing.T) {
+	_, views := cacheTestNote()
+	env, pc, _ := cacheTestEnv(views, nil)
+	require.Equal(t, 0, pc.Len())
+
+	ctx := newReqCtx(reqOpts{acceptEncoding: "gzip"})
+	runHandle(t, env, ctx, nil)
+	require.GreaterOrEqual(t, len(env.GetTelegramPostLinksByNoteVersionIDCalls()), 1,
+		"a cache miss runs full Resolve incl. telegram links")
+	require.Equal(t, 1, pc.Len(), "miss renders and fills the cache")
+	require.Contains(t, string(body(t, ctx)), "<h1>Test</h1>")
+}
+
+// Test d: every bypass gate must take the full (Resolve) path — the early
+// fast-path must never short-circuit them, even when a normal anon entry is
+// already cached.
+func TestPageCache_EarlyBypassTakesFullPath(t *testing.T) {
+	// runAndAssertFull proves the request ran Resolve by observing a new
+	// telegram-links DB query (which the early fast-path would have skipped).
+	runAndAssertFull := func(t *testing.T, env *EnvMock, ctx *fasthttp.RequestCtx, token *usertoken.Data) {
+		t.Helper()
+		before := len(env.GetTelegramPostLinksByNoteVersionIDCalls())
+		runHandle(t, env, ctx, token)
+		require.Greater(t, len(env.GetTelegramPostLinksByNoteVersionIDCalls()), before,
+			"bypass request must run full Resolve, not the early cache path")
+	}
+
+	t.Run("authenticated token", func(t *testing.T) {
+		_, views := cacheTestNote()
+		env, _, _ := cacheTestEnv(views, nil)
+		runHandle(t, env, newReqCtx(reqOpts{acceptEncoding: "gzip"}), nil) // prime anon entry
+		runAndAssertFull(t, env, newReqCtx(reqOpts{acceptEncoding: "gzip"}), &usertoken.Data{ID: 1, Role: "user"})
+	})
+
+	t.Run("version param", func(t *testing.T) {
+		_, views := cacheTestNote()
+		env, _, _ := cacheTestEnv(views, nil)
+		runHandle(t, env, newReqCtx(reqOpts{acceptEncoding: "gzip"}), nil)
+		runAndAssertFull(t, env, newReqCtx(reqOpts{acceptEncoding: "gzip", query: "version=latest"}), nil)
+	})
+
+	t.Run("non-gzip client", func(t *testing.T) {
+		_, views := cacheTestNote()
+		env, _, _ := cacheTestEnv(views, nil)
+		runHandle(t, env, newReqCtx(reqOpts{acceptEncoding: "gzip"}), nil)
+		runAndAssertFull(t, env, newReqCtx(reqOpts{}), nil) // no Accept-Encoding
+	})
+
+	t.Run("exotic accept-language", func(t *testing.T) {
+		_, views := cacheTestNote()
+		env, _, _ := cacheTestEnv(views, nil)
+		runHandle(t, env, newReqCtx(reqOpts{acceptEncoding: "gzip"}), nil)
+		runAndAssertFull(t, env, newReqCtx(reqOpts{acceptEncoding: "gzip", acceptLang: "de-DE,de;q=0.9"}), nil)
+	})
+
+	t.Run("setlang query", func(t *testing.T) {
+		_, views := cacheTestNote()
+		env, _, _ := cacheTestEnv(views, nil)
+		runHandle(t, env, newReqCtx(reqOpts{acceptEncoding: "gzip"}), nil) // prime anon entry
+		// ?setlang must hit handleSetLang (cookie + 302), never the early cache,
+		// even though it shares the cache-key path with a normal request.
+		ctx := newReqCtx(reqOpts{acceptEncoding: "gzip", query: "setlang=en"})
+		runHandle(t, env, ctx, nil)
+		require.Equal(t, http.StatusFound, ctx.Response.StatusCode(),
+			"setlang must redirect (302), not be served from the early cache")
+		require.NotEqual(t, "gzip", string(ctx.Response.Header.ContentEncoding()))
+	})
+
+	t.Run("personalized layout", func(t *testing.T) {
+		layouts, err := layoutloader.Load(cacheLoaderEnv{}, []model.LayoutSourceFile{
+			{ID: "/personal", Path: "_layouts/personal.html", Content: `<main>{{ if currentUser.IsAdmin() }}admin{{ end }}body</main>`},
+		}, layoutloader.Options{})
+		require.NoError(t, err)
+		require.True(t, layouts.Map["/personal"].Personalized)
+
+		note, views := cacheTestNote()
+		note.Layout = "personal"
+		env, pc, _ := cacheTestEnv(views, layouts)
+		runAndAssertFull(t, env, newReqCtx(reqOpts{acceptEncoding: "gzip"}), nil)
+		require.Equal(t, 0, pc.Len(), "personalized layout is never cached")
+	})
+
+	t.Run("note not found", func(t *testing.T) {
+		_, views := cacheTestNote()
+		env, _, _ := cacheTestEnv(views, nil)
+		ctx := newReqCtx(reqOpts{path: "/does-not-exist", acceptEncoding: "gzip"})
+		req := &appreq.Request{Req: ctx, Env: env}
+		req.SetUserToken(nil)
+		// render404 errors on this mock (no TrackNotFound); we only assert the
+		// early path did NOT short-circuit: an unresolved path must not even
+		// consult the page cache, and the status is 404.
+		_, _ = rendernotepage.Endpoint{}.Handle(req)
+		require.Empty(t, env.CachedPageCalls(),
+			"unresolved path must not consult the page cache in the early path")
+		require.Equal(t, http.StatusNotFound, ctx.Response.StatusCode())
+	})
+}
+
+// Test e (conservative-design safety): the early path must enforce CanReadNote
+// before serving a cache hit. Here a primed entry exists under the exact key the
+// early path builds, but access is denied — the primed bytes must NOT be served;
+// the request falls through to Resolve, which paywalls it.
+func TestPageCache_EarlyAccessEnforced(t *testing.T) {
+	_, views := cacheTestNote()
+	env, pc, _ := cacheTestEnv(views, nil)
+
+	// Prime a cache entry directly under the key the early path will build for a
+	// default anon request (path /test-note, host example.com, version 42,
+	// epoch 0, ui_lang "").
+	primed := []byte("PRIMED-SHOULD-NOT-BE-SERVED")
+	gz, err := pagecache.Gzip(primed)
+	require.NoError(t, err)
+	key := pagecache.Key{Path: "/test-note", Host: "example.com", NoteVersionID: 42, ConfigEpoch: 0, UILang: ""}
+	pc.Set(key, gz)
+	require.Equal(t, 1, pc.Len())
+
+	// Access now denied for this anonymous viewer.
+	env.CanReadNoteFunc = func(ctx context.Context, n *model.NoteView) (bool, error) { return false, nil }
+
+	ctx := newReqCtx(reqOpts{acceptEncoding: "gzip"})
+	runHandle(t, env, ctx, nil)
+	require.NotContains(t, string(body(t, ctx)), "PRIMED-SHOULD-NOT-BE-SERVED",
+		"early path must enforce CanReadNote before serving a cache hit")
+}

--- a/internal/case/rendernotepage/pagecache.go
+++ b/internal/case/rendernotepage/pagecache.go
@@ -158,6 +158,25 @@ func serveCachedPageEarly(ctx *fasthttp.RequestCtx, env Env, request Request) bo
 		return false
 	}
 
+	// Notes handled by a special Handle branch that returns before the cacheable
+	// branch — alt-permalink 301, note.Redirect 302, lang-redirect 302, and the
+	// unsupported-file placeholder — are never stored by the full path, so the
+	// early lookup structurally misses them. Bail defensively anyway so the early
+	// path can never serve such a request from a (hypothetical) cache entry,
+	// keeping it provably no less strict than Handle even across future reorders.
+	if note.AlternatePermalinks != nil && request.Path != note.Permalink {
+		return false
+	}
+	if note.Redirect != nil {
+		return false
+	}
+	if len(note.LangRedirects) > 0 && note.Lang == "" {
+		return false
+	}
+	if unsupportedFileExt(note.Path) != "" {
+		return false
+	}
+
 	// Independently enforce every anonymous-readability gate Resolve applies
 	// before the cacheable branch, BEFORE consulting the cache. This makes the
 	// early path provably no less strict than the full path (paywalled / signin /

--- a/internal/case/rendernotepage/pagecache.go
+++ b/internal/case/rendernotepage/pagecache.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"trip2g/internal/langdetect"
+	"trip2g/internal/model"
 	"trip2g/internal/pagecache"
 
 	"github.com/valyala/fasthttp"
@@ -75,21 +76,131 @@ func cacheDecision(
 		return zero, false
 	}
 
-	uiLang, ok := normalizeUILang(langdetect.DetectPreferred(
-		string(ctx.Request.Header.Cookie(langCookieName)),
-		string(ctx.Request.Header.Peek("Accept-Language")),
-	))
+	uiLang, ok := cacheableUILang(ctx)
 	if !ok {
 		return zero, false
 	}
 
+	return buildPageCacheKey(env, request, resp.Note, uiLang), true
+}
+
+// cacheableUILang resolves the request's preferred UI language and reports
+// whether it is in the cacheable whitelist. Shared by cacheDecision (store time)
+// and serveCachedPageEarly (the early read fast-path) so the two cannot drift.
+func cacheableUILang(ctx *fasthttp.RequestCtx) (string, bool) {
+	return normalizeUILang(langdetect.DetectPreferred(
+		string(ctx.Request.Header.Cookie(langCookieName)),
+		string(ctx.Request.Header.Peek("Accept-Language")),
+	))
+}
+
+// buildPageCacheKey assembles the page-cache key from a request + its resolved
+// note. The single source of truth for key construction, shared by cacheDecision
+// and serveCachedPageEarly so an early hit and its fill use identical keys.
+func buildPageCacheKey(env Env, request Request, note *model.NoteView, uiLang string) pagecache.Key {
 	return pagecache.Key{
 		Path:          request.Path,
 		Host:          request.Host,
-		NoteVersionID: resp.Note.VersionID,
+		NoteVersionID: note.VersionID,
 		ConfigEpoch:   env.ConfigEpoch(),
 		UILang:        uiLang,
-	}, true
+	}
+}
+
+// serveCachedPageEarly attempts to serve an anonymous, gzip-accepting request
+// from the page cache BEFORE Resolve runs, so a hit skips Resolve's per-request
+// DB enrichment (telegram links et al.). It fires only when every gate
+// cacheDecision enforces at store time also holds here. On ANY unmet gate or a
+// cache miss it returns false and the caller takes the full unchanged path; it
+// is a pure short-circuit that only serves an identical cache hit sooner.
+//
+// SAFETY: a stored entry was anonymously readable when stored (the full Resolve,
+// incl. the sign-in wall, paywall and CanReadNote, passed before the fill). The
+// note is re-resolved here from the SAME in-memory source and finder Resolve
+// uses, so its VersionID — part of the key — is identical. As a conservative
+// access gate we still call CanReadNote before serving, so the early path can
+// never serve a page the current viewer may not read. For anonymous viewers
+// CanReadNote is in-memory (note.Free / ".html" path), adding no DB work.
+func serveCachedPageEarly(ctx *fasthttp.RequestCtx, env Env, request Request) bool {
+	if request.UserToken != nil { // anonymous viewers only
+		return false
+	}
+	if request.Version != "" { // admin live/latest preview
+		return false
+	}
+	// ?setlang= is processed by handleSetLang (sets a cookie + redirects) on the
+	// full path and is NOT part of the cache key; never short-circuit it.
+	if len(ctx.QueryArgs().Peek("setlang")) > 0 {
+		return false
+	}
+	if !ctx.Request.Header.HasAcceptEncoding("gzip") {
+		return false
+	}
+	uiLang, ok := cacheableUILang(ctx)
+	if !ok {
+		return false
+	}
+
+	// Mirror Resolve's anonymous note-source selection (resolve.go): live unless
+	// the site shows draft versions. Admin ?version= switching cannot apply here.
+	siteConfig := env.SiteConfig(ctx)
+	notes := env.LiveNoteViews()
+	if siteConfig.ShowDraftVersions {
+		notes = env.LatestNoteViews()
+	}
+
+	var publicURL string
+	if request.Host != "" {
+		publicURL = env.PublicURL()
+	}
+	note := resolveNote(notes, request.Host, request.Path, publicURL)
+	if note == nil {
+		return false
+	}
+
+	// Independently enforce every anonymous-readability gate Resolve applies
+	// before the cacheable branch, BEFORE consulting the cache. This makes the
+	// early path provably no less strict than the full path (paywalled / signin /
+	// unreadable notes never reach a cache hit) and, like the full path, never
+	// consults the cache for them.
+	//
+	// Sign-in wall: a require_signin subgraph blocks anonymous readers
+	// (resolve.go). CanReadNote does NOT re-check this for anonymous viewers, so
+	// the explicit gate is load-bearing, not redundant.
+	for _, sg := range note.Subgraphs {
+		if sg != nil && sg.RequireSignin {
+			return false
+		}
+	}
+	// Paywall: non-free notes are never anonymously readable (resolve.go).
+	if !note.Free {
+		return false
+	}
+
+	// Layout selection mirrors Handle: note.Layout else the site default.
+	layout := note.Layout
+	if layout == "" {
+		layout = siteConfig.DefaultLayout
+	}
+	if layoutIsPersonalized(env, layout) {
+		return false
+	}
+
+	// Conservative access gate (see SAFETY above): the real access function,
+	// also catching ".html" notes. For anonymous viewers it is in-memory
+	// (note.Free / ".html" path), so it adds no DB work.
+	hasAccess, err := env.CanReadNote(ctx, note)
+	if err != nil || !hasAccess {
+		return false
+	}
+
+	cached, ok := env.CachedPage(buildPageCacheKey(env, request, note, uiLang))
+	if !ok {
+		return false
+	}
+
+	writeCachedPage(ctx, cached)
+	return true
 }
 
 // layoutIsPersonalized reports whether the named custom layout exists, parses,


### PR DESCRIPTION
## What

Move the anonymous page-cache lookup **before** `rendernotepage.Resolve`, so a
cache HIT skips Resolve's per-request DB enrichment. Today the cache is consulted
only *after* `Resolve` (`endpoint.go`), so even a HIT pays a per-request SQLite
parse+plan for `GetTelegramPostLinksByNoteVersionID` (and the rest of Resolve's
enrichment). A CPU profile under anonymous read load showed SQLite parse/plan
dominating the hot path because of this.

A new `serveCachedPageEarly()` runs at the top of `Handle`, before `Resolve`. On
a hit it serves the pre-gzipped bytes and returns; on **any** unmet gate or a
cache miss it returns `false` and the request falls through to the existing,
**completely unchanged** `Resolve` + `cacheDecision` + fill path. It is a pure
short-circuit — it only serves an identical cache hit sooner.

## Design: CONSERVATIVE

The early path still calls `env.CanReadNote(ctx, note)` (plus the paywall and
sign-in-wall gates) before serving, so it can never serve a page the current
viewer may not read. It skips only the *rest* of Resolve's work (telegram links,
similar-notes, render) — which is where the per-request DB cost lives.

### Why conservative (CanReadNote safety analysis)

`CanReadNote` for an **anonymous** viewer (`canreadnote.Resolve`, nil token, no
federated scope) is purely in-memory and returns:
- `false` if `note.Path` ends in `.html`;
- otherwise `note.Free`.

It does **not** check `RequireSignin` for anonymous viewers (that branch is
authenticated-only). So relying on `CanReadNote` alone would leave the sign-in
wall to cache-invalidation only. Because anonymous `CanReadNote` is in-memory
(no DB), keeping it on the hit path costs nothing, so the conservative design is
unconditionally safe **and** captures essentially the full win (the heavy item,
`GetTelegramPostLinksByNoteVersionID`, is skipped on a hit). Security beats the
few microseconds the aggressive design might save, so conservative was chosen.

## Independent gate enforcement (no less strict than the full path)

Running before `Resolve` means the early path must re-apply every
anonymous-readability gate Resolve applies before the cacheable branch. It does,
in order, bailing (fall through) on any failure:

1. anonymous only (`token == nil`);
2. no `?version=`;
3. no `?setlang=` (handled by `handleSetLang` — cookie + redirect — and not part
   of the cache key, so it must never be short-circuited);
4. client accepts gzip;
5. UI lang in the cacheable whitelist (`{"en","ru",""}`);
6. note resolves in-memory via the **same** `resolveNote` finder + the **same**
   Live/Latest source Resolve selects (so the note — and its `VersionID` — is
   identical);
7. **sign-in wall**: no `RequireSignin` subgraph (mirrors `resolve.go`);
8. **paywall**: `note.Free` (mirrors `resolve.go`);
9. layout not personalized;
10. **`CanReadNote`** (the real access function, also catching `.html` notes).

Only then is `env.CachedPage(key)` consulted; a hit serves the bytes, a miss
falls through. Redirect/301/302/unsupported-file/404/onboarding cases only matter
on misses (those responses are never stored), so they fall through and stay
correct. The `?setlang` guard is the one query-only early-return that shares a
cache-key path with normal requests, hence its explicit gate.

## DRY

`cacheDecision` (store time) and `serveCachedPageEarly` (read time) now share
`cacheableUILang()` and `buildPageCacheKey()` — a single source of truth for the
UI-lang whitelist and key construction — so an early hit and its fill cannot
drift to different keys.

## Tests (TDD, Red → Green)

New `endpoint_cache_reorder_test.go`:
- **`TestPageCache_EarlyHitSkipsResolveDBWork`** (the RED test): a primed cache
  entry + anon gzip request serves the cached bytes and does **not** call
  `GetTelegramPostLinksByNoteVersionID` again. Failed today (count 2), passes
  after the reorder (count 1) — the key RED→GREEN assertion.
- `TestPageCache_EarlyHitBytesMatchRender`: early-hit bytes are byte-identical to
  the filling render.
- `TestPageCache_MissFallsThrough`: a miss runs full Resolve (telegram queried)
  and fills the cache.
- `TestPageCache_EarlyBypassTakesFullPath`: every bypass gate (authenticated
  token, `?version=`, non-gzip, exotic Accept-Language, `?setlang=`, personalized
  layout, note-not-found) takes the full path — no early short-circuit.
- `TestPageCache_EarlyAccessEnforced`: a primed entry whose `CanReadNote` now
  returns `false` is **never** served from the early path (pins the conservative
  safety gate).

All existing `rendernotepage` tests still pass, including
`TestPageCache_NonNoteBranchesBypass` (paywall never consults the cache — the
explicit paywall/sign-in gates preserve that invariant).

`go test -race ./internal/case/rendernotepage/...` → ok. `go vet` clean.
