### PR TITLE
fix(lint): resolve golangci failures on main (stmtcache + page-cache tests)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -435,6 +435,12 @@ linters:
           - noctx
           - wrapcheck
           - nilnil
+      - path: 'internal/db/stmtcache\.go'
+        linters:
+          - sqlclosecheck  # StmtCache caches long-lived *sql.Stmt for reuse (closed on reprepare/evict), never by the caller
+      - path: 'internal/db/stmtcache_test\.go'
+        linters:
+          - sqlclosecheck  # tests eager-Close() rows between queries to assert cache state, rather than defer
       - path: 'endpoint\.go'
         linters:
           - errcheck

--- a/internal/case/rendernotepage/endpoint_cache_reorder_test.go
+++ b/internal/case/rendernotepage/endpoint_cache_reorder_test.go
@@ -41,7 +41,7 @@ func TestPageCache_EarlyHitSkipsResolveDBWork(t *testing.T) {
 	runHandle(t, env, ctx, nil)
 	require.Equal(t, "gzip", string(ctx.Response.Header.ContentEncoding()))
 	require.Len(t, env.StoreCachedPageCalls(), 1, "hit must not re-fill the cache")
-	require.Equal(t, tgBefore, len(env.GetTelegramPostLinksByNoteVersionIDCalls()),
+	require.Len(t, env.GetTelegramPostLinksByNoteVersionIDCalls(), tgBefore,
 		"cache HIT must skip GetTelegramPostLinksByNoteVersionID (Resolve DB enrichment)")
 }
 
@@ -221,7 +221,7 @@ func TestPageCache_EarlyNeverServesRedirectGates(t *testing.T) {
 		// Non-canonical request path: note is reachable at /test-note but its
 		// canonical permalink differs and it has alternate permalinks → 301.
 		note.Permalink = "/canonical-note"
-		note.AlternatePermalinks = map[model.URLNormalizationMethod]string{
+		note.AlternatePermalinks = map[model.URLNormalizationMethod]string{ //nolint:exhaustive // fixture: only the SimpleTranslit alternate permalink is exercised
 			model.URLNormSimpleTranslit: "/test-note",
 		}
 		env, pc, _ := cacheTestEnv(views, nil)

--- a/internal/db/stmtcache.go
+++ b/internal/db/stmtcache.go
@@ -63,8 +63,8 @@ func (c *StmtCache) getStmt(ctx context.Context, query string) (*sql.Stmt, error
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	// Re-check: another goroutine may have prepared it while we waited.
-	if stmt, ok := c.stmts[query]; ok {
-		return stmt, nil
+	if s, found := c.stmts[query]; found {
+		return s, nil
 	}
 	stmt, err := c.db.PrepareContext(ctx, query)
 	if err != nil {
@@ -99,11 +99,11 @@ func (c *StmtCache) QueryContext(ctx context.Context, query string, args ...inte
 	}
 	rows, err := stmt.QueryContext(ctx, args...)
 	if isSchemaChangedErr(err) {
-		stmt, rerr := c.reprepare(ctx, query)
+		fresh, rerr := c.reprepare(ctx, query)
 		if rerr != nil {
 			return nil, rerr
 		}
-		return stmt.QueryContext(ctx, args...)
+		return fresh.QueryContext(ctx, args...)
 	}
 	return rows, err
 }
@@ -129,11 +129,11 @@ func (c *StmtCache) ExecContext(ctx context.Context, query string, args ...inter
 	}
 	res, err := stmt.ExecContext(ctx, args...)
 	if isSchemaChangedErr(err) {
-		stmt, rerr := c.reprepare(ctx, query)
+		fresh, rerr := c.reprepare(ctx, query)
 		if rerr != nil {
 			return nil, rerr
 		}
-		return stmt.ExecContext(ctx, args...)
+		return fresh.ExecContext(ctx, args...)
 	}
 	return res, err
 }

--- a/internal/db/stmtcache_test.go
+++ b/internal/db/stmtcache_test.go
@@ -44,6 +44,7 @@ func TestStmtCacheReusesPreparedStatement(t *testing.T) {
 
 	rows1, err := cache.QueryContext(ctx, q, 1)
 	require.NoError(t, err)
+	require.NoError(t, rows1.Err())
 	require.NoError(t, rows1.Close())
 
 	cache.mu.RLock()
@@ -56,6 +57,7 @@ func TestStmtCacheReusesPreparedStatement(t *testing.T) {
 	// Second call with the same SQL must reuse the same *sql.Stmt pointer.
 	rows2, err := cache.QueryContext(ctx, q, 2)
 	require.NoError(t, err)
+	require.NoError(t, rows2.Err())
 	require.NoError(t, rows2.Close())
 
 	cache.mu.RLock()
@@ -137,6 +139,7 @@ func TestStmtCacheRecoversAfterSchemaChange(t *testing.T) {
 	// Cache the statement via QueryContext too (the path with the explicit fallback).
 	rows, err := cache.QueryContext(ctx, q, 1)
 	require.NoError(t, err)
+	require.NoError(t, rows.Err())
 	require.NoError(t, rows.Close())
 
 	// Schema change that bumps the schema cookie but keeps the query valid.
@@ -150,6 +153,7 @@ func TestStmtCacheRecoversAfterSchemaChange(t *testing.T) {
 	require.True(t, rows.Next())
 	require.NoError(t, rows.Scan(&name))
 	require.Equal(t, "alpha", name)
+	require.NoError(t, rows.Err())
 }
 
 // TestIsSchemaChangedErr covers the SQLITE_SCHEMA detection predicate used by
@@ -223,5 +227,5 @@ func TestStmtCacheConcurrentReuse(t *testing.T) {
 
 	cache.mu.RLock()
 	defer cache.mu.RUnlock()
-	require.Equal(t, 1, len(cache.stmts), "concurrent identical SQL must prepare exactly one statement")
+	require.Len(t, cache.stmts, 1, "concurrent identical SQL must prepare exactly one statement")
 }


### PR DESCRIPTION
## What

Fixes the 18 `golangci-lint` failures currently red on `main` — inherited from the page-cache PR (#54) and the stmt-cache PR (#57), not from any in-flight work. `lint` is green on this branch.

## Changes

- **`internal/db/stmtcache.go`** — rename shadowed locals (`govet shadow`). Pure rename, no logic change: the SQLITE_SCHEMA retry still uses the freshly-reprepared statement.
- **`.golangci.yaml`** — exclude `sqlclosecheck` for `stmtcache.go` / `stmtcache_test.go`. A prepared-statement cache deliberately keeps each `*sql.Stmt` open for reuse (closed only on reprepare/evict), and its tests eager-`Close()` rows between queries to assert cache state — both intentional, so the check is a false positive here. Matches the repo's existing path-based exclusion idiom.
- **`internal/db/stmtcache_test.go`** — check `rows.Err()` (`rowserrcheck`); `require.Len` instead of `require.Equal(…, len(…))` (`testifylint`).
- **`internal/case/rendernotepage/endpoint_cache_reorder_test.go`** — `require.Len` (`testifylint`); localized `//nolint:exhaustive` (with reason) on a one-entry fixture map.

## Verify

- `golangci-lint run --build-tags dev` → `0 issues.`
- `go build -tags dev ./...` → ok
- `go test ./internal/db/... ./internal/case/rendernotepage/...` → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
