### PR TITLE
test(e2e): Krisp-ingest e2e (cron executor:code → krisp-mock → transcripts)

### DIFF
--- a/Dockerfile.fleet
+++ b/Dockerfile.fleet
@@ -10,6 +10,6 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o /fleet ./cmd/fleet
 
 FROM alpine:latest
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates python3
 COPY --from=builder /fleet /fleet
 ENTRYPOINT ["/fleet"]

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -429,6 +429,21 @@ services:
       retries: 10
       start_period: 10s
 
+  # Deterministic Krisp API stub for the krisp-ingest e2e test.
+  # Serves synthetic meetings and block-tree transcripts. See cmd/krispmock/main.go.
+  krisp-mock:
+    build:
+      context: .
+      dockerfile: Dockerfile.krispmock
+    container_name: trip2g-test-krispmock
+    ports:
+      - "29092:9092"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:9092/health || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
   # Deterministic OpenAI-compatible LLM stub for fleet e2e tests.
   # Responds to POST /v1/chat/completions: call 1 → write_note to segments/,
   # call 2+ → finish. No external deps. See cmd/llmmock/main.go.
@@ -460,6 +475,8 @@ services:
         condition: service_healthy
       llm-mock:
         condition: service_healthy
+      krisp-mock:
+        condition: service_healthy
     ports:
       - "29090:9090"
     environment:
@@ -478,6 +495,10 @@ services:
       - TRIP2G_FLEET_TOKEN_CEILING=100000
       - TRIP2G_FLEET_STEP_CEILING=25
       - TRIP2G_FLEET_OFFERED_TOOLS=search,read_note,patch_note,write_note
+      - TRIP2G_FLEET_ALLOWED_PROGRAMS=python
+      # Krisp mock credentials forwarded to code executor via env_passthrough in the role.
+      - KRISP_TOKEN=test-krisp-token
+      - KRISP_BASE_URL=http://krisp-mock:9092
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://localhost:9090/health || exit 1"]
       interval: 5s

--- a/docs/fleet/krisp/roles/transcript-ingest.md
+++ b/docs/fleet/krisp/roles/transcript-ingest.md
@@ -1,0 +1,76 @@
+---
+description: "Krisp meetings → transcript notes (cron ingest, deterministic)"
+mode: cron
+cron_schedule: "* * * * *"
+executor: code
+write_patterns: ["transcripts/**"]
+env_passthrough: ["KRISP_TOKEN", "KRISP_BASE_URL"]
+max_depth: 1
+---
+```python
+import os
+import json
+import urllib.request
+
+base_url = os.environ['KRISP_BASE_URL'].rstrip('/')
+token = os.environ['KRISP_TOKEN']
+
+
+def api_post(path, payload):
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        base_url + path,
+        data=data,
+        headers={
+            'Authorization': 'Bearer ' + token,
+            'Content-Type': 'application/json',
+        },
+    )
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read())
+
+
+def api_get(path):
+    req = urllib.request.Request(
+        base_url + path,
+        headers={'Authorization': 'Bearer ' + token},
+    )
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read())
+
+
+resp = api_post('/v2/meetings/list', {'page': 1, 'limit': 100, 'isOwner': True})
+meetings = resp.get('data', {}).get('rows', [])
+
+changes = []
+for meeting in meetings:
+    mid = meeting['id']
+    name = meeting.get('name', mid)
+    started_at = meeting.get('started_at', '')
+    speakers = meeting.get('speakers', [])
+
+    tree = api_get('/v2/block/' + mid + '/tree')
+
+    lines = ['# ' + name, '', 'Date: ' + started_at, '']
+    for child in tree.get('children', []):
+        if child.get('block_type') != 'utterance':
+            continue
+        idx = child.get('speakerIndex', 0)
+        if 0 < idx <= len(speakers):
+            sp = speakers[idx - 1]
+            speaker = sp.get('first_name', '') + ' ' + sp.get('last_name', '')
+        else:
+            speaker = 'Speaker ' + str(idx)
+        speech = child.get('speech', {})
+        start = speech.get('start', 0.0)
+        text = speech.get('text', '')
+        mins = int(start) // 60
+        secs = int(start) % 60
+        lines.append(speaker.strip() + ' | {:02d}:{:02d}'.format(mins, secs))
+        lines.append(text)
+        lines.append('')
+
+    changes.append({'path': 'transcripts/' + mid + '.md', 'content': '\n'.join(lines)})
+
+print(json.dumps({'changes': changes, 'answer': 'ingested ' + str(len(changes))}))
+```

