### PR TITLE
fix(defaulttemplate): deterministic OG-tag order — byte-stable, user-independent free-note render

### DIFF
--- a/internal/case/rendernotepage/default_template_cache_invariant_test.go
+++ b/internal/case/rendernotepage/default_template_cache_invariant_test.go
@@ -1,0 +1,70 @@
+package rendernotepage_test
+
+import (
+	"context"
+	"testing"
+
+	"trip2g/internal/usertoken"
+
+	"github.com/stretchr/testify/require"
+)
+
+// renderFreeNoteHTML renders the shared free test note through the real
+// default-template page path (Endpoint.Handle -> defaulttemplate.WriteRender) for
+// the given viewer token and returns the response HTML body.
+func renderFreeNoteHTML(t *testing.T, env *EnvMock, token *usertoken.Data) string {
+	t.Helper()
+	ctx := newReqCtx(reqOpts{})
+	runHandle(t, env, ctx, token)
+	return string(body(t, ctx))
+}
+
+// TestDefaultTemplate_FreeNoteRenderIsByteStable pins the REAL invariant required
+// before the anonymous page cache (PR #54) can be extended to logged-in users:
+// the default-template HTML of a free note must be byte-STABLE — the same inputs
+// must always produce the same bytes. A page cache stores one rendered body and
+// replays it; if the render is nondeterministic, the stored page is an arbitrary
+// one of several variants.
+//
+// RED baseline: this fails today because buildOGTags (endpoint.go) returns a
+// map[string]string and the template iterates it with `range ctx.OGTags`
+// (views.html), so Go's randomized map order shuffles the <meta property="og:*">
+// tags between renders. Rendering the SAME note many times therefore yields
+// several distinct byte sequences. Goes GREEN once OG-tag emission is ordered.
+func TestDefaultTemplate_FreeNoteRenderIsByteStable(t *testing.T) {
+	_, views := cacheTestNote()
+	env, _, _ := cacheTestEnv(views, nil)
+
+	first := renderFreeNoteHTML(t, env, nil)
+	for i := 1; i < 20; i++ {
+		require.Equal(t, first, renderFreeNoteHTML(t, env, nil),
+			"default-template render of a free note must be byte-identical across repeated renders (render #%d differs)", i)
+	}
+}
+
+// TestDefaultTemplate_FreeNoteHTMLIsUserIndependent_NonAdmin is the proof-of-safety
+// for extending the page cache to logged-in users: the default-template HTML of a
+// free note must be byte-identical for an anonymous viewer and a NON-admin
+// logged-in viewer. The live default template has no per-user server branches on
+// the note path (the only IsAdmin() branch is the onboarding page), so once OG-tag
+// order is deterministic the two renders coincide — meaning the same cached page
+// is safe to serve to both. (Admins legitimately differ and stay cache-bypassed.)
+//
+// This is RED before the OG-order fix (same map-iteration nondeterminism) and
+// GREEN after it.
+func TestDefaultTemplate_FreeNoteHTMLIsUserIndependent_NonAdmin(t *testing.T) {
+	_, views := cacheTestNote()
+	env, _, _ := cacheTestEnv(views, nil)
+	// Logged-in, non-admin viewer with two active subgraphs. Only this render
+	// reaches handleUserToken -> ListActiveUserSubgraphs (resolve.go:440); the live
+	// default template never bakes these into the note HTML.
+	env.ListActiveUserSubgraphsFunc = func(ctx context.Context, userID int64) ([]string, error) {
+		return []string{"alpha", "beta"}, nil
+	}
+
+	anonHTML := renderFreeNoteHTML(t, env, nil)
+	loggedInHTML := renderFreeNoteHTML(t, env, &usertoken.Data{ID: 123, Role: "user"})
+
+	require.Equal(t, anonHTML, loggedInHTML,
+		"default-template HTML of a free note must be identical for anon and non-admin logged-in viewers")
+}

