### PR TITLE
feat: DB pool/file metrics, _dqs hardening, drop mattn driver

### DIFF
--- a/cmd/server/queue_test.go
+++ b/cmd/server/queue_test.go
@@ -8,10 +8,10 @@ import (
 	"time"
 	"trip2g/internal/logger"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/require"
 	"maragu.dev/goqite"
 	"maragu.dev/goqite/jobs"
+	_ "modernc.org/sqlite"
 )
 
 //go:embed testdata/goqite_schema.sql
@@ -20,7 +20,7 @@ var goqiteSchema string
 func newTestQueue(t *testing.T, ctx context.Context) *appQueue {
 	t.Helper()
 
-	db, err := sql.Open("sqlite3", ":memory:")
+	db, err := sql.Open("sqlite", ":memory:")
 	require.NoError(t, err)
 	t.Cleanup(func() { db.Close() })
 

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -280,6 +280,9 @@ func (a *app) startInternalServer() {
 	// port — no separate listener, no net/http→fasthttp request bridge.
 	debugMux := http.NewServeMux()
 
+	// Register DB observability collectors (pool stats + file metrics).
+	metrics.RegisterDBCollectors(a.conn, a.writeConn, a.queueConn, a.config.DatabaseFile)
+
 	// Prometheus metrics endpoint
 	debugMux.Handle("/metrics", metrics.Setup())
 

--- a/cmd/tge2e/config.go
+++ b/cmd/tge2e/config.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strconv"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 	"trip2g/internal/appconfig"
 	"trip2g/internal/dataencryption"
 )
@@ -78,7 +78,7 @@ func LoadCredentialsFromDB(ctx context.Context, dbPath string) (*Credentials, er
 	}
 
 	// Open database
-	db, err := sql.Open("sqlite3", dbPath)
+	db, err := sql.Open("sqlite", dbPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}

--- a/cmd/tge2e/patchdb.go
+++ b/cmd/tge2e/patchdb.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 	"trip2g/internal/dataencryption"
 )
 
@@ -49,7 +49,7 @@ func runPatchDB() error {
 	}
 
 	// Open database
-	db, err := sql.Open("sqlite3", dbPath)
+	db, err := sql.Open("sqlite", dbPath)
 	if err != nil {
 		return fmt.Errorf("failed to open database: %w", err)
 	}

