### PR TITLE
fix(lint): resolve govet-shadow, rowserrcheck, exhaustive, sqlclosecheck, testifylint nits in stmtcache

### DIFF
--- a/internal/case/rendernotepage/endpoint_cache_reorder_test.go
+++ b/internal/case/rendernotepage/endpoint_cache_reorder_test.go
@@ -41,7 +41,7 @@ func TestPageCache_EarlyHitSkipsResolveDBWork(t *testing.T) {
 	runHandle(t, env, ctx, nil)
 	require.Equal(t, "gzip", string(ctx.Response.Header.ContentEncoding()))
 	require.Len(t, env.StoreCachedPageCalls(), 1, "hit must not re-fill the cache")
-	require.Equal(t, tgBefore, len(env.GetTelegramPostLinksByNoteVersionIDCalls()),
+	require.Len(t, env.GetTelegramPostLinksByNoteVersionIDCalls(), tgBefore,
 		"cache HIT must skip GetTelegramPostLinksByNoteVersionID (Resolve DB enrichment)")
 }
 
@@ -221,7 +221,7 @@ func TestPageCache_EarlyNeverServesRedirectGates(t *testing.T) {
 		// Non-canonical request path: note is reachable at /test-note but its
 		// canonical permalink differs and it has alternate permalinks → 301.
 		note.Permalink = "/canonical-note"
-		note.AlternatePermalinks = map[model.URLNormalizationMethod]string{
+		note.AlternatePermalinks = map[model.URLNormalizationMethod]string{ //nolint:exhaustive // test only needs one alternate to trigger the 301
 			model.URLNormSimpleTranslit: "/test-note",
 		}
 		env, pc, _ := cacheTestEnv(views, nil)

--- a/internal/db/stmtcache.go
+++ b/internal/db/stmtcache.go
@@ -63,10 +63,10 @@ func (c *StmtCache) getStmt(ctx context.Context, query string) (*sql.Stmt, error
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	// Re-check: another goroutine may have prepared it while we waited.
-	if stmt, ok := c.stmts[query]; ok {
-		return stmt, nil
+	if cached, cacheHit := c.stmts[query]; cacheHit {
+		return cached, nil
 	}
-	stmt, err := c.db.PrepareContext(ctx, query)
+	stmt, err := c.db.PrepareContext(ctx, query) //nolint:sqlclosecheck // stmt is transferred to cache; closed on eviction
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func (c *StmtCache) reprepare(ctx context.Context, query string) (*sql.Stmt, err
 		delete(c.stmts, query)
 		_ = old.Close()
 	}
-	stmt, err := c.db.PrepareContext(ctx, query)
+	stmt, err := c.db.PrepareContext(ctx, query) //nolint:sqlclosecheck // stmt is transferred to cache; closed on eviction
 	if err != nil {
 		return nil, err
 	}
@@ -93,23 +93,23 @@ func (c *StmtCache) reprepare(ctx context.Context, query string) (*sql.Stmt, err
 }
 
 func (c *StmtCache) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
-	stmt, err := c.getStmt(ctx, query)
+	stmt, err := c.getStmt(ctx, query) //nolint:sqlclosecheck // borrowed from cache; cache owns the lifetime
 	if err != nil {
 		return nil, err
 	}
 	rows, err := stmt.QueryContext(ctx, args...)
 	if isSchemaChangedErr(err) {
-		stmt, rerr := c.reprepare(ctx, query)
+		fresh, rerr := c.reprepare(ctx, query) //nolint:sqlclosecheck // fresh is stored in cache by reprepare; cache owns lifetime
 		if rerr != nil {
 			return nil, rerr
 		}
-		return stmt.QueryContext(ctx, args...)
+		return fresh.QueryContext(ctx, args...)
 	}
 	return rows, err
 }
 
 func (c *StmtCache) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
-	stmt, err := c.getStmt(ctx, query)
+	stmt, err := c.getStmt(ctx, query) //nolint:sqlclosecheck // borrowed from cache; cache owns the lifetime
 	if err != nil {
 		// Could not prepare a cached statement; fall back to the inner DBTX so
 		// the caller still gets a *sql.Row whose deferred error surfaces on
@@ -123,17 +123,17 @@ func (c *StmtCache) QueryRowContext(ctx context.Context, query string, args ...i
 }
 
 func (c *StmtCache) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
-	stmt, err := c.getStmt(ctx, query)
+	stmt, err := c.getStmt(ctx, query) //nolint:sqlclosecheck // borrowed from cache; cache owns the lifetime
 	if err != nil {
 		return nil, err
 	}
 	res, err := stmt.ExecContext(ctx, args...)
 	if isSchemaChangedErr(err) {
-		stmt, rerr := c.reprepare(ctx, query)
+		fresh, rerr := c.reprepare(ctx, query) //nolint:sqlclosecheck // fresh is stored in cache by reprepare; cache owns lifetime
 		if rerr != nil {
 			return nil, rerr
 		}
-		return stmt.ExecContext(ctx, args...)
+		return fresh.ExecContext(ctx, args...)
 	}
 	return res, err
 }

--- a/internal/db/stmtcache_test.go
+++ b/internal/db/stmtcache_test.go
@@ -44,7 +44,8 @@ func TestStmtCacheReusesPreparedStatement(t *testing.T) {
 
 	rows1, err := cache.QueryContext(ctx, q, 1)
 	require.NoError(t, err)
-	require.NoError(t, rows1.Close())
+	defer rows1.Close()
+	require.NoError(t, rows1.Err())
 
 	cache.mu.RLock()
 	stmt1, ok := cache.stmts[q]
@@ -56,7 +57,8 @@ func TestStmtCacheReusesPreparedStatement(t *testing.T) {
 	// Second call with the same SQL must reuse the same *sql.Stmt pointer.
 	rows2, err := cache.QueryContext(ctx, q, 2)
 	require.NoError(t, err)
-	require.NoError(t, rows2.Close())
+	defer rows2.Close()
+	require.NoError(t, rows2.Err())
 
 	cache.mu.RLock()
 	stmt2 := cache.stmts[q]
@@ -137,7 +139,8 @@ func TestStmtCacheRecoversAfterSchemaChange(t *testing.T) {
 	// Cache the statement via QueryContext too (the path with the explicit fallback).
 	rows, err := cache.QueryContext(ctx, q, 1)
 	require.NoError(t, err)
-	require.NoError(t, rows.Close())
+	require.NoError(t, rows.Close()) //nolint:sqlclosecheck // must close immediately; row reassigned below
+	require.NoError(t, rows.Err())
 
 	// Schema change that bumps the schema cookie but keeps the query valid.
 	_, err = dbh.ExecContext(ctx, "ALTER TABLE items ADD COLUMN extra TEXT")
@@ -150,6 +153,7 @@ func TestStmtCacheRecoversAfterSchemaChange(t *testing.T) {
 	require.True(t, rows.Next())
 	require.NoError(t, rows.Scan(&name))
 	require.Equal(t, "alpha", name)
+	require.NoError(t, rows.Err())
 }
 
 // TestIsSchemaChangedErr covers the SQLITE_SCHEMA detection predicate used by
@@ -223,5 +227,5 @@ func TestStmtCacheConcurrentReuse(t *testing.T) {
 
 	cache.mu.RLock()
 	defer cache.mu.RUnlock()
-	require.Equal(t, 1, len(cache.stmts), "concurrent identical SQL must prepare exactly one statement")
+	require.Len(t, cache.stmts, 1, "concurrent identical SQL must prepare exactly one statement")
 }


### PR DESCRIPTION
## Summary
- Fix all 18 lint issues introduced by #55 / #57 that `make lint` flags with the project golangci config
- **govet shadow ×3**: `getStmt` double-check used `cached`/`cacheHit` instead of re-declaring `stmt`/`ok`; `QueryContext`/`ExecContext` reprepare path renamed inner `stmt` to `fresh`
- **rowserrcheck ×4**: added `rows.Err()` check after each `QueryContext` call in tests; used `defer rows.Close()` where safe (non-reassigned rows)
- **exhaustive ×1**: `AlternatePermalinks` map literal in reorder test gets `//nolint:exhaustive` — intentionally single-key fixture to trigger the 301
- **sqlclosecheck ×8**: `//nolint:sqlclosecheck` on lines where `*sql.Stmt` ownership is transferred to / borrowed from the cache (cache closes them on eviction); explicit close before row reassignment also annotated
- **testifylint ×2**: replaced `require.Equal(t, n, len(x))` with `require.Len(t, x, n)`

## Test plan
- [x] `make lint` → 0 issues
- [x] `go test -race ./internal/db/... ./internal/case/rendernotepage/...` → all passed
- [x] `go build ./internal/db/... ./internal/case/rendernotepage/...` → ok