### PR TITLE
fix(fleet): audit punch-list — shutdown error, LLM hardening, registry sync, agent-path tests

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/signal"
@@ -79,7 +80,7 @@ func run() error {
 	// --dry-run: connect, print + flag each role's resolved config, then exit
 	// WITHOUT registering/reconciling any webhooks (eyeball roles before go-live).
 	if cli.dryRun {
-		runDryRun(ctx, lg, discovery, cli.cfg)
+		runDryRun(ctx, lg, discovery, cli.cfg, os.Stdout)
 		return nil
 	}
 
@@ -113,11 +114,14 @@ func run() error {
 		case srvListenErr := <-srvErrCh:
 			return fmt.Errorf("http server: %w", srvListenErr)
 		case <-ctx.Done():
-			_ = gracefulShutdown(lg, srv, reconciler.Deregister, cli.cfg.KeepWebhooksOnShutdown, cli.cfg.ShutdownGrace)
+			shutdownErr := gracefulShutdown(lg, srv, reconciler.Deregister, cli.cfg.KeepWebhooksOnShutdown, cli.cfg.ShutdownGrace)
 			select {
 			case srvListenErr := <-srvErrCh:
 				return fmt.Errorf("http server: %w", srvListenErr)
 			default:
+				if shutdownErr != nil {
+					return fmt.Errorf("graceful shutdown: %w", shutdownErr)
+				}
 				return nil
 			}
 		case <-ticker.C:
@@ -446,12 +450,12 @@ func parseFlags(ctx context.Context) (cliFlags, error) {
 // runDryRun discovers (parses) every role over the admin lane, prints each
 // role's resolved config with a flag on any that fail Validate, and returns
 // without touching webhooks. It is the fleet's pre-flight doctor.
-func runDryRun(ctx context.Context, lg logger.Logger, d *fleet.Discovery, cfg fleet.Config) {
+func runDryRun(ctx context.Context, lg logger.Logger, d *fleet.Discovery, cfg fleet.Config, out io.Writer) {
 	roles, errs := d.DiscoverParsed(ctx)
 	for _, e := range errs {
 		lg.Warn("dry-run: parse error", "err", e)
 	}
-	fmt.Fprint(os.Stdout, reportRoles(roles, cfg.OfferedTools, cfg.DefaultModel))
+	fmt.Fprint(out, reportRoles(roles, cfg.OfferedTools, cfg.DefaultModel))
 }
 
 // reportRoles renders a human-readable resolved-config report for each role,

--- a/cmd/fleet/main_agentpaths_test.go
+++ b/cmd/fleet/main_agentpaths_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/stretchr/testify/require"
+
+	"trip2g/internal/fleet"
+	"trip2g/internal/logger"
+)
+
+// newOpenAIStub starts an httptest server speaking the OpenAI chat-completions
+// wire shape, returning the scripted responses in order (the last one repeats).
+func newOpenAIStub(t *testing.T, responses []string) *httptest.Server {
+	t.Helper()
+	var call int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		idx := call
+		if idx >= len(responses) {
+			idx = len(responses) - 1
+		}
+		call++
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, responses[idx])
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// toolCallCompletion renders one chat completion whose message is a single
+// tool call with the given name and JSON arguments.
+func toolCallCompletion(name string, args map[string]any) string {
+	raw, _ := json.Marshal(args)
+	return `{"id":"1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant",` +
+		`"tool_calls":[{"id":"c1","type":"function","function":{"name":"` + name + `","arguments":` +
+		strMustQuote(string(raw)) + `}}]},"finish_reason":"tool_calls"}],` +
+		`"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`
+}
+
+func strMustQuote(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+// TestRunOnce_EndToEnd is the --once end-to-end path: a role note runs offline
+// against a file KB with a stub LLM (write_note then finish); the write must
+// land in the vault and the run must complete without a trip2g connection.
+func TestRunOnce_EndToEnd(t *testing.T) {
+	vault := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(vault, "notes"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(vault, "notes", "input.md"), []byte("raw meeting notes"), 0o644))
+
+	roleDir := t.TempDir()
+	rolePath := filepath.Join(roleDir, "summarizer.md")
+	role := `---
+mode: change
+trigger_on: [update]
+trigger_include: [notes/**]
+read_patterns: [notes/**]
+write_patterns: [notes/**]
+tools: [read_note, write_note]
+model: test-model
+---
+Read notes/input.md and write a summary to notes/summary.md.
+`
+	require.NoError(t, os.WriteFile(rolePath, []byte(role), 0o644))
+
+	llmStub := newOpenAIStub(t, []string{
+		toolCallCompletion("write_note", map[string]any{"path": "notes/summary.md", "content": "SUMMARY"}),
+		toolCallCompletion("finish", map[string]any{"answer": "summarized"}),
+	})
+
+	cli := cliFlags{
+		cfg: fleet.Config{
+			LLMAPIKey:    "test-key",
+			LLMBaseURL:   llmStub.URL + "/v1",
+			DefaultModel: "test-model",
+			TokenCeiling: 100000,
+			StepCeiling:  25,
+			OfferedTools: []string{"search", "read_note", "write_note", "patch_note"},
+		},
+		oncePath: rolePath,
+		vaultDir: vault,
+	}
+
+	require.NoError(t, runOnce(context.Background(), cli))
+
+	written, err := os.ReadFile(filepath.Join(vault, "notes", "summary.md"))
+	require.NoError(t, err)
+	require.Equal(t, "SUMMARY", string(written), "--once must persist the agent's write to the file KB")
+}
+
+// TestRunDryRun_Integration drives runDryRun against a fake trip2g GraphQL
+// endpoint: it must print each role's resolved config (flagging invalid ones)
+// and issue ONLY the DiscoverRoles query — never a webhook mutation.
+func TestRunDryRun_Integration(t *testing.T) {
+	goodRole := "---\nmode: change\ntrigger_on: [update]\ntrigger_include: [boards/**]\nread_patterns: [boards/**]\nwrite_patterns: [boards/**]\ntools: [search, patch_note]\n---\nBody.\n"
+
+	var ops []string
+	gqlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request: %v", err)
+		}
+		var in struct {
+			OperationName string `json:"operationName"`
+		}
+		if uerr := json.Unmarshal(raw, &in); uerr != nil {
+			t.Errorf("decode request: %v", uerr)
+		}
+		ops = append(ops, in.OperationName)
+
+		w.Header().Set("Content-Type", "application/json")
+		if in.OperationName != "DiscoverRoles" {
+			fmt.Fprint(w, `{"errors":[{"message":"unexpected operation `+in.OperationName+`"}]}`)
+			return
+		}
+		notes := []map[string]any{
+			{
+				"value":   "roles/good.md",
+				"content": goodRole,
+				"latestNoteView": map[string]any{"meta": []map[string]string{
+					{"key": "mode", "raw": "change"},
+					{"key": "trigger_on", "raw": "[update]"},
+					{"key": "trigger_include", "raw": "[boards/**]"},
+					{"key": "read_patterns", "raw": "[boards/**]"},
+					{"key": "write_patterns", "raw": "[boards/**]"},
+					{"key": "tools", "raw": "[search, patch_note]"},
+				}},
+			},
+			{
+				"value":          "roles/bad.md",
+				"content":        "No trigger config.\n",
+				"latestNoteView": map[string]any{"meta": []map[string]string{{"key": "mode", "raw": "change"}}},
+			},
+		}
+		data, err := json.Marshal(map[string]any{"notePaths": notes})
+		if err != nil {
+			t.Errorf("marshal response: %v", err)
+		}
+		fmt.Fprint(w, `{"data":`+string(data)+`}`)
+	}))
+	t.Cleanup(gqlSrv.Close)
+
+	cfg := fleet.Config{
+		OfferedTools: []string{"search", "read_note", "patch_note", "write_note"},
+		DefaultModel: "gpt-4o-mini",
+		AgentsFolder: "roles/",
+	}
+	gql := graphql.NewClient(gqlSrv.URL, &http.Client{Timeout: 5 * time.Second})
+	discovery := fleet.NewDiscovery(gql, cfg.AgentsFolder, cfg.OfferedTools)
+
+	var out bytes.Buffer
+	runDryRun(context.Background(), &logger.DummyLogger{}, discovery, cfg, &out)
+
+	report := out.String()
+	require.Contains(t, report, "roles/good.md")
+	require.Contains(t, report, "STATUS: OK")
+	require.Contains(t, report, "roles/bad.md")
+	require.Contains(t, report, "FLAGGED")
+
+	require.Equal(t, []string{"DiscoverRoles"}, ops,
+		"--dry-run must only discover; webhook queries/mutations are forbidden")
+	require.NotContains(t, report, "error", "report should be clean")
+}

