### PR TITLE
feat(mockserver): jsonnet-driven mock server + krisp/llm configs

### DIFF
--- a/cmd/mockserver/configs/krisp.jsonnet
+++ b/cmd/mockserver/configs/krisp.jsonnet
@@ -1,0 +1,201 @@
+// krisp.jsonnet — deterministic Krisp API stub for fleet e2e tests.
+// Replicates cmd/krispmock/main.go field-for-field.
+//
+// Routes:
+//   GET  /health              → 200 "ok"
+//   POST /v2/meetings/list   → paginated synthetic meetings
+//   GET  /v2/block/<id>/tree → block tree with utterances
+
+local req = std.parseJson(std.extVar("request"));
+
+local mockReqID = "00000000-0000-0000-0000-000000000001";
+local meetingID1 = "aabbccddeeff00112233445566778800";
+local meetingID2 = "1122334455667788aabbccddeeff0011";
+local meetingID3 = "99aabbccddeeff001122334455667788";
+
+local permEdit = "edit";
+local blockTypeMeeting = "meeting";
+local blockTypeUtt = "utterance";
+local statusDone = "done";
+
+local speakerID(n) = std.format("%032x", n);
+
+// blockChildID replicates Go's blockChildID: meetingID[:24] + %08x(pos) when
+// len(meetingID) >= 24, else %032x(pos).
+local blockChildID(meetingID, pos) =
+  if std.length(meetingID) < 24 then
+    std.format("%032x", pos)
+  else
+    meetingID[:24] + std.format("%08x", pos);
+
+// makeSpeakers replicates Go's makeSpeakers(names).
+local makeSpeakers(names) = [
+  {
+    id: speakerID(i + 1),
+    first_name: names[i],
+    last_name: "Mock",
+    email: names[i] + "@mock.example",
+    photo: "",
+  }
+  for i in std.range(0, std.length(names) - 1)
+];
+
+// selfAccess is the shared self_access block used in meetings and trees.
+local selfAccess = {
+  is_owner: true,
+  type: "personal",
+  resources: {
+    transcript: permEdit,
+    meeting_note: permEdit,
+    recording: permEdit,
+    agenda: permEdit,
+  },
+};
+
+// makeMeeting replicates Go's makeMeeting.
+local makeMeeting(id, name, startedAt, duration, names) = {
+  id: id,
+  name: name,
+  started_at: startedAt,
+  duration: duration,
+  speakers: makeSpeakers(names),
+  is_demo: false,
+  created_at: startedAt,
+  includes_external_attendees: false,
+  resources: {
+    transcript: {
+      status: "complete",
+      processor: "krisp",
+    },
+    recording: false,
+    recordings: [],
+    meeting_notes: {},
+  },
+  thumbnails: [],
+  user_interactions: {
+    read: false,
+    starred: false,
+    hidden: false,
+    listen_later: false,
+    progress: null,
+    is_new: true,
+  },
+  app_name: "Meet",
+  parent_id: null,
+  accesses: [],
+  status: statusDone,
+  self_access: selfAccess,
+  is_private: false,
+  highlight: null,
+  tags: [],
+  folders: [],
+  storage_size: 0,
+};
+
+// syntheticMeetings replicates Go's syntheticMeetings().
+local syntheticMeetings = [
+  makeMeeting(meetingID1, "Team Sync Q1 Planning", "2026-01-15T10:00:00Z", 3600, ["Alice", "Bob"]),
+  makeMeeting(meetingID2, "Product Demo and Feedback Session", "2026-02-20T14:30:00Z", 2700, ["Carol", "Dave"]),
+  makeMeeting(meetingID3, "Engineering Architecture Review", "2026-03-10T09:00:00Z", 5400, ["Eve", "Frank", "Grace"]),
+];
+
+// treeUtterances replicates Go's treeUtterances(id).
+local treeUtterances(id) =
+  if id == meetingID1 then [
+    { speakerIdx: 1, start: 0.0,  text: "Good morning, let us get started with the Q1 planning." },
+    { speakerIdx: 2, start: 15.5, text: "I have prepared the roadmap items for this quarter." },
+    { speakerIdx: 1, start: 40.0, text: "Great, let us go through each milestone in order." },
+    { speakerIdx: 2, start: 65.0, text: "The first milestone is the launch of the new dashboard." },
+  ]
+  else if id == meetingID2 then [
+    { speakerIdx: 1, start: 0.0,  text: "Welcome everyone to the product demo session." },
+    { speakerIdx: 2, start: 12.0, text: "Thank you. Let me walk you through the new features." },
+    { speakerIdx: 1, start: 35.0, text: "The search functionality looks very intuitive." },
+    { speakerIdx: 2, start: 52.0, text: "We redesigned the search to reduce the number of clicks." },
+  ]
+  else if id == meetingID3 then [
+    { speakerIdx: 1, start: 0.0,  text: "Today we are reviewing the architecture proposal." },
+    { speakerIdx: 2, start: 18.0, text: "I will cover the data layer decisions first." },
+    { speakerIdx: 3, start: 42.0, text: "The caching strategy needs to address cache invalidation." },
+    { speakerIdx: 1, start: 68.0, text: "Agreed. Let us document the eviction policy." },
+    { speakerIdx: 2, start: 90.0, text: "I will write up the ADR after this call." },
+  ]
+  else [
+    { speakerIdx: 1, start: 0.0,  text: "Synthetic transcript for meeting " + id + "." },
+    { speakerIdx: 2, start: 20.0, text: "Content is generated deterministically for testing." },
+  ];
+
+// buildBlockChildren replicates Go's buildBlockChildren.
+local buildBlockChildren(meetingID, utterances) = [
+  {
+    id: blockChildID(meetingID, i),
+    permission: permEdit,
+    label: "label",
+    block_type: blockTypeUtt,
+    speakerIndex: utterances[i].speakerIdx,
+    speech: {
+      text: utterances[i].text,
+      start: utterances[i].start,
+    },
+    resources: [],
+    children: [],
+    associated_to: [],
+    "$version": 1,
+    content: {
+      is_edited: false,
+      status: "ready",
+      language: "en-US",
+    },
+  }
+  for i in std.range(0, std.length(utterances) - 1)
+];
+
+// syntheticTree replicates Go's syntheticTree(id).
+local syntheticTree(id) =
+  local utterances = treeUtterances(id);
+  {
+    id: id,
+    permission: permEdit,
+    label: "label",
+    block_type: blockTypeMeeting,
+    resources: [],
+    children: buildBlockChildren(id, utterances),
+    associated_to: [],
+    "$version": 1,
+    content: {
+      is_demo: false,
+      status: statusDone,
+    },
+    self_access: selfAccess,
+    accesses: {},
+    access_requests: {},
+    folders: [],
+  };
+
+if req.method == "GET" && req.path == "/health" then
+  { bodyText: "ok", headers: { "Content-Type": "text/plain; charset=utf-8" } }
+
+else if req.method == "POST" && req.path == "/v2/meetings/list" then
+  local body = if req.body != "" then std.parseJson(req.body) else {};
+  local page = if std.objectHas(body, "page") then body.page else 0;
+  local rows = if page > 1 then [] else syntheticMeetings;
+  {
+    body: {
+      code: 0,
+      message: "success",
+      data: {
+        rows: rows,
+        count: std.length(syntheticMeetings),
+      },
+      req_id: mockReqID,
+    },
+  }
+
+else if req.method == "GET" && std.startsWith(req.path, "/v2/block/") && std.endsWith(req.path, "/tree") then
+  // Extract <id> from /v2/block/<id>/tree by splitting on "/" and taking index 3.
+  local parts = std.split(req.path, "/");
+  local id = parts[3];
+  { body: syntheticTree(id) }
+
+else
+  { status: 404, bodyText: "not found\n", headers: { "Content-Type": "text/plain; charset=utf-8" } }

