### PR TITLE
feat(fleet): graceful shutdown — drain in-flight + keep-webhooks flag

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -109,15 +109,7 @@ func run() error {
 		case srvListenErr := <-srvErrCh:
 			return fmt.Errorf("http server: %w", srvListenErr)
 		case <-ctx.Done():
-			log.Print("shutdown: deregistering webhooks")
-			shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-			deregErr := reconciler.Deregister(shutdownCtx)
-			if deregErr != nil {
-				log.Printf("deregister: %v", deregErr)
-			}
-			_ = srv.Shutdown(shutdownCtx)
-			cancel()
-			// Check if the server goroutine also reported an error.
+			_ = gracefulShutdown(srv, reconciler.Deregister, cli.cfg.KeepWebhooksOnShutdown, cli.cfg.ShutdownGrace)
 			select {
 			case srvListenErr := <-srvErrCh:
 				return fmt.Errorf("http server: %w", srvListenErr)
@@ -303,6 +295,51 @@ func syncOnce(ctx context.Context, f *fleet.Fleet, d *fleet.Discovery, r *fleet.
 	}
 }
 
+// gracefulShutdown drains in-flight deliveries (srv.Shutdown waits for active
+// handlers — runs are synchronous, so this drains runs too) within the grace
+// window, then deregisters owned webhooks unless keepWebhooks is set (rolling
+// deploys keep them so trip2g retries against the next instance). deregister may
+// be nil (no-op). Returns the drain error, if any.
+//
+// Drain runs BEFORE deregister so in-flight writes always finish; the tradeoff
+// is that on a clean (non-keep) shutdown trip2g may see connection-refused for
+// up to grace until deregister runs — those deliveries are retried, and not
+// losing in-flight writes is the priority.
+func gracefulShutdown(srv *http.Server, deregister func(context.Context) error, keepWebhooks bool, grace time.Duration) error {
+	log.Printf("shutdown: draining in-flight runs (grace %s)", grace)
+	drainCtx, cancel := context.WithTimeout(context.Background(), grace)
+	defer cancel()
+	shutdownErr := srv.Shutdown(drainCtx)
+	if shutdownErr != nil {
+		log.Printf("shutdown: drain incomplete: %v", shutdownErr)
+	}
+
+	if keepWebhooks {
+		log.Print("shutdown: keeping webhooks (--keep-webhooks-on-shutdown)")
+		return shutdownErr
+	}
+	if deregister != nil {
+		log.Print("shutdown: deregistering webhooks")
+		deregCtx, cancel2 := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel2()
+		if deregErr := deregister(deregCtx); deregErr != nil {
+			log.Printf("shutdown: deregister: %v", deregErr)
+		}
+	}
+	return shutdownErr
+}
+
+// effectiveGrace converts the --shutdown-grace-seconds flag to a duration,
+// flooring non-positive values to 30s so the drain path is never skipped (a
+// zero/expired grace would make srv.Shutdown force-close in-flight runs).
+func effectiveGrace(seconds int) time.Duration {
+	d := time.Duration(seconds) * time.Second
+	if d <= 0 {
+		return 30 * time.Second
+	}
+	return d
+}
+
 // parseFlags registers all fleet flags on a dedicated FlagSet wired to
 // appconfig.EnvFlag so every flag gets a TRIP2G_FLEET_<FLAG_NAME> environment
 // variable fallback (standard kebab-to-SCREAMING_SNAKE mapping). The
@@ -313,6 +350,7 @@ func parseFlags(ctx context.Context) (cliFlags, error) {
 	var offered string
 	var allowedPrograms string
 	var poll int
+	var graceSeconds int
 
 	fs := flag.NewFlagSet("fleet", flag.ContinueOnError)
 
@@ -355,6 +393,10 @@ func parseFlags(ctx context.Context) (cliFlags, error) {
 		"stdout cap per code child (bytes)")
 	fs.IntVar(&poll, "poll-seconds", 30,
 		"discovery/reconcile poll interval seconds")
+	fs.IntVar(&graceSeconds, "shutdown-grace-seconds", 30,
+		"max seconds to drain in-flight runs on shutdown before forcing close")
+	fs.BoolVar(&cli.cfg.KeepWebhooksOnShutdown, "keep-webhooks-on-shutdown", false,
+		"do not deregister webhooks on shutdown (rolling deploys: trip2g keeps them and retries)")
 
 	// One-shot offline harness flags.
 	fs.StringVar(&cli.oncePath, "once", "",
@@ -391,6 +433,7 @@ func parseFlags(ctx context.Context) (cliFlags, error) {
 	cli.cfg.OfferedTools = splitCSV(offered)
 	cli.cfg.AllowedPrograms = splitCSV(allowedPrograms)
 	cli.cfg.PollInterval = time.Duration(poll) * time.Second
+	cli.cfg.ShutdownGrace = effectiveGrace(graceSeconds)
 	return cli, nil
 }
 

--- a/cmd/fleet/main_test.go
+++ b/cmd/fleet/main_test.go
@@ -1,7 +1,13 @@
 package main
 
 import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"trip2g/internal/fleet"
 
@@ -200,4 +206,161 @@ func TestTrailingSlashNormalization(t *testing.T) {
 		got := normalizeCallbackURL(tc.input)
 		require.Equal(t, tc.want, got, "input: %s", tc.input)
 	}
+}
+
+// newIdleTestServer starts a real HTTP server on a random loopback port using
+// the provided handler. The caller must call srv.Shutdown or srv.Close when done.
+func newIdleTestServer(t *testing.T, handler http.Handler) (*http.Server, string) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv := &http.Server{Handler: handler}
+	go func() { _ = srv.Serve(ln) }()
+	return srv, ln.Addr().String()
+}
+
+// waitShutdownDraining blocks until srv.Shutdown has closed the listener (a new
+// dial is refused), proving Shutdown has been entered and is in its drain loop
+// waiting for the in-flight handler. Releasing the handler only after this makes
+// the subsequent 200 a genuine drain guarantee: a force-close (srv.Close) would
+// instead drop the in-flight connection and the request would not get 200.
+func waitShutdownDraining(t *testing.T, addr string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		c, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err != nil {
+			return true // refused → listener closed → Shutdown is draining
+		}
+		_ = c.Close()
+		return false
+	}, 3*time.Second, 5*time.Millisecond)
+}
+
+// TestGracefulShutdown_DrainsInFlightAndDeregisters asserts that gracefulShutdown
+// waits for an active in-flight request to complete (drain) before returning, and
+// then calls the deregister function exactly once when keepWebhooks is false.
+func TestGracefulShutdown_DrainsInFlightAndDeregisters(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		close(entered)
+		<-release
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv, addr := newIdleTestServer(t, mux)
+
+	// Fire a request in a background goroutine; capture the status code.
+	var respCode int
+	reqDone := make(chan struct{})
+	go func() {
+		defer close(reqDone)
+		resp, httpErr := http.Get("http://" + addr + "/")
+		if httpErr == nil {
+			respCode = resp.StatusCode
+			resp.Body.Close()
+		}
+	}()
+
+	<-entered // handler is now blocking inside the server
+
+	var deregCount atomic.Int32
+	stubDereg := func(_ context.Context) error {
+		if n := deregCount.Add(1); n < 0 {
+			return fmt.Errorf("unexpected: deregCount overflowed to %d", n)
+		}
+		return nil
+	}
+
+	shutdownErr := make(chan error, 1)
+	go func() {
+		shutdownErr <- gracefulShutdown(srv, stubDereg, false, 5*time.Second)
+	}()
+
+	// Block until Shutdown has closed the listener and is draining the active
+	// request, so releasing the handler now proves Shutdown WAITED for it.
+	waitShutdownDraining(t, addr)
+	close(release) // unblock the handler → it writes 200
+
+	<-reqDone
+	err := <-shutdownErr
+
+	require.NoError(t, err, "gracefulShutdown must return nil when drain succeeds")
+	require.Equal(t, http.StatusOK, respCode, "in-flight request must drain and complete with 200")
+	require.Equal(t, int32(1), deregCount.Load(), "deregister must be called exactly once")
+}
+
+// TestGracefulShutdown_KeepWebhooksSkipsDeregister asserts that when
+// keepWebhooks is true the deregister function is never called, but the
+// in-flight request is still drained normally (200 response).
+func TestGracefulShutdown_KeepWebhooksSkipsDeregister(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		close(entered)
+		<-release
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv, addr := newIdleTestServer(t, mux)
+
+	var respCode int
+	reqDone := make(chan struct{})
+	go func() {
+		defer close(reqDone)
+		resp, httpErr := http.Get("http://" + addr + "/")
+		if httpErr == nil {
+			respCode = resp.StatusCode
+			resp.Body.Close()
+		}
+	}()
+
+	<-entered
+
+	var deregCount atomic.Int32
+	stubDereg := func(_ context.Context) error {
+		if n := deregCount.Add(1); n < 0 {
+			return fmt.Errorf("unexpected: deregCount overflowed to %d", n)
+		}
+		return nil
+	}
+
+	shutdownErr := make(chan error, 1)
+	go func() {
+		shutdownErr <- gracefulShutdown(srv, stubDereg, true, 5*time.Second)
+	}()
+
+	// Same drain-ordering guarantee as the deregister test (see waitShutdownDraining).
+	waitShutdownDraining(t, addr)
+	close(release)
+
+	<-reqDone
+	err := <-shutdownErr
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, respCode, "in-flight request must still drain with keepWebhooks=true")
+	require.Equal(t, int32(0), deregCount.Load(), "deregister must NOT be called when keepWebhooks=true")
+}
+
+// TestGracefulShutdown_DeregisterNilSafe asserts that passing a nil deregister
+// function does not panic and returns without error on an idle server.
+func TestGracefulShutdown_DeregisterNilSafe(t *testing.T) {
+	srv, _ := newIdleTestServer(t, http.NewServeMux())
+	err := gracefulShutdown(srv, nil, false, time.Second)
+	require.NoError(t, err)
+}
+
+// TestEffectiveGrace_FloorsNonPositive guards the floor that protects the drain
+// path: a zero/negative grace must become 30s, never an already-expired context
+// (which would make srv.Shutdown force-close in-flight runs). This floor is the
+// only thing keeping --shutdown-grace-seconds=0 (incl. via env) from skipping
+// the drain entirely, so it is tested directly.
+func TestEffectiveGrace_FloorsNonPositive(t *testing.T) {
+	require.Equal(t, 30*time.Second, effectiveGrace(0), "0 must floor to 30s")
+	require.Equal(t, 30*time.Second, effectiveGrace(-5), "negative must floor to 30s")
+	require.Equal(t, 45*time.Second, effectiveGrace(45), "positive must pass through")
 }