--- a/cmd/fleet/main_test.go
+++ b/cmd/fleet/main_test.go
@@ -365,3 +365,32 @@ func TestEffectiveGrace_FloorsNonPositive(t *testing.T) {
 	require.Equal(t, 30*time.Second, effectiveGrace(-5), "negative must floor to 30s")
 	require.Equal(t, 45*time.Second, effectiveGrace(45), "positive must pass through")
 }
+
+// TestGracefulShutdown_DrainFailureReturnsError asserts that a drain that
+// cannot finish within the grace window surfaces a non-nil error (run()
+// propagates it so a supervisor can tell a failed drain from a clean exit).
+func TestGracefulShutdown_DrainFailureReturnsError(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	defer close(release)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		close(entered)
+		<-release
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv, addr := newIdleTestServer(t, mux)
+
+	go func() {
+		resp, httpErr := http.Get("http://" + addr + "/")
+		if httpErr == nil {
+			resp.Body.Close()
+		}
+	}()
+	<-entered // handler now stuck past any 50ms grace
+
+	err := gracefulShutdown(&logger.DummyLogger{}, srv, nil, false, 50*time.Millisecond)
+	require.Error(t, err, "drain incomplete within grace must be reported, not swallowed")
+}

--- a/internal/agentruntime/coderun.go
+++ b/internal/agentruntime/coderun.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"trip2g/internal/webhookutil"
@@ -32,8 +33,22 @@ type interpreterRegistry struct {
 	byName  map[string]*interpreter
 }
 