--- a/internal/defaulttemplate/template.go
+++ b/internal/defaulttemplate/template.go
@@ -2,6 +2,7 @@ package defaulttemplate
 
 import (
 	"encoding/json"
+	"sort"
 	"strings"
 
 	"trip2g/internal/db"
@@ -19,6 +20,13 @@ import (
 type HrefLang struct {
 	Lang string // "en", "ru", "x-default"
 	Href string // full URL including scheme+host
+}
+
+// OGTag is a single Open Graph / Twitter meta tag. It exists so the template can
+// emit ctx.OGTags in a stable (property-sorted) order — see OGTagsSorted.
+type OGTag struct {
+	Property string
+	Value    string
 }
 
 // PaywallError holds data needed to render the paywall page.
@@ -82,6 +90,25 @@ type Ctx struct {
 	// LayoutSections holds vault-based layout section files for glob-based
 	// header/footer/sidebar resolution. Populated from NoteViews.LayoutSections.
 	LayoutSections []model.LayoutSectionEntry
+}
+
+// OGTagsSorted returns the Open Graph / Twitter meta tags sorted by property, so
+// the template emits them deterministically. ctx.OGTags is a map, and Go
+// randomizes map iteration order, which would otherwise shuffle the
+// <meta property="og:*"> tags between renders and make the rendered page — and
+// thus its cached bytes — vary byte-for-byte for identical inputs.
+func (ctx *Ctx) OGTagsSorted() []OGTag {
+	if len(ctx.OGTags) == 0 {
+		return nil
+	}
+	tags := make([]OGTag, 0, len(ctx.OGTags))
+	for property, value := range ctx.OGTags {
+		tags = append(tags, OGTag{Property: property, Value: value})
+	}
+	sort.Slice(tags, func(i, j int) bool {
+		return tags[i].Property < tags[j].Property
+	})
+	return tags
 }
 
 // IsWide reports whether the note opted into full-width rendering via

--- a/internal/defaulttemplate/views.html
+++ b/internal/defaulttemplate/views.html
@@ -46,8 +46,8 @@
 {% endif %}
 
 {% if ctx.OGTags != nil %}
-{% for property, value := range ctx.OGTags %}
-<meta property="{%s= property %}" content="{%s= value %}">
+{% for _, tag := range ctx.OGTagsSorted() %}
+<meta property="{%s= tag.Property %}" content="{%s= tag.Value %}">
 {% endfor %}
 {% endif %}
 

--- a/internal/defaulttemplate/views.html.go
+++ b/internal/defaulttemplate/views.html.go
@@ -183,16 +183,16 @@ func StreamRender(qw422016 *qt422016.Writer, ctx *Ctx) {
 		qw422016.N().S(`
 `)
 //line views.html:49
-		for property, value := range ctx.OGTags {
+		for _, tag := range ctx.OGTagsSorted() {
 //line views.html:49
 			qw422016.N().S(`
 <meta property="`)
 //line views.html:50
-			qw422016.N().S(property)
+			qw422016.N().S(tag.Property)
 //line views.html:50
 			qw422016.N().S(`" content="`)
 //line views.html:50
-			qw422016.N().S(value)
+			qw422016.N().S(tag.Value)
 //line views.html:50
 			qw422016.N().S(`">
 `)


### PR DESCRIPTION
## Why

Groundwork for extending the anonymous page cache (PR #54) to logged-in users on the **default template** (not custom Jet layouts). The page cache stores one rendered body and replays it, so the render must be **byte-stable** for identical inputs and **user-independent** for non-admin viewers of a free note.

While building the invariant test we found the real blocker is **not** per-user CSS (the `resp.UserSubgraphs` paywall-unlock at `internal/case/rendernotepage/view.html.go:156` is **dead code** — `StreamNoteContent`/`WriteNoteContent` have zero production references; the live note page is rendered by `internal/defaulttemplate`). The live default template has no per-user server branch on the note path. The only thing that made the HTML differ between renders was **nondeterministic Open Graph `<meta>` tag order**: `buildOGTags` returns `map[string]string` and the template iterated it with `range ctx.OGTags`, so Go's randomized map order shuffled the tags — even between two anonymous renders.

## What

- `fix(defaulttemplate)`: emit OG tags in a stable, property-sorted order. Added `OGTag` type + `(*Ctx).OGTagsSorted()` and switched the template loop to it. OG **content is unchanged**; only ordering is now deterministic. Regenerated `views.html.go` (quicktemplate).
- `test(rendernotepage)`:
  - `TestDefaultTemplate_FreeNoteRenderIsByteStable` — same free note rendered 20x must be byte-identical (RED before the fix on the OG-order diff, GREEN after).
  - `TestDefaultTemplate_FreeNoteHTMLIsUserIndependent_NonAdmin` — anon vs non-admin logged-in (`Role:"user"`, `ListActiveUserSubgraphs -> ["alpha","beta"]`) HTML must be byte-identical; the cache-for-all safety proof.

## Evidence

RED before fix (the entire diff was OG `<meta>` order):
```
--- Expected
+<meta property="og:url" content="https://example.com/test-note">
 <meta property="og:type" content="article">
 <meta property="twitter:card" content="summary_large_image">
-<meta property="og:url" content="https://example.com/test-note">
```
After fix: `go test -race ./internal/defaulttemplate/... ./internal/case/rendernotepage/...` -> both packages OK; the two new tests pass across repeated runs.

## Notes / follow-ups

- Admins legitimately differ (onboarding page `IsAdmin()` branch) and stay cache-bypassed.
- This PR does **not** itself enable cache-for-all; it removes the byte-stability blocker and proves user-independence for non-admins. Wiring logged-in cache reuse is a separate change.
