### PR TITLE
feat(fleet): code-executor — executor: code role + exec tool (off by default)

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -309,6 +309,7 @@ func syncOnce(ctx context.Context, f *fleet.Fleet, d *fleet.Discovery, r *fleet.
 func parseFlags(ctx context.Context) (cliFlags, error) {
 	var cli cliFlags
 	var offered string
+	var allowedPrograms string
 	var poll int
 
 	fs := flag.NewFlagSet("fleet", flag.ContinueOnError)
@@ -346,6 +347,8 @@ func parseFlags(ctx context.Context) (cliFlags, error) {
 		"role-note folder (LIKE prefix)")
 	fs.StringVar(&offered, "offered-tools", "search,read_note,patch_note,write_note",
 		"comma-separated allowed tools")
+	fs.StringVar(&allowedPrograms, "allowed-programs", "",
+		"comma-separated programs allowed for code execution (empty = disabled; e.g. python,bash)")
 	fs.IntVar(&poll, "poll-seconds", 30,
 		"discovery/reconcile poll interval seconds")
 
@@ -374,6 +377,7 @@ func parseFlags(ctx context.Context) (cliFlags, error) {
 	}
 
 	cli.cfg.OfferedTools = splitCSV(offered)
+	cli.cfg.AllowedPrograms = splitCSV(allowedPrograms)
 	cli.cfg.PollInterval = time.Duration(poll) * time.Second
 	return cli, nil
 }

--- a/internal/agentruntime/coderun.go
+++ b/internal/agentruntime/coderun.go
@@ -1,0 +1,288 @@
+package agentruntime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"trip2g/internal/webhookutil"
+)
+
+// Program name string constants used in programBinary, fenceLangToProgram, and
+// codeExt to satisfy the goconst linter (each string appears 3+ times).
+const (
+	progPython     = "python"
+	progPython3    = "python3"
+	progBash       = "bash"
+	progJavaScript = "javascript"
+	progNode       = "node"
+)
+
+// maxStdoutBytes caps code-child stdout to prevent memory exhaustion.
+const maxStdoutBytes = 1 << 20 // 1 MiB
+
+// CodeSpec is the parameters for one code-execution call.
+type CodeSpec struct {
+	Program        string        // canonical program name or fence lang (python, bash, node, ...)
+	Code           string        // source text written to a per-run temp file
+	Input          []byte        // delivery bag JSON; nil or empty → "{}"
+	Timeout        time.Duration // per-run timeout; 0 = bounded by ctx only
+	EnvPassthrough []string      // exact parent env var names to forward to child
+	EnvPrefix      []string      // parent env var name prefixes to forward to child
+}
+
+// codeOutput is the stdout JSON contract that every code program must emit.
+type codeOutput struct {
+	Changes []rawCodeChange `json:"changes"`
+	Answer  string          `json:"answer"`
+}
+
+// rawCodeChange is one entry in the stdout changes array.
+type rawCodeChange struct {
+	Path    string `json:"path"`
+	Content string `json:"content,omitempty"`
+	Find    string `json:"find,omitempty"`
+	Replace string `json:"replace,omitempty"`
+}
+
+// RunBlock executes spec.Code under spec.Program in a throwaway temp workdir.
+//
+// Secret-scrub is a HARD security invariant: cmd.Env is set to a minimal
+// allowlist (PATH + FLEET_INPUT only). The parent process env is NEVER
+// inherited. Passing nil to cmd.Env inherits the parent env (os/exec default),
+// which exposes JWT secrets and LLM API keys to the child; we never do that.
+//
+// FLEET_INPUT points to a temp file containing spec.Input (the delivery bag
+// JSON) so the child can read structured trigger data. The scoped write token
+// is not in the bag or the env.
+//
+// stdout is capped at maxStdoutBytes; stderr is also captured for diagnostics.
+// Non-zero exit or context timeout returns an error; timedOut distinguishes
+// the two failure modes.
+func RunBlock(ctx context.Context, spec CodeSpec) (string, string, bool, error) {
+	binary, berr := programBinary(spec.Program)
+	if berr != nil {
+		return "", "", false, berr
+	}
+
+	// Per-run throwaway workdir: prevents cross-run contamination.
+	workDir, mkErr := os.MkdirTemp("", "fleet-coderun-*")
+	if mkErr != nil {
+		return "", "", false, fmt.Errorf("coderun: create workdir: %w", mkErr)
+	}
+	defer os.RemoveAll(workDir)
+
+	codeFile := filepath.Join(workDir, "run"+codeExt(spec.Program))
+	if wErr := os.WriteFile(codeFile, []byte(spec.Code), 0o600); wErr != nil {
+		return "", "", false, fmt.Errorf("coderun: write code file: %w", wErr)
+	}
+
+	inputData := spec.Input
+	if len(inputData) == 0 {
+		inputData = []byte("{}")
+	}
+	inputFile := filepath.Join(workDir, "input.json")
+	if wErr := os.WriteFile(inputFile, inputData, 0o600); wErr != nil {
+		return "", "", false, fmt.Errorf("coderun: write input file: %w", wErr)
+	}
+
+	runCtx := ctx
+	if spec.Timeout > 0 {
+		var cancel context.CancelFunc
+		runCtx, cancel = context.WithTimeout(ctx, spec.Timeout)
+		defer cancel()
+	}
+
+	cmd := exec.CommandContext(runCtx, binary, codeFile)
+	cmd.Dir = workDir
+	// Secret-scrub: build an explicit MINIMAL env. NEVER nil (inherits parent)
+	// or os.Environ() (exposes all secrets). The base is PATH + FLEET_INPUT only.
+	// Selective pass-through adds only explicitly declared vars/prefixes on top.
+	cmd.Env = buildChildEnv(inputFile, spec.EnvPassthrough, spec.EnvPrefix)
+
+	var outBuf, errBuf limitedBuffer
+	outBuf.limit = maxStdoutBytes
+	errBuf.limit = maxStdoutBytes
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	runErr := cmd.Run()
+	outStr := outBuf.String()
+	errStr := errBuf.String()
+
+	if runCtx.Err() != nil {
+		return outStr, errStr, true, errors.New("coderun: timed out")
+	}
+	if runErr != nil {
+		msg := errStr
+		if msg == "" {
+			msg = runErr.Error()
+		}
+		return outStr, errStr, false, fmt.Errorf("coderun: non-zero exit: %s", msg)
+	}
+	return outStr, errStr, false, nil
+}
+
+// parseCodeOutput parses the code child's stdout JSON into []AgentChange +
+// answer string. stdout must match {"changes":[...],"answer":"..."}.
+// A "content"-only entry → AgentChangeKindWrite; "find"/"replace" → AgentChangeKindPatch.
+func parseCodeOutput(stdout string) ([]webhookutil.AgentChange, string, error) {
+	var out codeOutput
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		preview := stdout
+		if len(preview) > 200 {
+			preview = preview[:200] + "..."
+		}
+		return nil, "", fmt.Errorf("coderun: parse stdout: %w (got: %q)", err, preview)
+	}
+	changes := make([]webhookutil.AgentChange, 0, len(out.Changes))
+	for i, c := range out.Changes {
+		if c.Path == "" {
+			return nil, "", fmt.Errorf("coderun: change[%d]: missing path", i)
+		}
+		if c.Find != "" || c.Replace != "" {
+			changes = append(changes, webhookutil.AgentChange{
+				Path:    c.Path,
+				Find:    c.Find,
+				Replace: c.Replace,
+				Kind:    webhookutil.AgentChangeKindPatch,
+			})
+		} else {
+			changes = append(changes, webhookutil.AgentChange{
+				Path:    c.Path,
+				Content: c.Content,
+				Kind:    webhookutil.AgentChangeKindWrite,
+			})
+		}
+	}
+	return changes, out.Answer, nil
+}
+
+// programBinary resolves a program name or fence language tag to the binary to
+// run. Returns an error for unrecognized names so the caller can fail fast.
+func programBinary(name string) (string, error) {
+	switch name {
+	case progPython, "py", progPython3:
+		return progPython3, nil
+	case progBash, "sh":
+		return progBash, nil
+	case "js", progJavaScript, progNode:
+		return progNode, nil
+	}
+	return "", fmt.Errorf("coderun: unknown program %q (supported: python, bash, node)", name)
+}
+
+// fenceLangToProgram maps a Markdown fence language tag to the canonical
+// program name used for allowlist checks (python, bash, node).
+// Returns "" for unrecognised tags.
+func fenceLangToProgram(lang string) string {
+	switch strings.ToLower(lang) {
+	case progPython, "py":
+		return progPython
+	case progBash, "sh":
+		return progBash
+	case "js", progJavaScript, progNode:
+		return progNode
+	}
+	return ""
+}
+
+// extractFirstFencedBlock returns the fence language tag and code body of the
+// first fenced code block (```lang\n...\n```) in body.
+// Returns ("", "") when no complete block is found.
+func extractFirstFencedBlock(body string) (string, string) {
+	idx := strings.Index(body, "```")
+	if idx == -1 {
+		return "", ""
+	}
+	rest := body[idx+3:]
+	nl := strings.IndexByte(rest, '\n')
+	if nl == -1 {
+		return "", ""
+	}
+	langStr := strings.TrimSpace(rest[:nl])
+	content := rest[nl+1:]
+	end := strings.Index(content, "```")
+	if end == -1 {
+		return "", ""
+	}
+	return langStr, content[:end]
+}
+
+// codeExt returns a filename extension for the program so runtimes that check
+// the filename (e.g. node) work correctly.
+func codeExt(program string) string {
+	switch program {
+	case progPython, "py", progPython3:
+		return ".py"
+	case "js", progJavaScript, progNode:
+		return ".js"
+	default: // bash, sh, unknown
+		return ".sh"
+	}
+}
+
+// buildChildEnv constructs the child process environment: a minimal base
+// (PATH + FLEET_INPUT) plus selected parent vars via the explicit-allowlist
+// (passthrough) and prefix-match mechanisms.
+//
+// Secret-scrub guarantee: only vars that are explicitly listed in passthrough
+// OR whose name starts with an entry in prefix are forwarded. No other parent
+// env var is included. An empty passthrough AND empty prefix → base only.
+func buildChildEnv(inputFile string, passthrough, prefix []string) []string {
+	env := []string{
+		"PATH=" + os.Getenv("PATH"),
+		"FLEET_INPUT=" + inputFile,
+	}
+	if len(passthrough) == 0 && len(prefix) == 0 {
+		return env
+	}
+	passthroughSet := make(map[string]struct{}, len(passthrough))
+	for _, name := range passthrough {
+		passthroughSet[name] = struct{}{}
+	}
+	for _, kv := range os.Environ() {
+		name, _, ok := strings.Cut(kv, "=")
+		if !ok {
+			continue
+		}
+		if _, found := passthroughSet[name]; found {
+			env = append(env, kv)
+			continue
+		}
+		for _, p := range prefix {
+			if strings.HasPrefix(name, p) {
+				env = append(env, kv)
+				break
+			}
+		}
+	}
+	return env
+}
+
+// limitedBuffer is an io.Writer that accumulates up to limit bytes and silently
+// discards the rest. Used to bound stdout/stderr capture.
+type limitedBuffer struct {
+	limit int
+	data  []byte
+}
+
+func (b *limitedBuffer) Write(p []byte) (int, error) {
+	rem := b.limit - len(b.data)
+	if rem > 0 {
+		if len(p) <= rem {
+			b.data = append(b.data, p...)
+		} else {
+			b.data = append(b.data, p[:rem]...)
+		}
+	}
+	return len(p), nil
+}
+
+func (b *limitedBuffer) String() string { return string(b.data) }

