### PR TITLE
feat(fleet): cron-mode roles + TRIP2G_FLEET_ env prefix

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -267,16 +267,16 @@ func normalizeCallbackURL(u string) string {
 func validateConfig(cfg fleet.Config) error {
 	missing := []string{}
 	if cfg.CallbackURL == "" {
-		missing = append(missing, "CallbackURL (--callback-url / TRIP2G_CALLBACK_URL)")
+		missing = append(missing, "CallbackURL (--callback-url / TRIP2G_FLEET_CALLBACK_URL)")
 	}
 	if cfg.JWTSecret == "" {
-		missing = append(missing, "JWTSecret (--jwt-secret / TRIP2G_JWT_SECRET)")
+		missing = append(missing, "JWTSecret (--jwt-secret / TRIP2G_FLEET_JWT_SECRET)")
 	}
 	if cfg.FleetSecret == "" {
-		missing = append(missing, "FleetSecret (--fleet-secret / TRIP2G_FLEET_SECRET)")
+		missing = append(missing, "FleetSecret (--fleet-secret / TRIP2G_FLEET_FLEET_SECRET)")
 	}
 	if cfg.LLMAPIKey == "" {
-		missing = append(missing, "LLMAPIKey (--llm-api-key / TRIP2G_LLM_API_KEY)")
+		missing = append(missing, "LLMAPIKey (--llm-api-key / TRIP2G_FLEET_LLM_API_KEY)")
 	}
 	if len(missing) > 0 {
 		return fmt.Errorf("fleet: missing required config: %s", strings.Join(missing, ", "))
@@ -305,8 +305,10 @@ func syncOnce(ctx context.Context, f *fleet.Fleet, d *fleet.Discovery, r *fleet.
 }
 
 // parseFlags registers all fleet flags on a dedicated FlagSet wired to
-// appconfig.EnvFlag so every flag gets a TRIP2G_<FLAG_NAME> environment
-// variable fallback (standard kebab-to-SCREAMING_SNAKE mapping).
+// appconfig.EnvFlag so every flag gets a TRIP2G_FLEET_<FLAG_NAME> environment
+// variable fallback (standard kebab-to-SCREAMING_SNAKE mapping). The
+// TRIP2G_FLEET_ prefix distinguishes fleet config from the trip2g app's
+// TRIP2G_ namespace when both run in the same environment.
 func parseFlags(ctx context.Context) (cliFlags, error) {
 	var cli cliFlags
 	var offered string
@@ -367,7 +369,7 @@ func parseFlags(ctx context.Context) (cliFlags, error) {
 
 	ef := appconfig.New(appconfig.EnvFlagConfig{
 		FlagSet:           fs,
-		EnvPrefix:         "TRIP2G_",
+		EnvPrefix:         "TRIP2G_FLEET_",
 		ShowEnvKeyInUsage: true,
 		ShowEnvValInUsage: true,
 	})

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -463,21 +463,21 @@ services:
     ports:
       - "29090:9090"
     environment:
-      - TRIP2G_FLEET_ID=e2e
-      - TRIP2G_LISTEN=:9090
-      - TRIP2G_CALLBACK_URL=http://fleet:9090
-      - TRIP2G_TRIP2G_URL=http://app:20081
-      - TRIP2G_JWT_SECRET=test-secret-key-for-testing-only-do-not-use-in-production
-      - TRIP2G_ADMIN_EMAIL=fleet@local
-      - TRIP2G_FLEET_SECRET=e2e-fleet-secret
-      - TRIP2G_LLM_BASE_URL=http://llm-mock:9091/v1
-      - TRIP2G_LLM_API_KEY=x
-      - TRIP2G_DEFAULT_MODEL=mock
-      - TRIP2G_AGENTS_FOLDER=roles/
-      - TRIP2G_POLL_SECONDS=3
-      - TRIP2G_TOKEN_CEILING=100000
-      - TRIP2G_STEP_CEILING=25
-      - TRIP2G_OFFERED_TOOLS=search,read_note,patch_note,write_note
+      - TRIP2G_FLEET_FLEET_ID=e2e
+      - TRIP2G_FLEET_LISTEN=:9090
+      - TRIP2G_FLEET_CALLBACK_URL=http://fleet:9090
+      - TRIP2G_FLEET_TRIP2G_URL=http://app:20081
+      - TRIP2G_FLEET_JWT_SECRET=test-secret-key-for-testing-only-do-not-use-in-production
+      - TRIP2G_FLEET_ADMIN_EMAIL=fleet@local
+      - TRIP2G_FLEET_FLEET_SECRET=e2e-fleet-secret
+      - TRIP2G_FLEET_LLM_BASE_URL=http://llm-mock:9091/v1
+      - TRIP2G_FLEET_LLM_API_KEY=x
+      - TRIP2G_FLEET_DEFAULT_MODEL=mock
+      - TRIP2G_FLEET_AGENTS_FOLDER=roles/
+      - TRIP2G_FLEET_POLL_SECONDS=3
+      - TRIP2G_FLEET_TOKEN_CEILING=100000
+      - TRIP2G_FLEET_STEP_CEILING=25
+      - TRIP2G_FLEET_OFFERED_TOOLS=search,read_note,patch_note,write_note
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://localhost:9090/health || exit 1"]
       interval: 5s

--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -51,9 +51,15 @@ func (f *Fleet) roleByKey(key string) (Role, bool) {
 	return r, ok
 }
 
-// secretFor derives the per-role HMAC secret used to verify deliveries.
+// secretFor derives the per-role HMAC secret used to verify change deliveries.
 func (f *Fleet) secretFor(role Role) string {
 	return deriveSecret(f.cfg.FleetSecret, f.cfg.FleetID, role.NotePath, specVer(role))
+}
+
+// cronSecretFor derives the per-role HMAC secret used to verify cron deliveries.
+// It uses cronSpecVer so change-webhook and cron-webhook secrets are distinct.
+func (f *Fleet) cronSecretFor(role Role) string {
+	return deriveSecret(f.cfg.FleetSecret, f.cfg.FleetID, role.NotePath, cronSpecVer(role))
 }
 
 // clampBudget enforces the non-overridable fleet ceiling. An unset (<=0)

--- a/internal/fleet/gqlfake_test.go
+++ b/internal/fleet/gqlfake_test.go
@@ -19,12 +19,27 @@ type gqlDoerFunc func(*http.Request) (*http.Response, error)
 
 func (f gqlDoerFunc) Do(r *http.Request) (*http.Response, error) { return f(r) }
 
+// emptyCronNodesData is the ListCronWebhooks response for an empty cron-webhook set.
+const emptyCronNodesData = `{"admin":{"allCronWebhooks":{"nodes":[]}}}`
+
 // fakeAdminGQL builds a genqlient client whose transport routes each admin-lane
 // request to respond, keyed by GraphQL operationName. respond returns the JSON
 // object placed under the {"data": ...} envelope; a non-nil error is sent as a
 // GraphQL errors[] entry. The real genqlient decode path runs over the result,
 // so a field/typename mismatch surfaces in the test.
+//
+// ListCronWebhooks is automatically handled with an empty-list response when
+// the respond func doesn't cover it (returns an error). This lets existing
+// change-mode tests remain unchanged after cron reconcile was added.
 func fakeAdminGQL(respond func(op string, vars json.RawMessage) (string, error)) graphql.Client {
+	innerRespond := respond
+	respond = func(op string, vars json.RawMessage) (string, error) {
+		data, err := innerRespond(op, vars)
+		if err != nil && op == "ListCronWebhooks" {
+			return emptyCronNodesData, nil
+		}
+		return data, err
+	}
 	doer := gqlDoerFunc(func(req *http.Request) (*http.Response, error) {
 		raw, err := io.ReadAll(req.Body)
 		if err != nil {

--- a/internal/fleet/handler.go
+++ b/internal/fleet/handler.go
@@ -14,6 +14,16 @@ import (
 	"trip2g/internal/webhookutil"
 )
 
+// cronDeliveryPayload mirrors trip2g's cron-webhook delivery body
+// (delivercronwebhook.cronWebhookPayload). Only the fields the fleet needs are
+// decoded; instruction, response_schema, secrets, and previous_error are owned
+// by trip2g's retry logic and are not forwarded to the role body.
+type cronDeliveryPayload struct {
+	Depth         int            `json:"depth"`
+	APIToken      string         `json:"api_token"`
+	AttachedNotes []attachedNote `json:"attached_notes"`
+}
+
 // deliveryPayload mirrors deliverchangewebhook.changeWebhookPayload plus the
 // Section-B attached_notes field. api_token is the per-delivery scoped token.
 type deliveryPayload struct {
@@ -50,9 +60,22 @@ type attachedNote struct {
 // maxBodyBytes caps the delivery payload size to guard against DoS.
 const maxBodyBytes = 10 * 1024 * 1024 // 10 MiB
 
-// ServeDelivery handles POST /deliver/<urlKey>.
+// inputKeyDepth is the JSON key for the depth field in the $FLEET_INPUT bag.
+const inputKeyDepth = "depth"
+
+// statusError is the AgentResponse status value for hard-failure responses.
+const statusError = "error"
+
+// ServeDelivery handles POST /deliver/<urlKey> (change deliveries) and
+// POST /deliver/cron/<urlKey> (cron-triggered deliveries).
 func (f *Fleet) ServeDelivery(w http.ResponseWriter, r *http.Request) {
-	key := strings.TrimPrefix(r.URL.Path, "/deliver/")
+	rawPath := strings.TrimPrefix(r.URL.Path, "/deliver/")
+	isCron := strings.HasPrefix(rawPath, "cron/")
+	key := rawPath
+	if isCron {
+		key = strings.TrimPrefix(rawPath, "cron/")
+	}
+
 	role, ok := f.roleByKey(key)
 	if !ok {
 		http.Error(w, "unknown delivery key", http.StatusNotFound)
@@ -64,8 +87,19 @@ func (f *Fleet) ServeDelivery(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "read body", http.StatusBadRequest)
 		return
 	}
-	if !webhookutil.VerifyHMAC(body, f.secretFor(role), r.Header.Get("X-Webhook-Signature")) {
+
+	// Select the HMAC secret that matches this delivery type.
+	secret := f.secretFor(role)
+	if isCron {
+		secret = f.cronSecretFor(role)
+	}
+	if !webhookutil.VerifyHMAC(body, secret, r.Header.Get("X-Webhook-Signature")) {
 		http.Error(w, "bad signature", http.StatusUnauthorized)
+		return
+	}
+
+	if isCron {
+		f.serveCronDelivery(w, r, role, body)
 		return
 	}
 
@@ -125,36 +159,17 @@ func (f *Fleet) ServeDelivery(w http.ResponseWriter, r *http.Request) {
 			errMsgs = append(errMsgs, fmt.Sprintf("item %d: render: %v", i+1, rerr))
 			continue
 		}
-		var res *agentruntime.Result
-		var runErr error
-		if role.Executor == executorCode {
-			// Code executor: body already rendered to a program; run it deterministically.
-			// The run context (runCtx) already carries the role timeout — Timeout: 0
-			// means "use ctx only" so we don't double-apply the deadline.
-			res, runErr = f.codeRunner(runCtx, agentruntime.CodeInput{
-				Body:            instruction,
-				WritePatterns:   role.WritePatterns,
-				KB:              newRemoteKB(f.client, payload.APIToken, overlay),
-				AllowedPrograms: f.cfg.AllowedPrograms,
-				Input:           buildInputBag(rc),
-				EnvPassthrough:  role.EnvPassthrough,
-				EnvPrefix:       role.EnvPrefix,
-				MaxStdoutBytes:  f.cfg.MaxStdoutBytes,
-			})
-		} else {
-			res, runErr = agentruntime.Run(runCtx, agentruntime.Input{
-				Instruction:     instruction,
-				ReadPatterns:    role.ReadPatterns,
-				WritePatterns:   role.WritePatterns,
-				Tools:           role.Tools,
-				Model:           orDefault(role.Model, f.cfg.DefaultModel),
-				MaxTokens:       clampBudget(role.MaxTokens, f.cfg.TokenCeiling),
-				MaxSteps:        clampBudget(role.MaxSteps, f.cfg.StepCeiling),
-				AllowedPrograms: f.cfg.AllowedPrograms,
-				LLM:             f.llm,
-				KB:              newRemoteKB(f.client, payload.APIToken, overlay),
-			})
-		}
+		// Code executor: body already rendered to a program; run it deterministically.
+		// The run context (runCtx) already carries the role timeout — Timeout: 0
+		// means "use ctx only" so we don't double-apply the deadline.
+		res, runErr := f.execRole(execRoleInput{
+			Ctx:      runCtx,
+			Role:     role,
+			Instr:    instruction,
+			APIToken: payload.APIToken,
+			Overlay:  overlay,
+			InputBag: buildInputBag(rc),
+		})
 		if runErr != nil {
 			errMsgs = append(errMsgs, fmt.Sprintf("item %d: %v", i+1, runErr))
 			continue
@@ -171,7 +186,7 @@ func (f *Fleet) ServeDelivery(w http.ResponseWriter, r *http.Request) {
 	// Whole batch failed: surface a non-2xx so trip2g's retry/backoff engages.
 	if successCount == 0 {
 		writeJSON(w, http.StatusBadGateway, webhookutil.AgentResponse{
-			Status:  "error",
+			Status:  statusError,
 			Message: strings.Join(errMsgs, "; "),
 		})
 		return
@@ -209,10 +224,10 @@ func (f *Fleet) ServeDelivery(w http.ResponseWriter, r *http.Request) {
 // included.
 func buildInputBag(rc renderCtx) []byte {
 	bag := map[string]any{
-		"changed_files":  rc.ChangedFiles,
-		"change_file":    rc.ChangeFile,
-		"attached_notes": rc.AttachedNotes,
-		"depth":          rc.Depth,
+		forEachChangedFiles:  rc.ChangedFiles,
+		"change_file":        rc.ChangeFile,
+		forEachAttachedNotes: rc.AttachedNotes,
+		inputKeyDepth:        rc.Depth,
 	}
 	data, _ := json.Marshal(bag)
 	return data
@@ -266,6 +281,119 @@ func statusSeverity(status string) int {
 	default: // completed / empty
 		return 0
 	}
+}
+
+// serveCronDelivery handles a cron-triggered POST /deliver/cron/<key>.
+// Unlike change delivery, there are no changed_files; the role body is rendered
+// once with an empty change context and the wall-clock `now` variable.
+func (f *Fleet) serveCronDelivery(w http.ResponseWriter, r *http.Request, role Role, body []byte) {
+	var payload cronDeliveryPayload
+	if uerr := json.Unmarshal(body, &payload); uerr != nil {
+		http.Error(w, "bad payload", http.StatusBadRequest)
+		return
+	}
+
+	overlay := make(map[string]string, len(payload.AttachedNotes))
+	for _, n := range payload.AttachedNotes {
+		overlay[n.Path] = n.Content
+	}
+
+	rc := renderCtx{
+		AttachedNotes: payload.AttachedNotes,
+		Depth:         payload.Depth,
+		Now:           time.Now(),
+	}
+
+	instruction, rerr := renderInstruction(role.Body, rc)
+	if rerr != nil {
+		writeJSON(w, http.StatusBadRequest, webhookutil.AgentResponse{
+			Status:  statusError,
+			Message: fmt.Sprintf("render: %v", rerr),
+		})
+		return
+	}
+
+	// Detach the run from the request context (same rationale as change delivery).
+	runCtx, cancel := context.WithTimeout(context.Background(),
+		time.Duration(role.EffectiveTimeoutSeconds())*time.Second)
+	defer cancel()
+
+	res, runErr := f.execRole(execRoleInput{
+		Ctx:      runCtx,
+		Role:     role,
+		Instr:    instruction,
+		APIToken: payload.APIToken,
+		Overlay:  overlay,
+		InputBag: buildCronInputBag(rc),
+	})
+	if runErr != nil {
+		//nolint:sloglint // Fleet has no logger instance; global slog is intentional here
+		slog.WarnContext(r.Context(), "fleet: cron run error", "role", role.NotePath, "error", runErr)
+		writeJSON(w, http.StatusBadGateway, webhookutil.AgentResponse{
+			Status:  statusError,
+			Message: runErr.Error(),
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, webhookutil.AgentResponse{
+		Status:     res.Status,
+		Message:    res.Answer,
+		TokensUsed: res.TokensUsed,
+		Steps:      res.Steps,
+	})
+}
+
+// buildCronInputBag marshals the cron render context into the JSON bag delivered
+// to code programs via $FLEET_INPUT. Exposes now as an RFC3339 string.
+func buildCronInputBag(rc renderCtx) []byte {
+	bag := map[string]any{
+		forEachAttachedNotes: rc.AttachedNotes,
+		inputKeyDepth:        rc.Depth,
+		"now":                rc.Now.Format(time.RFC3339),
+	}
+	data, _ := json.Marshal(bag)
+	return data
+}
+
+// execRoleInput bundles the parameters for a single role execution dispatch.
+type execRoleInput struct {
+	Ctx      context.Context
+	Role     Role
+	Instr    string
+	APIToken string
+	Overlay  map[string]string
+	InputBag []byte // JSON bag for code executor ($FLEET_INPUT); nil for LLM executor
+}
+
+// execRole dispatches a single rendered instruction through the role's configured
+// executor (LLM agent run or deterministic code runner). Called from both change
+// delivery (with buildInputBag) and cron delivery (with buildCronInputBag).
+func (f *Fleet) execRole(p execRoleInput) (*agentruntime.Result, error) {
+	if p.Role.Executor == executorCode {
+		return f.codeRunner(p.Ctx, agentruntime.CodeInput{
+			Body:            p.Instr,
+			WritePatterns:   p.Role.WritePatterns,
+			KB:              newRemoteKB(f.client, p.APIToken, p.Overlay),
+			AllowedPrograms: f.cfg.AllowedPrograms,
+			Input:           p.InputBag,
+			EnvPassthrough:  p.Role.EnvPassthrough,
+			EnvPrefix:       p.Role.EnvPrefix,
+			MaxStdoutBytes:  f.cfg.MaxStdoutBytes,
+		})
+	}
+	return agentruntime.Run(p.Ctx, agentruntime.Input{
+		Instruction:     p.Instr,
+		ReadPatterns:    p.Role.ReadPatterns,
+		WritePatterns:   p.Role.WritePatterns,
+		Tools:           p.Role.Tools,
+		Model:           orDefault(p.Role.Model, f.cfg.DefaultModel),
+		MaxTokens:       clampBudget(p.Role.MaxTokens, f.cfg.TokenCeiling),
+		MaxSteps:        clampBudget(p.Role.MaxSteps, f.cfg.StepCeiling),
+		AllowedPrograms: f.cfg.AllowedPrograms,
+		LLM:             f.llm,
+		KB:              newRemoteKB(f.client, p.APIToken, p.Overlay),
+	})
 }
 
 func writeJSON(w http.ResponseWriter, code int, v any) {

--- a/internal/fleet/handler_test.go
+++ b/internal/fleet/handler_test.go
@@ -546,6 +546,167 @@ func (e *errLLM) Chat(_ context.Context, _ string, _ []agentruntime.Message, _ [
 	return agentruntime.ChatResult{}, errors.New(e.msg)
 }
 
+// -- Cron delivery tests --
+
+// newCronFleet builds a Fleet with a cron-mode role for delivery tests.
+func newCronFleet(llm agentruntime.LLM) *Fleet {
+	role := Role{
+		NotePath:      "roles/kb-refresh.md",
+		Body:          `Refresh the KB at {{ now.Format("2006-01-02") }}.`,
+		Mode:          "cron",
+		CronSchedule:  "0 */6 * * *",
+		ReadPatterns:  []string{"kb/**"},
+		WritePatterns: []string{"kb/**"},
+		MaxTokens:     4000,
+		MaxSteps:      6,
+	}
+	cfg := Config{
+		FleetID: "f1", FleetSecret: "seed", DefaultModel: "gpt-4o-mini",
+		TokenCeiling: 100000, StepCeiling: 25,
+	}
+	f := NewFleet(cfg, &ClientMock{}, llm)
+	f.SetRoles([]Role{role})
+	return f
+}
+
+// cronDeliveryBody returns a minimal cron delivery payload (no changes[]).
+func cronDeliveryBody(t *testing.T) []byte {
+	t.Helper()
+	b, _ := json.Marshal(map[string]any{
+		"depth":          0,
+		"api_token":      "cron-token",
+		"attached_notes": []map[string]any{},
+	})
+	return b
+}
+
+// postCron sends a POST to /deliver/cron/<key> with a cron-signed HMAC.
+func postCron(t *testing.T, f *Fleet, key string, body []byte, sign bool) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/deliver/cron/"+key, bytes.NewReader(body))
+	if sign {
+		role, ok := f.roleByKey(key)
+		require.True(t, ok)
+		req.Header.Set("X-Webhook-Signature", webhookutil.SignHMAC(body, f.cronSecretFor(role)))
+	}
+	rec := httptest.NewRecorder()
+	f.ServeDelivery(rec, req)
+	return rec
+}
+
+// TestServeCronDelivery_HappyPath asserts that a cron delivery (no changes[])
+// triggers a single LLM run and returns 200 with spend data.
+func TestServeCronDelivery_HappyPath(t *testing.T) {
+	llm := &recordLLM{}
+	f := newCronFleet(llm)
+	key := urlKey("roles/kb-refresh.md")
+	rec := postCron(t, f, key, cronDeliveryBody(t), true)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, llm.systems, 1, "cron delivery must trigger exactly one LLM run")
+
+	var resp webhookutil.AgentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, agentruntime.StatusCompleted, resp.Status)
+	require.Equal(t, 5, resp.TokensUsed) // (3+2)*1
+}
+
+// TestServeCronDelivery_NowVarRendered asserts the `now` template variable is
+// non-zero and renders into the instruction (proof the var is injected).
+func TestServeCronDelivery_NowVarRendered(t *testing.T) {
+	llm := &recordLLM{}
+	f := newCronFleet(llm)
+	key := urlKey("roles/kb-refresh.md")
+	rec := postCron(t, f, key, cronDeliveryBody(t), true)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, llm.systems, 1)
+	// The body template is "Refresh the KB at {{ now.Format \"2006-01-02\" }}."
+	// A rendered date looks like "2026-06-30"; it must not be the zero-value "0001-01-01".
+	require.NotContains(t, llm.systems[0], "0001-01-01", "now must not be zero")
+	require.Regexp(t, `\d{4}-\d{2}-\d{2}`, llm.systems[0], "now must render as a date")
+}
+
+// TestServeCronDelivery_BadHMAC401 asserts that a wrong HMAC is rejected.
+func TestServeCronDelivery_BadHMAC401(t *testing.T) {
+	f := newCronFleet(&recordLLM{})
+	key := urlKey("roles/kb-refresh.md")
+	rec := postCron(t, f, key, cronDeliveryBody(t), false) // unsigned
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// TestServeCronDelivery_ChangeHMACRejected asserts the change-webhook HMAC is
+// NOT accepted for a cron delivery (the two secrets are derived differently).
+func TestServeCronDelivery_ChangeHMACRejected(t *testing.T) {
+	llm := &recordLLM{}
+	f := newCronFleet(llm)
+	key := urlKey("roles/kb-refresh.md")
+	body := cronDeliveryBody(t)
+
+	// Sign with the change secret (not the cron secret).
+	role, ok := f.roleByKey(key)
+	require.True(t, ok)
+	req := httptest.NewRequest(http.MethodPost, "/deliver/cron/"+key, bytes.NewReader(body))
+	req.Header.Set("X-Webhook-Signature", webhookutil.SignHMAC(body, f.secretFor(role)))
+	rec := httptest.NewRecorder()
+	f.ServeDelivery(rec, req)
+
+	require.Equal(t, http.StatusUnauthorized, rec.Code,
+		"change-webhook HMAC must not be valid for cron delivery")
+}
+
+// TestServeCronDelivery_WithAttachedNotes asserts that attached_notes in the
+// cron payload are accessible via the overlay/KB.
+func TestServeCronDelivery_WithAttachedNotes(t *testing.T) {
+	role := Role{
+		NotePath:      "roles/notes-role.md",
+		Body:          "Process {{ range attached_notes }}{{ .Path }} {{ end }}.",
+		Mode:          "cron",
+		CronSchedule:  "*/5 * * * *",
+		ReadPatterns:  []string{"**"},
+		WritePatterns: []string{"**"},
+		MaxSteps:      6,
+	}
+	cfg := Config{
+		FleetID: "f1", FleetSecret: "seed", DefaultModel: "gpt-4o-mini",
+		TokenCeiling: 100000, StepCeiling: 25,
+	}
+	llm := &recordLLM{}
+	f := NewFleet(cfg, &ClientMock{}, llm)
+	f.SetRoles([]Role{role})
+
+	key := urlKey(role.NotePath)
+	body, _ := json.Marshal(map[string]any{
+		"depth":     0,
+		"api_token": "tok",
+		"attached_notes": []map[string]any{
+			{"path": "kb/a.md", "content": "content A"},
+			{"path": "kb/b.md", "content": "content B"},
+		},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/deliver/cron/"+key, bytes.NewReader(body))
+	req.Header.Set("X-Webhook-Signature", webhookutil.SignHMAC(body, f.cronSecretFor(role)))
+	rec := httptest.NewRecorder()
+	f.ServeDelivery(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, llm.systems, 1)
+	require.Contains(t, llm.systems[0], "kb/a.md")
+	require.Contains(t, llm.systems[0], "kb/b.md")
+}
+
+// TestServeCronDelivery_RunError502 asserts a cron run error produces 502.
+func TestServeCronDelivery_RunError502(t *testing.T) {
+	f := newCronFleet(&errLLM{msg: "llm unavailable"})
+	key := urlKey("roles/kb-refresh.md")
+	rec := postCron(t, f, key, cronDeliveryBody(t), true)
+
+	require.GreaterOrEqual(t, rec.Code, 500)
+	var resp webhookutil.AgentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, "error", resp.Status)
+}
+
 // newTestFleetWithLLM builds a Fleet with the given LLM.
 func newTestFleetWithLLM(client Client, llm agentruntime.LLM) *Fleet {
 	role := Role{

--- a/internal/fleet/reconcile.go
+++ b/internal/fleet/reconcile.go
@@ -27,16 +27,25 @@ func NewReconciler(gql graphql.Client, cfg Config) *Reconciler {
 	return &Reconciler{gql: gql, cfg: cfg}
 }
 
-// Reconcile makes the registered change-webhooks match desired roles. Foreign
-// webhooks (description without this fleet's prefix) are never touched.
+// Reconcile makes the registered change-webhooks and cron-webhooks match
+// desired roles. Foreign webhooks (description without this fleet's prefix)
+// are never touched.
 func (r *Reconciler) Reconcile(ctx context.Context, roles []Role) error {
+	if err := r.reconcileChange(ctx, roles); err != nil {
+		return err
+	}
+	return r.reconcileCron(ctx, roles)
+}
+
+// reconcileChange syncs change-webhooks for change-mode and both-mode roles.
+func (r *Reconciler) reconcileChange(ctx context.Context, roles []Role) error {
 	existing, err := r.listOwned(ctx)
 	if err != nil {
 		return err
 	}
 	desired := map[string]Role{} // marker -> role
 	for _, role := range roles {
-		if role.Mode != "change" && role.Mode != "both" {
+		if role.Mode != modeChange && role.Mode != modeBoth {
 			continue
 		}
 		desired[markerFor(r.cfg.FleetID, role)] = role
@@ -62,6 +71,40 @@ func (r *Reconciler) Reconcile(ctx context.Context, roles []Role) error {
 	return nil
 }
 
+// reconcileCron syncs cron-webhooks for cron-mode and both-mode roles.
+func (r *Reconciler) reconcileCron(ctx context.Context, roles []Role) error {
+	existing, err := r.listOwnedCron(ctx)
+	if err != nil {
+		return err
+	}
+	desired := map[string]Role{} // cronMarker -> role
+	for _, role := range roles {
+		if role.Mode != modeCron && role.Mode != modeBoth {
+			continue
+		}
+		desired[cronMarkerFor(r.cfg.FleetID, role)] = role
+	}
+
+	// Delete owned cron-webhooks whose marker is no longer desired.
+	for marker, id := range existing {
+		if _, keep := desired[marker]; !keep {
+			if derr := r.deleteCron(ctx, id); derr != nil {
+				return derr
+			}
+		}
+	}
+	// Create cron-webhooks for desired markers not yet present.
+	for marker, role := range desired {
+		if _, present := existing[marker]; present {
+			continue // marker already matches => spec unchanged
+		}
+		if cerr := r.createCron(ctx, role); cerr != nil {
+			return cerr
+		}
+	}
+	return nil
+}
+
 // Deregister removes every webhook owned by this fleet (shutdown).
 func (r *Reconciler) Deregister(ctx context.Context) error {
 	existing, err := r.listOwned(ctx)
@@ -70,6 +113,15 @@ func (r *Reconciler) Deregister(ctx context.Context) error {
 	}
 	for _, id := range existing {
 		if derr := r.delete(ctx, id); derr != nil {
+			return derr
+		}
+	}
+	existingCron, err := r.listOwnedCron(ctx)
+	if err != nil {
+		return err
+	}
+	for _, id := range existingCron {
+		if derr := r.deleteCron(ctx, id); derr != nil {
 			return derr
 		}
 	}
@@ -100,7 +152,7 @@ func (r *Reconciler) create(ctx context.Context, role Role) error {
 		WritePatterns:    orEmpty(role.WritePatterns),
 		AttachNotes:      orEmpty(role.AttachNotes),
 		TransformJsonnet: "",
-		ConcurrencyMode:  orDefault(role.Concurrency, "allow_overlap"),
+		ConcurrencyMode:  orDefault(role.Concurrency, concurrencyAllowOverlap),
 		PassApiKey:       true,
 		IncludeContent:   true,
 		MaxDepth:         int64(role.MaxDepth),
@@ -135,6 +187,78 @@ func (r *Reconciler) delete(ctx context.Context, id int64) error {
 		return fmt.Errorf("changeWebhookDelete: %s", ep.Message)
 	}
 	return nil
+}
+
+func (r *Reconciler) listOwnedCron(ctx context.Context) (map[string]int64, error) {
+	resp, err := trip2ggql.ListCronWebhooks(ctx, r.gql)
+	if err != nil {
+		return nil, err
+	}
+	prefix := "fleetcron:" + r.cfg.FleetID + ":"
+	owned := map[string]int64{}
+	for _, n := range resp.Admin.AllCronWebhooks.Nodes {
+		if strings.HasPrefix(n.Description, prefix) {
+			owned[n.Description] = n.Id
+		}
+	}
+	return owned, nil
+}
+
+func (r *Reconciler) createCron(ctx context.Context, role Role) error {
+	input := trip2ggql.CreateCronWebhookInput{
+		Url:             r.cfg.CallbackURL + "/deliver/cron/" + urlKey(role.NotePath),
+		CronSchedule:    role.CronSchedule,
+		ReadPatterns:    orEmpty(role.ReadPatterns),
+		WritePatterns:   orEmpty(role.WritePatterns),
+		AttachNotes:     orEmpty(role.AttachNotes),
+		ConcurrencyMode: orDefault(role.Concurrency, "allow_overlap"),
+		MaxDepth:        int64(role.MaxDepth),
+		TimeoutSeconds:  int64(role.EffectiveTimeoutSeconds()),
+		PassApiKey:      true,
+		Enabled:         true,
+		Description:     cronMarkerFor(r.cfg.FleetID, role),
+		Secret:          deriveSecret(r.cfg.FleetSecret, r.cfg.FleetID, role.NotePath, cronSpecVer(role)),
+	}
+	resp, err := trip2ggql.CreateCronWebhook(ctx, r.gql, input)
+	if err != nil {
+		return err
+	}
+	if ep, ok := resp.Admin.CreateCronWebhook.(*trip2ggql.CreateCronWebhookAdminAdminMutationCreateCronWebhookErrorPayload); ok {
+		return fmt.Errorf("createCronWebhook: %s", ep.Message)
+	}
+	return nil
+}
+
+func (r *Reconciler) deleteCron(ctx context.Context, id int64) error {
+	resp, err := trip2ggql.DeleteCronWebhook(ctx, r.gql, trip2ggql.DeleteCronWebhookInput{Id: id})
+	if err != nil {
+		return err
+	}
+	if ep, ok := resp.Admin.DeleteCronWebhook.(*trip2ggql.DeleteCronWebhookAdminAdminMutationDeleteCronWebhookErrorPayload); ok {
+		return fmt.Errorf("deleteCronWebhook: %s", ep.Message)
+	}
+	return nil
+}
+
+// cronMarkerFor is the cron reconcile dedup key stored in the cron-webhook description.
+// Uses "fleetcron:" prefix to distinguish from change-webhook markers ("fleet:").
+func cronMarkerFor(fleetID string, role Role) string {
+	return "fleetcron:" + fleetID + ":" + role.NotePath + "#" + cronSpecVer(role)
+}
+
+// cronSpecVer is a short content hash of the cron-webhook-relevant role fields.
+// Bumping any field rotates the marker (delete+recreate).
+func cronSpecVer(role Role) string {
+	h := sha256.Sum256([]byte(strings.Join([]string{
+		role.CronSchedule,
+		strings.Join(role.ReadPatterns, ","),
+		strings.Join(role.WritePatterns, ","),
+		strings.Join(role.AttachNotes, ","),
+		role.Concurrency,
+		strconv.Itoa(role.MaxDepth),
+		strconv.Itoa(role.EffectiveTimeoutSeconds()),
+	}, "|")))
+	return base64.RawURLEncoding.EncodeToString(h[:6])
 }
 
 // markerFor is the reconcile dedup key stored in the webhook description.

--- a/internal/fleet/reconcile_test.go
+++ b/internal/fleet/reconcile_test.go
@@ -282,3 +282,192 @@ func TestReconcile_Delete_ErrorPayload_SurfacesAsError(t *testing.T) {
 	require.Error(t, err, "ErrorPayload from changeWebhookDelete must propagate as an error")
 	require.Contains(t, err.Error(), "not found")
 }
+
+// -- Cron webhook reconcile tests --
+
+// newCronRole returns a minimal cron-mode role that passes Validate.
+func newCronRole() Role {
+	return Role{
+		NotePath:       "roles/kb-refresh.md",
+		Mode:           "cron",
+		CronSchedule:   "0 */6 * * *",
+		ReadPatterns:   []string{"kb/**"},
+		WritePatterns:  []string{"kb/**"},
+		AttachNotes:    []string{"kb/**"},
+		TimeoutSeconds: 120,
+	}
+}
+
+// cronNodesData builds an allCronWebhooks {nodes} data object from id/description pairs.
+func cronNodesData(nodes ...[2]string) string {
+	parts := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		parts = append(parts, fmt.Sprintf(`{"id":%s,"description":%q}`, n[0], n[1]))
+	}
+	return `{"admin":{"allCronWebhooks":{"nodes":[` + strings.Join(parts, ",") + `]}}}`
+}
+
+const createCronOKData = `{"admin":{"createCronWebhook":{"__typename":"CreateCronWebhookPayload","cronWebhook":{"id":10}}}}`
+const deleteCronOKData = `{"admin":{"deleteCronWebhook":{"__typename":"DeleteCronWebhookPayload","deletedId":0}}}`
+
+// createCronInputFrom decodes a CreateCronWebhook request's typed input variable.
+func createCronInputFrom(t *testing.T, vars json.RawMessage) trip2ggql.CreateCronWebhookInput {
+	t.Helper()
+	var v struct {
+		Input trip2ggql.CreateCronWebhookInput `json:"input"`
+	}
+	require.NoError(t, json.Unmarshal(vars, &v))
+	return v.Input
+}
+
+// TestReconcile_CreatesCronWebhookForCronRole asserts that a cron-mode role
+// triggers a CreateCronWebhook call with the expected fields.
+func TestReconcile_CreatesCronWebhookForCronRole(t *testing.T) {
+	var createdInput *trip2ggql.CreateCronWebhookInput
+	gql := fakeAdminGQL(func(op string, vars json.RawMessage) (string, error) {
+		switch op {
+		case "ListChangeWebhooks":
+			return nodesData(), nil
+		case "ListCronWebhooks":
+			return cronNodesData(), nil
+		case "CreateCronWebhook":
+			in := createCronInputFrom(t, vars)
+			createdInput = &in
+			return createCronOKData, nil
+		}
+		return "", fmt.Errorf("unexpected op %q", op)
+	})
+	role := newCronRole()
+	require.NoError(t, newReconciler(gql).Reconcile(context.Background(), []Role{role}))
+	require.NotNil(t, createdInput, "CreateCronWebhook must be called")
+	require.Equal(t, "0 */6 * * *", createdInput.CronSchedule)
+	require.True(t, createdInput.PassApiKey, "cron webhook must pass api_key")
+	require.True(t, createdInput.Enabled, "cron webhook must be enabled")
+	require.Equal(t, int64(120), createdInput.TimeoutSeconds)
+	require.Contains(t, createdInput.Url, "/deliver/cron/")
+	require.Contains(t, createdInput.Description, "fleetcron:f1:roles/kb-refresh.md#")
+}
+
+// TestReconcile_BothModeRegistersChangeAndCronWebhooks asserts that a both-mode
+// role registers exactly one change webhook AND one cron webhook.
+func TestReconcile_BothModeRegistersChangeAndCronWebhooks(t *testing.T) {
+	var changeCalls, cronCalls int
+	gql := fakeAdminGQL(func(op string, vars json.RawMessage) (string, error) {
+		switch op {
+		case "ListChangeWebhooks":
+			return nodesData(), nil
+		case "ListCronWebhooks":
+			return cronNodesData(), nil
+		case "CreateChangeWebhook":
+			changeCalls++
+			return createOKData, nil
+		case "CreateCronWebhook":
+			cronCalls++
+			return createCronOKData, nil
+		}
+		return "", fmt.Errorf("unexpected op %q", op)
+	})
+	role := Role{
+		NotePath:       "roles/both.md",
+		Mode:           "both",
+		CronSchedule:   "*/15 * * * *",
+		TriggerOn:      []string{"update"},
+		TriggerInclude: []string{"notes/**"},
+	}
+	require.NoError(t, newReconciler(gql).Reconcile(context.Background(), []Role{role}))
+	require.Equal(t, 1, changeCalls, "one change webhook must be created")
+	require.Equal(t, 1, cronCalls, "one cron webhook must be created")
+}
+
+// TestReconcile_CronWebhookNoChangeWhenMarkerMatches asserts that an existing
+// cron webhook with a matching marker is not deleted and not recreated.
+func TestReconcile_CronWebhookNoChangeWhenMarkerMatches(t *testing.T) {
+	role := newCronRole()
+	desc := cronMarkerFor("f1", role)
+	var createCronCalls, deleteCronCalls int
+	gql := fakeAdminGQL(func(op string, vars json.RawMessage) (string, error) {
+		switch op {
+		case "ListChangeWebhooks":
+			return nodesData(), nil
+		case "ListCronWebhooks":
+			return cronNodesData([2]string{"10", desc}), nil
+		case "CreateCronWebhook":
+			createCronCalls++
+			return createCronOKData, nil
+		case "DeleteCronWebhook":
+			deleteCronCalls++
+			return deleteCronOKData, nil
+		}
+		return "", fmt.Errorf("unexpected op %q", op)
+	})
+	require.NoError(t, newReconciler(gql).Reconcile(context.Background(), []Role{role}))
+	require.Zero(t, createCronCalls, "no cron webhook should be created when marker matches")
+	require.Zero(t, deleteCronCalls, "no cron webhook should be deleted when marker matches")
+}
+
+// TestReconcile_DeletesStaleOwnedCronWebhook asserts that a cron webhook owned
+// by this fleet but no longer desired is deleted.
+func TestReconcile_DeletesStaleOwnedCronWebhook(t *testing.T) {
+	var deletedCronIDs []int64
+	gql := fakeAdminGQL(func(op string, vars json.RawMessage) (string, error) {
+		switch op {
+		case "ListChangeWebhooks":
+			return nodesData(), nil
+		case "ListCronWebhooks":
+			return cronNodesData([2]string{"55", "fleetcron:f1:roles/old.md#stale"}), nil
+		case "DeleteCronWebhook":
+			var v struct {
+				Input trip2ggql.DeleteCronWebhookInput `json:"input"`
+			}
+			require.NoError(t, json.Unmarshal(vars, &v))
+			deletedCronIDs = append(deletedCronIDs, v.Input.Id)
+			return deleteCronOKData, nil
+		}
+		return "", fmt.Errorf("unexpected op %q", op)
+	})
+	require.NoError(t, newReconciler(gql).Reconcile(context.Background(), nil))
+	require.Equal(t, []int64{55}, deletedCronIDs, "stale fleet-owned cron webhook must be deleted")
+}
+
+// TestDeregister_DeletesOwnedCronWebhooks asserts Deregister also removes
+// cron webhooks owned by this fleet.
+func TestDeregister_DeletesOwnedCronWebhooks(t *testing.T) {
+	var deletedCronIDs []int64
+	gql := fakeAdminGQL(func(op string, vars json.RawMessage) (string, error) {
+		switch op {
+		case "ListChangeWebhooks":
+			return nodesData(), nil
+		case "ListCronWebhooks":
+			return cronNodesData([2]string{"20", "fleetcron:f1:roles/x.md#abc"}), nil
+		case "DeleteCronWebhook":
+			var v struct {
+				Input trip2ggql.DeleteCronWebhookInput `json:"input"`
+			}
+			require.NoError(t, json.Unmarshal(vars, &v))
+			deletedCronIDs = append(deletedCronIDs, v.Input.Id)
+			return deleteCronOKData, nil
+		}
+		return "", fmt.Errorf("unexpected op %q", op)
+	})
+	require.NoError(t, newReconciler(gql).Deregister(context.Background()))
+	require.Equal(t, []int64{20}, deletedCronIDs, "cron webhook must be removed on deregister")
+}
+
+// TestReconcile_CronCreate_ErrorPayload_SurfacesAsError asserts that an
+// ErrorPayload from createCronWebhook propagates as an error.
+func TestReconcile_CronCreate_ErrorPayload_SurfacesAsError(t *testing.T) {
+	gql := fakeAdminGQL(func(op string, vars json.RawMessage) (string, error) {
+		switch op {
+		case "ListChangeWebhooks":
+			return nodesData(), nil
+		case "ListCronWebhooks":
+			return cronNodesData(), nil
+		case "CreateCronWebhook":
+			return `{"admin":{"createCronWebhook":{"__typename":"ErrorPayload","message":"invalid schedule"}}}`, nil
+		}
+		return "", fmt.Errorf("unexpected op %q", op)
+	})
+	err := newReconciler(gql).Reconcile(context.Background(), []Role{newCronRole()})
+	require.Error(t, err, "ErrorPayload from createCronWebhook must propagate as an error")
+	require.Contains(t, err.Error(), "invalid schedule")
+}

--- a/internal/fleet/remotekb.go
+++ b/internal/fleet/remotekb.go
@@ -28,6 +28,15 @@ func newRemoteKB(client Client, token string, overlay map[string]string) *remote
 
 var _ agentruntime.KB = (*remoteKB)(nil)
 
+// JSON field name constants used in the updateNotes mutation input maps.
+const (
+	kbKeyContent = "content" // upsert operation field: note body
+	kbKeyFind    = "find"    // patch operation field: search string
+	kbKeyReplace = "replace" // patch operation field: replacement string
+	kbKeyPath    = "path"    // operation field: note path
+	kbKeyChanges = "changes" // UpdateNotesInput field: list of change operations
+)
+
 const searchScopedQuery = `query Search($q: String!) {
   search(input: {query: $q}) { nodes { document { ... on PublicNote { path } } } }
 }`
@@ -105,7 +114,7 @@ func (k *remoteKB) Read(ctx context.Context, path string) (string, error) {
 
 func (k *remoteKB) Write(ctx context.Context, path, content string) error {
 	if err := k.update(ctx, []map[string]any{
-		{"upsert": map[string]any{"path": path, "content": content}},
+		{"upsert": map[string]any{kbKeyPath: path, kbKeyContent: content}},
 	}); err != nil {
 		return err
 	}
@@ -115,7 +124,7 @@ func (k *remoteKB) Write(ctx context.Context, path, content string) error {
 
 func (k *remoteKB) Patch(ctx context.Context, path, find, replace string) error {
 	if err := k.update(ctx, []map[string]any{
-		{"patch": map[string]any{"path": path, "find": find, "replace": replace}},
+		{"patch": map[string]any{kbKeyPath: path, kbKeyFind: find, kbKeyReplace: replace}},
 	}); err != nil {
 		return err
 	}
@@ -149,7 +158,7 @@ type updateNotesResult struct {
 
 func (k *remoteKB) update(ctx context.Context, changes []map[string]any) error {
 	raw, err := k.client.GraphQLScoped(ctx, k.token, updateNotesMutation,
-		map[string]any{"input": map[string]any{"changes": changes}})
+		map[string]any{"input": map[string]any{kbKeyChanges: changes}})
 	if err != nil {
 		return err
 	}

--- a/internal/fleet/render.go
+++ b/internal/fleet/render.go
@@ -3,6 +3,7 @@ package fleet
 import (
 	"bytes"
 	"strings"
+	"time"
 
 	"github.com/CloudyKit/jet/v6"
 )
@@ -15,6 +16,7 @@ type renderCtx struct {
 	ChangeFile    *changeInfo
 	AttachedNotes []attachedNote
 	Depth         int
+	Now           time.Time // wall-clock time at delivery; zero for legacy contexts
 }
 
 // renderInstruction renders a role-note body as a Jet template against the
@@ -40,6 +42,7 @@ func renderInstruction(body string, ctx renderCtx) (string, error) {
 	vars.Set("change_file", ctx.ChangeFile)
 	vars.Set(forEachAttachedNotes, ctx.AttachedNotes)
 	vars.Set("depth", ctx.Depth)
+	vars.Set("now", ctx.Now)
 
 	var buf bytes.Buffer
 	if execErr := tmpl.Execute(&buf, vars, nil); execErr != nil {

--- a/internal/fleet/role.go
+++ b/internal/fleet/role.go
@@ -103,19 +103,60 @@ const (
 	forEachAttachedNotes = "attached_notes"
 )
 
+// Role mode values for Role.Mode.
+const (
+	modeChange = "change"
+	modeCron   = "cron"
+	modeBoth   = "both"
+)
+
+// Concurrency mode values for Role.Concurrency.
+const (
+	concurrencyAllowOverlap = "allow_overlap"
+	concurrencySkip         = "skip"
+	concurrencyQueueOne     = "queue_one"
+)
+
 // Validate fails fast on misconfiguration discovered at poll time, before any
 // webhook is registered. Tools must be a subset of the fleet's offered set.
 func (r Role) Validate(offered []string) error {
 	switch r.Mode {
-	case "change":
+	case modeChange, modeCron, modeBoth:
 		// supported
-	case "cron", "both":
-		return fmt.Errorf("role %s: mode %q is not yet supported by this fleet (cron-mode roles are not yet supported by this fleet)", r.NotePath, r.Mode)
 	default:
 		return fmt.Errorf("role %s: mode must be change|cron|both, got %q", r.NotePath, r.Mode)
 	}
-	// Change-mode trigger sanity (only mode change reaches here): a webhook that
-	// fires on no events or matches no paths silently never runs.
+	// cron_schedule is required for any mode that registers a cron webhook.
+	if (r.Mode == modeCron || r.Mode == modeBoth) && r.CronSchedule == "" {
+		return fmt.Errorf("role %s: cron_schedule is required for mode %q", r.NotePath, r.Mode)
+	}
+	// Change-mode trigger sanity: only applies when a change webhook is registered
+	// (mode change or both). A webhook that fires on no events or matches no
+	// paths silently never runs.
+	if r.Mode == modeChange || r.Mode == modeBoth {
+		if err := r.validateChangeModeFields(); err != nil {
+			return err
+		}
+	}
+	switch r.Concurrency {
+	case "", concurrencyAllowOverlap, concurrencySkip, concurrencyQueueOne:
+	default:
+		return fmt.Errorf("role %s: concurrency must be allow_overlap|skip|queue_one, got %q", r.NotePath, r.Concurrency)
+	}
+	switch r.ForEach {
+	case "", forEachChangedFiles, forEachAttachedNotes:
+	default:
+		return fmt.Errorf("role %s: for_each must be changed_files|attached_notes, got %q", r.NotePath, r.ForEach)
+	}
+	if r.TimeoutSeconds < 0 {
+		return fmt.Errorf("role %s: timeout_seconds must be >= 0, got %d", r.NotePath, r.TimeoutSeconds)
+	}
+	return r.validateExecutorFields(offered)
+}
+
+// validateChangeModeFields checks the trigger fields required for change-webhook registration.
+// It is called from Validate when mode is "change" or "both".
+func (r Role) validateChangeModeFields() error {
 	if len(r.TriggerOn) == 0 {
 		return fmt.Errorf("role %s: trigger_on is empty (webhook would fire on no events); set trigger_on to some of create|update|remove", r.NotePath)
 	}
@@ -135,20 +176,11 @@ func (r Role) Validate(offered []string) error {
 			r.NotePath,
 		)
 	}
-	switch r.Concurrency {
-	case "", "allow_overlap", "skip", "queue_one":
-	default:
-		return fmt.Errorf("role %s: concurrency must be allow_overlap|skip|queue_one, got %q", r.NotePath, r.Concurrency)
-	}
-	switch r.ForEach {
-	case "", forEachChangedFiles, forEachAttachedNotes:
-	default:
-		return fmt.Errorf("role %s: for_each must be changed_files|attached_notes, got %q", r.NotePath, r.ForEach)
-	}
-	if r.TimeoutSeconds < 0 {
-		return fmt.Errorf("role %s: timeout_seconds must be >= 0, got %d", r.NotePath, r.TimeoutSeconds)
-	}
-	// Executor-specific validation.
+	return nil
+}
+
+// validateExecutorFields checks executor-specific fields. It is called from Validate.
+func (r Role) validateExecutorFields(offered []string) error {
 	switch r.Executor {
 	case "", executorLLM:
 		// LLM path (default): validate the role-declared tool allowlist.

--- a/internal/fleet/role_test.go
+++ b/internal/fleet/role_test.go
@@ -148,31 +148,66 @@ func TestRoleValidate_DefaultConcurrencyAllowed(t *testing.T) {
 	require.Error(t, bad.Validate(nil))
 }
 
-// TestRoleValidate_CronModeRejected is a regression test for F6: cron-mode
-// roles must fail fast at discovery because cron reconcile is not yet
-// implemented. mode:change must still pass.
-func TestRoleValidate_CronModeRejected(t *testing.T) {
-	cases := []struct {
-		mode    string
-		wantErr bool
-	}{
-		{"change", false},
-		{"cron", true},
-		{"both", true},
+// TestRoleValidate_CronModeAccepted verifies that cron and both modes are now
+// accepted by Validate. Previously they were rejected as "not yet supported";
+// the cron-mode implementation removes that restriction.
+func TestRoleValidate_CronModeAccepted(t *testing.T) {
+	// A minimal valid cron-only role (no trigger_on/include needed).
+	cronRole := func() Role {
+		return Role{
+			NotePath:     "roles/a.md",
+			Mode:         "cron",
+			CronSchedule: "*/5 * * * *",
+		}
 	}
-	for _, tc := range cases {
-		t.Run("mode="+tc.mode, func(t *testing.T) {
-			r := validChangeRole()
-			r.Mode = tc.mode
-			err := r.Validate(nil)
-			if tc.wantErr {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "not yet supported")
-			} else {
-				require.NoError(t, err)
-			}
-		})
+	// A minimal valid both-mode role needs change fields + cron_schedule.
+	bothRole := func() Role {
+		return Role{
+			NotePath:       "roles/a.md",
+			Mode:           "both",
+			CronSchedule:   "0 * * * *",
+			TriggerOn:      []string{"update"},
+			TriggerInclude: []string{"boards/**"},
+		}
 	}
+
+	t.Run("cron_with_schedule_passes", func(t *testing.T) {
+		require.NoError(t, cronRole().Validate(nil))
+	})
+	t.Run("cron_without_schedule_fails", func(t *testing.T) {
+		r := cronRole()
+		r.CronSchedule = ""
+		err := r.Validate(nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cron_schedule")
+	})
+	t.Run("both_with_all_required_fields_passes", func(t *testing.T) {
+		require.NoError(t, bothRole().Validate(nil))
+	})
+	t.Run("both_without_schedule_fails", func(t *testing.T) {
+		r := bothRole()
+		r.CronSchedule = ""
+		err := r.Validate(nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cron_schedule")
+	})
+	t.Run("both_without_trigger_on_fails", func(t *testing.T) {
+		r := bothRole()
+		r.TriggerOn = nil
+		err := r.Validate(nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "trigger_on")
+	})
+	t.Run("both_without_trigger_include_fails", func(t *testing.T) {
+		r := bothRole()
+		r.TriggerInclude = nil
+		err := r.Validate(nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "trigger_include")
+	})
+	t.Run("change_still_passes", func(t *testing.T) {
+		require.NoError(t, validChangeRole().Validate(nil))
+	})
 }
 
 // TestRoleValidate_RejectsEmptyTriggerOn: a change-mode role with no trigger_on

--- a/internal/fleet/trip2ggql/genqlient.gen.go
+++ b/internal/fleet/trip2ggql/genqlient.gen.go
@@ -294,6 +294,265 @@ func (v *CreateChangeWebhookResponse) GetAdmin() CreateChangeWebhookAdminAdminMu
 	return v.Admin
 }
 
+// CreateCronWebhookAdminAdminMutation includes the requested fields of the GraphQL type AdminMutation.
+type CreateCronWebhookAdminAdminMutation struct {
+	CreateCronWebhook CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookOrErrorPayload `json:"-"`
+}
+
+// GetCreateCronWebhook returns CreateCronWebhookAdminAdminMutation.CreateCronWebhook, and is useful for accessing the field via an interface.
+func (v *CreateCronWebhookAdminAdminMutation) GetCreateCronWebhook() CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookOrErrorPayload {
+	return v.CreateCronWebhook
+}
+
+func (v *CreateCronWebhookAdminAdminMutation) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*CreateCronWebhookAdminAdminMutation
+		CreateCronWebhook json.RawMessage `json:"createCronWebhook"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.CreateCronWebhookAdminAdminMutation = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.CreateCronWebhook
+		src := firstPass.CreateCronWebhook
+		if len(src) != 0 && string(src) != "null" {
+			err = __unmarshalCreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookOrErrorPayload(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal CreateCronWebhookAdminAdminMutation.CreateCronWebhook: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalCreateCronWebhookAdminAdminMutation struct {
+	CreateCronWebhook json.RawMessage `json:"createCronWebhook"`
+}
+
+func (v *CreateCronWebhookAdminAdminMutation) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *CreateCronWebhookAdminAdminMutation) __premarshalJSON() (*__premarshalCreateCronWebhookAdminAdminMutation, error) {
+	var retval __premarshalCreateCronWebhookAdminAdminMutation
+
+	{
+
+		dst := &retval.CreateCronWebhook
+		src := v.CreateCronWebhook
+		var err error
+		*dst, err = __marshalCreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookOrErrorPayload(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal CreateCronWebhookAdminAdminMutation.CreateCronWebhook: %w", err)
+		}
+	}
+	return &retval, nil
+}
+
+// CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookOrErrorPayload includes the requested fields of the GraphQL interface CreateCronWebhookOrErrorPayload.
+//
+// CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookOrErrorPayload is implemented by the following types:
+// CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookPayload
+// CreateCronWebhookAdminAdminMutationCreateCronWebhookErrorPayload
+type CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookOrErrorPayload interface {
+	implementsGraphQLInterfaceCreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookOrErrorPayload()
+	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
+	GetTypename() string
+}
+
+func (v *CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookPayload) implementsGraphQLInterfaceCreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookOrErrorPayload() {
+}
+func (v *CreateCronWebhookAdminAdminMutationCreateCronWebhookErrorPayload) implementsGraphQLInterfaceCreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookOrErrorPayload() {
+}
+
+func __unmarshalCreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookOrErrorPayload(b []byte, v *CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookOrErrorPayload) error {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var tn struct {
+		TypeName string `json:"__typename"`
+	}
+	err := json.Unmarshal(b, &tn)
+	if err != nil {
+		return err
+	}
+
+	switch tn.TypeName {
+	case "CreateCronWebhookPayload":
+		*v = new(CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookPayload)
+		return json.Unmarshal(b, *v)
+	case "ErrorPayload":
+		*v = new(CreateCronWebhookAdminAdminMutationCreateCronWebhookErrorPayload)
+		return json.Unmarshal(b, *v)
+	case "":
+		return fmt.Errorf(
+			"response was missing CreateCronWebhookOrErrorPayload.__typename")
+	default:
+		return fmt.Errorf(
+			`unexpected concrete type for CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookOrErrorPayload: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalCreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookOrErrorPayload(v *CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookOrErrorPayload) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookPayload:
+		typename = "CreateCronWebhookPayload"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookPayload
+		}{typename, v}
+		return json.Marshal(result)
+	case *CreateCronWebhookAdminAdminMutationCreateCronWebhookErrorPayload:
+		typename = "ErrorPayload"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*CreateCronWebhookAdminAdminMutationCreateCronWebhookErrorPayload
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`unexpected concrete type for CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookOrErrorPayload: "%T"`, v)
+	}
+}
+
+// CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookPayload includes the requested fields of the GraphQL type CreateCronWebhookPayload.
+type CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookPayload struct {
+	Typename    string                                                                                                  `json:"__typename"`
+	CronWebhook CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookPayloadCronWebhookAdminCronWebhook `json:"cronWebhook"`
+}
+
+// GetTypename returns CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookPayload.Typename, and is useful for accessing the field via an interface.
+func (v *CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookPayload) GetTypename() string {
+	return v.Typename
+}
+
+// GetCronWebhook returns CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookPayload.CronWebhook, and is useful for accessing the field via an interface.
+func (v *CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookPayload) GetCronWebhook() CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookPayloadCronWebhookAdminCronWebhook {
+	return v.CronWebhook
+}
+
+// CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookPayloadCronWebhookAdminCronWebhook includes the requested fields of the GraphQL type AdminCronWebhook.
+type CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookPayloadCronWebhookAdminCronWebhook struct {
+	Id int64 `json:"id"`
+}
+
+// GetId returns CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookPayloadCronWebhookAdminCronWebhook.Id, and is useful for accessing the field via an interface.
+func (v *CreateCronWebhookAdminAdminMutationCreateCronWebhookCreateCronWebhookPayloadCronWebhookAdminCronWebhook) GetId() int64 {
+	return v.Id
+}
+
+// CreateCronWebhookAdminAdminMutationCreateCronWebhookErrorPayload includes the requested fields of the GraphQL type ErrorPayload.
+type CreateCronWebhookAdminAdminMutationCreateCronWebhookErrorPayload struct {
+	Typename string `json:"__typename"`
+	Message  string `json:"message"`
+}
+
+// GetTypename returns CreateCronWebhookAdminAdminMutationCreateCronWebhookErrorPayload.Typename, and is useful for accessing the field via an interface.
+func (v *CreateCronWebhookAdminAdminMutationCreateCronWebhookErrorPayload) GetTypename() string {
+	return v.Typename
+}
+
+// GetMessage returns CreateCronWebhookAdminAdminMutationCreateCronWebhookErrorPayload.Message, and is useful for accessing the field via an interface.
+func (v *CreateCronWebhookAdminAdminMutationCreateCronWebhookErrorPayload) GetMessage() string {
+	return v.Message
+}
+
+type CreateCronWebhookInput struct {
+	Url              string   `json:"url"`
+	CronSchedule     string   `json:"cronSchedule"`
+	Instruction      string   `json:"instruction"`
+	Secret           string   `json:"secret"`
+	PassApiKey       bool     `json:"passApiKey"`
+	TimeoutSeconds   int64    `json:"timeoutSeconds"`
+	MaxDepth         int64    `json:"maxDepth"`
+	MaxRetries       int64    `json:"maxRetries"`
+	Enabled          bool     `json:"enabled"`
+	Description      string   `json:"description"`
+	ReadPatterns     []string `json:"readPatterns"`
+	WritePatterns    []string `json:"writePatterns"`
+	TransformJsonnet string   `json:"transformJsonnet"`
+	AttachNotes      []string `json:"attachNotes"`
+	ConcurrencyMode  string   `json:"concurrencyMode"`
+}
+
+// GetUrl returns CreateCronWebhookInput.Url, and is useful for accessing the field via an interface.
+func (v *CreateCronWebhookInput) GetUrl() string { return v.Url }
+
+// GetCronSchedule returns CreateCronWebhookInput.CronSchedule, and is useful for accessing the field via an interface.
+func (v *CreateCronWebhookInput) GetCronSchedule() string { return v.CronSchedule }
+
+// GetInstruction returns CreateCronWebhookInput.Instruction, and is useful for accessing the field via an interface.
+func (v *CreateCronWebhookInput) GetInstruction() string { return v.Instruction }
+
+// GetSecret returns CreateCronWebhookInput.Secret, and is useful for accessing the field via an interface.
+func (v *CreateCronWebhookInput) GetSecret() string { return v.Secret }
+
+// GetPassApiKey returns CreateCronWebhookInput.PassApiKey, and is useful for accessing the field via an interface.
+func (v *CreateCronWebhookInput) GetPassApiKey() bool { return v.PassApiKey }
+
+// GetTimeoutSeconds returns CreateCronWebhookInput.TimeoutSeconds, and is useful for accessing the field via an interface.
+func (v *CreateCronWebhookInput) GetTimeoutSeconds() int64 { return v.TimeoutSeconds }
+
+// GetMaxDepth returns CreateCronWebhookInput.MaxDepth, and is useful for accessing the field via an interface.
+func (v *CreateCronWebhookInput) GetMaxDepth() int64 { return v.MaxDepth }
+
+// GetMaxRetries returns CreateCronWebhookInput.MaxRetries, and is useful for accessing the field via an interface.
+func (v *CreateCronWebhookInput) GetMaxRetries() int64 { return v.MaxRetries }
+
+// GetEnabled returns CreateCronWebhookInput.Enabled, and is useful for accessing the field via an interface.
+func (v *CreateCronWebhookInput) GetEnabled() bool { return v.Enabled }
+
+// GetDescription returns CreateCronWebhookInput.Description, and is useful for accessing the field via an interface.
+func (v *CreateCronWebhookInput) GetDescription() string { return v.Description }
+
+// GetReadPatterns returns CreateCronWebhookInput.ReadPatterns, and is useful for accessing the field via an interface.
+func (v *CreateCronWebhookInput) GetReadPatterns() []string { return v.ReadPatterns }
+
+// GetWritePatterns returns CreateCronWebhookInput.WritePatterns, and is useful for accessing the field via an interface.
+func (v *CreateCronWebhookInput) GetWritePatterns() []string { return v.WritePatterns }
+
+// GetTransformJsonnet returns CreateCronWebhookInput.TransformJsonnet, and is useful for accessing the field via an interface.
+func (v *CreateCronWebhookInput) GetTransformJsonnet() string { return v.TransformJsonnet }
+
+// GetAttachNotes returns CreateCronWebhookInput.AttachNotes, and is useful for accessing the field via an interface.
+func (v *CreateCronWebhookInput) GetAttachNotes() []string { return v.AttachNotes }
+
+// GetConcurrencyMode returns CreateCronWebhookInput.ConcurrencyMode, and is useful for accessing the field via an interface.
+func (v *CreateCronWebhookInput) GetConcurrencyMode() string { return v.ConcurrencyMode }
+
+// CreateCronWebhookResponse is returned by CreateCronWebhook on success.
+type CreateCronWebhookResponse struct {
+	Admin CreateCronWebhookAdminAdminMutation `json:"admin"`
+}
+
+// GetAdmin returns CreateCronWebhookResponse.Admin, and is useful for accessing the field via an interface.
+func (v *CreateCronWebhookResponse) GetAdmin() CreateCronWebhookAdminAdminMutation { return v.Admin }
+
 // DeleteChangeWebhookAdminAdminMutation includes the requested fields of the GraphQL type AdminMutation.
 type DeleteChangeWebhookAdminAdminMutation struct {
 	ChangeWebhookDelete DeleteChangeWebhookAdminAdminMutationChangeWebhookDeleteChangeWebhookDeleteOrErrorPayload `json:"-"`
@@ -482,6 +741,199 @@ func (v *DeleteChangeWebhookResponse) GetAdmin() DeleteChangeWebhookAdminAdminMu
 	return v.Admin
 }
 
+// DeleteCronWebhookAdminAdminMutation includes the requested fields of the GraphQL type AdminMutation.
+type DeleteCronWebhookAdminAdminMutation struct {
+	DeleteCronWebhook DeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookOrErrorPayload `json:"-"`
+}
+
+// GetDeleteCronWebhook returns DeleteCronWebhookAdminAdminMutation.DeleteCronWebhook, and is useful for accessing the field via an interface.
+func (v *DeleteCronWebhookAdminAdminMutation) GetDeleteCronWebhook() DeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookOrErrorPayload {
+	return v.DeleteCronWebhook
+}
+
+func (v *DeleteCronWebhookAdminAdminMutation) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*DeleteCronWebhookAdminAdminMutation
+		DeleteCronWebhook json.RawMessage `json:"deleteCronWebhook"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.DeleteCronWebhookAdminAdminMutation = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.DeleteCronWebhook
+		src := firstPass.DeleteCronWebhook
+		if len(src) != 0 && string(src) != "null" {
+			err = __unmarshalDeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookOrErrorPayload(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal DeleteCronWebhookAdminAdminMutation.DeleteCronWebhook: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalDeleteCronWebhookAdminAdminMutation struct {
+	DeleteCronWebhook json.RawMessage `json:"deleteCronWebhook"`
+}
+
+func (v *DeleteCronWebhookAdminAdminMutation) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *DeleteCronWebhookAdminAdminMutation) __premarshalJSON() (*__premarshalDeleteCronWebhookAdminAdminMutation, error) {
+	var retval __premarshalDeleteCronWebhookAdminAdminMutation
+
+	{
+
+		dst := &retval.DeleteCronWebhook
+		src := v.DeleteCronWebhook
+		var err error
+		*dst, err = __marshalDeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookOrErrorPayload(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal DeleteCronWebhookAdminAdminMutation.DeleteCronWebhook: %w", err)
+		}
+	}
+	return &retval, nil
+}
+
+// DeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookOrErrorPayload includes the requested fields of the GraphQL interface DeleteCronWebhookOrErrorPayload.
+//
+// DeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookOrErrorPayload is implemented by the following types:
+// DeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookPayload
+// DeleteCronWebhookAdminAdminMutationDeleteCronWebhookErrorPayload
+type DeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookOrErrorPayload interface {
+	implementsGraphQLInterfaceDeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookOrErrorPayload()
+	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
+	GetTypename() string
+}
+
+func (v *DeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookPayload) implementsGraphQLInterfaceDeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookOrErrorPayload() {
+}
+func (v *DeleteCronWebhookAdminAdminMutationDeleteCronWebhookErrorPayload) implementsGraphQLInterfaceDeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookOrErrorPayload() {
+}
+
+func __unmarshalDeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookOrErrorPayload(b []byte, v *DeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookOrErrorPayload) error {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var tn struct {
+		TypeName string `json:"__typename"`
+	}
+	err := json.Unmarshal(b, &tn)
+	if err != nil {
+		return err
+	}
+
+	switch tn.TypeName {
+	case "DeleteCronWebhookPayload":
+		*v = new(DeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookPayload)
+		return json.Unmarshal(b, *v)
+	case "ErrorPayload":
+		*v = new(DeleteCronWebhookAdminAdminMutationDeleteCronWebhookErrorPayload)
+		return json.Unmarshal(b, *v)
+	case "":
+		return fmt.Errorf(
+			"response was missing DeleteCronWebhookOrErrorPayload.__typename")
+	default:
+		return fmt.Errorf(
+			`unexpected concrete type for DeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookOrErrorPayload: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalDeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookOrErrorPayload(v *DeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookOrErrorPayload) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *DeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookPayload:
+		typename = "DeleteCronWebhookPayload"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*DeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookPayload
+		}{typename, v}
+		return json.Marshal(result)
+	case *DeleteCronWebhookAdminAdminMutationDeleteCronWebhookErrorPayload:
+		typename = "ErrorPayload"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*DeleteCronWebhookAdminAdminMutationDeleteCronWebhookErrorPayload
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`unexpected concrete type for DeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookOrErrorPayload: "%T"`, v)
+	}
+}
+
+// DeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookPayload includes the requested fields of the GraphQL type DeleteCronWebhookPayload.
+type DeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookPayload struct {
+	Typename  string `json:"__typename"`
+	DeletedId int64  `json:"deletedId"`
+}
+
+// GetTypename returns DeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookPayload.Typename, and is useful for accessing the field via an interface.
+func (v *DeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookPayload) GetTypename() string {
+	return v.Typename
+}
+
+// GetDeletedId returns DeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookPayload.DeletedId, and is useful for accessing the field via an interface.
+func (v *DeleteCronWebhookAdminAdminMutationDeleteCronWebhookDeleteCronWebhookPayload) GetDeletedId() int64 {
+	return v.DeletedId
+}
+
+// DeleteCronWebhookAdminAdminMutationDeleteCronWebhookErrorPayload includes the requested fields of the GraphQL type ErrorPayload.
+type DeleteCronWebhookAdminAdminMutationDeleteCronWebhookErrorPayload struct {
+	Typename string `json:"__typename"`
+	Message  string `json:"message"`
+}
+
+// GetTypename returns DeleteCronWebhookAdminAdminMutationDeleteCronWebhookErrorPayload.Typename, and is useful for accessing the field via an interface.
+func (v *DeleteCronWebhookAdminAdminMutationDeleteCronWebhookErrorPayload) GetTypename() string {
+	return v.Typename
+}
+
+// GetMessage returns DeleteCronWebhookAdminAdminMutationDeleteCronWebhookErrorPayload.Message, and is useful for accessing the field via an interface.
+func (v *DeleteCronWebhookAdminAdminMutationDeleteCronWebhookErrorPayload) GetMessage() string {
+	return v.Message
+}
+
+type DeleteCronWebhookInput struct {
+	Id int64 `json:"id"`
+}
+
+// GetId returns DeleteCronWebhookInput.Id, and is useful for accessing the field via an interface.
+func (v *DeleteCronWebhookInput) GetId() int64 { return v.Id }
+
+// DeleteCronWebhookResponse is returned by DeleteCronWebhook on success.
+type DeleteCronWebhookResponse struct {
+	Admin DeleteCronWebhookAdminAdminMutation `json:"admin"`
+}
+
+// GetAdmin returns DeleteCronWebhookResponse.Admin, and is useful for accessing the field via an interface.
+func (v *DeleteCronWebhookResponse) GetAdmin() DeleteCronWebhookAdminAdminMutation { return v.Admin }
+
 // DiscoverRolesNotePathsNotePath includes the requested fields of the GraphQL type NotePath.
 type DiscoverRolesNotePathsNotePath struct {
 	Value          string                                       `json:"value"`
@@ -575,6 +1027,309 @@ type ListChangeWebhooksResponse struct {
 // GetAdmin returns ListChangeWebhooksResponse.Admin, and is useful for accessing the field via an interface.
 func (v *ListChangeWebhooksResponse) GetAdmin() ListChangeWebhooksAdminAdminQuery { return v.Admin }
 
+// ListCronWebhooksAdminAdminQuery includes the requested fields of the GraphQL type AdminQuery.
+type ListCronWebhooksAdminAdminQuery struct {
+	AllCronWebhooks ListCronWebhooksAdminAdminQueryAllCronWebhooksAdminCronWebhooksConnection `json:"allCronWebhooks"`
+}
+
+// GetAllCronWebhooks returns ListCronWebhooksAdminAdminQuery.AllCronWebhooks, and is useful for accessing the field via an interface.
+func (v *ListCronWebhooksAdminAdminQuery) GetAllCronWebhooks() ListCronWebhooksAdminAdminQueryAllCronWebhooksAdminCronWebhooksConnection {
+	return v.AllCronWebhooks
+}
+
+// ListCronWebhooksAdminAdminQueryAllCronWebhooksAdminCronWebhooksConnection includes the requested fields of the GraphQL type AdminCronWebhooksConnection.
+type ListCronWebhooksAdminAdminQueryAllCronWebhooksAdminCronWebhooksConnection struct {
+	Nodes []ListCronWebhooksAdminAdminQueryAllCronWebhooksAdminCronWebhooksConnectionNodesAdminCronWebhook `json:"nodes"`
+}
+
+// GetNodes returns ListCronWebhooksAdminAdminQueryAllCronWebhooksAdminCronWebhooksConnection.Nodes, and is useful for accessing the field via an interface.
+func (v *ListCronWebhooksAdminAdminQueryAllCronWebhooksAdminCronWebhooksConnection) GetNodes() []ListCronWebhooksAdminAdminQueryAllCronWebhooksAdminCronWebhooksConnectionNodesAdminCronWebhook {
+	return v.Nodes
+}
+
+// ListCronWebhooksAdminAdminQueryAllCronWebhooksAdminCronWebhooksConnectionNodesAdminCronWebhook includes the requested fields of the GraphQL type AdminCronWebhook.
+type ListCronWebhooksAdminAdminQueryAllCronWebhooksAdminCronWebhooksConnectionNodesAdminCronWebhook struct {
+	Id          int64  `json:"id"`
+	Description string `json:"description"`
+}
+
+// GetId returns ListCronWebhooksAdminAdminQueryAllCronWebhooksAdminCronWebhooksConnectionNodesAdminCronWebhook.Id, and is useful for accessing the field via an interface.
+func (v *ListCronWebhooksAdminAdminQueryAllCronWebhooksAdminCronWebhooksConnectionNodesAdminCronWebhook) GetId() int64 {
+	return v.Id
+}
+
+// GetDescription returns ListCronWebhooksAdminAdminQueryAllCronWebhooksAdminCronWebhooksConnectionNodesAdminCronWebhook.Description, and is useful for accessing the field via an interface.
+func (v *ListCronWebhooksAdminAdminQueryAllCronWebhooksAdminCronWebhooksConnectionNodesAdminCronWebhook) GetDescription() string {
+	return v.Description
+}
+
+// ListCronWebhooksResponse is returned by ListCronWebhooks on success.
+type ListCronWebhooksResponse struct {
+	Admin ListCronWebhooksAdminAdminQuery `json:"admin"`
+}
+
+// GetAdmin returns ListCronWebhooksResponse.Admin, and is useful for accessing the field via an interface.
+func (v *ListCronWebhooksResponse) GetAdmin() ListCronWebhooksAdminAdminQuery { return v.Admin }
+
+// UpdateCronWebhookAdminAdminMutation includes the requested fields of the GraphQL type AdminMutation.
+type UpdateCronWebhookAdminAdminMutation struct {
+	UpdateCronWebhook UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookOrErrorPayload `json:"-"`
+}
+
+// GetUpdateCronWebhook returns UpdateCronWebhookAdminAdminMutation.UpdateCronWebhook, and is useful for accessing the field via an interface.
+func (v *UpdateCronWebhookAdminAdminMutation) GetUpdateCronWebhook() UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookOrErrorPayload {
+	return v.UpdateCronWebhook
+}
+
+func (v *UpdateCronWebhookAdminAdminMutation) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*UpdateCronWebhookAdminAdminMutation
+		UpdateCronWebhook json.RawMessage `json:"updateCronWebhook"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.UpdateCronWebhookAdminAdminMutation = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.UpdateCronWebhook
+		src := firstPass.UpdateCronWebhook
+		if len(src) != 0 && string(src) != "null" {
+			err = __unmarshalUpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookOrErrorPayload(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal UpdateCronWebhookAdminAdminMutation.UpdateCronWebhook: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalUpdateCronWebhookAdminAdminMutation struct {
+	UpdateCronWebhook json.RawMessage `json:"updateCronWebhook"`
+}
+
+func (v *UpdateCronWebhookAdminAdminMutation) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *UpdateCronWebhookAdminAdminMutation) __premarshalJSON() (*__premarshalUpdateCronWebhookAdminAdminMutation, error) {
+	var retval __premarshalUpdateCronWebhookAdminAdminMutation
+
+	{
+
+		dst := &retval.UpdateCronWebhook
+		src := v.UpdateCronWebhook
+		var err error
+		*dst, err = __marshalUpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookOrErrorPayload(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal UpdateCronWebhookAdminAdminMutation.UpdateCronWebhook: %w", err)
+		}
+	}
+	return &retval, nil
+}
+
+// UpdateCronWebhookAdminAdminMutationUpdateCronWebhookErrorPayload includes the requested fields of the GraphQL type ErrorPayload.
+type UpdateCronWebhookAdminAdminMutationUpdateCronWebhookErrorPayload struct {
+	Typename string `json:"__typename"`
+	Message  string `json:"message"`
+}
+
+// GetTypename returns UpdateCronWebhookAdminAdminMutationUpdateCronWebhookErrorPayload.Typename, and is useful for accessing the field via an interface.
+func (v *UpdateCronWebhookAdminAdminMutationUpdateCronWebhookErrorPayload) GetTypename() string {
+	return v.Typename
+}
+
+// GetMessage returns UpdateCronWebhookAdminAdminMutationUpdateCronWebhookErrorPayload.Message, and is useful for accessing the field via an interface.
+func (v *UpdateCronWebhookAdminAdminMutationUpdateCronWebhookErrorPayload) GetMessage() string {
+	return v.Message
+}
+
+// UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookOrErrorPayload includes the requested fields of the GraphQL interface UpdateCronWebhookOrErrorPayload.
+//
+// UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookOrErrorPayload is implemented by the following types:
+// UpdateCronWebhookAdminAdminMutationUpdateCronWebhookErrorPayload
+// UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookPayload
+type UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookOrErrorPayload interface {
+	implementsGraphQLInterfaceUpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookOrErrorPayload()
+	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
+	GetTypename() string
+}
+
+func (v *UpdateCronWebhookAdminAdminMutationUpdateCronWebhookErrorPayload) implementsGraphQLInterfaceUpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookOrErrorPayload() {
+}
+func (v *UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookPayload) implementsGraphQLInterfaceUpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookOrErrorPayload() {
+}
+
+func __unmarshalUpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookOrErrorPayload(b []byte, v *UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookOrErrorPayload) error {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var tn struct {
+		TypeName string `json:"__typename"`
+	}
+	err := json.Unmarshal(b, &tn)
+	if err != nil {
+		return err
+	}
+
+	switch tn.TypeName {
+	case "ErrorPayload":
+		*v = new(UpdateCronWebhookAdminAdminMutationUpdateCronWebhookErrorPayload)
+		return json.Unmarshal(b, *v)
+	case "UpdateCronWebhookPayload":
+		*v = new(UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookPayload)
+		return json.Unmarshal(b, *v)
+	case "":
+		return fmt.Errorf(
+			"response was missing UpdateCronWebhookOrErrorPayload.__typename")
+	default:
+		return fmt.Errorf(
+			`unexpected concrete type for UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookOrErrorPayload: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalUpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookOrErrorPayload(v *UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookOrErrorPayload) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *UpdateCronWebhookAdminAdminMutationUpdateCronWebhookErrorPayload:
+		typename = "ErrorPayload"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*UpdateCronWebhookAdminAdminMutationUpdateCronWebhookErrorPayload
+		}{typename, v}
+		return json.Marshal(result)
+	case *UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookPayload:
+		typename = "UpdateCronWebhookPayload"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookPayload
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`unexpected concrete type for UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookOrErrorPayload: "%T"`, v)
+	}
+}
+
+// UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookPayload includes the requested fields of the GraphQL type UpdateCronWebhookPayload.
+type UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookPayload struct {
+	Typename    string                                                                                                  `json:"__typename"`
+	CronWebhook UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookPayloadCronWebhookAdminCronWebhook `json:"cronWebhook"`
+}
+
+// GetTypename returns UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookPayload.Typename, and is useful for accessing the field via an interface.
+func (v *UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookPayload) GetTypename() string {
+	return v.Typename
+}
+
+// GetCronWebhook returns UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookPayload.CronWebhook, and is useful for accessing the field via an interface.
+func (v *UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookPayload) GetCronWebhook() UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookPayloadCronWebhookAdminCronWebhook {
+	return v.CronWebhook
+}
+
+// UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookPayloadCronWebhookAdminCronWebhook includes the requested fields of the GraphQL type AdminCronWebhook.
+type UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookPayloadCronWebhookAdminCronWebhook struct {
+	Id int64 `json:"id"`
+}
+
+// GetId returns UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookPayloadCronWebhookAdminCronWebhook.Id, and is useful for accessing the field via an interface.
+func (v *UpdateCronWebhookAdminAdminMutationUpdateCronWebhookUpdateCronWebhookPayloadCronWebhookAdminCronWebhook) GetId() int64 {
+	return v.Id
+}
+
+type UpdateCronWebhookInput struct {
+	Id               int64    `json:"id"`
+	Url              string   `json:"url"`
+	CronSchedule     string   `json:"cronSchedule"`
+	Instruction      string   `json:"instruction"`
+	PassApiKey       bool     `json:"passApiKey"`
+	TimeoutSeconds   int64    `json:"timeoutSeconds"`
+	MaxDepth         int64    `json:"maxDepth"`
+	MaxRetries       int64    `json:"maxRetries"`
+	Enabled          bool     `json:"enabled"`
+	Description      string   `json:"description"`
+	ReadPatterns     []string `json:"readPatterns"`
+	WritePatterns    []string `json:"writePatterns"`
+	TransformJsonnet string   `json:"transformJsonnet"`
+	AttachNotes      []string `json:"attachNotes"`
+	ConcurrencyMode  string   `json:"concurrencyMode"`
+}
+
+// GetId returns UpdateCronWebhookInput.Id, and is useful for accessing the field via an interface.
+func (v *UpdateCronWebhookInput) GetId() int64 { return v.Id }
+
+// GetUrl returns UpdateCronWebhookInput.Url, and is useful for accessing the field via an interface.
+func (v *UpdateCronWebhookInput) GetUrl() string { return v.Url }
+
+// GetCronSchedule returns UpdateCronWebhookInput.CronSchedule, and is useful for accessing the field via an interface.
+func (v *UpdateCronWebhookInput) GetCronSchedule() string { return v.CronSchedule }
+
+// GetInstruction returns UpdateCronWebhookInput.Instruction, and is useful for accessing the field via an interface.
+func (v *UpdateCronWebhookInput) GetInstruction() string { return v.Instruction }
+
+// GetPassApiKey returns UpdateCronWebhookInput.PassApiKey, and is useful for accessing the field via an interface.
+func (v *UpdateCronWebhookInput) GetPassApiKey() bool { return v.PassApiKey }
+
+// GetTimeoutSeconds returns UpdateCronWebhookInput.TimeoutSeconds, and is useful for accessing the field via an interface.
+func (v *UpdateCronWebhookInput) GetTimeoutSeconds() int64 { return v.TimeoutSeconds }
+
+// GetMaxDepth returns UpdateCronWebhookInput.MaxDepth, and is useful for accessing the field via an interface.
+func (v *UpdateCronWebhookInput) GetMaxDepth() int64 { return v.MaxDepth }
+
+// GetMaxRetries returns UpdateCronWebhookInput.MaxRetries, and is useful for accessing the field via an interface.
+func (v *UpdateCronWebhookInput) GetMaxRetries() int64 { return v.MaxRetries }
+
+// GetEnabled returns UpdateCronWebhookInput.Enabled, and is useful for accessing the field via an interface.
+func (v *UpdateCronWebhookInput) GetEnabled() bool { return v.Enabled }
+
+// GetDescription returns UpdateCronWebhookInput.Description, and is useful for accessing the field via an interface.
+func (v *UpdateCronWebhookInput) GetDescription() string { return v.Description }
+
+// GetReadPatterns returns UpdateCronWebhookInput.ReadPatterns, and is useful for accessing the field via an interface.
+func (v *UpdateCronWebhookInput) GetReadPatterns() []string { return v.ReadPatterns }
+
+// GetWritePatterns returns UpdateCronWebhookInput.WritePatterns, and is useful for accessing the field via an interface.
+func (v *UpdateCronWebhookInput) GetWritePatterns() []string { return v.WritePatterns }
+
+// GetTransformJsonnet returns UpdateCronWebhookInput.TransformJsonnet, and is useful for accessing the field via an interface.
+func (v *UpdateCronWebhookInput) GetTransformJsonnet() string { return v.TransformJsonnet }
+
+// GetAttachNotes returns UpdateCronWebhookInput.AttachNotes, and is useful for accessing the field via an interface.
+func (v *UpdateCronWebhookInput) GetAttachNotes() []string { return v.AttachNotes }
+
+// GetConcurrencyMode returns UpdateCronWebhookInput.ConcurrencyMode, and is useful for accessing the field via an interface.
+func (v *UpdateCronWebhookInput) GetConcurrencyMode() string { return v.ConcurrencyMode }
+
+// UpdateCronWebhookResponse is returned by UpdateCronWebhook on success.
+type UpdateCronWebhookResponse struct {
+	Admin UpdateCronWebhookAdminAdminMutation `json:"admin"`
+}
+
+// GetAdmin returns UpdateCronWebhookResponse.Admin, and is useful for accessing the field via an interface.
+func (v *UpdateCronWebhookResponse) GetAdmin() UpdateCronWebhookAdminAdminMutation { return v.Admin }
+
 // __CreateChangeWebhookInput is used internally by genqlient
 type __CreateChangeWebhookInput struct {
 	Input ChangeWebhookCreateInput `json:"input"`
@@ -582,6 +1337,14 @@ type __CreateChangeWebhookInput struct {
 
 // GetInput returns __CreateChangeWebhookInput.Input, and is useful for accessing the field via an interface.
 func (v *__CreateChangeWebhookInput) GetInput() ChangeWebhookCreateInput { return v.Input }
+
+// __CreateCronWebhookInput is used internally by genqlient
+type __CreateCronWebhookInput struct {
+	Input CreateCronWebhookInput `json:"input"`
+}
+
+// GetInput returns __CreateCronWebhookInput.Input, and is useful for accessing the field via an interface.
+func (v *__CreateCronWebhookInput) GetInput() CreateCronWebhookInput { return v.Input }
 
 // __DeleteChangeWebhookInput is used internally by genqlient
 type __DeleteChangeWebhookInput struct {
@@ -591,6 +1354,14 @@ type __DeleteChangeWebhookInput struct {
 // GetInput returns __DeleteChangeWebhookInput.Input, and is useful for accessing the field via an interface.
 func (v *__DeleteChangeWebhookInput) GetInput() ChangeWebhookDeleteInput { return v.Input }
 
+// __DeleteCronWebhookInput is used internally by genqlient
+type __DeleteCronWebhookInput struct {
+	Input DeleteCronWebhookInput `json:"input"`
+}
+
+// GetInput returns __DeleteCronWebhookInput.Input, and is useful for accessing the field via an interface.
+func (v *__DeleteCronWebhookInput) GetInput() DeleteCronWebhookInput { return v.Input }
+
 // __DiscoverRolesInput is used internally by genqlient
 type __DiscoverRolesInput struct {
 	Like string `json:"like"`
@@ -598,6 +1369,14 @@ type __DiscoverRolesInput struct {
 
 // GetLike returns __DiscoverRolesInput.Like, and is useful for accessing the field via an interface.
 func (v *__DiscoverRolesInput) GetLike() string { return v.Like }
+
+// __UpdateCronWebhookInput is used internally by genqlient
+type __UpdateCronWebhookInput struct {
+	Input UpdateCronWebhookInput `json:"input"`
+}
+
+// GetInput returns __UpdateCronWebhookInput.Input, and is useful for accessing the field via an interface.
+func (v *__UpdateCronWebhookInput) GetInput() UpdateCronWebhookInput { return v.Input }
 
 // The mutation executed by CreateChangeWebhook.
 const CreateChangeWebhook_Operation = `
@@ -644,6 +1423,51 @@ func CreateChangeWebhook(
 	return data_, err_
 }
 
+// The mutation executed by CreateCronWebhook.
+const CreateCronWebhook_Operation = `
+mutation CreateCronWebhook ($input: CreateCronWebhookInput!) {
+	admin {
+		createCronWebhook(input: $input) {
+			__typename
+			... on CreateCronWebhookPayload {
+				cronWebhook {
+					id
+				}
+			}
+			... on ErrorPayload {
+				message
+			}
+		}
+	}
+}
+`
+
+// CreateCronWebhook registers one cron-webhook for a role.
+func CreateCronWebhook(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	input CreateCronWebhookInput,
+) (data_ *CreateCronWebhookResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "CreateCronWebhook",
+		Query:  CreateCronWebhook_Operation,
+		Variables: &__CreateCronWebhookInput{
+			Input: input,
+		},
+	}
+
+	data_ = &CreateCronWebhookResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
+
 // The mutation executed by DeleteChangeWebhook.
 const DeleteChangeWebhook_Operation = `
 mutation DeleteChangeWebhook ($input: ChangeWebhookDeleteInput!) {
@@ -676,6 +1500,49 @@ func DeleteChangeWebhook(
 	}
 
 	data_ = &DeleteChangeWebhookResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
+
+// The mutation executed by DeleteCronWebhook.
+const DeleteCronWebhook_Operation = `
+mutation DeleteCronWebhook ($input: DeleteCronWebhookInput!) {
+	admin {
+		deleteCronWebhook(input: $input) {
+			__typename
+			... on DeleteCronWebhookPayload {
+				deletedId
+			}
+			... on ErrorPayload {
+				message
+			}
+		}
+	}
+}
+`
+
+// DeleteCronWebhook removes one owned cron-webhook by id.
+func DeleteCronWebhook(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	input DeleteCronWebhookInput,
+) (data_ *DeleteCronWebhookResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "DeleteCronWebhook",
+		Query:  DeleteCronWebhook_Operation,
+		Variables: &__DeleteCronWebhookInput{
+			Input: input,
+		},
+	}
+
+	data_ = &DeleteCronWebhookResponse{}
 	resp_ := &graphql.Response{Data: data_}
 
 	err_ = client_.MakeRequest(
@@ -756,6 +1623,89 @@ func ListChangeWebhooks(
 	}
 
 	data_ = &ListChangeWebhooksResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
+
+// The query executed by ListCronWebhooks.
+const ListCronWebhooks_Operation = `
+query ListCronWebhooks {
+	admin {
+		allCronWebhooks {
+			nodes {
+				id
+				description
+			}
+		}
+	}
+}
+`
+
+// ListCronWebhooks returns every cron-webhook; the reconciler filters to the
+// ones this fleet owns by description marker.
+func ListCronWebhooks(
+	ctx_ context.Context,
+	client_ graphql.Client,
+) (data_ *ListCronWebhooksResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "ListCronWebhooks",
+		Query:  ListCronWebhooks_Operation,
+	}
+
+	data_ = &ListCronWebhooksResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
+
+// The mutation executed by UpdateCronWebhook.
+const UpdateCronWebhook_Operation = `
+mutation UpdateCronWebhook ($input: UpdateCronWebhookInput!) {
+	admin {
+		updateCronWebhook(input: $input) {
+			__typename
+			... on UpdateCronWebhookPayload {
+				cronWebhook {
+					id
+				}
+			}
+			... on ErrorPayload {
+				message
+			}
+		}
+	}
+}
+`
+
+// UpdateCronWebhook patches one cron-webhook (currently unused by reconciler
+// but generated for completeness so callers can patch without delete+recreate).
+func UpdateCronWebhook(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	input UpdateCronWebhookInput,
+) (data_ *UpdateCronWebhookResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "UpdateCronWebhook",
+		Query:  UpdateCronWebhook_Operation,
+		Variables: &__UpdateCronWebhookInput{
+			Input: input,
+		},
+	}
+
+	data_ = &UpdateCronWebhookResponse{}
 	resp_ := &graphql.Response{Data: data_}
 
 	err_ = client_.MakeRequest(

--- a/internal/fleet/trip2ggql/operations.graphql
+++ b/internal/fleet/trip2ggql/operations.graphql
@@ -59,3 +59,63 @@ mutation DeleteChangeWebhook($input: ChangeWebhookDeleteInput!) {
     }
   }
 }
+
+# ListCronWebhooks returns every cron-webhook; the reconciler filters to the
+# ones this fleet owns by description marker.
+query ListCronWebhooks {
+  admin {
+    allCronWebhooks {
+      nodes {
+        id
+        description
+      }
+    }
+  }
+}
+
+# CreateCronWebhook registers one cron-webhook for a role.
+mutation CreateCronWebhook($input: CreateCronWebhookInput!) {
+  admin {
+    createCronWebhook(input: $input) {
+      ... on CreateCronWebhookPayload {
+        cronWebhook {
+          id
+        }
+      }
+      ... on ErrorPayload {
+        message
+      }
+    }
+  }
+}
+
+# UpdateCronWebhook patches one cron-webhook (currently unused by reconciler
+# but generated for completeness so callers can patch without delete+recreate).
+mutation UpdateCronWebhook($input: UpdateCronWebhookInput!) {
+  admin {
+    updateCronWebhook(input: $input) {
+      ... on UpdateCronWebhookPayload {
+        cronWebhook {
+          id
+        }
+      }
+      ... on ErrorPayload {
+        message
+      }
+    }
+  }
+}
+
+# DeleteCronWebhook removes one owned cron-webhook by id.
+mutation DeleteCronWebhook($input: DeleteCronWebhookInput!) {
+  admin {
+    deleteCronWebhook(input: $input) {
+      ... on DeleteCronWebhookPayload {
+        deletedId
+      }
+      ... on ErrorPayload {
+        message
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

- **Cron-mode fleet roles** (`mode: cron|both`) — symmetric to change-mode. The fleet registers a trip2g **CRON webhook** per cron-mode role (`reconcileCron`, owned by a `fleetcron:<id>:` marker), delivered to **`/deliver/cron/<key>`**; the agent runs with a scheduled bag (no `changed_files`). `Validate` now **accepts `cron|both`** (the "not yet supported" rejection is gone) and **requires `cron_schedule`** for those modes.
- **genqlient cron-webhook ops** (List/Create/Delete CronWebhook, under `admin{}`) added alongside the existing change-webhook ops.
- **`TRIP2G_FLEET_` env prefix** for `cmd/fleet` (was `TRIP2G_`) — namespaces fleet config distinctly from the app's `TRIP2G_*` (matters when the fleet is bundled with trip2g). `docker-compose.test.yml`'s fleet service env updated accordingly (15 vars).

## Unlocks

The TG voice-note transcriber, the live cron-dashboard demo, scheduled KB-refresh roles, and the Krisp-ingest e2e (a cron `executor: code` role).

## Verify

`go build -tags dev ./...` clean; `go test` (fleet / cmd-fleet / agentruntime) pass; `golangci-lint run --build-tags dev` → 0 issues. Tests added/updated: `Validate` accepts cron + requires cron_schedule; `reconcileCron` creates/deletes cron webhooks (faked admin lane); cron-delivery renders+runs with no `changed_files`; env read from `TRIP2G_FLEET_*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