--- a/e2e/krisp-ingest.spec.js
+++ b/e2e/krisp-ingest.spec.js
@@ -24,6 +24,9 @@
  */
 
 import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import { graphqlSignIn } from './helpers/auth.js';
 
 const APP_URL = process.env.APP_URL || 'http://localhost:20081';
@@ -65,86 +68,16 @@ async function gqlApi(request, apiKey, query, variables = {}) {
 }
 
 // ---------------------------------------------------------------------------
-// Role content — mirrors docs/fleet/krisp/roles/transcript-ingest.md.
-// Defined inline so the spec is self-contained (same pattern as fleet.spec.js).
+// Role content — read the SHIPPED role-note verbatim so the e2e exercises the
+// exact file we ship. An inline copy silently drifts from the doc (it already
+// had: double-quoted Python vs the doc's single quotes).
 // ---------------------------------------------------------------------------
 
-// Python lines are joined as-is; triple-backticks are plain string items.
-const roleSeed = [
-  '---',
-  'description: "Krisp meetings -> transcript notes (cron ingest, deterministic)"',
-  'mode: cron',
-  'cron_schedule: "* * * * *"',
-  'executor: code',
-  'write_patterns: ["transcripts/**"]',
-  'env_passthrough: ["KRISP_TOKEN", "KRISP_BASE_URL"]',
-  'max_depth: 1',
-  '---',
-  '```python',
-  'import os',
-  'import json',
-  'import urllib.request',
-  '',
-  'base_url = os.environ["KRISP_BASE_URL"].rstrip("/")',
-  'token = os.environ["KRISP_TOKEN"]',
-  '',
-  '',
-  'def api_post(path, payload):',
-  '    data = json.dumps(payload).encode()',
-  '    req = urllib.request.Request(',
-  '        base_url + path,',
-  '        data=data,',
-  '        headers={',
-  '            "Authorization": "Bearer " + token,',
-  '            "Content-Type": "application/json",',
-  '        },',
-  '    )',
-  '    with urllib.request.urlopen(req) as resp:',
-  '        return json.loads(resp.read())',
-  '',
-  '',
-  'def api_get(path):',
-  '    req = urllib.request.Request(',
-  '        base_url + path,',
-  '        headers={"Authorization": "Bearer " + token},',
-  '    )',
-  '    with urllib.request.urlopen(req) as resp:',
-  '        return json.loads(resp.read())',
-  '',
-  '',
-  'resp = api_post("/v2/meetings/list", {"page": 1, "limit": 100, "isOwner": True})',
-  'meetings = resp.get("data", {}).get("rows", [])',
-  '',
-  'changes = []',
-  'for meeting in meetings:',
-  '    mid = meeting["id"]',
-  '    name = meeting.get("name", mid)',
-  '    started_at = meeting.get("started_at", "")',
-  '    speakers = meeting.get("speakers", [])',
-  '    tree = api_get("/v2/block/" + mid + "/tree")',
-  '    lines = ["# " + name, "", "Date: " + started_at, ""]',
-  '    for child in tree.get("children", []):',
-  '        if child.get("block_type") != "utterance":',
-  '            continue',
-  '        idx = child.get("speakerIndex", 0)',
-  '        if 0 < idx <= len(speakers):',
-  '            sp = speakers[idx - 1]',
-  '            speaker = sp.get("first_name", "") + " " + sp.get("last_name", "")',
-  '        else:',
-  '            speaker = "Speaker " + str(idx)',
-  '        speech = child.get("speech", {})',
-  '        start = speech.get("start", 0.0)',
-  '        text = speech.get("text", "")',
-  '        mins = int(start) // 60',
-  '        secs = int(start) % 60',
-  '        lines.append(speaker.strip() + " | {:02d}:{:02d}".format(mins, secs))',
-  '        lines.append(text)',
-  '        lines.append("")',
-  '    changes.append({"path": "transcripts/" + mid + ".md", "content": "\\n".join(lines)})',
-  '',
-  'print(json.dumps({"changes": changes, "answer": "ingested " + str(len(changes))}))',
-  '```',
-].join('\n');
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const roleSeed = fs.readFileSync(
+  path.join(REPO_ROOT, 'docs/fleet/krisp/roles/transcript-ingest.md'),
+  'utf8',
+);
 
 // ---------------------------------------------------------------------------
 // Test suite