--- a/docs/dev/modernc_sqlite.md
+++ b/docs/dev/modernc_sqlite.md
@@ -1,0 +1,120 @@
+# modernc.org/sqlite — driver details, metrics & gaps
+
+**TL;DR.** trip2g's production database runs on the **pure-Go `modernc.org/sqlite` driver** (v1.53.0), not the CGO `mattn/go-sqlite3`. The driver exposes more than we use: per-connection `DBStatus` counters, `FileControl`, online backup, custom SQL functions, and several DSN knobs. The one observability win worth shipping is **`sql.DBStats` + file/WAL gauges** (the `db_status` per-conn counters are the *wrong* granularity for our pooled, single-writer setup). The cheapest correctness win is **`_dqs=false`**. The `modernc.org/libc` version must stay pinned to exactly what the driver's `go.mod` requires (`v1.73.4` today) — a soft invariant worth a CI guard.
+
+---
+
+## 1. Which driver we actually use
+
+| Path | Driver | Registered name | Notes |
+|------|--------|-----------------|-------|
+| App runtime (`internal/db/setup.go`, `internal/dbmate/sqlite`, `internal/simplebackup`) | `modernc.org/sqlite` | `"sqlite"` | Pure Go, no CGO. The real production path. |
+| `cmd/tge2e` e2e tooling, `cmd/server/queue_test.go` | (was `mattn/go-sqlite3`) → `modernc.org/sqlite` | `"sqlite"` | Migrated off mattn. |
+
+`github.com/mattn/go-sqlite3` is **no longer compiled into any binary** (`go list -test -deps ./...` shows only `modernc.org/sqlite`). It survives in `go.mod` as `// indirect` solely because `github.com/amacneil/dbmate/v2` requires it in *its own* `go.mod` (dbmate ships a mattn-based `pkg/driver/sqlite`). Fully removing the line needs a dbmate release/fork that drops mattn — out of scope.
+
+> The doc string *"DBStatus\* are the operations accepted by `DBStatus.Status`. They report their value differently depending on the op"* comes from **`modernc.org/sqlite@v1.53.0/dbstatus.go`** — the production driver — not from mattn.
+
+## 2. DSN params & pragmas in use
+
+All connection settings go through **modernc DSN params** (`_pragma`, `_txlock`, `_dqs`), because the driver applies them to *every* pooled connection. A one-off `db.Exec("PRAGMA …")` would only configure the single pooled conn it happened to run on. Built in `openConnection()` (`internal/db/setup.go`).
+
+| Setting | Value | Why |
+|---------|-------|-----|
+| `busy_timeout` | `20000` ms | Queue instead of failing on lock contention. |
+| `journal_mode` | `WAL` | Concurrent readers + single writer. |
+| `foreign_keys` | `1` | Enforce FKs (immediate). |
+| `synchronous` | `NORMAL` | WAL-appropriate durability/throughput. |
+| `temp_store` | `2` (MEMORY) | Temp tables/indexes in RAM. |
+| `mmap_size` | `268435456` (256 MB) | Memory-mapped reads. |
+| `cache_size` | `-64000` (64 MB) | Per-conn page cache. |
+| `wal_autocheckpoint` | `1000` pages | Bound WAL growth. |
+| `query_only` | `1` *(replica only)* | Hard read-only guardrail. |
+| `_txlock` | `immediate` *(write pool only)* | `BEGIN IMMEDIATE` takes the write lock at txn start, avoiding the deferred→write upgrade that fails instantly with `SQLITE_BUSY_SNAPSHOT` (517). **Correctly scoped to the writer; do not add to the read pool.** |
+| `_dqs` | `false` | Disable the double-quoted-string-literal fallback so DQS mistakes become parse errors instead of silent string literals (<https://www.sqlite.org/quirks.html#dblquote>). Cheap correctness hardening. |
+
+**Pool topology** (`cmd/server/boot.go`, `internal/db/setup.go`): three separate `*sql.DB` pools — `Read` (`MaxOpenConns=25`, `ConnMaxIdleTime=30s`), `Write` (`MaxOpenConns=1`), `Queue` (`MaxOpenConns=1`, isolated so goqite polling never blocks app writes). In read-replica mode all three collapse to one strict-read-only pool.
+
+## 3. `DBStatus` (`sqlite3_db_status`) — why it is *not* our primary metric source
+
+modernc exposes `sqlite3_db_status` via an escape hatch:
+
+```go
+err := sqlConn.Raw(func(dc any) error {
+    cur, hi, err := dc.(sqlite.DBStatus).Status(sqlite.DBStatusCacheSpill, false)
+    // …
+    return err
+})
+```
+
+These counters live on an **individual `sqlite3*` handle**. We never hold one: `database/sql` owns 25 read conns + 1 writer and rotates which one `Raw()` hands you, recycling them on `ConnMaxIdleTime=30s`. Consequences:
+
+- **No per-conn identity** — you sample a random, drifting subset; recycled conns reset their counters to zero, so a Prometheus *counter* built on this sawtooths and lies.
+- **`reset=true` is destructive/racy** across samplers.
+- The *memory* ops (`CacheUsed`/`StmtUsed`/`SchemaUsed`) are gauges and less broken, but still scoped to "whichever conn answered" — not actionable.
+
+If we ever chase a cache-tuning question, the only ops with signal for *this* workload (WAL + 256 MB mmap + 64 MB cache + single writer) are, ranked: **`CacheMiss`/`CacheHit`** (is the 64 MB cache sized right?), **`CacheSpill`** (dirty-page flush pressure on the writer), **`CacheWrite`**, and maybe **`CacheUsed`**. Everything else (`StmtUsed`, `SchemaUsed`, `Lookaside*`, `DeferredFKs`, `CacheUsedShared`, `TempbufSpill`) is noise here. Even those four would be a best-effort *smell test* behind an opt-in flag, never SLO metrics.
+
+## 4. What we export to Prometheus instead
+
+Added in `internal/metrics/db.go`, registered in `cmd/server/server.go` `startInternalServer()` before the `/metrics` handler.
+
+**Pool metrics** — `collectors.NewDBStatsCollector(db, name)` for each pool, label `db_name="read"|"write"|"queue"`. Emits `go_sql_*`, including:
+- `go_sql_open_connections`, `go_sql_in_use_connections`, `go_sql_idle_connections`
+- `go_sql_wait_count_total`, **`go_sql_wait_duration_seconds_total`** ← the write-pool (`MaxOpenConns=1`) backpressure signal we were flying blind on
+- `go_sql_max_idle_closed_total`, `go_sql_max_lifetime_closed_total` (churn)
+
+**File / WAL gauges** — a small custom collector sampling the read pool (PRAGMAs) + the filesystem:
+- `trip2g_db_size_bytes` = `page_count * page_size`
+- `trip2g_db_freelist_pages` (`PRAGMA freelist_count`) — fragmentation / VACUUM-need
+- `trip2g_db_wal_bytes` = `os.Stat(<dbfile>-wal)` size
+
+> WAL size is read from the **filesystem**, *not* via `PRAGMA wal_checkpoint(PASSIVE)`: a checkpoint has side effects, fails on `query_only` replicas, and is Litestream-hostile. The PRAGMAs used are pure reads and work under `query_only`.
+
+This closes the audit gaps (`WaitDuration` invisible, read pool unobserved, no file/WAL signal) with ~20 lines and no per-conn-identity hand-wringing.
+
+## 5. modernc features trip2g does **not** use yet
+
+| Capability | What it enables | Relevance | Verdict |
+|---|---|---|---|
+| `DBStatus` | Per-conn cache/mem counters via `Raw` | low | Pool rotation kills the signal — prefer `DBStats` + PRAGMA (§4). |
+| `FileControl` → `FileControlDataVersion` | Cheap conn-local "did anyone write since I last looked" (pager `DATA_VERSION`) | **med** | Worth a spike as a **read-side cache-invalidation** primitive (addresses the read-replica "silent hole"). |
+| Online Backup API (`Backup.Step`) | Incremental page-copy snapshot, yields the write lock between steps | **med** | Only if backup-time lock contention ever shows up in `WaitDuration`. `VACUUM INTO` (current) is simpler and defragments — keep it for now. |
+| `Serialize`/`Deserialize` | DB ↔ `[]byte` | skip | Memory bomb for multi-GB DBs; the S3 gzip-stream path is correct. Test fixtures only. |
+| `RegisterDeterministicScalarFunction` / scalar / aggregate UDFs | Run Go in SQL (deterministic ones usable in indexes) | low | Vector scoring stays faster in-app; couples ranking to the DB. Only useful for a future computed/partial index. |
+| `RegisterCollationUtf8` | Custom sort/compare (locale/Cyrillic) | low | Defer until a concrete `NOCASE`-insufficient sort bug appears. |
+| `Limit` (`sqlite3_limit`) | Per-conn caps (SQL length, expr depth, …) | low | Hardening for untrusted SQL; all SQL today is first-party (sqlc/dbmate). |
+| preupdate/commit/rollback hooks | In-driver change reactions | low | Redundant with the app-level `note_changes`/SSE change feed. |
+| Virtual tables, custom VFS, pluggable page cache | Expose Go as SQL / replace IO layer | skip | No use case; Litestream/standard VFS is what we want. |
+| DSN `_time_*` / `_inttotime` / `_texttotime` | Time storage/parse format | skip | We control schema + Go types; changing is a data-format migration risk for zero gain. |
+| DSN `_error_rc=true` | Clearer open-time error strings | low | Harmless nice-to-have. |
+| FTS5 | Keyword full-text index | low | Different feature from embedding search; would be net-new (hybrid lexical+semantic), not a gap. |
+| json1 / math / `DBSTAT_VTAB` | JSON/math in SQL; page-usage introspection | low | `STAT4` already helps via the `ANALYZE` vacuum cron; `DBSTAT_VTAB` is an ad-hoc debugging aid. |
+
+**Genuinely actionable:** `_dqs=false` (done, §2), a `FileControlDataVersion` spike for read-side invalidation, and revisiting the online Backup API only if `WaitDuration` later proves backup lock contention.
+
+## 6. `modernc.org/libc` version invariant
+
+The driver is transpiled C running on `modernc.org/libc`'s runtime, so a libc that is newer or older than the one the driver was generated against can mismatch in subtle, hard-to-debug ways (bad codegen interactions, not a clean compile error). The upstream guidance: **use the exact `modernc.org/libc` version from the driver's `go.mod`.**
+
+**Status: satisfied today.** `modernc.org/sqlite@v1.53.0`'s `go.mod` requires `modernc.org/libc v1.73.4`; trip2g's `go.mod` pins `v1.73.4`; the resolved build list agrees.
+
+**Risk:** nothing enforces it, and libc is an `// indirect` dep — drift leaves no diff in our own code. It can move via `go get -u`, an unrelated dependency raising its libc floor, or a `modernc.org/sqlite` bump that pins a *different* libc (making our stale explicit pin wrong).
+
+**Guard (recommended):**
+1. Annotate the pin: `modernc.org/libc v1.73.4 // indirect; MUST match modernc.org/sqlite's required libc`
+2. CI assertion:
+   ```bash
+   want=$(grep -E '^\s*modernc.org/libc ' "$(go mod download -json modernc.org/sqlite | jq -r .Dir)/go.mod" | awk '{print $2}')
+   have=$(go list -m -f '{{.Version}}' modernc.org/libc)
+   [ "$want" = "$have" ] || { echo "libc drift: sqlite wants $want, build has $have"; exit 1; }
+   ```
+3. Re-pin libc in the same PR whenever you bump `modernc.org/sqlite`.
+
+## 7. References
+
+- modernc DSN params: `modernc.org/sqlite@v1.53.0/driver.go` (`_pragma`, `_txlock`, `_dqs`, `_time_format`, `_error_rc`, …)
+- `DBStatus`: `modernc.org/sqlite@v1.53.0/dbstatus.go`
+- SQLite double-quote quirk: <https://www.sqlite.org/quirks.html#dblquote>
+- `sqlite3_db_status` ops: <https://www.sqlite.org/c3ref/c_dbstatus_options.html>
+- Related docs: [`sqlite.md`](./sqlite.md) (config, WAL, R/W split), [`simplebackup.md`](./simplebackup.md).

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/kr/pretty v0.3.1
 	github.com/lib/pq v1.10.9
 	github.com/mailru/easyjson v0.9.0
-	github.com/mattn/go-sqlite3 v1.14.28
 	github.com/minio/minio-go/v7 v7.0.91
 	github.com/nicksnyder/go-i18n/v2 v2.6.1
 	github.com/oklog/ulid/v2 v2.1.1
@@ -249,6 +248,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/mattn/go-sqlite3 v1.14.28 // indirect
 	github.com/mattn/goreman v0.3.16 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/mgechev/revive v1.9.0 // indirect

--- a/internal/db/setup.go
+++ b/internal/db/setup.go
@@ -172,6 +172,11 @@ func openConnection(config SetupConfig, queryLog logger.Logger) (*sql.DB, error)
 	q.Add("_pragma", "cache_size(-64000)")
 	q.Add("_pragma", "wal_autocheckpoint(1000)")
 
+	// Disable SQLite's double-quoted-string-literal fallback so a double-quoted
+	// token that doesn't resolve as an identifier becomes a parse error instead
+	// of a silent string literal. https://www.sqlite.org/quirks.html#dblquote
+	q.Add("_dqs", "false")
+
 	if !config.ReadOnly {
 		// Writers must take the write lock at BEGIN. The default deferred
 		// mode starts every transaction as a reader; upgrading to a write

--- a/internal/metrics/db.go
+++ b/internal/metrics/db.go
@@ -1,0 +1,121 @@
+package metrics
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+)
+
+// dbFileCollector is a custom Prometheus Collector that reads SQLite file-level
+// metrics via PRAGMAs and the filesystem. It uses read-only PRAGMAs only
+// (page_count, page_size, freelist_count) so it is safe to run on read replicas
+// opened with query_only=1.
+type dbFileCollector struct {
+	db     *sql.DB
+	dbPath string
+
+	descSize     *prometheus.Desc
+	descFreelist *prometheus.Desc
+	descWAL      *prometheus.Desc
+}
+
+// NewDBFileCollector returns a Prometheus Collector that exposes three gauges:
+//   - trip2g_db_size_bytes      — logical DB size (page_count * page_size)
+//   - trip2g_db_freelist_pages  — freelist page count (fragmentation / VACUUM signal)
+//   - trip2g_db_wal_bytes       — WAL file size from the filesystem
+//
+// Use the read pool so PRAGMAs never contend with the single writer.
+func NewDBFileCollector(db *sql.DB, dbPath string) prometheus.Collector {
+	return &dbFileCollector{
+		db:     db,
+		dbPath: dbPath,
+		descSize: prometheus.NewDesc(
+			"trip2g_db_size_bytes",
+			"SQLite database logical size in bytes (page_count * page_size)",
+			nil, nil,
+		),
+		descFreelist: prometheus.NewDesc(
+			"trip2g_db_freelist_pages",
+			"SQLite freelist page count (fragmentation / VACUUM-need signal)",
+			nil, nil,
+		),
+		descWAL: prometheus.NewDesc(
+			"trip2g_db_wal_bytes",
+			"Size of the -wal file in bytes (WAL growth vs checkpointing)",
+			nil, nil,
+		),
+	}
+}
+
+// Describe implements prometheus.Collector.
+func (c *dbFileCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.descSize
+	ch <- c.descFreelist
+	ch <- c.descWAL
+}
+
+// Collect implements prometheus.Collector. It runs read-only PRAGMAs with a
+// short timeout and reads the WAL file size from the filesystem. If a PRAGMA
+// query fails, that individual metric is skipped — Collect never panics.
+func (c *dbFileCollector) Collect(ch chan<- prometheus.Metric) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var pageCount, pageSize, freelistCount int64
+
+	if err := c.db.QueryRowContext(ctx, "PRAGMA page_count").Scan(&pageCount); err != nil {
+		// DB closed or otherwise unavailable — skip size+freelist metrics.
+		goto walMetric
+	}
+	if err := c.db.QueryRowContext(ctx, "PRAGMA page_size").Scan(&pageSize); err != nil {
+		goto walMetric
+	}
+
+	ch <- prometheus.MustNewConstMetric(c.descSize, prometheus.GaugeValue, float64(pageCount*pageSize))
+
+	if err := c.db.QueryRowContext(ctx, "PRAGMA freelist_count").Scan(&freelistCount); err == nil {
+		ch <- prometheus.MustNewConstMetric(c.descFreelist, prometheus.GaugeValue, float64(freelistCount))
+	}
+
+walMetric:
+	// WAL size: filesystem stat only — never issue PRAGMA wal_checkpoint which
+	// has side effects and may fail on query_only connections.
+	var walBytes float64
+	if info, err := os.Stat(c.dbPath + "-wal"); err == nil {
+		walBytes = float64(info.Size())
+	} else if !errors.Is(err, os.ErrNotExist) {
+		// Stat error other than "not found" — emit 0 but still emit the metric.
+		walBytes = 0
+	}
+	ch <- prometheus.MustNewConstMetric(c.descWAL, prometheus.GaugeValue, walBytes)
+}
+
+// RegisterDBCollectors registers go_sql_* pool stats collectors for the three
+// database pools (read, write, queue) and one DBFileCollector for the shared
+// SQLite file. Registration is idempotent: AlreadyRegisteredError is silently
+// ignored.
+func RegisterDBCollectors(read, write, queue *sql.DB, dbPath string) {
+	mustRegisterOnce(collectors.NewDBStatsCollector(read, "read"))
+	mustRegisterOnce(collectors.NewDBStatsCollector(write, "write"))
+	mustRegisterOnce(collectors.NewDBStatsCollector(queue, "queue"))
+	mustRegisterOnce(NewDBFileCollector(read, dbPath))
+}
+
+// mustRegisterOnce registers c on the default registry and panics only on
+// errors other than AlreadyRegisteredError.
+func mustRegisterOnce(c prometheus.Collector) {
+	err := prometheus.Register(c)
+	if err == nil {
+		return
+	}
+	var already prometheus.AlreadyRegisteredError
+	if errors.As(err, &already) {
+		return
+	}
+	panic(err)
+}