--- a/internal/agentruntime/coderun_test.go
+++ b/internal/agentruntime/coderun_test.go
@@ -1,0 +1,632 @@
+package agentruntime
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"trip2g/internal/webhookutil"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ─── RunBlock ────────────────────────────────────────────────────────────────
+
+// TestRunBlock_BashEchoWriteJSON runs a bash one-liner that emits a write JSON
+// and asserts the output is returned verbatim.
+func TestRunBlock_BashEchoWriteJSON(t *testing.T) {
+	code := `echo '{"changes":[{"path":"notes/a.md","content":"hello"}],"answer":"done"}'`
+	stdout, stderr, timedOut, err := RunBlock(context.Background(), CodeSpec{
+		Program: "bash",
+		Code:    code,
+	})
+	require.NoError(t, err)
+	require.False(t, timedOut)
+	require.Empty(t, stderr)
+	require.Contains(t, stdout, `"notes/a.md"`)
+	require.Contains(t, stdout, `"hello"`)
+}
+
+// TestRunBlock_NonZeroExit asserts a failing script returns an error with stderr.
+func TestRunBlock_NonZeroExit(t *testing.T) {
+	code := `echo "oops" >&2; exit 1`
+	_, stderr, timedOut, err := RunBlock(context.Background(), CodeSpec{
+		Program: "bash",
+		Code:    code,
+	})
+	require.Error(t, err)
+	require.False(t, timedOut)
+	require.Contains(t, stderr, "oops")
+}
+
+// TestRunBlock_TimeoutKills asserts a long-running script is killed when the
+// per-spec timeout fires.
+func TestRunBlock_TimeoutKills(t *testing.T) {
+	_, _, timedOut, err := RunBlock(context.Background(), CodeSpec{
+		Program: "bash",
+		Code:    "sleep 60",
+		Timeout: 150 * time.Millisecond,
+	})
+	require.Error(t, err)
+	require.True(t, timedOut, "expected timedOut=true when Timeout fires")
+}
+
+// TestRunBlock_SecretScrub is the SECURITY proof: a sentinel env var set in
+// the test process must NOT be visible to the child. This proves the
+// secret-scrub guarantee: cmd.Env is an explicit minimal allowlist
+// (PATH + FLEET_INPUT only), never nil (inherits parent) or os.Environ().
+func TestRunBlock_SecretScrub(t *testing.T) {
+	const sentinel = "FLEET_CODERUN_TEST_SENTINEL"
+	t.Setenv(sentinel, "PARENT_SECRET_VALUE")
+
+	// The script echoes "absent" when the sentinel is NOT in the child env.
+	code := `if [ -z "${FLEET_CODERUN_TEST_SENTINEL}" ]; then
+  echo '{"changes":[],"answer":"absent"}'
+else
+  echo '{"changes":[],"answer":"present"}'
+fi`
+
+	stdout, _, _, err := RunBlock(context.Background(), CodeSpec{
+		Program: "bash",
+		Code:    code,
+	})
+	require.NoError(t, err)
+	_, answer, perr := parseCodeOutput(stdout)
+	require.NoError(t, perr)
+	require.Equal(t, "absent", answer,
+		"sentinel env var must NOT be inherited by the child (secret-scrub failed)")
+}
+
+// TestRunBlock_FleetInputWritten asserts the delivery bag is accessible via
+// $FLEET_INPUT in the child (the bag JSON is written to a temp file).
+func TestRunBlock_FleetInputWritten(t *testing.T) {
+	bag := []byte(`{"depth":3}`)
+	code := `python3 -c "
+import json, os
+data = json.load(open(os.environ['FLEET_INPUT']))
+print('{\"changes\":[],\"answer\":\"depth=' + str(data['depth']) + '\"}')
+"`
+	stdout, _, _, err := RunBlock(context.Background(), CodeSpec{
+		Program: "bash",
+		Code:    code,
+		Input:   bag,
+	})
+	require.NoError(t, err)
+	_, answer, perr := parseCodeOutput(stdout)
+	require.NoError(t, perr)
+	require.Equal(t, "depth=3", answer)
+}
+
+// ─── parseCodeOutput ─────────────────────────────────────────────────────────
+
+func TestParseCodeOutput_WriteShape(t *testing.T) {
+	stdout := `{"changes":[{"path":"notes/a.md","content":"hello world"}],"answer":"written"}`
+	changes, answer, err := parseCodeOutput(stdout)
+	require.NoError(t, err)
+	require.Equal(t, "written", answer)
+	require.Len(t, changes, 1)
+	require.Equal(t, "notes/a.md", changes[0].Path)
+	require.Equal(t, "hello world", changes[0].Content)
+	require.Equal(t, webhookutil.AgentChangeKindWrite, changes[0].Kind)
+}
+
+func TestParseCodeOutput_PatchShape(t *testing.T) {
+	stdout := `{"changes":[{"path":"boards/sprint.md","find":"@todo","replace":"@done"}],"answer":"patched"}`
+	changes, answer, err := parseCodeOutput(stdout)
+	require.NoError(t, err)
+	require.Equal(t, "patched", answer)
+	require.Len(t, changes, 1)
+	require.Equal(t, webhookutil.AgentChangeKindPatch, changes[0].Kind)
+	require.Equal(t, "@todo", changes[0].Find)
+	require.Equal(t, "@done", changes[0].Replace)
+}
+
+func TestParseCodeOutput_BadJSON(t *testing.T) {
+	_, _, err := parseCodeOutput("not json")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parse stdout")
+}
+
+func TestParseCodeOutput_MissingPath(t *testing.T) {
+	_, _, err := parseCodeOutput(`{"changes":[{"content":"oops"}],"answer":""}`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing path")
+}
+
+func TestParseCodeOutput_EmptyChanges(t *testing.T) {
+	changes, answer, err := parseCodeOutput(`{"changes":[],"answer":"noop"}`)
+	require.NoError(t, err)
+	require.Equal(t, "noop", answer)
+	require.Empty(t, changes)
+}
+
+// ─── RunCode ─────────────────────────────────────────────────────────────────
+
+// TestRunCode_EndToEnd runs a bash script that emits a write change and asserts
+// the change is applied via ScopedKB.
+func TestRunCode_EndToEnd(t *testing.T) {
+	kb := newMemKB(nil)
+	body := "```bash\necho '{\"changes\":[{\"path\":\"notes/a.md\",\"content\":\"generated\"}],\"answer\":\"ok\"}'\n```"
+
+	res, err := RunCode(context.Background(), CodeInput{
+		Body:            body,
+		WritePatterns:   []string{"notes/**"},
+		KB:              kb,
+		AllowedPrograms: []string{"bash"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, StatusCompleted, res.Status)
+	require.Equal(t, 1, res.Steps)
+	require.Equal(t, 0, res.TokensUsed)
+	require.Equal(t, "ok", res.Answer)
+	require.Len(t, res.Changes, 1)
+	require.Equal(t, "notes/a.md", res.Changes[0].Path)
+	require.Equal(t, "generated", kb.docs["notes/a.md"])
+}
+
+// TestRunCode_ScopeEnforcement asserts writes outside write_patterns are denied
+// and not applied — exec/code is NOT a scope bypass.
+func TestRunCode_ScopeEnforcement(t *testing.T) {
+	kb := newMemKB(nil)
+	// Script tries to write two files: one in scope and one out of scope.
+	script := `echo '{"changes":[{"path":"notes/in.md","content":"in"},{"path":"other/out.md","content":"out"}],"answer":"tried"}'`
+	body := "```bash\n" + script + "\n```"
+
+	res, err := RunCode(context.Background(), CodeInput{
+		Body:            body,
+		WritePatterns:   []string{"notes/**"},
+		KB:              kb,
+		AllowedPrograms: []string{"bash"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, StatusCompleted, res.Status)
+	require.Len(t, res.Changes, 1, "only in-scope write must succeed")
+	require.Equal(t, "notes/in.md", res.Changes[0].Path)
+	require.Len(t, res.Denials, 1, "out-of-scope write must be recorded as a denial")
+	require.Contains(t, res.Denials[0], "other/out.md")
+	_, leaked := kb.docs["other/out.md"]
+	require.False(t, leaked, "out-of-scope path must not appear in KB")
+}
+
+// TestRunCode_ProgramNotInAllowlist asserts a program not in allowed_programs
+// is rejected before execution.
+func TestRunCode_ProgramNotInAllowlist(t *testing.T) {
+	kb := newMemKB(nil)
+	body := "```python\nprint('{\"changes\":[],\"answer\":\"hi\"}')\n```"
+
+	_, err := RunCode(context.Background(), CodeInput{
+		Body:            body,
+		WritePatterns:   []string{"notes/**"},
+		KB:              kb,
+		AllowedPrograms: []string{"bash"}, // python not allowed
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not in --allowed-programs")
+}
+
+// TestRunCode_AllowlistEmpty asserts code execution is disabled when
+// AllowedPrograms is empty (the default off-by-default state).
+func TestRunCode_AllowlistEmpty(t *testing.T) {
+	kb := newMemKB(nil)
+	body := "```bash\necho '{\"changes\":[],\"answer\":\"hi\"}'\n```"
+
+	_, err := RunCode(context.Background(), CodeInput{
+		Body:            body,
+		WritePatterns:   []string{"notes/**"},
+		KB:              kb,
+		AllowedPrograms: nil, // empty = disabled
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "disabled")
+}
+
+// TestRunCode_NoFencedBlock asserts RunCode fails cleanly when the body has no
+// fenced code block.
+func TestRunCode_NoFencedBlock(t *testing.T) {
+	kb := newMemKB(nil)
+	_, err := RunCode(context.Background(), CodeInput{
+		Body:            "just text, no code block",
+		WritePatterns:   []string{"**"},
+		KB:              kb,
+		AllowedPrograms: []string{"bash"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no fenced code block")
+}
+
+// ─── exec tool via Run ───────────────────────────────────────────────────────
+
+// TestRun_ExecToolGatedByAllowedPrograms asserts:
+//  1. exec is NOT in the offered tool set when AllowedPrograms is empty.
+//  2. exec IS in the offered set when AllowedPrograms is non-empty.
+func TestRun_ExecToolGatedByAllowedPrograms(t *testing.T) {
+	kb := newMemKB(map[string]string{"notes/a.md": "content"})
+
+	t.Run("absent when AllowedPrograms empty", func(t *testing.T) {
+		llm := &stubLLM{
+			script: []ChatResult{
+				{ToolCalls: []ToolCall{toolCall("1", toolFinish, map[string]any{"answer": "done"})},
+					PromptTokens: 5, CompletionTokens: 5},
+			},
+		}
+		_, err := Run(context.Background(), Input{
+			Instruction:     "x",
+			ReadPatterns:    []string{"**"},
+			WritePatterns:   []string{"**"},
+			Model:           "m",
+			MaxTokens:       10000,
+			MaxSteps:        5,
+			AllowedPrograms: nil, // empty → exec disabled
+			LLM:             llm,
+			KB:              kb,
+		})
+		require.NoError(t, err)
+		for _, td := range llm.seenTools {
+			require.NotEqual(t, toolExec, td.Name,
+				"exec must NOT be offered when AllowedPrograms is empty")
+		}
+	})
+
+	t.Run("present when AllowedPrograms non-empty", func(t *testing.T) {
+		llm := &stubLLM{
+			script: []ChatResult{
+				{ToolCalls: []ToolCall{toolCall("1", toolFinish, map[string]any{"answer": "done"})},
+					PromptTokens: 5, CompletionTokens: 5},
+			},
+		}
+		_, err := Run(context.Background(), Input{
+			Instruction:     "x",
+			ReadPatterns:    []string{"**"},
+			WritePatterns:   []string{"**"},
+			Model:           "m",
+			MaxTokens:       10000,
+			MaxSteps:        5,
+			AllowedPrograms: []string{"bash"},
+			LLM:             llm,
+			KB:              kb,
+		})
+		require.NoError(t, err)
+		found := false
+		for _, td := range llm.seenTools {
+			if td.Name == toolExec {
+				found = true
+			}
+		}
+		require.True(t, found, "exec must be offered when AllowedPrograms is non-empty")
+	})
+}
+
+// TestRun_ExecToolRunsAndApplies drives Run with a stubLLM that calls exec
+// with a bash one-liner, then finishes. Asserts the write is applied via
+// ScopedKB and recorded in res.Changes.
+func TestRun_ExecToolRunsAndApplies(t *testing.T) {
+	kb := newMemKB(nil)
+	bashCode := `echo '{"changes":[{"path":"notes/exec.md","content":"from exec"}],"answer":"wrote"}'`
+
+	llm := &stubLLM{
+		script: []ChatResult{
+			{
+				ToolCalls: []ToolCall{toolCall("1", toolExec, map[string]any{
+					"program": "bash",
+					"code":    bashCode,
+				})},
+				PromptTokens: 10, CompletionTokens: 5,
+			},
+			{ToolCalls: []ToolCall{toolCall("2", toolFinish, map[string]any{"answer": "done"})},
+				PromptTokens: 5, CompletionTokens: 5},
+		},
+	}
+
+	res, err := Run(context.Background(), Input{
+		Instruction:     "run some code",
+		ReadPatterns:    []string{"**"},
+		WritePatterns:   []string{"notes/**"},
+		Model:           "m",
+		MaxTokens:       10000,
+		MaxSteps:        5,
+		AllowedPrograms: []string{"bash"},
+		LLM:             llm,
+		KB:              kb,
+	})
+	require.NoError(t, err)
+	require.Equal(t, StatusCompleted, res.Status)
+	require.Equal(t, "from exec", kb.docs["notes/exec.md"],
+		"exec tool write must land in KB")
+	require.Len(t, res.Changes, 1)
+	require.Equal(t, "notes/exec.md", res.Changes[0].Path)
+}
+
+// TestRun_ExecToolDeniedOutOfScope drives Run with a stubLLM that calls exec
+// with a write targeting a path outside write_patterns. The write must be
+// denied (recorded in res.Denials) and not reach the KB.
+func TestRun_ExecToolDeniedOutOfScope(t *testing.T) {
+	kb := newMemKB(nil)
+	bashCode := `echo '{"changes":[{"path":"secret/x.md","content":"leak"}],"answer":"tried"}'`
+
+	llm := &stubLLM{
+		script: []ChatResult{
+			{
+				ToolCalls: []ToolCall{toolCall("1", toolExec, map[string]any{
+					"program": "bash",
+					"code":    bashCode,
+				})},
+				PromptTokens: 10, CompletionTokens: 5,
+			},
+			{ToolCalls: []ToolCall{toolCall("2", toolFinish, map[string]any{"answer": "done"})},
+				PromptTokens: 5, CompletionTokens: 5},
+		},
+	}
+
+	res, err := Run(context.Background(), Input{
+		Instruction:     "try to leak",
+		ReadPatterns:    []string{"**"},
+		WritePatterns:   []string{"notes/**"}, // secret/** not allowed
+		Model:           "m",
+		MaxTokens:       10000,
+		MaxSteps:        5,
+		AllowedPrograms: []string{"bash"},
+		LLM:             llm,
+		KB:              kb,
+	})
+	require.NoError(t, err)
+	require.Empty(t, res.Changes, "out-of-scope exec write must not appear in Changes")
+	require.Len(t, res.Denials, 1)
+	require.Contains(t, res.Denials[0], "secret/x.md")
+	_, leaked := kb.docs["secret/x.md"]
+	require.False(t, leaked, "out-of-scope path must not appear in KB")
+}
+
+// TestRun_ExecToolProgramNotInAllowlist asserts that when the model calls exec
+// with a program not in AllowedPrograms, the tool returns an error string and
+// does not run any code.
+func TestRun_ExecToolProgramNotInAllowlist(t *testing.T) {
+	kb := newMemKB(nil)
+
+	llm := &stubLLM{
+		script: []ChatResult{
+			{
+				ToolCalls: []ToolCall{toolCall("1", toolExec, map[string]any{
+					"program": "node", // not in allowlist
+					"code":    `console.log(JSON.stringify({changes:[],answer:"hi"}))`,
+				})},
+				PromptTokens: 10, CompletionTokens: 5,
+			},
+			{ToolCalls: []ToolCall{toolCall("2", toolFinish, map[string]any{"answer": "done"})},
+				PromptTokens: 5, CompletionTokens: 5},
+		},
+	}
+
+	res, err := Run(context.Background(), Input{
+		Instruction:     "use node",
+		ReadPatterns:    []string{"**"},
+		WritePatterns:   []string{"**"},
+		Model:           "m",
+		MaxTokens:       10000,
+		MaxSteps:        5,
+		AllowedPrograms: []string{"bash"}, // only bash allowed
+		LLM:             llm,
+		KB:              kb,
+	})
+	require.NoError(t, err)
+	require.Empty(t, res.Changes, "disallowed program must not produce changes")
+	// The model should have received an error message about the program.
+	var gotError bool
+	for _, msg := range llm.seen {
+		if strings.Contains(msg.Content, "not in allowed_programs") {
+			gotError = true
+		}
+	}
+	require.True(t, gotError, "model must receive error about disallowed program")
+}
+
+// TestRun_DefaultToolCountUnchangedWithoutAllowedPrograms asserts that with
+// AllowedPrograms=nil, the default tool set is still exactly 5 (backward-compat).
+func TestRun_DefaultToolCountUnchangedWithoutAllowedPrograms(t *testing.T) {
+	kb := newMemKB(map[string]string{"notes/a.md": "x"})
+	llm := &stubLLM{
+		script: []ChatResult{
+			{ToolCalls: []ToolCall{toolCall("1", toolFinish, map[string]any{"answer": "done"})},
+				PromptTokens: 5, CompletionTokens: 5},
+		},
+	}
+	_, err := Run(context.Background(), Input{
+		Instruction:     "x",
+		ReadPatterns:    []string{"**"},
+		Model:           "m",
+		MaxTokens:       10000,
+		MaxSteps:        5,
+		AllowedPrograms: nil,
+		LLM:             llm,
+		KB:              kb,
+	})
+	require.NoError(t, err)
+	require.Len(t, llm.seenTools, 5,
+		"AllowedPrograms=nil must not add exec to the offered set")
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+func TestExtractFirstFencedBlock(t *testing.T) {
+	cases := []struct {
+		name     string
+		body     string
+		wantLang string
+		wantCode string
+	}{
+		{"bash block", "```bash\necho hi\n```", "bash", "echo hi\n"},
+		{"python block", "```python\nprint('x')\n```", "python", "print('x')\n"},
+		{"no block", "just text", "", ""},
+		{"unclosed block", "```bash\necho hi", "", ""},
+		{"first of two", "```bash\nfirst\n```\n```python\nsecond\n```", "bash", "first\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lang, code := extractFirstFencedBlock(tc.body)
+			require.Equal(t, tc.wantLang, lang)
+			require.Equal(t, tc.wantCode, code)
+		})
+	}
+}
+
+func TestFenceLangToProgram(t *testing.T) {
+	require.Equal(t, "python", fenceLangToProgram("python"))
+	require.Equal(t, "python", fenceLangToProgram("py"))
+	require.Equal(t, "bash", fenceLangToProgram("bash"))
+	require.Equal(t, "bash", fenceLangToProgram("sh"))
+	require.Equal(t, "node", fenceLangToProgram("node"))
+	require.Equal(t, "node", fenceLangToProgram("js"))
+	require.Equal(t, "node", fenceLangToProgram("javascript"))
+	require.Empty(t, fenceLangToProgram("ruby"))
+}
+
+func TestProgramBinary(t *testing.T) {
+	b, err := programBinary("python")
+	require.NoError(t, err)
+	require.Equal(t, "python3", b)
+
+	b, err = programBinary("bash")
+	require.NoError(t, err)
+	require.Equal(t, "bash", b)
+
+	_, err = programBinary("ruby")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown program")
+}
+
+func TestIsAllowed(t *testing.T) {
+	require.True(t, isAllowed("bash", []string{"bash", "python"}))
+	require.False(t, isAllowed("node", []string{"bash", "python"}))
+	require.False(t, isAllowed("bash", nil))
+}
+
+// TestRunBlock_WorkdirIsolation asserts each RunBlock call gets a clean working
+// directory with no files from a previous run.
+func TestRunBlock_WorkdirIsolation(t *testing.T) {
+	// First run creates a file in its workdir.
+	code1 := `echo '{"changes":[],"answer":"run1"}'`
+	_, _, _, err := RunBlock(context.Background(), CodeSpec{Program: "bash", Code: code1})
+	require.NoError(t, err)
+
+	// Second run should have a clean workdir (the first run's temp dir was removed).
+	code2 := `ls | wc -l | tr -d ' ' | xargs -I{} echo '{"changes":[],"answer":"{}"}'`
+	stdout, _, _, err := RunBlock(context.Background(), CodeSpec{Program: "bash", Code: code2})
+	require.NoError(t, err)
+	_, answer, perr := parseCodeOutput(stdout)
+	require.NoError(t, perr)
+	// The workdir should contain exactly 2 files: run.sh and input.json.
+	require.Equal(t, "2", answer,
+		"workdir should contain exactly 2 files (run.sh + input.json)")
+}
+
+// TestRunBlock_ParentSecretAbsent is an additional secret-scrub probe: sets a
+// sentinel in the parent env and asserts it is absent from the child. This
+// complements TestRunBlock_SecretScrub with a differently-named sentinel to
+// rule out any pattern-matching false negatives.
+func TestRunBlock_ParentSecretAbsent(t *testing.T) {
+	t.Setenv("FLEET_SECRET_LEAK_TEST", "must-not-appear-in-child")
+
+	code := `if [ -z "${FLEET_SECRET_LEAK_TEST}" ]; then
+  echo '{"changes":[],"answer":"absent"}'
+else
+  echo '{"changes":[],"answer":"present"}'
+fi`
+	stdout, _, _, err := RunBlock(context.Background(), CodeSpec{
+		Program: "bash",
+		Code:    code,
+	})
+	require.NoError(t, err)
+	_, answer, perr := parseCodeOutput(stdout)
+	require.NoError(t, perr)
+	require.Equal(t, "absent", answer,
+		"parent secret sentinel must NOT be inherited by child (secret-scrub)")
+}
+
+// TestLimitedBuffer caps at the limit and does not error on overflow.
+func TestLimitedBuffer(t *testing.T) {
+	b := &limitedBuffer{limit: 5}
+	n, err := b.Write([]byte("hello world"))
+	require.NoError(t, err)
+	require.Equal(t, 11, n, "Write must return len(p) even when capped")
+	require.Equal(t, "hello", b.String(), "data must be capped at limit")
+}
+
+// TestRunCode_RequiresKB asserts RunCode returns an error when KB is nil.
+func TestRunCode_RequiresKB(t *testing.T) {
+	_, err := RunCode(context.Background(), CodeInput{
+		Body:            "```bash\necho hi\n```",
+		AllowedPrograms: []string{"bash"},
+		KB:              nil,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "KB is required")
+}
+
+// ─── env pass-through ────────────────────────────────────────────────────────
+
+// TestRunBlock_EnvPassthrough asserts the selective env pass-through mechanism:
+//   - EnvPassthrough ["FOO"] + EnvPrefix ["BAR_"] → child gets FOO and BAR_X
+//   - but NOT SECRET (a parent var that matches neither list nor prefix).
+//
+// This proves the deny-by-default + explicit-opt-in contract: secrets not
+// declared in env_passthrough or env_prefix do NOT reach the child.
+func TestRunBlock_EnvPassthrough(t *testing.T) {
+	t.Setenv("FLEET_ENVTEST_FOO", "1")
+	t.Setenv("FLEET_ENVTEST_BAR_X", "2")
+	t.Setenv("FLEET_ENVTEST_SECRET", "should-not-appear")
+
+	// The script counts how many of the three vars are visible.
+	code := `python3 -c "
+import os, json
+got = {}
+for k in ['FLEET_ENVTEST_FOO','FLEET_ENVTEST_BAR_X','FLEET_ENVTEST_SECRET']:
+    if k in os.environ:
+        got[k] = os.environ[k]
+print(json.dumps({'changes':[],'answer':json.dumps(got)}))
+"`
+	stdout, _, _, err := RunBlock(context.Background(), CodeSpec{
+		Program:        "bash",
+		Code:           code,
+		EnvPassthrough: []string{"FLEET_ENVTEST_FOO"},
+		EnvPrefix:      []string{"FLEET_ENVTEST_BAR_"},
+	})
+	require.NoError(t, err)
+	_, answer, perr := parseCodeOutput(stdout)
+	require.NoError(t, perr)
+
+	require.Contains(t, answer, "FLEET_ENVTEST_FOO",
+		"passthrough var FOO must be visible to child")
+	require.Contains(t, answer, "FLEET_ENVTEST_BAR_X",
+		"prefix-matched var BAR_X must be visible to child")
+	require.NotContains(t, answer, "FLEET_ENVTEST_SECRET",
+		"SECRET must NOT be passed to child (not in passthrough or prefix)")
+}
+
+// TestRunBlock_EnvPassthroughBaseOnly asserts the base-only path: when neither
+// EnvPassthrough nor EnvPrefix is set, the specific parent sentinel is absent
+// from the child. (bash injects a few vars of its own like SHLVL, so we check
+// for the sentinel specifically rather than asserting zero extra vars.)
+func TestRunBlock_EnvPassthroughBaseOnly(t *testing.T) {
+	t.Setenv("FLEET_ENVTEST_EXTRA", "should-not-appear")
+
+	code := `if [ -z "${FLEET_ENVTEST_EXTRA}" ]; then
+  echo '{"changes":[],"answer":"absent"}'
+else
+  echo '{"changes":[],"answer":"present"}'
+fi`
+	stdout, _, _, err := RunBlock(context.Background(), CodeSpec{
+		Program:        "bash",
+		Code:           code,
+		EnvPassthrough: nil,
+		EnvPrefix:      nil,
+	})
+	require.NoError(t, err)
+	_, answer, perr := parseCodeOutput(stdout)
+	require.NoError(t, perr)
+	require.Equal(t, "absent", answer,
+		"parent sentinel must NOT be inherited when EnvPassthrough and EnvPrefix are both empty")
+}
+
+// ─── verify env isolation does not depend on the test binary's environment ──
+// Tests in this file use t.Setenv which correctly restores values on cleanup.
+// The parent-env isolation under test is enforced by buildChildEnv in coderun.go.

--- a/internal/agentruntime/runcode.go
+++ b/internal/agentruntime/runcode.go
@@ -1,0 +1,119 @@
+package agentruntime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"trip2g/internal/webhookutil"
+)
+
+// CodeInput is the parameters for a code-role run (executor: code).
+// Body must be pre-rendered (Jet-evaluated by the caller); RunCode extracts
+// the first fenced code block from the rendered text.
+type CodeInput struct {
+	Body            string        // Jet-rendered role body
+	Program         string        // optional override; empty → derived from fence language
+	WritePatterns   []string      // scope enforcement (same semantics as LLM write_patterns)
+	KB              KB            // write destination
+	AllowedPrograms []string      // fleet allowlist; empty → code execution disabled
+	Timeout         time.Duration // per-run timeout; 0 → bounded by ctx only
+	Input           []byte        // delivery bag JSON written to $FLEET_INPUT
+	EnvPassthrough  []string      // exact parent env var names forwarded to child
+	EnvPrefix       []string      // parent env var name prefixes forwarded to child
+}
+
+// RunCode executes a code role. It:
+//  1. Extracts the first fenced code block from Body.
+//  2. Resolves the program (explicit override wins, then fence lang).
+//  3. Checks the program against AllowedPrograms (empty list = disabled).
+//  4. Runs the code via RunBlock (secret-scrubbed env, throwaway workdir).
+//  5. Parses stdout as {"changes":[...],"answer":"..."} JSON.
+//  6. Applies each change via ScopedKB(WritePatterns) — the same scope
+//     enforcement as write_note. Out-of-scope paths are denied, not written.
+//
+// Returns *Result with TokensUsed=0, Steps=1 on success. exec/code is NOT a
+// scope bypass: all writes go through write_patterns enforcement.
+func RunCode(ctx context.Context, in CodeInput) (*Result, error) {
+	if in.KB == nil {
+		return nil, errors.New("coderun: KB is required")
+	}
+
+	lang, code := extractFirstFencedBlock(in.Body)
+	if code == "" {
+		return nil, errors.New("coderun: no fenced code block found in rendered body")
+	}
+
+	program := in.Program
+	if program == "" {
+		program = fenceLangToProgram(lang)
+	}
+	if program == "" {
+		return nil, fmt.Errorf("coderun: fence language %q not supported (use python, bash, or node)", lang)
+	}
+
+	if !isAllowed(program, in.AllowedPrograms) {
+		if len(in.AllowedPrograms) == 0 {
+			return nil, errors.New("coderun: code execution disabled (set --allowed-programs)")
+		}
+		return nil, fmt.Errorf("coderun: program %q not in --allowed-programs %v", program, in.AllowedPrograms)
+	}
+
+	stdout, _, _, runErr := RunBlock(ctx, CodeSpec{
+		Program:        program,
+		Code:           code,
+		Input:          in.Input,
+		Timeout:        in.Timeout,
+		EnvPassthrough: in.EnvPassthrough,
+		EnvPrefix:      in.EnvPrefix,
+	})
+	if runErr != nil {
+		return nil, fmt.Errorf("coderun: %w", runErr)
+	}
+
+	rawChanges, answer, perr := parseCodeOutput(stdout)
+	if perr != nil {
+		return nil, perr
+	}
+
+	// Apply changes through ScopedKB — NOT a scope bypass. Every write goes
+	// through write_patterns enforcement just like write_note.
+	// No read scope: code roles read from the delivery bag ($FLEET_INPUT).
+	scoped := NewScopedKB(in.KB, nil, in.WritePatterns)
+	res := &Result{
+		Status:     StatusCompleted,
+		Steps:      1,
+		TokensUsed: 0,
+		Answer:     answer,
+	}
+	for _, ch := range rawChanges {
+		var applyErr error
+		switch ch.Kind {
+		case webhookutil.AgentChangeKindPatch:
+			applyErr = scoped.Patch(ctx, ch.Path, ch.Find, ch.Replace)
+		default: // AgentChangeKindWrite or empty
+			applyErr = scoped.Write(ctx, ch.Path, ch.Content)
+		}
+		if errors.Is(applyErr, ErrWriteDenied) {
+			res.Denials = append(res.Denials, "write "+ch.Path)
+			continue
+		}
+		if applyErr != nil {
+			return nil, fmt.Errorf("coderun: apply %s: %w", ch.Path, applyErr)
+		}
+		res.Changes = append(res.Changes, ch)
+	}
+	return res, nil
+}
+
+// isAllowed reports whether program is in the allowedPrograms list.
+// Both program and list entries use canonical names (python, bash, node).
+func isAllowed(program string, allowedPrograms []string) bool {
+	for _, p := range allowedPrograms {
+		if p == program {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agentruntime/runtime.go
+++ b/internal/agentruntime/runtime.go
@@ -24,7 +24,15 @@ const (
 	toolWriteNote = "write_note"
 	toolPatchNote = "patch_note"
 	toolFinish    = "finish"
+	toolExec      = "exec"
 )
+
+// toolInvoker is the extension-point function type for the tool registry seam.
+// Built-in tools (search, read_note, write_note, patch_note, finish) are
+// handled by execTool's switch. Extension tools (exec, future MCP plug-ins)
+// register an invoker here via buildInvokers so the loop never needs a new
+// switch case. future: populate from MCP server descriptors, config, etc.
+type toolInvoker func(ctx context.Context, scoped *ScopedKB, res *Result, call ToolCall) string
 
 // Input is one executor run, derived from a webhook delivery
 // (instruction + read_patterns + write_patterns + model) plus the safety
@@ -39,6 +47,11 @@ type Input struct {
 	// finish is always included regardless of this list.
 	// An empty (nil) Tools means the full default offered set (backward-compat).
 	Tools []string
+
+	// AllowedPrograms is the fleet-level allowlist for code execution. When
+	// non-empty, the exec(program, code) tool is advertised to the model and
+	// enabled at execution time. An empty slice disables exec entirely.
+	AllowedPrograms []string
 
 	// MaxTokens is the NON-overridable per-run token hard-cap (safety floor).
 	// The model has no tool to change it; the loop enforces it. Must be > 0.
@@ -98,13 +111,17 @@ func Run(ctx context.Context, in Input) (*Result, error) {
 	}
 
 	scoped := NewScopedKB(in.KB, in.ReadPatterns, in.WritePatterns)
-	tools := allowedToolDefs(in.Tools)
+	tools := allowedToolDefs(in.Tools, in.AllowedPrograms)
 	// permitted is the execution-time enforcement set: same as the advertised set.
 	// finish is always present (already guaranteed by allowedToolDefs).
 	permitted := make(map[string]bool, len(tools))
 	for _, td := range tools {
 		permitted[td.Name] = true
 	}
+
+	// Tool registry: extension invokers (exec + future MCP plug-ins) are called
+	// before the built-in switch in execTool. Built-in tools leave this nil-safe.
+	invokers := buildInvokers(in.AllowedPrograms)
 
 	messages := []Message{
 		{
@@ -167,7 +184,7 @@ func Run(ctx context.Context, in Input) (*Result, error) {
 				})
 				continue
 			}
-			output := execTool(ctx, scoped, res, call)
+			output := execTool(ctx, scoped, res, call, invokers)
 			messages = append(messages, Message{
 				Role:       RoleTool,
 				ToolCallID: call.ID,
@@ -183,7 +200,12 @@ func Run(ctx context.Context, in Input) (*Result, error) {
 // execTool runs one tool call against the scoped KB and returns the textual
 // result to feed back to the model. Scope denials are recorded and surfaced to
 // the model (so it learns), never silently swallowed.
-func execTool(ctx context.Context, scoped *ScopedKB, res *Result, call ToolCall) string {
+// Extension tools registered in invokers are dispatched before the built-in
+// switch, forming the tool registry seam for exec and future MCP plug-ins.
+func execTool(ctx context.Context, scoped *ScopedKB, res *Result, call ToolCall, invokers map[string]toolInvoker) string {
+	if fn, ok := invokers[call.Name]; ok {
+		return fn(ctx, scoped, res, call)
+	}
 	switch call.Name {
 	case toolSearch:
 		var args struct {
@@ -295,8 +317,9 @@ func formatPatterns(patterns []string) string {
 // allowedToolDefs returns the ToolDef slice the model will see. When allowlist
 // is non-empty, only tools named in it are included; finish is always injected
 // regardless. An empty allowlist returns the full default offered set.
-func allowedToolDefs(allowlist []string) []ToolDef {
-	all := toolDefs()
+// allowedPrograms gates whether exec is included in the base set.
+func allowedToolDefs(allowlist []string, allowedPrograms []string) []ToolDef {
+	all := toolDefs(allowedPrograms)
 	if len(allowlist) == 0 {
 		return all
 	}
@@ -316,8 +339,100 @@ func allowedToolDefs(allowlist []string) []ToolDef {
 	return out
 }
 
-func toolDefs() []ToolDef {
-	return []ToolDef{
+// buildInvokers constructs the extension tool registry. When allowedPrograms is
+// non-empty, exec is registered. future: add MCP server tool invokers here.
+func buildInvokers(allowedPrograms []string) map[string]toolInvoker {
+	if len(allowedPrograms) == 0 {
+		return nil
+	}
+	return map[string]toolInvoker{
+		toolExec: makeExecInvoker(allowedPrograms),
+	}
+}
+
+// makeExecInvoker returns an invoker for the exec(program, code) tool.
+// It runs the code via RunBlock (secret-scrubbed), parses stdout as write JSON,
+// and applies changes via the scoped KB — same write_patterns enforcement as
+// write_note. Out-of-scope writes are denied and recorded, not silently dropped.
+func makeExecInvoker(allowedPrograms []string) toolInvoker {
+	return func(ctx context.Context, scoped *ScopedKB, res *Result, call ToolCall) string {
+		var args struct {
+			Program string `json:"program"`
+			Code    string `json:"code"`
+		}
+		if err := json.Unmarshal([]byte(call.Arguments), &args); err != nil {
+			return "error: invalid arguments: " + err.Error()
+		}
+		if !isAllowed(args.Program, allowedPrograms) {
+			return fmt.Sprintf("error: program %q not in allowed_programs", args.Program)
+		}
+		stdout, _, _, runErr := RunBlock(ctx, CodeSpec{
+			Program: args.Program,
+			Code:    args.Code,
+			// No Input bag: exec tool runs inline; the model already has context.
+			// No Timeout: the call is bounded by the parent run context.
+		})
+		if runErr != nil {
+			return "error: " + runErr.Error()
+		}
+		changes, answer, perr := parseCodeOutput(stdout)
+		if perr != nil {
+			return "error: " + perr.Error()
+		}
+		nWritten := 0
+		for _, ch := range changes {
+			var applyErr error
+			switch ch.Kind {
+			case webhookutil.AgentChangeKindPatch:
+				applyErr = scoped.Patch(ctx, ch.Path, ch.Find, ch.Replace)
+			default: // AgentChangeKindWrite or empty
+				applyErr = scoped.Write(ctx, ch.Path, ch.Content)
+			}
+			if errors.Is(applyErr, ErrWriteDenied) {
+				res.Denials = append(res.Denials, "exec write "+ch.Path)
+				continue
+			}
+			if applyErr != nil {
+				return "error: apply " + ch.Path + ": " + applyErr.Error()
+			}
+			res.Changes = append(res.Changes, ch)
+			nWritten++
+		}
+		summary := fmt.Sprintf("ok: ran %s, %d write(s)", args.Program, nWritten)
+		if answer != "" {
+			summary += "; " + answer
+		}
+		return summary
+	}
+}
+
+// execToolDef returns the ToolDef for the exec tool advertised to the model
+// when AllowedPrograms is non-empty.
+func execToolDef() ToolDef {
+	return ToolDef{
+		Name:        toolExec,
+		Description: "Run a code snippet. stdout MUST be JSON: {\"changes\":[{\"path\",\"content\"} or {\"path\",\"find\",\"replace\"}],\"answer\":\"...\"}. Writes go through write_patterns scope — out-of-scope paths are denied.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"program": map[string]any{
+					"type":        "string",
+					"description": "Program to run: python, bash, or node.",
+				},
+				"code": map[string]any{
+					"type":        "string",
+					"description": "Source code to execute.",
+				},
+			},
+			"required": []string{"program", "code"},
+		},
+	}
+}
+
+// toolDefs returns the full set of ToolDefs offered to the model.
+// The exec tool is included when allowedPrograms is non-empty.
+func toolDefs(allowedPrograms []string) []ToolDef {
+	out := []ToolDef{
 		{
 			Name:        toolSearch,
 			Description: "Find documents within your read scope.",
@@ -377,4 +492,8 @@ func toolDefs() []ToolDef {
 			},
 		},
 	}
+	if len(allowedPrograms) > 0 {
+		out = append(out, execToolDef())
+	}
+	return out
 }

--- a/internal/fleet/config.go
+++ b/internal/fleet/config.go
@@ -11,20 +11,21 @@ import "time"
 // ceiling (TokenCeiling/StepCeiling) is the non-overridable floor: the
 // effective budget is min(frontmatter, ceiling).
 type Config struct {
-	FleetID       string        // reconcile marker prefix "fleet:<FleetID>:"
-	ListenAddr    string        // ":9090"
-	CallbackURL   string        // trip2g-reachable base; webhook url = CallbackURL + "/deliver/" + urlKey(path)
-	Trip2gBaseURL string        // e.g. "http://localhost:20081"
-	AdminAPIKey   string        // DEPRECATED/unused: legacy full-admin X-Api-Key (admin lane now authenticates via HAT)
-	JWTSecret     string        // shared user-token/JWT secret used to mint admin HATs (= trip2g UserToken.Secret)
-	AdminEmail    string        // admin identity the fleet self-provisions via HAT (default "fleet@local")
-	FleetSecret   string        // per-role HMAC secret seed
-	LLMBaseURL    string        // OpenAI-compatible base URL (fleet-local, NOT a trip2g secret)
-	LLMAPIKey     string        // fleet-local LLM credential
-	DefaultModel  string        // fallback when a role omits model
-	TokenCeiling  int           // non-overridable per-run token cap
-	StepCeiling   int           // non-overridable per-run step cap
-	AgentsFolder  string        // e.g. "roles/" -> notePaths like "roles/%"
-	OfferedTools  []string      // a role's tools must be a subset of these
-	PollInterval  time.Duration // discovery/reconcile poll cadence
+	FleetID         string        // reconcile marker prefix "fleet:<FleetID>:"
+	ListenAddr      string        // ":9090"
+	CallbackURL     string        // trip2g-reachable base; webhook url = CallbackURL + "/deliver/" + urlKey(path)
+	Trip2gBaseURL   string        // e.g. "http://localhost:20081"
+	AdminAPIKey     string        // DEPRECATED/unused: legacy full-admin X-Api-Key (admin lane now authenticates via HAT)
+	JWTSecret       string        // shared user-token/JWT secret used to mint admin HATs (= trip2g UserToken.Secret)
+	AdminEmail      string        // admin identity the fleet self-provisions via HAT (default "fleet@local")
+	FleetSecret     string        // per-role HMAC secret seed
+	LLMBaseURL      string        // OpenAI-compatible base URL (fleet-local, NOT a trip2g secret)
+	LLMAPIKey       string        // fleet-local LLM credential
+	DefaultModel    string        // fallback when a role omits model
+	TokenCeiling    int           // non-overridable per-run token cap
+	StepCeiling     int           // non-overridable per-run step cap
+	AgentsFolder    string        // e.g. "roles/" -> notePaths like "roles/%"
+	OfferedTools    []string      // a role's tools must be a subset of these
+	AllowedPrograms []string      // programs allowed for code execution (empty = disabled)
+	PollInterval    time.Duration // discovery/reconcile poll cadence
 }

--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -1,6 +1,7 @@
 package fleet
 
 import (
+	"context"
 	"sync"
 
 	"trip2g/internal/agentruntime"
@@ -15,11 +16,21 @@ type Fleet struct {
 
 	mu       sync.RWMutex
 	registry map[string]Role // urlKey(notePath) -> Role
+
+	// codeRunner is the code-role executor. Defaults to agentruntime.RunCode.
+	// Tests may inject a stub for deterministic testing without subprocess runs.
+	codeRunner func(context.Context, agentruntime.CodeInput) (*agentruntime.Result, error)
 }
 
-// NewFleet builds a Fleet with an empty registry.
+// NewFleet builds a Fleet with an empty registry and the default code runner.
 func NewFleet(cfg Config, client Client, llm agentruntime.LLM) *Fleet {
-	return &Fleet{cfg: cfg, client: client, llm: llm, registry: map[string]Role{}}
+	return &Fleet{
+		cfg:        cfg,
+		client:     client,
+		llm:        llm,
+		registry:   map[string]Role{},
+		codeRunner: agentruntime.RunCode,
+	}
 }
 
 // SetRoles atomically swaps the live role registry (called after each poll).

--- a/internal/fleet/handler.go
+++ b/internal/fleet/handler.go
@@ -125,17 +125,35 @@ func (f *Fleet) ServeDelivery(w http.ResponseWriter, r *http.Request) {
 			errMsgs = append(errMsgs, fmt.Sprintf("item %d: render: %v", i+1, rerr))
 			continue
 		}
-		res, runErr := agentruntime.Run(runCtx, agentruntime.Input{
-			Instruction:   instruction,
-			ReadPatterns:  role.ReadPatterns,
-			WritePatterns: role.WritePatterns,
-			Tools:         role.Tools,
-			Model:         orDefault(role.Model, f.cfg.DefaultModel),
-			MaxTokens:     clampBudget(role.MaxTokens, f.cfg.TokenCeiling),
-			MaxSteps:      clampBudget(role.MaxSteps, f.cfg.StepCeiling),
-			LLM:           f.llm,
-			KB:            newRemoteKB(f.client, payload.APIToken, overlay),
-		})
+		var res *agentruntime.Result
+		var runErr error
+		if role.Executor == executorCode {
+			// Code executor: body already rendered to a program; run it deterministically.
+			// The run context (runCtx) already carries the role timeout — Timeout: 0
+			// means "use ctx only" so we don't double-apply the deadline.
+			res, runErr = f.codeRunner(runCtx, agentruntime.CodeInput{
+				Body:            instruction,
+				WritePatterns:   role.WritePatterns,
+				KB:              newRemoteKB(f.client, payload.APIToken, overlay),
+				AllowedPrograms: f.cfg.AllowedPrograms,
+				Input:           buildInputBag(rc),
+				EnvPassthrough:  role.EnvPassthrough,
+				EnvPrefix:       role.EnvPrefix,
+			})
+		} else {
+			res, runErr = agentruntime.Run(runCtx, agentruntime.Input{
+				Instruction:     instruction,
+				ReadPatterns:    role.ReadPatterns,
+				WritePatterns:   role.WritePatterns,
+				Tools:           role.Tools,
+				Model:           orDefault(role.Model, f.cfg.DefaultModel),
+				MaxTokens:       clampBudget(role.MaxTokens, f.cfg.TokenCeiling),
+				MaxSteps:        clampBudget(role.MaxSteps, f.cfg.StepCeiling),
+				AllowedPrograms: f.cfg.AllowedPrograms,
+				LLM:             f.llm,
+				KB:              newRemoteKB(f.client, payload.APIToken, overlay),
+			})
+		}
 		if runErr != nil {
 			errMsgs = append(errMsgs, fmt.Sprintf("item %d: %v", i+1, runErr))
 			continue
@@ -182,6 +200,21 @@ func (f *Fleet) ServeDelivery(w http.ResponseWriter, r *http.Request) {
 		TokensUsed: totalTokens,
 		Steps:      totalSteps,
 	})
+}
+
+// buildInputBag marshals the trigger render context into the JSON bag delivered
+// to code programs via $FLEET_INPUT. It carries only non-secret trigger data
+// (the same fields exposed to Jet templates). The scoped write token is never
+// included.
+func buildInputBag(rc renderCtx) []byte {
+	bag := map[string]any{
+		"changed_files":  rc.ChangedFiles,
+		"change_file":    rc.ChangeFile,
+		"attached_notes": rc.AttachedNotes,
+		"depth":          rc.Depth,
+	}
+	data, _ := json.Marshal(bag)
+	return data
 }
 
 // fanOut expands the base render context into one context per for_each item,

--- a/internal/fleet/handler_test.go
+++ b/internal/fleet/handler_test.go
@@ -423,6 +423,114 @@ func TestServeDelivery_ForEach_AggregatesCappedStatus(t *testing.T) {
 		"aggregate status must reflect the capped item, not the last completed one")
 }
 
+// newCodeRoleFleet builds a Fleet with a code-executor role and a stub codeRunner.
+func newCodeRoleFleet(stubRunner func(context.Context, agentruntime.CodeInput) (*agentruntime.Result, error)) *Fleet {
+	role := Role{
+		NotePath:      "roles/code.md",
+		Mode:          "change",
+		Executor:      "code",
+		WritePatterns: []string{"boards/**"},
+		Body:          "```bash\necho hi\n```",
+	}
+	cfg := Config{
+		FleetID: "f1", FleetSecret: "seed", DefaultModel: "gpt-4o-mini",
+		TokenCeiling: 100000, StepCeiling: 25,
+		AllowedPrograms: []string{"bash"},
+	}
+	f := NewFleet(cfg, &ClientMock{}, nil) // llm=nil is fine for code roles
+	f.codeRunner = stubRunner
+	f.SetRoles([]Role{role})
+	return f
+}
+
+// TestServeDelivery_CodeRole_DispatchesRunCode asserts that a role with
+// executor:code invokes the codeRunner (not agentruntime.Run), and that the
+// response reports TokensUsed=0 (code roles have no LLM spend).
+func TestServeDelivery_CodeRole_DispatchesRunCode(t *testing.T) {
+	var runCodeCalled bool
+	var receivedWritePatterns []string
+
+	stub := func(_ context.Context, in agentruntime.CodeInput) (*agentruntime.Result, error) {
+		runCodeCalled = true
+		receivedWritePatterns = in.WritePatterns
+		return &agentruntime.Result{
+			Status:     agentruntime.StatusCompleted,
+			Answer:     "code done",
+			TokensUsed: 0,
+			Steps:      1,
+		}, nil
+	}
+
+	f := newCodeRoleFleet(stub)
+	key := urlKey("roles/code.md")
+	body, _ := json.Marshal(map[string]any{
+		"depth":       0,
+		"instruction": "run code",
+		"api_token":   "scoped-token",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/deliver/"+key, bytes.NewReader(body))
+	role, ok := f.roleByKey(key)
+	require.True(t, ok)
+	req.Header.Set("X-Webhook-Signature", webhookutil.SignHMAC(body, f.secretFor(role)))
+	rec := httptest.NewRecorder()
+	f.ServeDelivery(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, runCodeCalled, "code executor role must invoke codeRunner, not agentruntime.Run")
+	require.Equal(t, []string{"boards/**"}, receivedWritePatterns)
+
+	var resp webhookutil.AgentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, 0, resp.TokensUsed, "code roles have zero LLM token spend")
+	require.Equal(t, agentruntime.StatusCompleted, resp.Status)
+}
+
+// TestServeDelivery_CodeRole_PassesEnvPassthrough asserts that env_passthrough
+// and env_prefix declared on the role are threaded into the CodeInput.
+func TestServeDelivery_CodeRole_PassesEnvPassthrough(t *testing.T) {
+	var receivedEnvPassthrough []string
+	var receivedEnvPrefix []string
+
+	stub := func(_ context.Context, in agentruntime.CodeInput) (*agentruntime.Result, error) {
+		receivedEnvPassthrough = in.EnvPassthrough
+		receivedEnvPrefix = in.EnvPrefix
+		return &agentruntime.Result{Status: agentruntime.StatusCompleted}, nil
+	}
+
+	role := Role{
+		NotePath:       "roles/envcode.md",
+		Mode:           "change",
+		Executor:       "code",
+		WritePatterns:  []string{"notes/**"},
+		Body:           "```bash\necho hi\n```",
+		EnvPassthrough: []string{"MY_TOKEN"},
+		EnvPrefix:      []string{"KRISP_"},
+	}
+	cfg := Config{
+		FleetID: "f1", FleetSecret: "seed", DefaultModel: "gpt-4o-mini",
+		TokenCeiling: 100000, StepCeiling: 25,
+		AllowedPrograms: []string{"bash"},
+	}
+	f := NewFleet(cfg, &ClientMock{}, nil)
+	f.codeRunner = stub
+	f.SetRoles([]Role{role})
+
+	key := urlKey("roles/envcode.md")
+	body, _ := json.Marshal(map[string]any{
+		"depth": 0, "api_token": "tok",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/deliver/"+key, bytes.NewReader(body))
+	r, ok := f.roleByKey(key)
+	require.True(t, ok)
+	req.Header.Set("X-Webhook-Signature", webhookutil.SignHMAC(body, f.secretFor(r)))
+	rec := httptest.NewRecorder()
+	f.ServeDelivery(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, []string{"MY_TOKEN"}, receivedEnvPassthrough)
+	require.Equal(t, []string{"KRISP_"}, receivedEnvPrefix)
+}
+
 func TestClampBudget(t *testing.T) {
 	require.Equal(t, 4000, clampBudget(4000, 100000)) // frontmatter wins under ceiling
 	require.Equal(t, 100, clampBudget(4000, 100))     // ceiling wins

--- a/internal/fleet/role.go
+++ b/internal/fleet/role.go
@@ -8,10 +8,17 @@ import (
 	"trip2g/internal/webhookutil"
 )
 
+// Executor values for Role.Executor.
+const (
+	executorLLM  = "llm"  // default: run through agentruntime.Run (LLM tool loop)
+	executorCode = "code" // deterministic: body renders to a program; stdout = write JSON
+)
+
 // Role is a parsed role note: flat frontmatter (config) + body (instruction).
 type Role struct {
 	NotePath       string
 	Body           string
+	Executor       string // "" | "llm" | "code" (default: llm)
 	Model          string
 	Tools          []string
 	ReadPatterns   []string
@@ -26,8 +33,10 @@ type Role struct {
 	CronSchedule   string
 	AttachNotes    []string
 	MaxDepth       int
-	Concurrency    string // "allow_overlap" | "skip" | "queue_one"
-	ForEach        string // "" (single run) | "changed_files" | "attached_notes"
+	Concurrency    string   // "allow_overlap" | "skip" | "queue_one"
+	ForEach        string   // "" (single run) | "changed_files" | "attached_notes"
+	EnvPassthrough []string // exact env var names forwarded to code child process
+	EnvPrefix      []string // env var name prefixes forwarded to code child process
 }
 
 // ParseRole builds a Role from a note path, body, and flat frontmatter meta
@@ -37,6 +46,7 @@ func ParseRole(notePath, body string, m map[string]string) (Role, error) {
 	r := Role{
 		NotePath:       notePath,
 		Body:           body,
+		Executor:       strings.TrimSpace(m["executor"]),
 		Model:          strings.TrimSpace(m["model"]),
 		Tools:          parseList(m["tools"]),
 		ReadPatterns:   parseList(m["read_patterns"]),
@@ -49,6 +59,8 @@ func ParseRole(notePath, body string, m map[string]string) (Role, error) {
 		AttachNotes:    parseList(m["attach_notes"]),
 		Concurrency:    strings.TrimSpace(m["concurrency"]),
 		ForEach:        strings.TrimSpace(m["for_each"]),
+		EnvPassthrough: parseList(m["env_passthrough"]),
+		EnvPrefix:      parseList(m["env_prefix"]),
 	}
 	var err error
 	if r.MaxTokens, err = parseIntOpt(m["max_tokens"]); err != nil {
@@ -112,6 +124,9 @@ func (r Role) Validate(offered []string) error {
 	// change_file footgun: a body referencing change_file but not fanned out per
 	// changed file renders against nil, so every delivery fails. Note
 	// "changed_files" (plural) does not contain the "change_file" substring.
+	// For code executor roles the body IS still Jet-rendered, so the check
+	// applies. However, Python variable names like `change_file = ...` would
+	// be false positives; a future improvement could scope this more narrowly.
 	if strings.Contains(r.Body, "change_file") && r.ForEach != forEachChangedFiles {
 		return fmt.Errorf(
 			"role %s: body references change_file but for_each is not changed_files "+
@@ -132,12 +147,65 @@ func (r Role) Validate(offered []string) error {
 	if r.TimeoutSeconds < 0 {
 		return fmt.Errorf("role %s: timeout_seconds must be >= 0, got %d", r.NotePath, r.TimeoutSeconds)
 	}
-	for _, t := range r.Tools {
-		if !contains(offered, t) {
-			return fmt.Errorf("role %s: tool %q not offered by this fleet", r.NotePath, t)
+	// Executor-specific validation.
+	switch r.Executor {
+	case "", executorLLM:
+		// LLM path (default): validate the role-declared tool allowlist.
+		for _, t := range r.Tools {
+			if !contains(offered, t) {
+				return fmt.Errorf("role %s: tool %q not offered by this fleet", r.NotePath, t)
+			}
 		}
+	case executorCode:
+		// Code path: require a write scope and a resolvable fenced program block.
+		if len(r.WritePatterns) == 0 {
+			return fmt.Errorf("role %s: executor:code requires at least one write_patterns entry", r.NotePath)
+		}
+		lang, found := roleFenceLang(r.Body)
+		if !found {
+			return fmt.Errorf("role %s: executor:code body must contain a fenced code block (```lang...```)", r.NotePath)
+		}
+		if !resolveFenceLang(lang) {
+			return fmt.Errorf("role %s: executor:code fence language %q not supported (supported: python, bash, node)", r.NotePath, lang)
+		}
+		// env_prefix safety: an empty-string prefix would match every env var,
+		// defeating the deny-by-default secret-scrub guarantee.
+		for _, p := range r.EnvPrefix {
+			if p == "" {
+				return fmt.Errorf("role %s: env_prefix must not contain an empty entry (would match all env vars)", r.NotePath)
+			}
+		}
+	default:
+		return fmt.Errorf("role %s: executor must be llm|code, got %q", r.NotePath, r.Executor)
 	}
 	return nil
+}
+
+// roleFenceLang scans body for the first fenced code block and returns its
+// language tag. Returns ("", false) when no complete block is found.
+func roleFenceLang(body string) (string, bool) {
+	idx := strings.Index(body, "```")
+	if idx == -1 {
+		return "", false
+	}
+	rest := body[idx+3:]
+	nl := strings.IndexByte(rest, '\n')
+	if nl == -1 {
+		return "", false
+	}
+	langStr := strings.TrimSpace(rest[:nl])
+	end := strings.Index(rest[nl+1:], "```")
+	return langStr, end != -1
+}
+
+// resolveFenceLang reports whether a fence language tag maps to a supported
+// code executor program (python, bash, or node).
+func resolveFenceLang(lang string) bool {
+	switch strings.ToLower(lang) {
+	case "python", "py", "bash", "sh", "js", "javascript", "node":
+		return true
+	}
+	return false
 }
 
 func contains(set []string, v string) bool {

--- a/internal/fleet/role_test.go
+++ b/internal/fleet/role_test.go
@@ -215,3 +215,117 @@ func TestRoleValidate_RejectsChangeFileWithoutForEach(t *testing.T) {
 	ok.Body = "Files:{{ range changed_files }} {{ .Path }}{{ end }}."
 	require.NoError(t, ok.Validate(nil))
 }
+
+// validCodeRole is a minimal code-executor role that passes Validate.
+func validCodeRole() Role {
+	return Role{
+		NotePath:       "roles/code.md",
+		Mode:           "change",
+		Executor:       "code",
+		TriggerOn:      []string{"update"},
+		TriggerInclude: []string{"transcripts/**"},
+		WritePatterns:  []string{"notes/**"},
+		Body:           "```bash\necho '{\"changes\":[],\"answer\":\"ok\"}'\n```",
+	}
+}
+
+func TestParseRole_Executor(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want string
+	}{
+		{"code", "code"},
+		{"llm", "llm"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		t.Run("executor="+tc.raw, func(t *testing.T) {
+			r, err := ParseRole("roles/a.md", "body", meta("mode", "change", "executor", tc.raw))
+			require.NoError(t, err)
+			require.Equal(t, tc.want, r.Executor)
+		})
+	}
+}
+
+func TestRoleValidate_ExecutorDefault(t *testing.T) {
+	// Omitted executor (empty) is treated as llm — backward-compatible.
+	r := validChangeRole()
+	r.Executor = ""
+	require.NoError(t, r.Validate(nil))
+
+	r.Executor = "llm"
+	require.NoError(t, r.Validate(nil))
+}
+
+func TestRoleValidate_ExecutorInvalidValue(t *testing.T) {
+	r := validChangeRole()
+	r.Executor = "shell"
+	err := r.Validate(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "executor must be llm|code")
+}
+
+func TestRoleValidate_CodeExecutorRequiresWritePatterns(t *testing.T) {
+	r := validCodeRole()
+	r.WritePatterns = nil
+	err := r.Validate(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "write_patterns")
+}
+
+func TestRoleValidate_CodeExecutorRequiresFencedBlock(t *testing.T) {
+	r := validCodeRole()
+	r.Body = "no code block here"
+	err := r.Validate(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "fenced code block")
+}
+
+func TestRoleValidate_CodeExecutorUnknownFenceLang(t *testing.T) {
+	r := validCodeRole()
+	r.Body = "```ruby\nputs 'hi'\n```"
+	err := r.Validate(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "fence language")
+	require.Contains(t, err.Error(), "ruby")
+}
+
+func TestRoleValidate_CodeExecutorSupportedFenceLangs(t *testing.T) {
+	langs := []string{"python", "py", "bash", "sh", "js", "javascript", "node"}
+	for _, lang := range langs {
+		t.Run("lang="+lang, func(t *testing.T) {
+			r := validCodeRole()
+			r.Body = "```" + lang + "\necho 'hi'\n```"
+			require.NoError(t, r.Validate(nil))
+		})
+	}
+}
+
+func TestParseRole_EnvPassthrough(t *testing.T) {
+	r, err := ParseRole("roles/a.md", "```bash\necho hi\n```", meta(
+		"mode", "change",
+		"executor", "code",
+		"write_patterns", `["notes/**"]`,
+		"env_passthrough", `["MY_TOKEN", "API_KEY"]`,
+		"env_prefix", `["KRISP_"]`,
+	))
+	require.NoError(t, err)
+	require.Equal(t, []string{"MY_TOKEN", "API_KEY"}, r.EnvPassthrough)
+	require.Equal(t, []string{"KRISP_"}, r.EnvPrefix)
+}
+
+func TestRoleValidate_CodeExecutorEmptyEnvPrefixRejected(t *testing.T) {
+	r := validCodeRole()
+	r.EnvPrefix = []string{""} // empty prefix matches all vars → rejected
+	err := r.Validate(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "env_prefix")
+	require.Contains(t, err.Error(), "empty entry")
+}
+
+func TestRoleValidate_CodeExecutorValidEnvPassthrough(t *testing.T) {
+	r := validCodeRole()
+	r.EnvPassthrough = []string{"MY_TOKEN"}
+	r.EnvPrefix = []string{"KRISP_"}
+	require.NoError(t, r.Validate(nil))
+}


### PR DESCRIPTION
## What

Adds the fleet **code-executor** — deterministic code execution, two surfaces, **off by default**:
- **`executor: code` role kind** — the role body renders (Jet, same bag) to a program; the **first fenced code block** runs via its fence-language interpreter; stdout must be the write JSON (`{writes:[{path,content}|{path,find,replace}],answer}`) → applied through the **same `write_patterns` scope** as `write_note`. v1 = single block (a `// future:` TODO marks pipes/state/debugger).
- **`exec(program, code)` tool** — for LLM roles; same runner core; added via a `toolInvoker` / `buildInvokers` **registry seam**, so future external-MCP tools plug into the same extension point.

## Security (the important part)

- **Off by default**: `--allowed-programs` (env `TRIP2G_ALLOWED_PROGRAMS`) is empty → code execution disabled; programs not on the allowlist error clearly.
- **Secret-scrubbed child env**: `cmd.Env` is a minimal explicit allowlist (`PATH` + `FLEET_INPUT`) — the parent env is **never** inherited. Two tests assert a parent sentinel var is absent in the child.
- **Selective env opt-in**: role frontmatter `env_passthrough: [names]` / `env_prefix: [prefixes]` forwards **only** the declared fleet env vars (empty prefix rejected by Validate). Deny-by-default + per-role opt-in — both gates (fleet must have the var, role must request it). This is what lets e.g. a Krisp ingest role get `KRISP_TOKEN`.
- **Not a scope bypass**: code/exec writes go through `ScopedKB` (`write_patterns`); out-of-scope → denial. Tested for both the role (`TestRunCode_ScopeEnforcement`) and the exec tool (`TestRun_ExecToolDeniedOutOfScope`).
- Per-run throwaway temp workdir; bounded output; bounded by the role timeout on a detached context.

## Verify

- `go build -tags dev ./...` → clean.
- `go test -tags dev ./internal/agentruntime/... ./internal/fleet/... ./cmd/fleet/...` → pass.
- `golangci-lint run --build-tags dev` → 0 issues.

## Notes

- The deterministic Krisp ingest role + its e2e (krisp-mock) is the follow-up that builds on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