--- a/internal/fleet/config.go
+++ b/internal/fleet/config.go
@@ -11,22 +11,24 @@ import "time"
 // ceiling (TokenCeiling/StepCeiling) is the non-overridable floor: the
 // effective budget is min(frontmatter, ceiling).
 type Config struct {
-	FleetID         string        // reconcile marker prefix "fleet:<FleetID>:"
-	ListenAddr      string        // ":9090"
-	CallbackURL     string        // trip2g-reachable base; webhook url = CallbackURL + "/deliver/" + urlKey(path)
-	Trip2gBaseURL   string        // e.g. "http://localhost:20081"
-	AdminAPIKey     string        // DEPRECATED/unused: legacy full-admin X-Api-Key (admin lane now authenticates via HAT)
-	JWTSecret       string        // shared user-token/JWT secret used to mint admin HATs (= trip2g UserToken.Secret)
-	AdminEmail      string        // admin identity the fleet self-provisions via HAT (default "fleet@local")
-	FleetSecret     string        // per-role HMAC secret seed
-	LLMBaseURL      string        // OpenAI-compatible base URL (fleet-local, NOT a trip2g secret)
-	LLMAPIKey       string        // fleet-local LLM credential
-	DefaultModel    string        // fallback when a role omits model
-	TokenCeiling    int           // non-overridable per-run token cap
-	StepCeiling     int           // non-overridable per-run step cap
-	AgentsFolder    string        // e.g. "roles/" -> notePaths like "roles/%"
-	OfferedTools    []string      // a role's tools must be a subset of these
-	AllowedPrograms []string      // programs allowed for code execution (empty = disabled)
-	MaxStdoutBytes  int           // stdout cap per code child (bytes); 0 → 1 MiB default
-	PollInterval    time.Duration // discovery/reconcile poll cadence
+	FleetID                string        // reconcile marker prefix "fleet:<FleetID>:"
+	ListenAddr             string        // ":9090"
+	CallbackURL            string        // trip2g-reachable base; webhook url = CallbackURL + "/deliver/" + urlKey(path)
+	Trip2gBaseURL          string        // e.g. "http://localhost:20081"
+	AdminAPIKey            string        // DEPRECATED/unused: legacy full-admin X-Api-Key (admin lane now authenticates via HAT)
+	JWTSecret              string        // shared user-token/JWT secret used to mint admin HATs (= trip2g UserToken.Secret)
+	AdminEmail             string        // admin identity the fleet self-provisions via HAT (default "fleet@local")
+	FleetSecret            string        // per-role HMAC secret seed
+	LLMBaseURL             string        // OpenAI-compatible base URL (fleet-local, NOT a trip2g secret)
+	LLMAPIKey              string        // fleet-local LLM credential
+	DefaultModel           string        // fallback when a role omits model
+	TokenCeiling           int           // non-overridable per-run token cap
+	StepCeiling            int           // non-overridable per-run step cap
+	AgentsFolder           string        // e.g. "roles/" -> notePaths like "roles/%"
+	OfferedTools           []string      // a role's tools must be a subset of these
+	AllowedPrograms        []string      // programs allowed for code execution (empty = disabled)
+	MaxStdoutBytes         int           // stdout cap per code child (bytes); 0 → 1 MiB default
+	PollInterval           time.Duration // discovery/reconcile poll cadence
+	ShutdownGrace          time.Duration // max time to drain in-flight runs on shutdown
+	KeepWebhooksOnShutdown bool          // skip webhook deregister on shutdown (rolling deploys; trip2g retains + retries)
 }