--- a/cmd/mockserver/configs/llm.jsonnet
+++ b/cmd/mockserver/configs/llm.jsonnet
@@ -1,0 +1,112 @@
+// llm.jsonnet — deterministic OpenAI-compatible chat completions stub for fleet e2e tests.
+// Replicates cmd/llmmock/main.go field-for-field.
+//
+// Routes:
+//   GET  /health                  → 200 "ok"
+//   POST /v1/chat/completions     → mock tool-call response
+
+local req = std.parseJson(std.extVar("request"));
+
+// Replicates Go's extractInstruction(systemContent):
+//   find "\nInstruction:\n" in systemContent;
+//   clip at "\n\nAccess scope" if present;
+//   strip leading YAML frontmatter (---\n…\n---\n);
+//   TrimSpace the result.
+//   Falls back to the whole systemContent when the prefix is absent.
+
+local prefix = "\nInstruction:\n";
+local suffix = "\n\nAccess scope";
+
+local extractInstruction(sc) =
+  local starts = std.findSubstr(prefix, sc);
+  if std.length(starts) == 0 then
+    sc
+  else
+    local afterPrefix = sc[starts[0] + std.length(prefix):];
+    local ends = std.findSubstr(suffix, afterPrefix);
+    local clipped = if std.length(ends) > 0 then afterPrefix[:ends[0]] else afterPrefix;
+    local stripped =
+      if std.startsWith(clipped, "---\n") then
+        local inner = clipped[4:];
+        local innerEnds = std.findSubstr("\n---\n", inner);
+        if std.length(innerEnds) > 0 then
+          inner[innerEnds[0] + 5:]
+        else
+          clipped
+      else
+        clipped;
+    std.stripChars(stripped, " \t\n\r");
+
+// truncate replicates Go's truncate(s, n):
+//   TrimSpace, then clip to n Unicode code points.
+local truncate(s, n) =
+  local trimmed = std.stripChars(s, " \t\n\r");
+  if std.length(trimmed) <= n then trimmed else trimmed[:n];
+
+if req.method == "GET" && req.path == "/health" then
+  { bodyText: "ok", headers: { "Content-Type": "text/plain; charset=utf-8" } }
+
+else if req.method == "POST" && req.path == "/v1/chat/completions" then
+  local body = std.parseJson(req.body);
+  local model = if std.objectHas(body, "model") && body.model != "" then body.model else "mock";
+  local messages = if std.objectHas(body, "messages") then body.messages else [];
+
+  // Scan messages for tool role and system content.
+  local hasToolResult = std.length(std.filter(function(m) m.role == "tool", messages)) > 0;
+  local sysMsgs = std.filter(function(m) m.role == "system", messages);
+  local instructionContent =
+    if std.length(sysMsgs) > 0 then
+      extractInstruction(sysMsgs[0].content)
+    else
+      "Begin.";
+
+  local bodyLen = std.length(req.body);
+
+  local toolCall =
+    if hasToolResult then
+      {
+        id: "t2",
+        type: "function",
+        "function": {
+          name: "finish",
+          arguments: '{"answer":"done"}',
+        },
+      }
+    else
+      local content = "processed: " + truncate(instructionContent, 200);
+      // arguments must be a JSON string (not an object) — matches json.Marshal output.
+      // Go marshals map keys alphabetically: "content" < "path".
+      local argsObj = { content: content, path: "segments/sample.md" };
+      {
+        id: "t1",
+        type: "function",
+        "function": {
+          name: "write_note",
+          arguments: std.manifestJsonEx(argsObj, ""),
+        },
+      };
+
+  {
+    body: {
+      id: "cmpl-mock",
+      object: "chat.completion",
+      model: model,
+      choices: [{
+        index: 0,
+        message: {
+          role: "assistant",
+          content: null,
+          tool_calls: [toolCall],
+        },
+        finish_reason: "tool_calls",
+      }],
+      usage: {
+        prompt_tokens: std.floor(bodyLen / 4),
+        completion_tokens: 5,
+        total_tokens: std.floor(bodyLen / 4) + 5,
+      },
+    },
+  }
+
+else
+  { status: 404, bodyText: "not found\n", headers: { "Content-Type": "text/plain; charset=utf-8" } }