--- a/e2e/krisp-ingest.spec.js
+++ b/e2e/krisp-ingest.spec.js
@@ -1,0 +1,266 @@
+// @ts-check
+/**
+ * Krisp cron ingest e2e — deterministic, no LLM, no real data.
+ *
+ * Architecture under test:
+ *   trip2g app (Docker) ← cron webhook delivery →
+ *   fleet (Docker)      ← code executor (python3) →
+ *   krisp-mock (Docker) → synthetic meeting list + block trees →
+ *   fleet               → updateNotes (transcripts/**) via scoped token →
+ *   trip2g app
+ *
+ * Scenario:
+ *   1. Seed roles/krisp/transcript-ingest.md (cron role, executor:code).
+ *   2. Fleet discovers the role, reconciles a cron webhook registered against
+ *      the app (poll_seconds=3, so within ~3 s).
+ *   3. Admin fires triggerCronWebhook → fleet delivers → python3 calls krisp-mock,
+ *      builds transcript notes, prints {"changes":[...],"answer":"ingested 3"}.
+ *   4. Fleet writes transcripts/<id>.md back via scoped token.
+ *   5. Spec polls notePaths for the first meeting's transcript until present,
+ *      then asserts content matches the krisp-mock synthetic data.
+ *
+ * krisp-mock, fleet, and the app run as Docker compose services
+ * (see docker-compose.test.yml). APP_URL is the host-published app port.
+ */
+
+import { test, expect } from '@playwright/test';
+import { graphqlSignIn } from './helpers/auth.js';
+
+const APP_URL = process.env.APP_URL || 'http://localhost:20081';
+const GRAPHQL_URL = `${APP_URL}/_system/graphql`;
+
+// Role stored as a note at this path in the trip2g vault.
+const ROLE_PATH = 'roles/krisp/transcript-ingest.md';
+
+// First synthetic meeting ID from cmd/krispmock/main.go (meetingID1).
+const MEETING_ID_1 = 'aabbccddeeff00112233445566778800';
+const TRANSCRIPT_PATH_1 = `transcripts/${MEETING_ID_1}.md`;
+
+// ---------------------------------------------------------------------------
+// GraphQL helpers (same pattern as fleet.spec.js)
+// ---------------------------------------------------------------------------
+
+/** Admin cookie auth. */
+async function gqlAdmin(request, cookie, query, variables = {}) {
+  const r = await request.post(GRAPHQL_URL, {
+    headers: { 'Content-Type': 'application/json', Cookie: cookie },
+    data: { query, variables },
+  });
+  expect(r.ok()).toBeTruthy();
+  const j = await r.json();
+  if (j.errors) throw new Error(`GraphQL errors: ${JSON.stringify(j.errors)}`);
+  return j.data;
+}
+
+/** API key auth. */
+async function gqlApi(request, apiKey, query, variables = {}) {
+  const r = await request.post(GRAPHQL_URL, {
+    headers: { 'Content-Type': 'application/json', 'X-Api-Key': apiKey },
+    data: { query, variables },
+  });
+  expect(r.ok()).toBeTruthy();
+  const j = await r.json();
+  if (j.errors) throw new Error(`GraphQL errors: ${JSON.stringify(j.errors)}`);
+  return j.data;
+}
+
+// ---------------------------------------------------------------------------
+// Role content — mirrors docs/fleet/krisp/roles/transcript-ingest.md.
+// Defined inline so the spec is self-contained (same pattern as fleet.spec.js).
+// ---------------------------------------------------------------------------
+
+// Python lines are joined as-is; triple-backticks are plain string items.
+const roleSeed = [
+  '---',
+  'description: "Krisp meetings -> transcript notes (cron ingest, deterministic)"',
+  'mode: cron',
+  'cron_schedule: "* * * * *"',
+  'executor: code',
+  'write_patterns: ["transcripts/**"]',
+  'env_passthrough: ["KRISP_TOKEN", "KRISP_BASE_URL"]',
+  'max_depth: 1',
+  '---',
+  '```python',
+  'import os',
+  'import json',
+  'import urllib.request',
+  '',
+  'base_url = os.environ["KRISP_BASE_URL"].rstrip("/")',
+  'token = os.environ["KRISP_TOKEN"]',
+  '',
+  '',
+  'def api_post(path, payload):',
+  '    data = json.dumps(payload).encode()',
+  '    req = urllib.request.Request(',
+  '        base_url + path,',
+  '        data=data,',
+  '        headers={',
+  '            "Authorization": "Bearer " + token,',
+  '            "Content-Type": "application/json",',
+  '        },',
+  '    )',
+  '    with urllib.request.urlopen(req) as resp:',
+  '        return json.loads(resp.read())',
+  '',
+  '',
+  'def api_get(path):',
+  '    req = urllib.request.Request(',
+  '        base_url + path,',
+  '        headers={"Authorization": "Bearer " + token},',
+  '    )',
+  '    with urllib.request.urlopen(req) as resp:',
+  '        return json.loads(resp.read())',
+  '',
+  '',
+  'resp = api_post("/v2/meetings/list", {"page": 1, "limit": 100, "isOwner": True})',
+  'meetings = resp.get("data", {}).get("rows", [])',
+  '',
+  'changes = []',
+  'for meeting in meetings:',
+  '    mid = meeting["id"]',
+  '    name = meeting.get("name", mid)',
+  '    started_at = meeting.get("started_at", "")',
+  '    speakers = meeting.get("speakers", [])',
+  '    tree = api_get("/v2/block/" + mid + "/tree")',
+  '    lines = ["# " + name, "", "Date: " + started_at, ""]',
+  '    for child in tree.get("children", []):',
+  '        if child.get("block_type") != "utterance":',
+  '            continue',
+  '        idx = child.get("speakerIndex", 0)',
+  '        if 0 < idx <= len(speakers):',
+  '            sp = speakers[idx - 1]',
+  '            speaker = sp.get("first_name", "") + " " + sp.get("last_name", "")',
+  '        else:',
+  '            speaker = "Speaker " + str(idx)',
+  '        speech = child.get("speech", {})',
+  '        start = speech.get("start", 0.0)',
+  '        text = speech.get("text", "")',
+  '        mins = int(start) // 60',
+  '        secs = int(start) % 60',
+  '        lines.append(speaker.strip() + " | {:02d}:{:02d}".format(mins, secs))',
+  '        lines.append(text)',
+  '        lines.append("")',
+  '    changes.append({"path": "transcripts/" + mid + ".md", "content": "\\n".join(lines)})',
+  '',
+  'print(json.dumps({"changes": changes, "answer": "ingested " + str(len(changes))}))',
+  '```',
+].join('\n');
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+test.describe.serial('Krisp cron ingest (dockerized)', () => {
+  // Role seed + 30 s fleet reconcile + python execution + write-back.
+  test.setTimeout(120000);
+
+  /** @type {string} Admin session cookie. */
+  let cookie;
+  /** @type {string} Full-admin API key for note reads. */
+  let apiKey;
+
+  test.beforeAll({ timeout: 90000 }, async ({ request }) => {
+    const token = await graphqlSignIn(request, 'hello@example.com', '111111', { useCache: false });
+    const cookieName = process.env.USER_TOKEN_COOKIE_NAME || 'trip2g_e2e';
+    cookie = `${cookieName}=${token}`;
+
+    // Create a full-admin API key for note queries.
+    const keyData = await gqlAdmin(request, cookie, `
+      mutation {
+        admin {
+          createApiKey(input: { description: "krisp-ingest-e2e" }) {
+            ... on CreateApiKeyPayload { value apiKey { id } }
+            ... on ErrorPayload { message }
+          }
+        }
+      }
+    `);
+    expect(keyData.admin.createApiKey.message).toBeFalsy();
+    apiKey = keyData.admin.createApiKey.value;
+
+    // Seed the cron ingest role note.
+    const seedResult = await gqlApi(request, apiKey, `
+      mutation Up($input: UpdateNotesInput!) {
+        updateNotes(input: $input) {
+          ... on UpdateNotesSuccessPayload { paths }
+          ... on ErrorPayload { message }
+        }
+      }
+    `, {
+      input: {
+        changes: [
+          { upsert: { path: ROLE_PATH, content: roleSeed } },
+        ],
+      },
+    });
+    expect(seedResult.updateNotes.message).toBeFalsy();
+
+    // Wait for the fleet to discover the role and register a cron webhook.
+    // Fleet polls every 3 s (TRIP2G_FLEET_POLL_SECONDS=3 in compose); allow 30 s.
+    await expect
+      .poll(
+        async () => {
+          const d = await gqlAdmin(request, cookie, `
+            query { admin { allCronWebhooks { nodes { description } } } }
+          `);
+          return d.admin.allCronWebhooks.nodes.some(n =>
+            n.description.startsWith('fleetcron:e2e:' + ROLE_PATH + '#'),
+          );
+        },
+        { timeout: 30000, intervals: [1000] },
+      )
+      .toBeTruthy();
+  });
+
+  test('triggerCronWebhook → python ingest → transcripts/<id>.md written with meeting content', async ({ request }) => {
+    // Find the cron webhook registered by fleet.
+    const wh = await gqlAdmin(request, cookie, `
+      query { admin { allCronWebhooks { nodes { id description } } } }
+    `);
+    const cronWebhook = wh.admin.allCronWebhooks.nodes.find(n =>
+      n.description.startsWith('fleetcron:e2e:' + ROLE_PATH + '#'),
+    );
+    expect(cronWebhook, 'fleet cron webhook must be registered').toBeTruthy();
+
+    // Manually fire the cron webhook. This enqueues a background delivery job.
+    const triggerData = await gqlAdmin(request, cookie, `
+      mutation Trigger($input: TriggerCronWebhookInput!) {
+        admin {
+          triggerCronWebhook(input: $input) {
+            ... on TriggerCronWebhookPayload { deliveryId }
+            ... on ErrorPayload { message }
+          }
+        }
+      }
+    `, { input: { cronWebhookId: cronWebhook.id } });
+    expect(triggerData.admin.triggerCronWebhook.message).toBeFalsy();
+
+    // Poll until the fleet's python ingest writes transcripts/<meetingID1>.md.
+    // The delivery is async: background job → fleet → python → updateNotes.
+    // 90 s covers delivery queue latency + python execution + write-back.
+    await expect
+      .poll(
+        async () => {
+          const d = await gqlApi(request, apiKey, `
+            query N($f: NotePathsFilter) { notePaths(filter: $f) { content } }
+          `, { f: { paths: [TRANSCRIPT_PATH_1] } });
+          return (d.notePaths[0]?.content ?? '').length > 0;
+        },
+        { timeout: 90000, intervals: [2000] },
+      )
+      .toBeTruthy();
+
+    // Assert transcript content matches the krisp-mock synthetic data for meeting 1.
+    // meetingID1 speakers: Alice Mock (idx 1), Bob Mock (idx 2).
+    // First utterance: "Good morning, let us get started with the Q1 planning."
+    const d = await gqlApi(request, apiKey, `
+      query N($f: NotePathsFilter) { notePaths(filter: $f) { content } }
+    `, { f: { paths: [TRANSCRIPT_PATH_1] } });
+    const content = d.notePaths[0]?.content ?? '';
+
+    expect(content).toContain('Team Sync Q1 Planning');
+    expect(content).toContain('Alice Mock');
+    expect(content).toContain('Good morning, let us get started with the Q1 planning.');
+    expect(content).toContain('Bob Mock');
+  });
+});

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -264,8 +264,8 @@ trap cleanup EXIT INT TERM
 
 # Clean up any existing test containers (keep embedding running to avoid slow model reload)
 echo "🧹 Cleaning up existing test containers..."
