### PR TITLE
build(docker): bundle static fleet binary into the trip2g image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,11 @@ RUN go generate ./onboarding-vault && \
     -ldflags="-s -w -X main.GitCommit=${GIT_COMMIT}" \
     ./cmd/server
 
+# Secondary binary: the fleet agent host (static, LLM-only — no interpreters here;
+# code-execution roles add their own runtime, see docs/dev/fleet_packaging.md).
+RUN GOOS=linux GOARCH=${TARGETARCH} CGO_ENABLED=0 \
+    go build -o /fleet -ldflags="-s -w" ./cmd/fleet
+
 # Build final image
 FROM alpine:latest
 
@@ -66,5 +71,7 @@ RUN apk add --no-cache git ca-certificates
 WORKDIR /app
 
 COPY --from=builder /trip2g /trip2g
+# Secondary: run as a sidecar/second container — `docker run <image> /fleet`.
+COPY --from=builder /fleet /fleet
 
 CMD ["/trip2g"]

--- a/docs/dev/fleet_packaging.md
+++ b/docs/dev/fleet_packaging.md
@@ -1,0 +1,62 @@
+# Fleet packaging
+
+**TL;DR:** the trip2g image ships two static binaries — `/trip2g` (the primary, `CMD`) and `/fleet` (the agent host, secondary). The base image is **LLM-only**: no language interpreters. If a role uses `executor: code`, you add the interpreter yourself — extend the image or copy the static `/fleet` binary into your own runtime. This keeps the default image small and the code-execution surface an explicit operator choice (it's off by default anyway — `--allowed-programs` is empty).
+
+## One image, two binaries
+
+The main `Dockerfile` builds both binaries (`CGO_ENABLED=0`, fully static) into one Alpine image:
+
+```
+/trip2g   # CMD — the server
+/fleet    # secondary — run as a sidecar / second container
+```
+
+Run trip2g normally; run the fleet from the same image by overriding the command:
+
+```yaml
+# docker-compose
+services:
+  trip2g:
+    image: ghcr.io/trip2g/trip2g:latest        # CMD ["/trip2g"]
+  fleet:
+    image: ghcr.io/trip2g/trip2g:latest
+    command: ["/fleet"]
+    environment:
+      - TRIP2G_FLEET_TRIP2G_URL=http://trip2g:20081
+      - TRIP2G_FLEET_CALLBACK_URL=http://fleet:9090
+      - TRIP2G_FLEET_JWT_SECRET=...            # = the app's JWT secret
+      - TRIP2G_FLEET_LLM_BASE_URL=...
+      - TRIP2G_FLEET_LLM_API_KEY=...
+      # ... see cmd/fleet flags; every flag has a TRIP2G_FLEET_<NAME> env
+```
+
+trip2g stays a dumb event source; the fleet reconciles its own webhooks against it. One image is the whole unit.
+
+## Enabling `executor: code`
+
+A role with `executor: code` runs code through an interpreter (python, node, bash…). The base image has none. Two ways to add them — both rely on the binary being static, so it drops into any runtime:
+
+**A. Extend the image** (simplest):
+
+```dockerfile
+FROM ghcr.io/trip2g/trip2g:latest
+RUN apk add --no-cache python3        # or nodejs, bash, ...
+# run with --allowed-programs python (or TRIP2G_FLEET_ALLOWED_PROGRAMS=python)
+CMD ["/fleet"]
+```
+
+**B. Copy the static binary into your own runtime** (when you want a different base):
+
+```dockerfile
+FROM python:3.12-alpine
+COPY --from=ghcr.io/trip2g/trip2g:latest /fleet /usr/local/bin/fleet
+ENTRYPOINT ["fleet"]
+```
+
+Then opt code execution in explicitly:
+
+```
+--allowed-programs python,node        # default empty = code execution disabled
+```
+
+Keep the interpreter set minimal, and isolate the fleet container (network policy, read-only FS, non-root) — see [[process_isolation]]. The base image carries no interpreters precisely so you make this choice deliberately, per deployment.


### PR DESCRIPTION
## What

Bundle the **static `fleet` binary into the main trip2g image** — one image, two binaries: `/trip2g` (primary, `CMD`) + `/fleet` (secondary, run as a sidecar/second container). trip2g + fleet ship as one deployable unit.

## Lean by design — LLM-only

The base image stays minimal: **no language interpreters** (no `python3`). The default fleet is LLM-only, and code execution is off by default anyway (`--allowed-programs` empty). Enabling `executor: code` is an explicit operator choice — extend the image (`FROM … + apk add python3`) or `COPY --from` the static `/fleet` binary into your own runtime. Documented in **`docs/dev/fleet_packaging.md`** (both patterns; the binary is `CGO_ENABLED=0` static, so copy-from is trivial).

## Changes

- `Dockerfile` — builder stage also builds `/fleet` (static); final stage `COPY --from=builder /fleet /fleet`; `CMD` stays `/trip2g`. No new runtime deps.
- `docs/dev/fleet_packaging.md` (new) — one-image/two-binaries usage + the extend / copy-from recipes for code execution.

Left untouched: the e2e's `Dockerfile.fleet` (keeps `python3` for the `executor: code` krisp-ingest test) and `docker-compose.test.yml`.

## Verify

- `docker build --check` → clean, no warnings.
- `CGO_ENABLED=0 go build ./cmd/fleet` → statically linked ELF.
- Note: the full image build runs in the **post-merge Docker workflow** (it triggers on push to main/tags, not PRs). The change is additive — the trip2g build is unchanged and the fleet build is proven standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