--- a/cmd/mockserver/main.go
+++ b/cmd/mockserver/main.go
@@ -1,0 +1,190 @@
+// Command mockserver is a generic jsonnet-driven HTTP mock server.
+// It evaluates a jsonnet config file per request, passing the request as an
+// ext-var and using the returned object to write the HTTP response.
+//
+// Flags / env:
+//
+//	--config <path>           : jsonnet config file (required)
+//	--listen / MOCKSERVER_LISTEN : listen address (default ":9090")
+//	--log-level               : log verbosity debug|info|warn|error (default "info")
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"trip2g/internal/jsonneteval"
+	"trip2g/internal/logger"
+	"trip2g/internal/zerologger"
+)
+
+const (
+	defaultListen     = ":9090"
+	defaultLogLevel   = "info"
+	defaultCT         = "application/json"
+	defaultStatus     = 200
+	bodyLimit         = 2 * 1024 * 1024 // 2 MiB
+	readHeaderTimeout = 10 * time.Second
+)
+
+// responseShape is the object the jsonnet config must return.
+type responseShape struct {
+	// Status is the HTTP status code; defaults to 200 when zero.
+	Status int `json:"status"`
+	// Headers are written verbatim; defaults to {"Content-Type":"application/json"} when nil.
+	Headers map[string]string `json:"headers"`
+	// Body is any JSON value serialised and written as the response body.
+	Body json.RawMessage `json:"body"`
+	// BodyText, when non-nil, is written verbatim and takes precedence over Body.
+	BodyText *string `json:"bodyText"`
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "mockserver:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	var (
+		configPath string
+		listenAddr string
+		logLevel   string
+	)
+	flag.StringVar(&configPath, "config", "", "path to jsonnet config file (required)")
+	flag.StringVar(&listenAddr, "listen", envOr("MOCKSERVER_LISTEN", defaultListen), "listen address")
+	flag.StringVar(&logLevel, "log-level", defaultLogLevel, "log level (debug|info|warn|error)")
+	flag.Parse()
+
+	if configPath == "" {
+		return errors.New("--config is required")
+	}
+
+	configBytes, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("read config: %w", err)
+	}
+
+	lg := zerologger.New(logLevel, false)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", newHandler(string(configBytes), lg))
+
+	srv := &http.Server{
+		Addr:              listenAddr,
+		Handler:           mux,
+		ReadHeaderTimeout: readHeaderTimeout,
+	}
+	lg.Info("mockserver: listening", "addr", listenAddr, "config", configPath)
+
+	if err = srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return fmt.Errorf("serve: %w", err)
+	}
+	return nil
+}
+
+// newHandler returns an http.HandlerFunc that evaluates configSrc per request.
+// It is factored out of run so tests can drive it via httptest without a listener.
+func newHandler(configSrc string, lg logger.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(io.LimitReader(r.Body, bodyLimit))
+		if err != nil {
+			lg.Error("mockserver: read body", "error", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+
+		reqJSON, err := json.Marshal(buildReqObj(r, body))
+		if err != nil {
+			lg.Error("mockserver: marshal request", "error", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+
+		out, err := jsonneteval.EvalJSON(configSrc, map[string]string{"request": string(reqJSON)})
+		if err != nil {
+			lg.Error("mockserver: eval jsonnet", "error", err, "path", r.URL.Path)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+
+		var resp responseShape
+		if err = json.Unmarshal(out, &resp); err != nil {
+			lg.Error("mockserver: decode response shape", "error", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+
+		writeResp(w, lg, resp)
+	}
+}
+
+// buildReqObj constructs the request object passed to the jsonnet config as the
+// "request" ext-var. Headers and query params are flattened to the first value.
+func buildReqObj(r *http.Request, body []byte) map[string]any {
+	headers := make(map[string]string, len(r.Header))
+	for k, vals := range r.Header {
+		if len(vals) > 0 {
+			headers[k] = vals[0]
+		}
+	}
+
+	query := make(map[string]string)
+	for k, vals := range r.URL.Query() {
+		if len(vals) > 0 {
+			query[k] = vals[0]
+		}
+	}
+
+	return map[string]any{
+		"method":  r.Method,
+		"path":    r.URL.Path,
+		"query":   query,
+		"headers": headers,
+		"body":    string(body),
+	}
+}
+
+// writeResp applies defaults and writes status, headers, and body.
+func writeResp(w http.ResponseWriter, lg logger.Logger, resp responseShape) {
+	status := defaultStatus
+	if resp.Status != 0 {
+		status = resp.Status
+	}
+
+	if len(resp.Headers) > 0 {
+		for k, v := range resp.Headers {
+			w.Header().Set(k, v)
+		}
+	} else {
+		w.Header().Set("Content-Type", defaultCT)
+	}
+
+	w.WriteHeader(status)
+
+	if resp.BodyText != nil {
+		if _, err := io.WriteString(w, *resp.BodyText); err != nil {
+			lg.Error("mockserver: write body text", "error", err)
+		}
+		return
+	}
+	if len(resp.Body) > 0 {
+		if _, err := w.Write(resp.Body); err != nil {
+			lg.Error("mockserver: write body", "error", err)
+		}
+	}
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/cmd/mockserver/main_test.go
+++ b/cmd/mockserver/main_test.go
@@ -1,0 +1,492 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trip2g/internal/logger"
+)
+
+// TestHandlerStatus201 verifies that a config returning {status:201, headers:{"X-T":"v"}, body:{ok:true}}
+// produces the expected status, header, and JSON body.
+func TestHandlerStatus201(t *testing.T) {
+	const cfg = `{status: 201, headers: {"X-T": "v"}, body: {ok: true}}`
+	h := newHandler(cfg, &logger.DummyLogger{})
+
+	req := httptest.NewRequest(http.MethodGet, "/anything", nil)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	require.Equal(t, 201, w.Code)
+	require.Equal(t, "v", w.Header().Get("X-T"))
+
+	var body map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+	require.Equal(t, true, body["ok"])
+}
+
+// TestHandlerBodyText verifies that a config returning {bodyText:"hi"} writes raw text.
+func TestHandlerBodyText(t *testing.T) {
+	const cfg = `{bodyText: "hi"}`
+	h := newHandler(cfg, &logger.DummyLogger{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "hi", w.Body.String())
+}
+
+// TestHandlerDefaultContentType verifies that the default Content-Type is application/json
+// when the config does not specify headers.
+func TestHandlerDefaultContentType(t *testing.T) {
+	const cfg = `{body: {x: 1}}`
+	h := newHandler(cfg, &logger.DummyLogger{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
+}
+
+// TestHandlerEvalError verifies that a broken jsonnet config returns 500.
+func TestHandlerEvalError(t *testing.T) {
+	const cfg = `this is not valid jsonnet !!!`
+	h := newHandler(cfg, &logger.DummyLogger{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func loadKrispConfig(t *testing.T) string {
+	t.Helper()
+	src, err := os.ReadFile("configs/krisp.jsonnet")
+	require.NoError(t, err, "load krisp.jsonnet")
+	return string(src)
+}
+
+// TestKrispHealth verifies GET /health returns "ok".
+func TestKrispHealth(t *testing.T) {
+	h := newHandler(loadKrispConfig(t), &logger.DummyLogger{})
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "ok", w.Body.String())
+}
+
+// krisListResponse mirrors the top-level shape of POST /v2/meetings/list.
+type krisListResponse struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    struct {
+		Rows  []krisMeeting `json:"rows"`
+		Count int           `json:"count"`
+	} `json:"data"`
+	ReqID string `json:"req_id"`
+}
+
+type krisMeeting struct {
+	ID       string        `json:"id"`
+	Name     string        `json:"name"`
+	Speakers []krisSpeaker `json:"speakers"`
+}
+
+type krisSpeaker struct {
+	ID        string `json:"id"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+	Email     string `json:"email"`
+}
+
+// TestKrispMeetingsListPage1 verifies that page 1 returns 3 meetings with
+// the expected IDs, names, and speakers — the contract the e2e ingest depends on.
+func TestKrispMeetingsListPage1(t *testing.T) {
+	h := newHandler(loadKrispConfig(t), &logger.DummyLogger{})
+
+	body := strings.NewReader(`{"sort":"desc","sortKey":"created_at","page":1,"limit":200}`)
+	req := httptest.NewRequest(http.MethodPost, "/v2/meetings/list", body)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp krisListResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Equal(t, 0, resp.Code)
+	require.Equal(t, "success", resp.Message)
+	require.Equal(t, 3, resp.Data.Count)
+	require.Len(t, resp.Data.Rows, 3)
+
+	// Meeting 1.
+	require.Equal(t, "aabbccddeeff00112233445566778800", resp.Data.Rows[0].ID)
+	require.Equal(t, "Team Sync Q1 Planning", resp.Data.Rows[0].Name)
+	require.Len(t, resp.Data.Rows[0].Speakers, 2)
+	require.Equal(t, "Alice", resp.Data.Rows[0].Speakers[0].FirstName)
+	require.Equal(t, "Mock", resp.Data.Rows[0].Speakers[0].LastName)
+	require.Equal(t, "Alice@mock.example", resp.Data.Rows[0].Speakers[0].Email)
+	require.Equal(t, "Bob", resp.Data.Rows[0].Speakers[1].FirstName)
+
+	// Meeting 2.
+	require.Equal(t, "1122334455667788aabbccddeeff0011", resp.Data.Rows[1].ID)
+	require.Equal(t, "Product Demo and Feedback Session", resp.Data.Rows[1].Name)
+	require.Equal(t, "Carol", resp.Data.Rows[1].Speakers[0].FirstName)
+	require.Equal(t, "Dave", resp.Data.Rows[1].Speakers[1].FirstName)
+
+	// Meeting 3.
+	require.Equal(t, "99aabbccddeeff001122334455667788", resp.Data.Rows[2].ID)
+	require.Equal(t, "Engineering Architecture Review", resp.Data.Rows[2].Name)
+	require.Len(t, resp.Data.Rows[2].Speakers, 3)
+	require.Equal(t, "Eve", resp.Data.Rows[2].Speakers[0].FirstName)
+	require.Equal(t, "Frank", resp.Data.Rows[2].Speakers[1].FirstName)
+	require.Equal(t, "Grace", resp.Data.Rows[2].Speakers[2].FirstName)
+}
+
+// TestKrispMeetingsListPage2Empty verifies that page > 1 returns empty rows
+// while count still reflects the total.
+func TestKrispMeetingsListPage2Empty(t *testing.T) {
+	h := newHandler(loadKrispConfig(t), &logger.DummyLogger{})
+
+	body := strings.NewReader(`{"page":2,"limit":200}`)
+	req := httptest.NewRequest(http.MethodPost, "/v2/meetings/list", body)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp krisListResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Empty(t, resp.Data.Rows, "page 2 must return no rows")
+	require.Equal(t, 3, resp.Data.Count)
+}
+
+// krissTreeChild is a minimal view of a block-tree child node.
+type krissTreeChild struct {
+	BlockType    string `json:"block_type"`
+	SpeakerIndex int    `json:"speakerIndex"`
+	Speech       struct {
+		Text  string  `json:"text"`
+		Start float64 `json:"start"`
+	} `json:"speech"`
+}
+
+// krissTreeRoot is the top-level block tree response.
+type krissTreeRoot struct {
+	ID        string           `json:"id"`
+	BlockType string           `json:"block_type"`
+	Children  []krissTreeChild `json:"children"`
+}
+
+// TestKrispBlockTreeID1 verifies the block tree for meeting 1 has the expected
+// utterances — first text, speakerIndex ordering, and block_type hierarchy.
+func TestKrispBlockTreeID1(t *testing.T) {
+	const id1 = "aabbccddeeff00112233445566778800"
+	h := newHandler(loadKrispConfig(t), &logger.DummyLogger{})
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/block/"+id1+"/tree", nil)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var tree krissTreeRoot
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&tree))
+
+	require.Equal(t, id1, tree.ID)
+	require.Equal(t, "meeting", tree.BlockType)
+	require.Len(t, tree.Children, 4)
+
+	// First utterance: speakerIndex 1, exact text.
+	require.Equal(t, "utterance", tree.Children[0].BlockType)
+	require.Equal(t, 1, tree.Children[0].SpeakerIndex)
+	require.Equal(t, "Good morning, let us get started with the Q1 planning.", tree.Children[0].Speech.Text)
+	require.InDelta(t, 0.0, tree.Children[0].Speech.Start, 0.001)
+
+	// Second utterance: speakerIndex 2.
+	require.Equal(t, 2, tree.Children[1].SpeakerIndex)
+	require.Equal(t, "I have prepared the roadmap items for this quarter.", tree.Children[1].Speech.Text)
+	require.InDelta(t, 15.5, tree.Children[1].Speech.Start, 0.001)
+}
+
+// TestKrispBlockTreeID2 verifies the block tree for meeting 2.
+func TestKrispBlockTreeID2(t *testing.T) {
+	const id2 = "1122334455667788aabbccddeeff0011"
+	h := newHandler(loadKrispConfig(t), &logger.DummyLogger{})
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/block/"+id2+"/tree", nil)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var tree krissTreeRoot
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&tree))
+
+	require.Equal(t, id2, tree.ID)
+	require.Len(t, tree.Children, 4)
+	require.Equal(t, "Welcome everyone to the product demo session.", tree.Children[0].Speech.Text)
+}
+
+// TestKrispBlockTreeID3 verifies the block tree for meeting 3 has 5 utterances.
+func TestKrispBlockTreeID3(t *testing.T) {
+	const id3 = "99aabbccddeeff001122334455667788"
+	h := newHandler(loadKrispConfig(t), &logger.DummyLogger{})
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/block/"+id3+"/tree", nil)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var tree krissTreeRoot
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&tree))
+
+	require.Len(t, tree.Children, 5)
+	require.Equal(t, 3, tree.Children[2].SpeakerIndex)
+	require.Equal(t, "The caching strategy needs to address cache invalidation.", tree.Children[2].Speech.Text)
+}
+
+// TestKrispBlockTreeDefaultID verifies that an unknown id returns 2 generic utterances.
+func TestKrispBlockTreeDefaultID(t *testing.T) {
+	const unknownID = "000000000000000000000000ffffffff"
+	h := newHandler(loadKrispConfig(t), &logger.DummyLogger{})
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/block/"+unknownID+"/tree", nil)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var tree krissTreeRoot
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&tree))
+
+	require.Len(t, tree.Children, 2)
+	require.Contains(t, tree.Children[0].Speech.Text, unknownID)
+}
+
+func loadLLMConfig(t *testing.T) string {
+	t.Helper()
+	src, err := os.ReadFile("configs/llm.jsonnet")
+	require.NoError(t, err, "load llm.jsonnet")
+	return string(src)
+}
+
+// TestLLMHealth verifies GET /health returns "ok".
+func TestLLMHealth(t *testing.T) {
+	h := newHandler(loadLLMConfig(t), &logger.DummyLogger{})
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "ok", w.Body.String())
+}
+
+// llmResponse mirrors the top-level shape of POST /v1/chat/completions.
+type llmResponse struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Model   string `json:"model"`
+	Choices []struct {
+		Index   int `json:"index"`
+		Message struct {
+			Role      string `json:"role"`
+			ToolCalls []struct {
+				ID       string `json:"id"`
+				Type     string `json:"type"`
+				Function struct {
+					Name      string `json:"name"`
+					Arguments string `json:"arguments"`
+				} `json:"function"`
+			} `json:"tool_calls"`
+		} `json:"message"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+	Usage struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+		TotalTokens      int `json:"total_tokens"`
+	} `json:"usage"`
+}
+
+// chatMessage is a minimal OpenAI chat message for building test request bodies.
+type chatMessage struct {
+	Role    string  `json:"role"`
+	Content *string `json:"content"`
+}
+
+// chatRequest is a minimal OpenAI chat completions request for building test bodies.
+type chatRequest struct {
+	Model    string        `json:"model,omitempty"`
+	Messages []chatMessage `json:"messages"`
+}
+
+// strPtr is a test helper that returns a pointer to s.
+func strPtr(s string) *string { return &s }
+
+// systemPromptWith builds a system message that embeds an instruction via the
+// "\nInstruction:\n---\n<fm>\n---\n<body>\n\nAccess scope:" sentinel format.
+func systemPromptWith(instruction string) string {
+	return "System preamble.\nInstruction:\n---\nfm\n---\n" + instruction + "\n\nAccess scope: all"
+}
+
+// marshalBody marshals v to a JSON string for use as a request body.
+func marshalBody(t *testing.T, v any) *strings.Reader {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return strings.NewReader(string(b))
+}
+
+// TestLLMFirstCall verifies the first call (no tool result) returns write_note
+// with the extracted instruction as the content.
+func TestLLMFirstCall(t *testing.T) {
+	h := newHandler(loadLLMConfig(t), &logger.DummyLogger{})
+
+	sysContent := systemPromptWith("Do the thing")
+	body := marshalBody(t, chatRequest{
+		Model: "gpt-4o",
+		Messages: []chatMessage{
+			{Role: "system", Content: strPtr(sysContent)},
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", body)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp llmResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Equal(t, "cmpl-mock", resp.ID)
+	require.Equal(t, "chat.completion", resp.Object)
+	require.Equal(t, "gpt-4o", resp.Model)
+	require.Len(t, resp.Choices, 1)
+	require.Equal(t, "tool_calls", resp.Choices[0].FinishReason)
+	require.Equal(t, "assistant", resp.Choices[0].Message.Role)
+
+	calls := resp.Choices[0].Message.ToolCalls
+	require.Len(t, calls, 1)
+	require.Equal(t, "t1", calls[0].ID)
+	require.Equal(t, "write_note", calls[0].Function.Name)
+
+	// arguments must be a JSON string containing {path, content}.
+	var args map[string]string
+	require.NoError(t, json.Unmarshal([]byte(calls[0].Function.Arguments), &args))
+	require.Equal(t, "segments/sample.md", args["path"])
+	require.Equal(t, "processed: Do the thing", args["content"])
+}
+
+// TestLLMSubsequentCall verifies that a message list containing a tool-role
+// message triggers the finish tool call.
+func TestLLMSubsequentCall(t *testing.T) {
+	h := newHandler(loadLLMConfig(t), &logger.DummyLogger{})
+
+	sysContent := systemPromptWith("Do the thing")
+	toolContent := "ok"
+	body := marshalBody(t, chatRequest{
+		Model: "gpt-4o",
+		Messages: []chatMessage{
+			{Role: "system", Content: strPtr(sysContent)},
+			{Role: "assistant", Content: nil},
+			{Role: "tool", Content: strPtr(toolContent)},
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", body)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp llmResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Len(t, resp.Choices, 1)
+	require.Equal(t, "tool_calls", resp.Choices[0].FinishReason)
+
+	calls := resp.Choices[0].Message.ToolCalls
+	require.Len(t, calls, 1)
+	require.Equal(t, "t2", calls[0].ID)
+	require.Equal(t, "finish", calls[0].Function.Name)
+
+	var args map[string]string
+	require.NoError(t, json.Unmarshal([]byte(calls[0].Function.Arguments), &args))
+	require.Equal(t, "done", args["answer"])
+}
+
+// TestLLMModelEchoed verifies the model field is echoed from the request.
+func TestLLMModelEchoed(t *testing.T) {
+	h := newHandler(loadLLMConfig(t), &logger.DummyLogger{})
+
+	body := marshalBody(t, chatRequest{
+		Model:    "my-custom-model",
+		Messages: []chatMessage{{Role: "user", Content: strPtr("hello")}},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", body)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp llmResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Equal(t, "my-custom-model", resp.Model)
+}
+
+// TestLLMModelDefault verifies that an absent model field defaults to "mock".
+func TestLLMModelDefault(t *testing.T) {
+	h := newHandler(loadLLMConfig(t), &logger.DummyLogger{})
+
+	body := marshalBody(t, chatRequest{
+		Messages: []chatMessage{{Role: "user", Content: strPtr("hello")}},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", body)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp llmResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Equal(t, "mock", resp.Model)
+}
+
+// TestLLMInstructionNoPrefix verifies that when the system content has no
+// "\nInstruction:\n" prefix, the whole content is used as the instruction.
+func TestLLMInstructionNoPrefix(t *testing.T) {
+	h := newHandler(loadLLMConfig(t), &logger.DummyLogger{})
+
+	body := marshalBody(t, chatRequest{
+		Model:    "m",
+		Messages: []chatMessage{{Role: "system", Content: strPtr("Just do it")}},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", body)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp llmResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	calls := resp.Choices[0].Message.ToolCalls
+	var args map[string]string
+	require.NoError(t, json.Unmarshal([]byte(calls[0].Function.Arguments), &args))
+	require.Equal(t, "processed: Just do it", args["content"])
+}


### PR DESCRIPTION
## What (PR A of 2)

A **universal jsonnet-driven mock HTTP server** (`cmd/mockserver`) — one generic server whose behavior is a config file, replacing the bespoke Go mocks `cmd/krispmock` and `cmd/llmmock`. Future mocks become a single `.jsonnet`, no new Go.

This PR adds the server + the two configs + tests. **PR B** (follow-up) does the infra swap (docker-compose/Dockerfile/scripts) and removes the old Go mocks.

## How

- **`cmd/mockserver/main.go`** — per request, builds `{method, path, query, headers, body}` and passes it as the `request` ext-var (JSON string) to the existing `internal/jsonneteval.EvalJSON`; the config jsonnet returns `{status?, headers?, body?, bodyText?}`, which the server writes. So each config is a pure function of the request. Flags `--config`, `--listen` (env `MOCKSERVER_LISTEN`), `--log-level`; logs via `internal/logger`/`zerologger`. Handler factored as `newHandler(configSrc, lg)` for testing.
- **`cmd/mockserver/configs/krisp.jsonnet`** — faithful port of krispmock (3 synthetic meetings + full shape, per-id block-tree utterances, `/health`). Path id via `std.split`.
- **`cmd/mockserver/configs/llm.jsonnet`** — faithful port of llmmock (first-call `write_note "processed: <instruction>"` vs subsequent `finish`; `extractInstruction` ported with `std.findSubstr`/frontmatter-strip; `arguments` as a JSON string).
- **`cmd/mockserver/main_test.go`** — 17 tests: generic contract (status/headers/body/bodyText/eval-error→500) + behavior-equivalence for both configs (exactly what the e2e asserts).

## Verify

- build / `go test` / golangci v2.1.6 → **0 issues**, 17 tests pass.
- **Live equivalence diff** (the real proof): ran the old Go mocks and the new mockserver side-by-side and diffed responses (JSON-normalized) for all endpoints — **10/10 MATCH**: krisp health, meetings list (page 1 + page 2), block trees (id1/id2/id3/unknown); llm health, chat first-call, chat subsequent. Byte-equivalent, including the `usage` token math and the instruction extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