--- a/internal/metrics/db_test.go
+++ b/internal/metrics/db_test.go
@@ -1,0 +1,111 @@
+package metrics
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	_ "modernc.org/sqlite"
+)
+
+func openTestDB(t *testing.T) (*sql.DB, string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.db")
+	db, err := sql.Open("sqlite", path+"?_pragma=journal_mode(WAL)")
+	require.NoError(t, err)
+
+	// Seed a table so page_count > 0 and WAL has data.
+	_, err = db.Exec("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+	require.NoError(t, err)
+	for i := 0; i < 10; i++ {
+		_, err = db.Exec("INSERT INTO t (v) VALUES (?)", "hello")
+		require.NoError(t, err)
+	}
+
+	return db, path
+}
+
+func TestNewDBFileCollector_ThreeMetrics(t *testing.T) {
+	db, path := openTestDB(t)
+	defer db.Close()
+
+	reg := prometheus.NewRegistry()
+	c := NewDBFileCollector(db, path)
+	reg.MustRegister(c)
+
+	n := testutil.CollectAndCount(c)
+	require.Equal(t, 3, n, "expected exactly 3 metrics (size, freelist, wal)")
+}
+
+func TestNewDBFileCollector_SizePositive(t *testing.T) {
+	db, path := openTestDB(t)
+	defer db.Close()
+
+	reg := prometheus.NewRegistry()
+	c := NewDBFileCollector(db, path)
+	reg.MustRegister(c)
+
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+
+	var sizeVal float64
+	var walVal float64
+	var foundSize, foundWAL bool
+	for _, mf := range mfs {
+		switch mf.GetName() {
+		case "trip2g_db_size_bytes":
+			foundSize = true
+			sizeVal = mf.GetMetric()[0].GetGauge().GetValue()
+		case "trip2g_db_wal_bytes":
+			foundWAL = true
+			walVal = mf.GetMetric()[0].GetGauge().GetValue()
+		}
+	}
+
+	require.True(t, foundSize, "trip2g_db_size_bytes metric must be present")
+	require.True(t, foundWAL, "trip2g_db_wal_bytes metric must be present")
+	require.Greater(t, sizeVal, float64(0), "trip2g_db_size_bytes must be > 0")
+	require.GreaterOrEqual(t, walVal, float64(0), "trip2g_db_wal_bytes must be >= 0")
+}
+
+func TestNewDBFileCollector_WALFileAbsent(t *testing.T) {
+	// Open in DELETE journal mode so no -wal file is created.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nodelete.db")
+	db, err := sql.Open("sqlite", path+"?_pragma=journal_mode(DELETE)")
+	require.NoError(t, err)
+	defer db.Close()
+	_, err = db.Exec("CREATE TABLE x (id INTEGER PRIMARY KEY)")
+	require.NoError(t, err)
+
+	// Ensure no -wal file exists.
+	_, statErr := os.Stat(path + "-wal")
+	require.True(t, os.IsNotExist(statErr), "expect no -wal file in DELETE mode")
+
+	c := NewDBFileCollector(db, path)
+
+	// Collect should not panic and should still emit 3 metrics (wal=0).
+	n := testutil.CollectAndCount(c)
+	require.Equal(t, 3, n)
+}
+
+func TestNewDBFileCollector_ClosedDBSkipsGracefully(t *testing.T) {
+	db, path := openTestDB(t)
+
+	c := NewDBFileCollector(db, path)
+
+	// Close the DB before collecting — Collect must not panic.
+	require.NoError(t, db.Close())
+
+	// CollectAndCount internally catches no panic; if Collect panics the test
+	// process crashes, which is itself the assertion.
+	n := testutil.CollectAndCount(c)
+	// Some or all metrics may be absent on error; just verify no panic.
+	require.GreaterOrEqual(t, n, 0)
+}


### PR DESCRIPTION
## What

DB observability + driver cleanup around `modernc.org/sqlite`.

- **`feat(metrics)`** — export DB pool + file/WAL metrics (`internal/metrics/db.go`):
  - per-pool `go_sql_*` via `collectors.NewDBStatsCollector` (`db_name="read"|"write"|"queue"`), incl. `go_sql_wait_duration_seconds_total` — the single-writer backpressure signal we weren't exporting.
  - `trip2g_db_size_bytes`, `trip2g_db_freelist_pages`, `trip2g_db_wal_bytes` from read-only PRAGMAs + `os.Stat` of the `-wal` file (no `wal_checkpoint`; safe under `query_only=1`/replicas). Wired in `startInternalServer` before `/metrics`.
- **`feat(db)`** — `_dqs=false` DSN param: double-quoted-string mistakes now surface as parse errors instead of silent string literals (https://www.sqlite.org/quirks.html#dblquote). Applies to all pools.
- **`chore(deps)`** — stop importing the CGO `mattn/go-sqlite3` driver in `cmd/tge2e` and `cmd/server/queue_test.go`; use `modernc.org/sqlite` like the rest of the codebase. `go.mod` moves mattn from a direct require to `// indirect` (it stays in the graph only because `dbmate` requires it; it is no longer compiled into any binary).
- **`docs`** — `docs/dev/modernc_sqlite.md`: driver details, DSN/pragma table, why `DBStatus` per-conn counters are *not* a good Prometheus source here, the unused-feature gap table, and the `modernc.org/libc` pin invariant.

## Why

Closes the DB-layer observability gap (pool `WaitDuration`, read pool, file/WAL size were unobserved — `sql.DBStats` was only logged). Drops a redundant CGO driver from non-prod tooling. Hardens SQL parsing.

## Testing

- `go build ./...`, `go vet` clean.
- New `internal/metrics/db_test.go` (4 tests) — collector metric count + values, WAL-absent and closed-DB paths.
- `internal/db` (19 tests) and `cmd/server` suites pass with `_dqs=false` (no double-quoted-string-literal regressions).

> Note: a pre-existing `internal/case/insertnote` flake (`context deadline exceeded` during migration setup) is unrelated to this PR — it reproduces on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