-docker compose -f docker-compose.test.yml stop app app-replica app-replica2 app-peer app-peer2 app-peer3 minio fleet llm-mock test-data 2>/dev/null || true
-docker compose -f docker-compose.test.yml rm -f app app-replica app-replica2 app-peer app-peer2 app-peer3 fleet llm-mock test-data 2>/dev/null || true
+docker compose -f docker-compose.test.yml stop app app-replica app-replica2 app-peer app-peer2 app-peer3 minio fleet llm-mock krisp-mock test-data 2>/dev/null || true
+docker compose -f docker-compose.test.yml rm -f app app-replica app-replica2 app-peer app-peer2 app-peer3 fleet llm-mock krisp-mock test-data 2>/dev/null || true
 # MinIO needs no explicit volume drop: docker-compose.test.yml mounts its /data as
 # tmpfs, so every container (re)create starts with an empty backup store — no stale
 # backup can be restored over the freshly-seeded DB (keeps the onboarding spec valid).
@@ -329,7 +329,7 @@ fi
 # Start services (embedding is kept alive between runs; start it without recreate if not running)
 echo "🚀 Starting services..."
 docker compose -f docker-compose.test.yml up -d --no-recreate embedding 2>/dev/null || true
-docker compose -f docker-compose.test.yml up -d --build --force-recreate app app-replica app-replica2 app-peer app-peer2 app-peer3 minio llm-mock fleet
+docker compose -f docker-compose.test.yml up -d --build --force-recreate app app-replica app-replica2 app-peer app-peer2 app-peer3 minio llm-mock krisp-mock fleet
 
 # Wait for services
 ./scripts/waitfor localhost:20081 || {
@@ -365,9 +365,13 @@ docker compose -f docker-compose.test.yml up -d --build --force-recreate app app
   exit 1
 }
 
