### PR TITLE
ci: drop check-doc-links job (replace with trip2g lint later)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,6 @@ permissions:
   contents: read
 
 jobs:
-  check-doc-links:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Check bilingual doc cross-language link leaks
-        run: ./scripts/check-doc-lang-links.sh
-
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The check-doc-links job runs the legacy check-doc-lang-links.sh heuristic, which fails on every PR (false positives). Disabling it now; trip2g lint (feat/trip2g-lint, parked on the jsonnet-lang false-positive) replaces it properly later.