### PR TITLE
fix(metrics): range-over-int loop to satisfy intrange lint

### DIFF
--- a/internal/metrics/db_test.go
+++ b/internal/metrics/db_test.go
@@ -23,7 +23,7 @@ func openTestDB(t *testing.T) (*sql.DB, string) {
 	// Seed a table so page_count > 0 and WAL has data.
 	_, err = db.Exec("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
 	require.NoError(t, err)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		_, err = db.Exec("INSERT INTO t (v) VALUES (?)", "hello")
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
## What

Main's CI is **red on lint** — `internal/metrics/db_test.go:26` uses `for i := 0; i < 10; i++` (with `i` unused), which the **intrange** linter rejects (Go 1.22+). The line came in with PR #69 (modernc-sqlite-observability) and CI went red after it landed (build + test are green; only lint fails).

## Fix

One line: `for i := 0; i < 10; i++` → `for range 10` (the index was unused). Greens main's lint, unblocking all open PRs (incl. #70).

## Verify

- `go build -tags dev ./internal/metrics/...` → OK
- `go test -tags dev -count=1 ./internal/metrics/...` → ok
- `go tool …/golangci-lint run --build-tags dev ./internal/metrics/...` (CI-pinned v2.1.6) → **0 issues**

🤖 Generated with [Claude Code](https://claude.com/claude-code)