### PR TITLE
feat(fleet): Tier-0 code-exec sandbox (netns off + Landlock + rlimits + no-new-privs)

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -29,6 +29,8 @@ import (
 )
 
 func main() {
+	// Re-exec'd sandbox child? Confine and exec the interpreter; never returns.
+	agentruntime.MaybeRunSandboxChild()
 	if err := run(); err != nil {
 		fmt.Fprintln(os.Stderr, "fleet:", err)
 		os.Exit(1)
@@ -200,8 +202,12 @@ func runOnce(ctx context.Context, cli cliFlags) error {
 		Model:         model,
 		MaxTokens:     maxTokens,
 		MaxSteps:      maxSteps,
-		LLM:           llm,
-		KB:            kb,
+		Sandbox: agentruntime.SandboxPolicy{
+			Mode:    agentruntime.SandboxMode(cli.cfg.Sandbox),
+			Network: cli.cfg.SandboxNetwork,
+		},
+		LLM: llm,
+		KB:  kb,
 	})
 	if runErr != nil {
 		return fmt.Errorf("once: run: %w", runErr)
@@ -284,6 +290,11 @@ func validateConfig(cfg fleet.Config) error {
 	}
 	if len(cfg.OfferedTools) == 0 {
 		return errors.New("fleet: OfferedTools must be non-empty; use --offered-tools")
+	}
+	// Empty means the safe default (native); see SandboxPolicy.withDefaults.
+	if cfg.Sandbox != "" && cfg.Sandbox != string(agentruntime.SandboxNative) && cfg.Sandbox != string(agentruntime.SandboxOff) {
+		return fmt.Errorf("fleet: Sandbox must be %q or %q (got %q); use --sandbox",
+			agentruntime.SandboxNative, agentruntime.SandboxOff, cfg.Sandbox)
 	}
 	return nil
 }
@@ -395,6 +406,11 @@ func parseFlags(ctx context.Context) (cliFlags, error) {
 		"comma-separated programs allowed for code execution (empty = disabled; e.g. python,bash)")
 	fs.IntVar(&cli.cfg.MaxStdoutBytes, "max-stdout-bytes", 1<<20,
 		"stdout cap per code child (bytes)")
+	fs.StringVar(&cli.cfg.Sandbox, "sandbox", "native",
+		"code-exec sandbox mode: native|off (native = no network + Landlock FS confinement + rlimits + "+
+			"no-new-privs; Linux-only, falls back with a warning when unsupported)")
+	fs.BoolVar(&cli.cfg.SandboxNetwork, "sandbox-network", false,
+		"allow host network access inside the code-exec sandbox")
 	fs.IntVar(&poll, "poll-seconds", 30,
 		"discovery/reconcile poll interval seconds")
 	fs.IntVar(&graceSeconds, "shutdown-grace-seconds", 30,

--- a/cmd/fleet/main_test.go
+++ b/cmd/fleet/main_test.go
@@ -75,6 +75,16 @@ func TestValidateConfig_RejectsMissingFields(t *testing.T) {
 			wantErr: "OfferedTools",
 		},
 		{
+			name:    "sandbox_invalid_value",
+			mutate:  func(c *fleet.Config) { c.Sandbox = "chroot" },
+			wantErr: "Sandbox",
+		},
+		{
+			name:    "sandbox_off_ok",
+			mutate:  func(c *fleet.Config) { c.Sandbox = "off" },
+			wantErr: "",
+		},
+		{
 			name:    "all_fields_present",
 			mutate:  func(c *fleet.Config) {},
 			wantErr: "",

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -495,6 +495,8 @@ services:
       - TRIP2G_FLEET_STEP_CEILING=25
       - TRIP2G_FLEET_OFFERED_TOOLS=search,read_note,patch_note,write_note
       - TRIP2G_FLEET_ALLOWED_PROGRAMS=python
+      # Krisp ingest role fetches from krisp-mock: opt in to network inside the sandbox.
+      - TRIP2G_FLEET_SANDBOX_NETWORK=true
       # Krisp mock credentials forwarded to code executor via env_passthrough in the role.
       - KRISP_TOKEN=test-krisp-token
       - KRISP_BASE_URL=http://krisp-mock:9092

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/gotd/td v0.139.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/kr/pretty v0.3.1
+	github.com/landlock-lsm/go-landlock v0.9.0
 	github.com/lib/pq v1.10.9
 	github.com/mailru/easyjson v0.9.0
 	github.com/minio/minio-go/v7 v7.0.91
@@ -45,6 +46,7 @@ require (
 	golang.org/x/crypto v0.51.0
 	golang.org/x/net v0.54.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/sys v0.44.0
 	golang.org/x/text v0.37.0
 	gopkg.in/yaml.v3 v3.0.1
 	maragu.dev/goqite v0.3.1
@@ -364,7 +366,6 @@ require (
 	golang.org/x/exp/typeparams v0.0.0-20250210185358-939b2ce775ac // indirect
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
-	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260508192327-42602be52be6 // indirect
 	golang.org/x/time v0.11.0 // indirect
 	golang.org/x/tools v0.45.0 // indirect
@@ -383,6 +384,7 @@ require (
 	gorm.io/driver/bigquery v1.2.0 // indirect
 	gorm.io/gorm v1.25.12 // indirect
 	honnef.co/go/tools v0.6.1 // indirect
+	kernel.org/pub/linux/libs/security/libcap/psx v1.2.77 // indirect
 	modernc.org/libc v1.73.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -857,6 +857,8 @@ github.com/kunwardeep/paralleltest v1.0.14 h1:wAkMoMeGX/kGfhQBPODT/BL8XhK23ol/nu
 github.com/kunwardeep/paralleltest v1.0.14/go.mod h1:di4moFqtfz3ToSKxhNjhOZL+696QtJGCFe132CbBLGk=
 github.com/kyokomi/emoji/v2 v2.2.13 h1:GhTfQa67venUUvmleTNFnb+bi7S3aocF7ZCXU9fSO7U=
 github.com/kyokomi/emoji/v2 v2.2.13/go.mod h1:JUcn42DTdsXJo1SWanHh4HKDEyPaR5CqkmoirZZP9qE=
+github.com/landlock-lsm/go-landlock v0.9.0 h1:2q8G8yx9Hsd5bV+R6PJfgQl0zszNxC8KO+SIqGwfxlw=
+github.com/landlock-lsm/go-landlock v0.9.0/go.mod h1:mn5GSi81Jf7yMs5WSi+SUi4sUeNLUGVdbT4Id6wXNQw=
 github.com/lasiar/canonicalheader v1.1.2 h1:vZ5uqwvDbyJCnMhmFYimgMZnJMjwljN5VGY0VKbMXb4=
 github.com/lasiar/canonicalheader v1.1.2/go.mod h1:qJCeLFS0G/QlLQ506T+Fk/fWMa2VmBUiEI2cuMK4djI=
 github.com/ldez/exptostd v0.4.3 h1:Ag1aGiq2epGePuRJhez2mzOpZ8sI9Gimcb4Sb3+pk9Y=
@@ -1952,6 +1954,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.6.1 h1:R094WgE8K4JirYjBaOpz/AvTyUu/3wbmAoskKN/pxTI=
 honnef.co/go/tools v0.6.1/go.mod h1:3puzxxljPCe8RGJX7BIy1plGbxEOZni5mR2aXe3/uk4=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.77 h1:Z06sMOzc0GNCwp6efaVrIrz4ywGJ1v+DP0pjVkOfDuA=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.77/go.mod h1:+l6Ee2F59XiJ2I6WR5ObpC1utCQJZ/VLsEbQCD8RG24=
 maragu.dev/is v0.3.0 h1:A2B6ylehcHJw7gQqzgwDMWMkS6jmhaBu8s6fy+RG6yA=
 maragu.dev/is v0.3.0/go.mod h1:bviaM5S0fBshCw7wuumFGTju/izopZ/Yvq4g7Klc7y8=
 modernc.org/cc/v4 v4.28.4 h1:Hd/4Es+MBj+/7hSdZaisNyu6bv3V0Dp2MdllyfqaH+c=

--- a/internal/agentruntime/coderun.go
+++ b/internal/agentruntime/coderun.go
@@ -100,6 +100,7 @@ type CodeSpec struct {
 	EnvPassthrough []string      // exact parent env var names to forward to child
 	EnvPrefix      []string      // parent env var name prefixes to forward to child
 	MaxStdoutBytes int           // stdout cap; 0 → 1 MiB default
+	Sandbox        SandboxPolicy // OS-level isolation; zero value = safe default (native)
 }
 
 // codeOutput is the stdout JSON contract that every code program must emit.
@@ -167,24 +168,48 @@ func RunBlock(ctx context.Context, spec CodeSpec) (string, string, bool, error) 
 	// gosec G204 (excluded for this file in .golangci): runs an operator-
 	// allowlisted interpreter (allowed_programs) on the role's rendered code —
 	// executing that code IS the feature, and it's off by default.
-	cmd := exec.CommandContext(runCtx, interp.Cmd[0], append(interp.Cmd[1:], codeFile)...)
-	cmd.Dir = workDir
+	fullArgv := append(append([]string{}, interp.Cmd...), codeFile)
 	// Secret-scrub: build an explicit MINIMAL env. NEVER nil (inherits parent)
 	// or os.Environ() (exposes all secrets). The base is PATH + FLEET_INPUT only.
 	// Selective pass-through adds only explicitly declared vars/prefixes on top.
-	cmd.Env = buildChildEnv(inputFile, spec.EnvPassthrough, spec.EnvPrefix)
-
+	env := buildChildEnv(inputFile, spec.EnvPassthrough, spec.EnvPrefix)
 	limit := spec.MaxStdoutBytes
 	if limit == 0 {
 		limit = 1 << 20
 	}
+
+	policy := spec.Sandbox.withDefaults(spec.Timeout)
+	sandboxed := policy.Mode != SandboxOff
+	if sandboxed && !sandboxSupportedOS {
+		warnSandboxFallback("unsupported OS", nil)
+		sandboxed = false
+	}
+
+	var cmd *exec.Cmd
+	if sandboxed {
+		var sbErr error
+		cmd, sbErr = sandboxCommand(runCtx, fullArgv, workDir, policy)
+		if sbErr != nil {
+			warnSandboxFallback("sandbox setup failed", sbErr)
+			sandboxed = false
+		}
+	}
+	if !sandboxed {
+		cmd = exec.CommandContext(runCtx, fullArgv[0], fullArgv[1:]...)
+	}
 	var outBuf, errBuf limitedBuffer
-	outBuf.limit = limit
-	errBuf.limit = limit
-	cmd.Stdout = &outBuf
-	cmd.Stderr = &errBuf
+	prepareCmd(cmd, workDir, env, &outBuf, &errBuf, limit)
 
 	runErr := cmd.Run()
+	// A sandboxed command that failed to START never ran the child: namespace
+	// creation was denied (e.g. unprivileged userns disabled). Degrade to the
+	// pre-sandbox behavior with a warning instead of failing every code run.
+	if runErr != nil && sandboxed && cmd.ProcessState == nil && runCtx.Err() == nil {
+		warnSandboxFallback("sandboxed child failed to start", runErr)
+		cmd = exec.CommandContext(runCtx, fullArgv[0], fullArgv[1:]...)
+		prepareCmd(cmd, workDir, env, &outBuf, &errBuf, limit)
+		runErr = cmd.Run()
+	}
 	outStr := outBuf.String()
 	errStr := errBuf.String()
 
@@ -199,6 +224,17 @@ func RunBlock(ctx context.Context, spec CodeSpec) (string, string, bool, error) 
 		return outStr, errStr, false, fmt.Errorf("coderun: non-zero exit: %s", msg)
 	}
 	return outStr, errStr, false, nil
+}
+
+// prepareCmd applies the run wiring shared by the sandboxed and plain paths:
+// workdir, scrubbed env, and fresh capped stdout/stderr buffers.
+func prepareCmd(cmd *exec.Cmd, workDir string, env []string, outBuf, errBuf *limitedBuffer, limit int) {
+	cmd.Dir = workDir
+	cmd.Env = env
+	*outBuf = limitedBuffer{limit: limit}
+	*errBuf = limitedBuffer{limit: limit}
+	cmd.Stdout = outBuf
+	cmd.Stderr = errBuf
 }
 
 // parseCodeOutput parses the code child's stdout JSON into []AgentChange +

--- a/internal/agentruntime/runcode.go
+++ b/internal/agentruntime/runcode.go
@@ -23,6 +23,7 @@ type CodeInput struct {
 	EnvPassthrough  []string      // exact parent env var names forwarded to child
 	EnvPrefix       []string      // parent env var name prefixes forwarded to child
 	MaxStdoutBytes  int           // stdout cap per code child; 0 → 1 MiB default
+	Sandbox         SandboxPolicy // OS-level isolation; zero value = safe default (native)
 }
 
 // RunCode executes a code role. It:
@@ -73,6 +74,7 @@ func RunCode(ctx context.Context, in CodeInput) (*Result, error) {
 		EnvPassthrough: in.EnvPassthrough,
 		EnvPrefix:      in.EnvPrefix,
 		MaxStdoutBytes: in.MaxStdoutBytes,
+		Sandbox:        in.Sandbox,
 	})
 	if runErr != nil {
 		return nil, fmt.Errorf("coderun: %w", runErr)

--- a/internal/agentruntime/runtime.go
+++ b/internal/agentruntime/runtime.go
@@ -53,6 +53,10 @@ type Input struct {
 	// enabled at execution time. An empty slice disables exec entirely.
 	AllowedPrograms []string
 
+	// Sandbox is the OS-level isolation policy for the exec tool's code runs.
+	// The zero value is the safe default (native where supported).
+	Sandbox SandboxPolicy
+
 	// MaxTokens is the NON-overridable per-run token hard-cap (safety floor).
 	// The model has no tool to change it; the loop enforces it. Must be > 0.
 	MaxTokens int
@@ -121,7 +125,7 @@ func Run(ctx context.Context, in Input) (*Result, error) {
 
 	// Tool registry: extension invokers (exec + future MCP plug-ins) are called
 	// before the built-in switch in execTool. Built-in tools leave this nil-safe.
-	invokers := buildInvokers(in.AllowedPrograms)
+	invokers := buildInvokers(in.AllowedPrograms, in.Sandbox)
 
 	messages := []Message{
 		{
@@ -343,12 +347,12 @@ func allowedToolDefs(allowlist []string, allowedPrograms []string) []ToolDef {
 // non-empty, exec is registered.
 // Future MCP tools: add invokers here, gated by the same allowedPrograms mechanism
 // or a dedicated per-tool allowlist. Never add tools unconditionally.
-func buildInvokers(allowedPrograms []string) map[string]toolInvoker {
+func buildInvokers(allowedPrograms []string, sandbox SandboxPolicy) map[string]toolInvoker {
 	if len(allowedPrograms) == 0 {
 		return nil
 	}
 	return map[string]toolInvoker{
-		toolExec: makeExecInvoker(allowedPrograms),
+		toolExec: makeExecInvoker(allowedPrograms, sandbox),
 	}
 }
 
@@ -356,7 +360,7 @@ func buildInvokers(allowedPrograms []string) map[string]toolInvoker {
 // It runs the code via RunBlock (secret-scrubbed), parses stdout as write JSON,
 // and applies changes via the scoped KB — same write_patterns enforcement as
 // write_note. Out-of-scope writes are denied and recorded, not silently dropped.
-func makeExecInvoker(allowedPrograms []string) toolInvoker {
+func makeExecInvoker(allowedPrograms []string, sandbox SandboxPolicy) toolInvoker {
 	return func(ctx context.Context, scoped *ScopedKB, res *Result, call ToolCall) string {
 		var args struct {
 			Program string `json:"program"`
@@ -371,6 +375,7 @@ func makeExecInvoker(allowedPrograms []string) toolInvoker {
 		stdout, _, _, runErr := RunBlock(ctx, CodeSpec{
 			Program: args.Program,
 			Code:    args.Code,
+			Sandbox: sandbox,
 			// No Input bag: exec tool runs inline; the model already has context.
 			// No Timeout: the call is bounded by the parent run context.
 		})

--- a/internal/agentruntime/sandbox.go
+++ b/internal/agentruntime/sandbox.go
@@ -1,0 +1,102 @@
+package agentruntime
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// SandboxMode selects the OS-level isolation posture for code execution.
+type SandboxMode string
+
+const (
+	// SandboxOff disables OS-level isolation (pre-sandbox behavior: scrubbed
+	// env + throwaway workdir + timeout only).
+	SandboxOff SandboxMode = "off"
+	// SandboxNative is the Tier-0 posture (see docs/dev/process_isolation.md
+	// and the 2026-07-02 sandbox research): empty network namespace, Landlock
+	// filesystem confinement to the run workdir, rlimits, NO_NEW_PRIVS, and a
+	// drop to an unprivileged uid when the daemon runs as root. Pure-Go,
+	// Linux-only; unsupported platforms/kernels fall back with a warning.
+	SandboxNative SandboxMode = "native"
+)
+
+// SandboxPolicy configures the sandbox applied around one code run. The zero
+// value means the safe default (SandboxNative where supported, network off).
+type SandboxPolicy struct {
+	Mode    SandboxMode // "" → SandboxNative; anything but "off" sandboxes
+	Network bool        // opt-in: keep host network access inside the sandbox
+
+	// rlimits for the child; zero values take the defaults below.
+	CPUSeconds    int   // RLIMIT_CPU; 0 → derived from the run timeout, else 300s
+	MemoryBytes   int64 // RLIMIT_AS (virtual); 0 → 4 GiB (V8 reserves a lot)
+	FileSizeBytes int64 // RLIMIT_FSIZE; 0 → 64 MiB
+	MaxProcs      int   // RLIMIT_NPROC; 0 → 256
+	MaxOpenFiles  int   // RLIMIT_NOFILE; 0 → 512
+}
+
+const (
+	defaultSandboxCPUSeconds    = 300
+	defaultSandboxMemoryBytes   = 4 << 30
+	defaultSandboxFileSizeBytes = 64 << 20
+	defaultSandboxMaxProcs      = 256
+	defaultSandboxMaxOpenFiles  = 512
+	sandboxCPUGraceSeconds      = 5 // headroom over the wall-clock timeout
+)
+
+// withDefaults resolves the effective policy: empty mode means the safe
+// default, and zero rlimits take the package defaults. RLIMIT_CPU tracks the
+// run's wall-clock timeout (plus grace) so a fork-bombed child that escapes
+// the context kill still dies.
+func (p SandboxPolicy) withDefaults(timeout time.Duration) SandboxPolicy {
+	if p.Mode == "" {
+		p.Mode = SandboxNative
+	}
+	if p.CPUSeconds == 0 {
+		if timeout > 0 {
+			p.CPUSeconds = int(timeout/time.Second) + sandboxCPUGraceSeconds
+		} else {
+			p.CPUSeconds = defaultSandboxCPUSeconds
+		}
+	}
+	if p.MemoryBytes == 0 {
+		p.MemoryBytes = defaultSandboxMemoryBytes
+	}
+	if p.FileSizeBytes == 0 {
+		p.FileSizeBytes = defaultSandboxFileSizeBytes
+	}
+	if p.MaxProcs == 0 {
+		p.MaxProcs = defaultSandboxMaxProcs
+	}
+	if p.MaxOpenFiles == 0 {
+		p.MaxOpenFiles = defaultSandboxMaxOpenFiles
+	}
+	return p
+}
+
+// sandboxChildSpec is the JSON contract between RunBlock and the re-exec
+// child launcher: everything the child needs to confine itself before it
+// execs the interpreter.
+type sandboxChildSpec struct {
+	Argv          []string `json:"argv"`
+	WorkDir       string   `json:"workdir"`
+	RODirs        []string `json:"ro_dirs"`
+	RWDirs        []string `json:"rw_dirs"`
+	RWFiles       []string `json:"rw_files"`
+	CPUSeconds    int      `json:"cpu_seconds"`
+	MemoryBytes   int64    `json:"memory_bytes"`
+	FileSizeBytes int64    `json:"file_size_bytes"`
+	MaxProcs      int      `json:"max_procs"`
+	MaxOpenFiles  int      `json:"max_open_files"`
+}
+
+//nolint:gochecknoglobals // one-shot warning gate; package-level by design
+var sandboxWarnOnce sync.Once
+
+// warnSandboxFallback logs (once per process) that code execution is running
+// WITHOUT the sandbox so operators see the degraded posture in the logs.
+func warnSandboxFallback(reason string, err error) {
+	sandboxWarnOnce.Do(func() {
+		slog.Warn("coderun: sandbox unavailable, executing without OS-level isolation", "reason", reason, "err", err)
+	})
+}

--- a/internal/agentruntime/sandbox_linux.go
+++ b/internal/agentruntime/sandbox_linux.go
@@ -1,0 +1,178 @@
+//go:build linux
+
+package agentruntime
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+
+	"github.com/landlock-lsm/go-landlock/landlock"
+	"golang.org/x/sys/unix"
+)
+
+// sandboxSupportedOS gates the sandbox at compile time per GOOS.
+const sandboxSupportedOS = true
+
+// sandboxChildArg is the hidden argv[1] marking a re-exec'd sandbox child.
+const sandboxChildArg = "__fleet-coderun-child"
+
+// sandboxNobodyID is the uid/gid the child drops to when the daemon is root.
+const sandboxNobodyID = 65534
+
+// MaybeRunSandboxChild must be called first in main() (and in TestMain of any
+// test binary exercising the sandbox): when the process was re-exec'd as the
+// confined child it applies its limits and execs the interpreter, never
+// returning. In the normal parent process it is a no-op.
+func MaybeRunSandboxChild() {
+	if len(os.Args) != 3 || os.Args[1] != sandboxChildArg {
+		return
+	}
+	if err := runSandboxChild(os.Args[2]); err != nil {
+		fmt.Fprintln(os.Stderr, "coderun sandbox child:", err)
+		os.Exit(125)
+	}
+}
+
+// runSandboxChild applies rlimits, Landlock (BestEffort — no-op on kernels
+// without it), and NO_NEW_PRIVS, then execs the interpreter. The namespaces
+// and credential drop were already applied by the parent via SysProcAttr.
+func runSandboxChild(encoded string) error {
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return fmt.Errorf("decode spec: %w", err)
+	}
+	var spec sandboxChildSpec
+	if uerr := json.Unmarshal(raw, &spec); uerr != nil {
+		return fmt.Errorf("parse spec: %w", uerr)
+	}
+	if len(spec.Argv) == 0 {
+		return errors.New("empty argv")
+	}
+
+	limits := []struct {
+		name string
+		res  int
+		cur  uint64
+	}{
+		{"cpu", unix.RLIMIT_CPU, uint64(spec.CPUSeconds)},
+		{"as", unix.RLIMIT_AS, uint64(spec.MemoryBytes)},
+		{"fsize", unix.RLIMIT_FSIZE, uint64(spec.FileSizeBytes)},
+		{"nproc", unix.RLIMIT_NPROC, uint64(spec.MaxProcs)},
+		{"nofile", unix.RLIMIT_NOFILE, uint64(spec.MaxOpenFiles)},
+	}
+	for _, l := range limits {
+		if l.cur == 0 {
+			continue
+		}
+		if rlErr := unix.Setrlimit(l.res, &unix.Rlimit{Cur: l.cur, Max: l.cur}); rlErr != nil {
+			return fmt.Errorf("setrlimit %s: %w", l.name, rlErr)
+		}
+	}
+
+	// go-landlock also sets NO_NEW_PRIVS internally, but keep it explicit so
+	// the guarantee holds even when Landlock degrades to a no-op.
+	if pErr := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); pErr != nil {
+		return fmt.Errorf("prctl no_new_privs: %w", pErr)
+	}
+
+	var rules []landlock.Rule
+	if len(spec.RODirs) > 0 {
+		rules = append(rules, landlock.RODirs(spec.RODirs...).IgnoreIfMissing())
+	}
+	if len(spec.RWDirs) > 0 {
+		rules = append(rules, landlock.RWDirs(spec.RWDirs...).IgnoreIfMissing())
+	}
+	if len(spec.RWFiles) > 0 {
+		rules = append(rules, landlock.RWFiles(spec.RWFiles...).IgnoreIfMissing())
+	}
+	if llErr := landlock.V5.BestEffort().RestrictPaths(rules...); llErr != nil {
+		return fmt.Errorf("landlock: %w", llErr)
+	}
+
+	bin, err := exec.LookPath(spec.Argv[0])
+	if err != nil {
+		return fmt.Errorf("lookup %s: %w", spec.Argv[0], err)
+	}
+	return unix.Exec(bin, spec.Argv, os.Environ())
+}
+
+// sandboxCommand builds the re-exec child command implementing the Tier-0
+// posture: the parent contributes the namespaces + credential drop through
+// SysProcAttr; the child stub (runSandboxChild) applies rlimits, Landlock and
+// NO_NEW_PRIVS before exec'ing the interpreter.
+func sandboxCommand(ctx context.Context, argv []string, workDir string, p SandboxPolicy) (*exec.Cmd, error) {
+	self, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("sandbox: resolve self: %w", err)
+	}
+	spec := sandboxChildSpec{
+		Argv:          argv,
+		WorkDir:       workDir,
+		RODirs:        sandboxRODirs(argv[0]),
+		RWDirs:        []string{workDir},
+		RWFiles:       []string{"/dev/null", "/dev/zero", "/dev/urandom", "/dev/random", "/dev/full"},
+		CPUSeconds:    p.CPUSeconds,
+		MemoryBytes:   p.MemoryBytes,
+		FileSizeBytes: p.FileSizeBytes,
+		MaxProcs:      p.MaxProcs,
+		MaxOpenFiles:  p.MaxOpenFiles,
+	}
+	raw, err := json.Marshal(spec)
+	if err != nil {
+		return nil, fmt.Errorf("sandbox: marshal spec: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, self, sandboxChildArg, base64.StdEncoding.EncodeToString(raw))
+	attr := &syscall.SysProcAttr{}
+	if !p.Network {
+		attr.Cloneflags |= syscall.CLONE_NEWNET
+	}
+	if os.Geteuid() == 0 {
+		// Root can create the netns directly; drop the child to an
+		// unprivileged uid. The workdir must follow the ownership change.
+		attr.Credential = &syscall.Credential{Uid: sandboxNobodyID, Gid: sandboxNobodyID}
+		if chErr := chownTree(workDir, sandboxNobodyID, sandboxNobodyID); chErr != nil {
+			return nil, fmt.Errorf("sandbox: chown workdir: %w", chErr)
+		}
+	} else if !p.Network {
+		// Unprivileged netns creation requires a user namespace
+		// (the unshare --map-root-user pattern).
+		attr.Cloneflags |= syscall.CLONE_NEWUSER
+		attr.UidMappings = []syscall.SysProcIDMap{{ContainerID: 0, HostID: os.Getuid(), Size: 1}}
+		attr.GidMappings = []syscall.SysProcIDMap{{ContainerID: 0, HostID: os.Getgid(), Size: 1}}
+	}
+	cmd.SysProcAttr = attr
+	return cmd, nil
+}
+
+// sandboxRODirs returns the read-only system paths the interpreter needs
+// (missing ones are ignored via IgnoreIfMissing), plus the resolved directory
+// of the interpreter binary for non-standard installs.
+func sandboxRODirs(program string) []string {
+	dirs := []string{"/usr", "/bin", "/sbin", "/lib", "/lib32", "/lib64", "/etc", "/opt"}
+	if bin, err := exec.LookPath(program); err == nil {
+		if resolved, rerr := filepath.EvalSymlinks(bin); rerr == nil {
+			bin = resolved
+		}
+		dirs = append(dirs, filepath.Dir(bin))
+	}
+	return dirs
+}
+
+// chownTree recursively chowns a directory tree (the per-run temp workdir).
+func chownTree(root string, uid, gid int) error {
+	return filepath.WalkDir(root, func(path string, _ fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Chown(path, uid, gid)
+	})
+}

--- a/internal/agentruntime/sandbox_linux_test.go
+++ b/internal/agentruntime/sandbox_linux_test.go
@@ -1,0 +1,180 @@
+//go:build linux
+
+package agentruntime
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	llsys "github.com/landlock-lsm/go-landlock/landlock/syscall"
+	"github.com/stretchr/testify/require"
+)
+
+// requireSandboxSupport skips the test when the kernel refuses the sandbox's
+// namespaces (e.g. unprivileged user namespaces disabled) — the production
+// path falls back to unsandboxed execution there, so the isolation assertions
+// below would be meaningless.
+func requireSandboxSupport(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	cmd, err := sandboxCommand(context.Background(), []string{"true"}, dir, SandboxPolicy{}.withDefaults(0))
+	require.NoError(t, err)
+	cmd.Dir = dir
+	cmd.Env = []string{"PATH=" + os.Getenv("PATH")}
+	if runErr := cmd.Run(); runErr != nil {
+		t.Skipf("sandbox namespaces unavailable on this kernel: %v", runErr)
+	}
+}
+
+// landlockABI returns the kernel's Landlock ABI version (0 = unsupported).
+func landlockABI() int {
+	v, err := llsys.LandlockGetABIVersion()
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+// TestSandbox_NetworkBlocked proves the empty net namespace: a loopback TCP
+// server reachable from an unsandboxed child must be unreachable from the
+// sandboxed one.
+func TestSandbox_NetworkBlocked(t *testing.T) {
+	requireSandboxSupport(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+	go func() {
+		for {
+			c, aerr := ln.Accept()
+			if aerr != nil {
+				return
+			}
+			c.Close()
+		}
+	}()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	probe := fmt.Sprintf(`if (exec 3<>/dev/tcp/127.0.0.1/%d) 2>/dev/null; then
+  echo '{"changes":[],"answer":"reachable"}'
+else
+  echo '{"changes":[],"answer":"unreachable"}'
+fi`, port)
+
+	// Control: without the sandbox the server is reachable (proves the probe).
+	stdout, _, _, runErr := RunBlock(context.Background(), CodeSpec{
+		Program: "bash",
+		Code:    probe,
+		Sandbox: SandboxPolicy{Mode: SandboxOff},
+	})
+	require.NoError(t, runErr)
+	_, answer, perr := parseCodeOutput(stdout)
+	require.NoError(t, perr)
+	require.Equal(t, "reachable", answer, "control run must reach the loopback server")
+
+	// Sandboxed (default policy): the new netns has no route to the host loopback.
+	stdout, _, _, runErr = RunBlock(context.Background(), CodeSpec{
+		Program: "bash",
+		Code:    probe,
+	})
+	require.NoError(t, runErr)
+	_, answer, perr = parseCodeOutput(stdout)
+	require.NoError(t, perr)
+	require.Equal(t, "unreachable", answer, "sandboxed child must have no network access")
+}
+
+// TestSandbox_FSConfinedToWorkdir proves Landlock confinement: a file outside
+// the run workdir (and outside the read-only system dirs) is readable without
+// the sandbox but not inside it.
+func TestSandbox_FSConfinedToWorkdir(t *testing.T) {
+	requireSandboxSupport(t)
+	if landlockABI() < 1 {
+		t.Skip("kernel has no Landlock support (needs >= 5.13 with landlock LSM enabled)")
+	}
+
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "secret.txt")
+	require.NoError(t, os.WriteFile(secret, []byte("OUTSIDE-SECRET"), 0o644))
+
+	probe := fmt.Sprintf(`if cat %s >/dev/null 2>&1; then
+  echo '{"changes":[],"answer":"readable"}'
+else
+  echo '{"changes":[],"answer":"denied"}'
+fi`, secret)
+
+	stdout, _, _, runErr := RunBlock(context.Background(), CodeSpec{
+		Program: "bash",
+		Code:    probe,
+		Sandbox: SandboxPolicy{Mode: SandboxOff},
+	})
+	require.NoError(t, runErr)
+	_, answer, perr := parseCodeOutput(stdout)
+	require.NoError(t, perr)
+	require.Equal(t, "readable", answer, "control run must read the outside file")
+
+	stdout, _, _, runErr = RunBlock(context.Background(), CodeSpec{
+		Program: "bash",
+		Code:    probe,
+	})
+	require.NoError(t, runErr)
+	_, answer, perr = parseCodeOutput(stdout)
+	require.NoError(t, perr)
+	require.Equal(t, "denied", answer, "sandboxed child must not read outside its workdir")
+}
+
+// TestSandbox_WorkdirStaysWritable proves the flip side of confinement: the
+// sandboxed child can still create and read files in its own workdir.
+func TestSandbox_WorkdirStaysWritable(t *testing.T) {
+	requireSandboxSupport(t)
+
+	code := `echo data > out.txt && cat out.txt >/dev/null && echo '{"changes":[],"answer":"wrote"}'`
+	stdout, stderr, _, runErr := RunBlock(context.Background(), CodeSpec{
+		Program: "bash",
+		Code:    code,
+	})
+	require.NoError(t, runErr, "stderr: %s", stderr)
+	_, answer, perr := parseCodeOutput(stdout)
+	require.NoError(t, perr)
+	require.Equal(t, "wrote", answer)
+}
+
+// TestSandbox_RlimitCPUTrips proves RLIMIT_CPU: a busy loop is killed by the
+// kernel (SIGXCPU) well before the generous wall-clock timeout.
+func TestSandbox_RlimitCPUTrips(t *testing.T) {
+	requireSandboxSupport(t)
+
+	start := time.Now()
+	_, _, timedOut, runErr := RunBlock(context.Background(), CodeSpec{
+		Program: "bash",
+		Code:    "while :; do :; done",
+		Timeout: 30 * time.Second,
+		Sandbox: SandboxPolicy{CPUSeconds: 1},
+	})
+	require.Error(t, runErr, "busy loop must be killed by RLIMIT_CPU")
+	require.False(t, timedOut, "the rlimit, not the wall-clock timeout, must trip")
+	require.Less(t, time.Since(start), 15*time.Second, "SIGXCPU must fire near the 1s CPU limit")
+}
+
+// TestSandbox_FallbackWhenChildCannotStart exercises graceful degradation: a
+// policy whose namespaces cannot be created must fall back to plain execution
+// instead of failing the run. Simulated by requesting the sandbox from within
+// an environment where the probe already failed — covered indirectly: an OFF
+// policy and a NATIVE policy must both produce a working run end-to-end.
+func TestSandbox_ModesBothExecute(t *testing.T) {
+	for _, mode := range []SandboxMode{SandboxOff, SandboxNative} {
+		stdout, stderr, _, runErr := RunBlock(context.Background(), CodeSpec{
+			Program: "bash",
+			Code:    `echo '{"changes":[],"answer":"ok"}'`,
+			Sandbox: SandboxPolicy{Mode: mode},
+		})
+		require.NoError(t, runErr, "mode %s failed: %s", mode, stderr)
+		_, answer, perr := parseCodeOutput(stdout)
+		require.NoError(t, perr)
+		require.Equal(t, "ok", answer, "mode %s", mode)
+	}
+}

--- a/internal/agentruntime/sandbox_main_test.go
+++ b/internal/agentruntime/sandbox_main_test.go
@@ -1,0 +1,14 @@
+package agentruntime
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain hooks the sandbox re-exec protocol: sandboxed RunBlock re-execs
+// this test binary as the confined child, so the child branch must run before
+// the test framework takes over.
+func TestMain(m *testing.M) {
+	MaybeRunSandboxChild()
+	os.Exit(m.Run())
+}

--- a/internal/agentruntime/sandbox_other.go
+++ b/internal/agentruntime/sandbox_other.go
@@ -1,0 +1,21 @@
+//go:build !linux
+
+package agentruntime
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+)
+
+// sandboxSupportedOS gates the sandbox at compile time per GOOS.
+const sandboxSupportedOS = false
+
+// MaybeRunSandboxChild is a no-op on non-Linux platforms.
+func MaybeRunSandboxChild() {}
+
+// sandboxCommand is never reached on non-Linux (sandboxSupportedOS is false);
+// it exists so coderun.go compiles everywhere.
+func sandboxCommand(context.Context, []string, string, SandboxPolicy) (*exec.Cmd, error) {
+	return nil, errors.New("sandbox: not supported on this OS")
+}

--- a/internal/fleet/config.go
+++ b/internal/fleet/config.go
@@ -28,6 +28,8 @@ type Config struct {
 	OfferedTools           []string      // a role's tools must be a subset of these
 	AllowedPrograms        []string      // programs allowed for code execution (empty = disabled)
 	MaxStdoutBytes         int           // stdout cap per code child (bytes); 0 → 1 MiB default
+	Sandbox                string        // code-exec sandbox mode: "native" (default) | "off"
+	SandboxNetwork         bool          // allow host network inside the code-exec sandbox
 	PollInterval           time.Duration // discovery/reconcile poll cadence
 	ShutdownGrace          time.Duration // max time to drain in-flight runs on shutdown
 	KeepWebhooksOnShutdown bool          // skip webhook deregister on shutdown (rolling deploys; trip2g retains + retries)

--- a/internal/fleet/handler.go
+++ b/internal/fleet/handler.go
@@ -383,6 +383,7 @@ func (f *Fleet) execRole(p execRoleInput) (*agentruntime.Result, error) {
 			EnvPassthrough:  p.Role.EnvPassthrough,
 			EnvPrefix:       p.Role.EnvPrefix,
 			MaxStdoutBytes:  f.cfg.MaxStdoutBytes,
+			Sandbox:         f.sandboxPolicy(),
 		})
 	}
 	return agentruntime.Run(p.Ctx, agentruntime.Input{
@@ -394,9 +395,18 @@ func (f *Fleet) execRole(p execRoleInput) (*agentruntime.Result, error) {
 		MaxTokens:       clampBudget(p.Role.MaxTokens, f.cfg.TokenCeiling),
 		MaxSteps:        clampBudget(p.Role.MaxSteps, f.cfg.StepCeiling),
 		AllowedPrograms: f.cfg.AllowedPrograms,
+		Sandbox:         f.sandboxPolicy(),
 		LLM:             f.llm,
 		KB:              kb,
 	})
+}
+
+// sandboxPolicy maps the fleet-level sandbox config to the runtime policy.
+func (f *Fleet) sandboxPolicy() agentruntime.SandboxPolicy {
+	return agentruntime.SandboxPolicy{
+		Mode:    agentruntime.SandboxMode(f.cfg.Sandbox),
+		Network: f.cfg.SandboxNetwork,
+	}
 }
 
 func writeJSON(w http.ResponseWriter, code int, v any) {


### PR DESCRIPTION
Implements the Tier-0 recommendation from `docs/dev/2026-07-02_fleet_sandbox_research.md` (§4/§5) at the single exec choke point, `agentruntime.RunBlock` (`internal/agentruntime/coderun.go`). Both entry paths — `executor: code` roles and the LLM `exec` tool — are covered.

## Posture (default `--sandbox=native`)

Per run, a re-exec child launcher (`/proc/self/exe __fleet-coderun-child <spec>`, the runc/Windmill pattern) applies before exec'ing the interpreter:

- **Network off** — `CLONE_NEWNET` (empty netns, no route to anything). Non-root daemons get it via `CLONE_NEWUSER` + identity uid/gid map (the `unshare --map-root-user` pattern); root daemons create the netns directly. Opt back in per fleet with `--sandbox-network` / `TRIP2G_FLEET_SANDBOX_NETWORK`.
- **Filesystem confinement** — `go-landlock` (`landlock.V5.BestEffort()`): read-only system dirs (`/usr /bin /sbin /lib* /etc /opt` + resolved interpreter dir, `IgnoreIfMissing`), read-write **only** the throwaway run workdir, plus `/dev/null`-class RW files.
- **rlimits** — CPU (tracks the wall-clock timeout + 5s grace, else 300s), AS 4 GiB, FSIZE 64 MiB, NPROC 256, NOFILE 512 (all overridable via `SandboxPolicy`).
- **Privilege hygiene** — `PR_SET_NO_NEW_PRIVS` always; when the daemon runs as root the child drops to uid/gid 65534 (workdir chowned to match).

Composes with (does not replace) the existing gates: `--allowed-programs` (which binary may run), secret-scrubbed `buildChildEnv` (what it sees), and post-run `write_patterns` scope (what the KB persists).

## Fallback behavior

- **Non-Linux** (`sandbox_other.go`, GOOS build tags): compile-time no-op — logs one warning and runs exactly as before.
- **Kernel without Landlock** (<5.13 or LSM not enabled, e.g. unverified Fly 5.15 config): `BestEffort()` silently degrades the FS rules; netns/rlimits/NNP still apply.
- **Namespaces denied** (unprivileged userns disabled, container seccomp blocking `clone`): the sandboxed child fails to *start* (`cmd.ProcessState == nil` discriminator) → one `slog` warning → the run retries unsandboxed. No run ever fails just because the kernel can't sandbox.
- `--sandbox=off` restores today's behavior entirely.

## Support matrix

| Platform | netns | Landlock FS | rlimits/NNP | uid drop |
|---|---|---|---|---|
| Linux ≥5.13, landlock LSM on | yes | yes | yes | when root |
| Linux ≥5.13, landlock off | yes | no-op (BestEffort) | yes | when root |
| Linux, unprivileged userns disabled, non-root | fallback (warned) | fallback | fallback | — |
| Docker default seccomp (blocks clone-with-ns) | fallback (warned) | fallback | fallback | — |
| macOS / Windows | off (compile-gated no-op, warned) | — | — | — |

`CGO_ENABLED=0` preserved: go-landlock + psx are pure-Go (verified: `CGO_ENABLED=0 go build ./cmd/fleet` plus darwin/arm64, windows/amd64, linux/arm64 cross-builds).

## Config

- fleet: `--sandbox=native|off` (default `native`), `--sandbox-network` (default off) → `fleet.Config.Sandbox`/`SandboxNetwork` → `agentruntime.SandboxPolicy` threaded through `CodeInput`, `Input` (exec tool), and `CodeSpec`.
- `cmd/fleet` main() now calls `agentruntime.MaybeRunSandboxChild()` first (re-exec protocol); test binaries hook it in `TestMain`.
- e2e compose sets `TRIP2G_FLEET_SANDBOX_NETWORK=true` for the krisp-ingest role (it legitimately fetches from krisp-mock).

## Tests (Linux-gated, `t.Skip` when the kernel can't sandbox)

All passed live on a 6.8 kernel:
- `TestSandbox_NetworkBlocked` — loopback TCP server reachable unsandboxed, unreachable sandboxed.
- `TestSandbox_FSConfinedToWorkdir` — file outside the workdir readable unsandboxed, denied sandboxed (skips if Landlock ABI = 0).
- `TestSandbox_WorkdirStaysWritable` — confinement doesn't break the run contract.
- `TestSandbox_RlimitCPUTrips` — busy loop killed by SIGXCPU at ~1s, not the 30s wall clock.
- `TestSandbox_ModesBothExecute` — both modes produce working end-to-end runs.
- All pre-existing coderun/runcode tests now run under the native default and stay green (`go test -race`).

## Deliberately deferred

- Tier-1 (`nsjail`/`bwrap`) and Tier-2 (gVisor systrap) operator-selectable modes — the `--sandbox` enum leaves room (`native|off` today).
- Per-role network opt-in (frontmatter key) — network is a fleet-level knob for now.
- cgroup-v2 real-RSS caps (only coarse `RLIMIT_AS`) — unreliable on Fly's hybrid cgroup layout per the research.

## Verification

- `go build -tags dev ./...`, `CGO_ENABLED=0 go build ./cmd/fleet`, 3 cross-targets: clean
- `go test -race ./cmd/fleet/... ./internal/agentruntime/... ./internal/fleet/...`: green
- pinned golangci-lint (`--build-tags dev`) on changed packages: 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)