+// registry is guarded by registryMu: a startup --interpreters override may race
+// with concurrent role runs. Each *interpreterRegistry is immutable after build;
+// only the pointer swap needs the lock.
+//
 //nolint:gochecknoglobals // interpreter lookup built from embedded config (overridable via --interpreters); package-level by design
-var registry = mustBuildRegistry(defaultInterpretersJSON)
+var (
+	registryMu sync.RWMutex
+	registry   = mustBuildRegistry(defaultInterpretersJSON)
+)
+
+// currentRegistry returns the active immutable registry snapshot.
+func currentRegistry() *interpreterRegistry {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	return registry
+}
 
 // mustBuildRegistry panics if data cannot be parsed. Used at package init.
 func mustBuildRegistry(data []byte) *interpreterRegistry {
@@ -72,7 +87,9 @@ func SetInterpretersJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
+	registryMu.Lock()
 	registry = r
+	registryMu.Unlock()
 	return nil
 }
 
@@ -87,7 +104,7 @@ func LoadInterpretersFile(path string) error {
 
 // FenceLangKnown reports whether a Markdown fence label is registered.
 func FenceLangKnown(lang string) bool {
-	_, ok := registry.byLabel[strings.ToLower(lang)]
+	_, ok := currentRegistry().byLabel[strings.ToLower(lang)]
 	return ok
 }
 
@@ -131,7 +148,7 @@ type rawCodeChange struct {
 // Non-zero exit or context timeout returns an error; timedOut distinguishes
 // the two failure modes.
 func RunBlock(ctx context.Context, spec CodeSpec) (string, string, bool, error) {
-	interp, ok := registry.byName[spec.Program]
+	interp, ok := currentRegistry().byName[spec.Program]
 	if !ok {
 		return "", "", false, fmt.Errorf("coderun: unknown program %q", spec.Program)
 	}
@@ -239,7 +256,7 @@ func parseCodeOutput(stdout string) ([]webhookutil.AgentChange, string, error) {
 // programBinary resolves a program name to the binary to run via the interpreter
 // registry. Returns an error for unrecognized names so the caller can fail fast.
 func programBinary(name string) (string, error) {
-	if interp, ok := registry.byName[name]; ok {
+	if interp, ok := currentRegistry().byName[name]; ok {
 		return interp.Cmd[0], nil
 	}
 	return "", fmt.Errorf("coderun: unknown program %q", name)
@@ -249,7 +266,7 @@ func programBinary(name string) (string, error) {
 // program name used for allowlist checks (python, bash, node).
 // Returns "" for unrecognised tags.
 func fenceLangToProgram(lang string) string {
-	if interp, ok := registry.byLabel[strings.ToLower(lang)]; ok {
+	if interp, ok := currentRegistry().byLabel[strings.ToLower(lang)]; ok {
 		return interp.Name
 	}
 	return ""

--- a/internal/agentruntime/coderun_test.go
+++ b/internal/agentruntime/coderun_test.go
@@ -3,6 +3,7 @@ package agentruntime
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -512,12 +513,46 @@ func TestInterpretersJSON_Load(t *testing.T) {
 }
 
 func TestInterpretersJSON_Override(t *testing.T) {
-	orig := registry
-	t.Cleanup(func() { registry = orig })
+	t.Cleanup(func() { require.NoError(t, SetInterpretersJSON(defaultInterpretersJSON)) })
 	custom := []byte(`{"interpreters":[{"name":"bash","cmd":["bash"],"code_block_labels":["bash","sh"],"ext":".sh"}]}`)
 	require.NoError(t, SetInterpretersJSON(custom))
 	require.Equal(t, "bash", fenceLangToProgram("bash"))
 	require.Empty(t, fenceLangToProgram("python"))
+}
+
+// TestInterpreterRegistry_ConcurrentAccess exercises the registry under -race:
+// concurrent SetInterpretersJSON swaps against reads from every lookup path
+// (the same shape as a startup --interpreters override racing role runs).
+func TestInterpreterRegistry_ConcurrentAccess(t *testing.T) {
+	t.Cleanup(func() { require.NoError(t, SetInterpretersJSON(defaultInterpretersJSON)) })
+	custom := []byte(`{"interpreters":[{"name":"bash","cmd":["bash"],"code_block_labels":["bash","sh"],"ext":".sh"}]}`)
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for i := range 100 {
+				data := custom
+				if i%2 == 0 {
+					data = defaultInterpretersJSON
+				}
+				if err := SetInterpretersJSON(data); err != nil {
+					t.Errorf("SetInterpretersJSON: %v", err)
+				}
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				FenceLangKnown("bash")
+				fenceLangToProgram("sh")
+				_, _ = programBinary("bash")
+			}
+		}()
+	}
+	wg.Wait()
+	require.True(t, FenceLangKnown("bash"))
 }
 
 func TestMaxStdoutBytesFromConfig(t *testing.T) {

--- a/internal/agentruntime/llm.go
+++ b/internal/agentruntime/llm.go
@@ -49,3 +49,10 @@ type ChatResult struct {
 type LLM interface {
 	Chat(ctx context.Context, model string, messages []Message, tools []ToolDef) (ChatResult, error)
 }
+
+// BudgetedLLM is an optional LLM extension: providers that can cap a single
+// completion receive the run's remaining token budget per call, so the
+// TokenCeiling binds at the provider, not just in the loop's post-hoc check.
+type BudgetedLLM interface {
+	ChatWithBudget(ctx context.Context, model string, messages []Message, tools []ToolDef, maxCompletionTokens int) (ChatResult, error)
+}

--- a/internal/agentruntime/openai_llm.go
+++ b/internal/agentruntime/openai_llm.go
@@ -2,14 +2,31 @@ package agentruntime
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
 
 	goopenai "github.com/sashabaranov/go-openai"
+)
+
+// ErrEmptyCompletion is returned when the provider answers 200 with no choices.
+// Treating it as success would feed an empty assistant turn back into the loop
+// and mask provider-side failures (filtered content, truncated batches).
+var ErrEmptyCompletion = errors.New("llm: empty completion (no choices)")
+
+const (
+	llmMaxAttempts  = 3
+	llmRetryBaseGap = 500 * time.Millisecond
 )
 
 // OpenAILLM is the production LLM backed by any OpenAI-compatible chat
 // completions endpoint. BaseURL is the configurable knob: leave empty for the
 // default OpenAI endpoint, or point it at a local/vendor model
 // (e.g. "http://localhost:11434/v1" for Ollama).
+//
+// Transient failures (HTTP 429/5xx, network errors) are retried with
+// exponential backoff, bounded by llmMaxAttempts and the caller's context.
 type OpenAILLM struct {
 	client *goopenai.Client
 }
@@ -26,13 +43,26 @@ func NewOpenAILLM(apiKey, baseURL string) *OpenAILLM {
 
 // Chat issues one chat-completion request with the given tools.
 func (l *OpenAILLM) Chat(ctx context.Context, model string, messages []Message, tools []ToolDef) (ChatResult, error) {
+	return l.chat(ctx, model, messages, tools, 0)
+}
+
+// ChatWithBudget is the BudgetedLLM hook: maxCompletionTokens caps this single
+// completion so one runaway call cannot blow far past the run's token ceiling.
+func (l *OpenAILLM) ChatWithBudget(ctx context.Context, model string, messages []Message, tools []ToolDef, maxCompletionTokens int) (ChatResult, error) {
+	return l.chat(ctx, model, messages, tools, maxCompletionTokens)
+}
+
+func (l *OpenAILLM) chat(ctx context.Context, model string, messages []Message, tools []ToolDef, maxCompletionTokens int) (ChatResult, error) {
 	req := goopenai.ChatCompletionRequest{
 		Model:    model,
 		Messages: toOpenAIMessages(messages),
 		Tools:    toOpenAITools(tools),
 	}
+	if maxCompletionTokens > 0 {
+		req.MaxCompletionTokens = maxCompletionTokens
+	}
 
-	resp, err := l.client.CreateChatCompletion(ctx, req)
+	resp, err := l.createWithRetry(ctx, req)
 	if err != nil {
 		return ChatResult{}, err
 	}
@@ -42,7 +72,7 @@ func (l *OpenAILLM) Chat(ctx context.Context, model string, messages []Message, 
 		CompletionTokens: resp.Usage.CompletionTokens,
 	}
 	if len(resp.Choices) == 0 {
-		return out, nil
+		return out, ErrEmptyCompletion
 	}
 	msg := resp.Choices[0].Message
 	out.Content = msg.Content
@@ -54,6 +84,51 @@ func (l *OpenAILLM) Chat(ctx context.Context, model string, messages []Message, 
 		})
 	}
 	return out, nil
+}
+
+// createWithRetry retries transient failures with exponential backoff
+// (500ms, 1s). Non-retryable errors (4xx other than 429, context
+// cancellation) surface immediately.
+func (l *OpenAILLM) createWithRetry(ctx context.Context, req goopenai.ChatCompletionRequest) (goopenai.ChatCompletionResponse, error) {
+	var lastErr error
+	for attempt := range llmMaxAttempts {
+		if attempt > 0 {
+			gap := llmRetryBaseGap << (attempt - 1)
+			select {
+			case <-ctx.Done():
+				return goopenai.ChatCompletionResponse{}, ctx.Err()
+			case <-time.After(gap):
+			}
+		}
+		resp, err := l.client.CreateChatCompletion(ctx, req)
+		if err == nil {
+			return resp, nil
+		}
+		if !isRetryableLLMError(ctx, err) {
+			return goopenai.ChatCompletionResponse{}, err
+		}
+		lastErr = err
+	}
+	return goopenai.ChatCompletionResponse{}, fmt.Errorf("llm: giving up after %d attempts: %w", llmMaxAttempts, lastErr)
+}
+
+// isRetryableLLMError reports whether err is worth another attempt: rate
+// limiting (429), server-side failures (5xx), or transport-level errors.
+// Context cancellation and other 4xx (bad request, auth) are terminal.
+func isRetryableLLMError(ctx context.Context, err error) bool {
+	if ctx.Err() != nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var apiErr *goopenai.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.HTTPStatusCode == http.StatusTooManyRequests || apiErr.HTTPStatusCode >= http.StatusInternalServerError
+	}
+	var reqErr *goopenai.RequestError
+	if errors.As(err, &reqErr) {
+		return reqErr.HTTPStatusCode == http.StatusTooManyRequests || reqErr.HTTPStatusCode >= http.StatusInternalServerError
+	}
+	// Non-HTTP failure (connection refused, reset, DNS) — transient by nature.
+	return true
 }
 
 func toOpenAIMessages(messages []Message) []goopenai.ChatCompletionMessage {

--- a/internal/agentruntime/openai_llm_test.go
+++ b/internal/agentruntime/openai_llm_test.go
@@ -1,0 +1,122 @@
+package agentruntime
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// llmStubServer is an httptest server speaking the OpenAI chat-completions
+// wire shape. respond is called per request with the attempt number (1-based)
+// and the decoded request body; it returns the HTTP status and response JSON.
+func llmStubServer(t *testing.T, respond func(attempt int, body map[string]any) (int, string)) (*OpenAILLM, *atomic.Int32) {
+	t.Helper()
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		status, resp := respond(int(n), body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		fmt.Fprint(w, resp)
+	}))
+	t.Cleanup(srv.Close)
+	return NewOpenAILLM("test-key", srv.URL+"/v1"), &calls
+}
+
+const okCompletion = `{"id":"1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":7,"completion_tokens":3,"total_tokens":10}}`
+
+// TestOpenAILLM_RetriesTransientThenSucceeds: a 429 then a 500 must be retried;
+// the third attempt succeeds and its result is returned.
+func TestOpenAILLM_RetriesTransientThenSucceeds(t *testing.T) {
+	llm, calls := llmStubServer(t, func(attempt int, _ map[string]any) (int, string) {
+		switch attempt {
+		case 1:
+			return http.StatusTooManyRequests, `{"error":{"message":"rate limited","type":"rate_limit_exceeded"}}`
+		case 2:
+			return http.StatusInternalServerError, `{"error":{"message":"boom","type":"server_error"}}`
+		default:
+			return http.StatusOK, okCompletion
+		}
+	})
+
+	res, err := llm.Chat(context.Background(), "test-model", []Message{{Role: RoleUser, Content: "x"}}, nil)
+	require.NoError(t, err)
+	require.Equal(t, "hi", res.Content)
+	require.Equal(t, 7, res.PromptTokens)
+	require.Equal(t, 3, res.CompletionTokens)
+	require.Equal(t, int32(3), calls.Load())
+}
+
+// TestOpenAILLM_GivesUpAfterMaxAttempts: persistent 5xx exhausts the bounded
+// retry budget and surfaces the last error.
+func TestOpenAILLM_GivesUpAfterMaxAttempts(t *testing.T) {
+	llm, calls := llmStubServer(t, func(_ int, _ map[string]any) (int, string) {
+		return http.StatusBadGateway, `{"error":{"message":"upstream down","type":"server_error"}}`
+	})
+
+	_, err := llm.Chat(context.Background(), "test-model", []Message{{Role: RoleUser, Content: "x"}}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "giving up after 3 attempts")
+	require.Equal(t, int32(llmMaxAttempts), calls.Load())
+}
+
+// TestOpenAILLM_DoesNotRetryClientError: a 400 is terminal — exactly one request.
+func TestOpenAILLM_DoesNotRetryClientError(t *testing.T) {
+	llm, calls := llmStubServer(t, func(_ int, _ map[string]any) (int, string) {
+		return http.StatusBadRequest, `{"error":{"message":"bad request","type":"invalid_request_error"}}`
+	})
+
+	_, err := llm.Chat(context.Background(), "test-model", []Message{{Role: RoleUser, Content: "x"}}, nil)
+	require.Error(t, err)
+	require.Equal(t, int32(1), calls.Load())
+}
+
+// TestOpenAILLM_EmptyChoicesIsError: a 200 with zero choices must not be
+// treated as a silent empty completion. Usage still comes back so the run's
+// token accounting stays correct.
+func TestOpenAILLM_EmptyChoicesIsError(t *testing.T) {
+	llm, _ := llmStubServer(t, func(_ int, _ map[string]any) (int, string) {
+		return http.StatusOK, `{"id":"1","object":"chat.completion","choices":[],"usage":{"prompt_tokens":7,"completion_tokens":0,"total_tokens":7}}`
+	})
+
+	res, err := llm.Chat(context.Background(), "test-model", []Message{{Role: RoleUser, Content: "x"}}, nil)
+	require.ErrorIs(t, err, ErrEmptyCompletion)
+	require.Equal(t, 7, res.PromptTokens)
+}
+
+// TestOpenAILLM_ChatWithBudgetCapsCompletion: the remaining run budget is
+// forwarded as max_completion_tokens so the provider itself binds the ceiling.
+func TestOpenAILLM_ChatWithBudgetCapsCompletion(t *testing.T) {
+	var gotBudget float64
+	llm, _ := llmStubServer(t, func(_ int, body map[string]any) (int, string) {
+		gotBudget, _ = body["max_completion_tokens"].(float64)
+		return http.StatusOK, okCompletion
+	})
+
+	_, err := llm.ChatWithBudget(context.Background(), "test-model", []Message{{Role: RoleUser, Content: "x"}}, nil, 1234)
+	require.NoError(t, err)
+	require.Equal(t, 1234, int(gotBudget))
+}
+
+// TestOpenAILLM_PlainChatOmitsBudget: Chat (no budget) must not send a cap.
+func TestOpenAILLM_PlainChatOmitsBudget(t *testing.T) {
+	var hasBudget bool
+	llm, _ := llmStubServer(t, func(_ int, body map[string]any) (int, string) {
+		_, hasBudget = body["max_completion_tokens"]
+		return http.StatusOK, okCompletion
+	})
+
+	_, err := llm.Chat(context.Background(), "test-model", []Message{{Role: RoleUser, Content: "x"}}, nil)
+	require.NoError(t, err)
+	require.False(t, hasBudget)
+}

--- a/internal/agentruntime/runtime.go
+++ b/internal/agentruntime/runtime.go
@@ -145,7 +145,7 @@ func Run(ctx context.Context, in Input) (*Result, error) {
 			return res, nil
 		}
 
-		chat, err := in.LLM.Chat(ctx, in.Model, messages, tools)
+		chat, err := chatWithBudget(ctx, in.LLM, in.Model, messages, tools, in.MaxTokens-res.TokensUsed)
 		if err != nil {
 			return nil, fmt.Errorf("agentruntime: chat step %d: %w", step, err)
 		}
@@ -195,6 +195,15 @@ func Run(ctx context.Context, in Input) (*Result, error) {
 	}
 
 	return res, nil
+}
+
+// chatWithBudget passes the run's remaining token budget to LLMs that support
+// per-call completion caps (BudgetedLLM); others get the plain Chat call.
+func chatWithBudget(ctx context.Context, llm LLM, model string, messages []Message, tools []ToolDef, remaining int) (ChatResult, error) {
+	if b, ok := llm.(BudgetedLLM); ok {
+		return b.ChatWithBudget(ctx, model, messages, tools, remaining)
+	}
+	return llm.Chat(ctx, model, messages, tools)
 }
 
 // execTool runs one tool call against the scoped KB and returns the textual

--- a/internal/agentruntime/runtime_test.go
+++ b/internal/agentruntime/runtime_test.go
@@ -416,3 +416,70 @@ func TestRun_TokenHardCapStopsLoop(t *testing.T) {
 		t.Fatalf("loop stopped by step guard, not the cap (steps=%d)", res.Steps)
 	}
 }
+
+// TestRun_MaxStepsExhaustionStatus asserts the step guard: a model that keeps
+// calling tools without ever finishing stops at MaxSteps with StatusMaxSteps.
+func TestRun_MaxStepsExhaustionStatus(t *testing.T) {
+	kb := newMemKB(map[string]string{"subjects/subj1/profile.md": "x"})
+	llm := &stubLLM{
+		fallback: ChatResult{
+			ToolCalls:        []ToolCall{toolCall("loop", toolReadNote, map[string]any{"path": "subjects/subj1/profile.md"})},
+			PromptTokens:     1,
+			CompletionTokens: 1,
+		},
+	}
+
+	res, err := Run(context.Background(), Input{
+		Instruction:  "Loop forever.",
+		ReadPatterns: []string{"subjects/subj1/**"},
+		Model:        "test-model",
+		MaxTokens:    100000,
+		MaxSteps:     3,
+		LLM:          llm,
+		KB:           kb,
+	})
+	require.NoError(t, err)
+	require.Equal(t, StatusMaxSteps, res.Status)
+	require.Equal(t, 3, res.Steps)
+}
+
+// budgetRecordingLLM wraps stubLLM and records the per-call remaining budget
+// passed through the BudgetedLLM hook.
+type budgetRecordingLLM struct {
+	stubLLM
+	budgets []int
+}
+
+func (b *budgetRecordingLLM) ChatWithBudget(
+	ctx context.Context, model string, messages []Message, tools []ToolDef, maxCompletionTokens int,
+) (ChatResult, error) {
+	b.budgets = append(b.budgets, maxCompletionTokens)
+	return b.Chat(ctx, model, messages, tools)
+}
+
+// TestRun_PassesRemainingBudgetToBudgetedLLM asserts the loop hands each call
+// the run's remaining token budget (MaxTokens minus tokens already spent).
+func TestRun_PassesRemainingBudgetToBudgetedLLM(t *testing.T) {
+	kb := newMemKB(nil)
+	llm := &budgetRecordingLLM{
+		stubLLM: stubLLM{
+			script: []ChatResult{
+				{ToolCalls: []ToolCall{toolCall("1", toolSearch, map[string]any{"query": "x"})}, PromptTokens: 100, CompletionTokens: 50},
+				{ToolCalls: []ToolCall{toolCall("2", toolFinish, map[string]any{"answer": "done"})}, PromptTokens: 10, CompletionTokens: 5},
+			},
+		},
+	}
+
+	res, err := Run(context.Background(), Input{
+		Instruction:  "Do a thing.",
+		ReadPatterns: []string{"**"},
+		Model:        "test-model",
+		MaxTokens:    1000,
+		MaxSteps:     10,
+		LLM:          llm,
+		KB:           kb,
+	})
+	require.NoError(t, err)
+	require.Equal(t, StatusCompleted, res.Status)
+	require.Equal(t, []int{1000, 850}, llm.budgets)
+}


### PR DESCRIPTION
Implements the actionable risk items from `docs/dev/2026-07-02_fable_audit.md` (§2.6 / §4).

## Findings fixed

1. **Discarded graceful-shutdown error** — `cmd/fleet/main.go:116` (`_ = gracefulShutdown(...)`). The drain result is now propagated out of `run()`, so a failed/partial drain exits non-zero and a supervisor can tell it from a clean exit. New test: `TestGracefulShutdown_DrainFailureReturnsError`.

2. **Thin LLM client** — `internal/agentruntime/openai_llm.go`:
   - Bounded retry with exponential backoff (3 attempts, 500ms/1s) on HTTP 429/5xx and transport errors; other 4xx and context cancellation are terminal (`isRetryableLLMError`).
   - A 200 response with zero choices is now `ErrEmptyCompletion` instead of a silent empty success (was `openai_llm.go:44-46`); usage tokens still return so accounting stays correct.
   - Per-run spend hook: `Run` (`internal/agentruntime/runtime.go`) passes the remaining token budget (`MaxTokens - TokensUsed`) to LLMs implementing the new optional `BudgetedLLM` interface; `OpenAILLM.ChatWithBudget` forwards it as `max_completion_tokens`, so the existing TokenCeiling now binds at the provider, not just in the loop's post-hoc check. Plain `LLM` implementations are unaffected.
   - Tests against an OpenAI-wire httptest stub: retry-then-succeed, give-up-after-3, no-retry-on-400, empty-choices error, budget forwarded/omitted.

3. **Unsynchronized interpreter registry** — `internal/agentruntime/coderun.go:36`: `registry` is now guarded by an `RWMutex` (`currentRegistry()` snapshot accessor; each registry stays immutable after build, only the pointer swap locks). All readers (`RunBlock`, `FenceLangKnown`, `programBinary`, `fenceLangToProgram`) go through the accessor. New `-race` test: `TestInterpreterRegistry_ConcurrentAccess`.

4. **Agent-path test gaps** (audit §2.6):
   - `TestRunOnce_EndToEnd` (`cmd/fleet/main_agentpaths_test.go`) — full `--once` path: role note → file KB → stub LLM (write_note + finish) → asserts the write is persisted in the vault, no trip2g connection.
   - `TestRunDryRun_Integration` — `--dry-run` over a fake GraphQL endpoint: asserts the resolved-config report (OK + FLAGGED) and that ONLY `DiscoverRoles` is issued (no webhook queries/mutations). `runDryRun` now takes an `io.Writer` for testability.
   - `TestRun_MaxStepsExhaustionStatus` — the missing `StatusMaxSteps` assertion.

## Verification

- `go build -tags dev ./...` clean (after `go generate ./onboarding-vault/` for the gitignored `vault.zip`)
- `go test -race ./cmd/fleet/... ./internal/agentruntime/... ./internal/fleet/...` all green
- pinned golangci-lint (`--build-tags dev`) on changed packages: 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)