-# Wait for fleet services (needed by e2e/fleet.spec.js)
+# Wait for fleet services (needed by e2e/fleet.spec.js and e2e/krisp-ingest.spec.js)
 ./scripts/waitfor localhost:29091 -t 30 || {
   echo -e "${RED}✗ llm-mock failed to start${NC}"
+  exit 1
+}
+./scripts/waitfor localhost:29092 -t 30 || {
+  echo -e "${RED}✗ krisp-mock failed to start${NC}"
   exit 1
 }
 ./scripts/waitfor localhost:29090 -t 60 || {


### PR DESCRIPTION
## What

End-to-end test proving the **deterministic Krisp ingest on the fleet**: a **cron `executor: code` role** pulls meetings from the krisp-mock and writes transcript notes — exercising **cron-mode + the code-executor + `env_passthrough` + krisp-mock together**, on the docker e2e stack, with no LLM and no real data.

## Chain (verified live)

`triggerCronWebhook` (admin) → `/deliver/cron/<key>` → fleet renders the cron role → `executor: code` runs the role's python (stdlib `urllib`, `KRISP_TOKEN` + `KRISP_BASE_URL` via `env_passthrough`) → POST krisp-mock `/v2/meetings/list` + GET `/v2/block/{id}/tree` → walks `speakerIndex`+`speech` into a transcript → emits `{"changes":[{path,content}],"answer":"ingested N"}` → scoped `updateNotes` writes `transcripts/<id>.md`. Round-trip < 6s.

## Changes

- **`Dockerfile.fleet`** — add `python3` (the code-executor needs the interpreter in the fleet image to run `executor: code` python roles).
- **`docker-compose.test.yml`** — `krisp-mock` service + fleet env: `TRIP2G_FLEET_ALLOWED_PROGRAMS=python`, `KRISP_TOKEN`, `KRISP_BASE_URL`.
- **`docs/fleet/krisp/roles/transcript-ingest.md`** (new) — the cron `executor: code` ingest role. Pull-all each run; re-writing identical content is a content-hash no-op, so no cursor needed.
- **`e2e/krisp-ingest.spec.js`** (new) — seed the role → wait for the fleet to register the cron webhook → fire it via `admin.triggerCronWebhook` → poll for `transcripts/<id>.md` → assert the synthetic transcript content.
- **`scripts/test-e2e.sh`** — wire krisp-mock into up/wait/stop/rm.

## Verify

`npx playwright test e2e/krisp-ingest.spec.js` → **1 passed (5.6s)** live; `go build` clean. No Go changed (infra/config/spec), so golangci N/A.

## Notes

- Next: the real `gpt-5.4-nano` run (segment/wiki on the ingested transcripts).
- The Go krisp-mock will be replaced by the universal jsonnet mock (#36) later — the role + spec are unaffected (they hit the mock's HTTP endpoints regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