### PR DESCRIPTION
## What

Completes the fleet's **graceful shutdown** so a clean stop drains in-flight runs and leaves nothing behind — and adds a rolling-deploy escape hatch.

## Context

The daemon already had `signal.NotifyContext(SIGTERM)` + `reconciler.Deregister` + `srv.Shutdown`. And because **delivery runs are synchronous inside the HTTP handler** (`ServeDelivery`/`serveCronDelivery` run `execRole` then `writeJSON` — no fire-and-forget goroutine), `srv.Shutdown` already waits for in-flight runs to finish. This PR closes the remaining gaps and proves the lifecycle with tests.

## Changes

- **`internal/fleet/config.go`** — `Config.ShutdownGrace time.Duration` + `Config.KeepWebhooksOnShutdown bool`.
- **`cmd/fleet/main.go`**
  - `--shutdown-grace-seconds` (default **30**) — replaces the hardcoded **15s** that was *shared* between drain and deregister and too short for a long agent run; drain now gets the full window.
  - `--keep-webhooks-on-shutdown` (default false) — **rolling-deploy escape hatch**: skip deregister so trip2g keeps the webhooks and retries against the next instance. (Both auto-exposed as `TRIP2G_FLEET_SHUTDOWN_GRACE_SECONDS` / `TRIP2G_FLEET_KEEP_WEBHOOKS_ON_SHUTDOWN` via appconfig.)
  - Extracted a testable `gracefulShutdown(srv, deregister, keepWebhooks, grace)`: **drain in-flight first** (`srv.Shutdown` within the grace window) **then deregister** owned webhooks unless kept. `run()`'s `ctx.Done()` branch now calls it.

## Lifecycle (the design you confirmed)

- **SIGKILL** → webhooks persist (trip2g owns them) → restart → reconcile re-adopts by `fleet:`/`fleetcron:` markers (idempotent) → **SIGTERM** → drain + deregister → nothing remains.
- **Rolling deploy** → `--keep-webhooks-on-shutdown` → drain, but keep webhooks; trip2g retries against the replacement.

## Tests (TDD)

`cmd/fleet/main_test.go`, deterministic (channels, no sleeps), real `*http.Server` on `127.0.0.1:0`:
- **DrainsInFlightAndDeregisters** — a blocked in-flight request completes (200) when `gracefulShutdown` runs, and deregister is called exactly once.
- **KeepWebhooksSkipsDeregister** — `keepWebhooks=true` drains the request but never calls deregister.
- **DeregisterNilSafe** — nil deregister doesn't panic.
- **EffectiveGrace_FloorsNonPositive** — guards the floor that keeps `--shutdown-grace-seconds=0` from skipping the drain.

The drain tests use `waitShutdownDraining` to block until `srv.Shutdown` has **entered its drain loop** (new connections refused) *before* releasing the handler — so the 200 genuinely proves Shutdown *waited*. Verified adversarially: a throwaway swap of `srv.Shutdown`→`srv.Close()` (force-close) makes the in-flight request drop (non-200), i.e. the test fails against a non-draining implementation — it is not vacuous.

(The pre-existing `TestServeDelivery_RunDetachedFromRequestContext` already guards that ServeDelivery runs synchronously — so `srv.Shutdown` genuinely drains real deliveries.)

## Review

Independently reviewed against the CI toolchain + an adversarial code-review pass. The review caught that the original drain test was **racy/vacuous** (passed ~99.9% even against a force-close); fixed with the deterministic `waitShutdownDraining` ordering above. The drain-before-deregister tradeoff (LOW) is now documented in code; the grace floor (LOW) is extracted to a unit-tested `effectiveGrace`.

## Verify (CI toolchain)

- `go build -tags dev ./internal/fleet/... ./cmd/fleet/...` → OK
- `go vet` → OK
- `go test -tags dev -count=1 -race ./cmd/fleet/... ./internal/fleet/...` → **PASS** (race-clean)
- `go tool …/golangci-lint run --build-tags dev ./cmd/fleet/... ./internal/fleet/...` (CI-pinned **v2.1.6**) → **0 issues**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
