### PR TITLE
refactor(server): split shared appState from per-tx scope, drop tx EnvMap, guard nested tx

### DIFF
--- a/cmd/server/auth.go
+++ b/cmd/server/auth.go
@@ -38,14 +38,14 @@ func (a *app) setTokenValidator() {
 }
 
 func (a *app) UpsertAPIKeyLogAction(ctx context.Context, name string) error {
-	if txEnv, ok := ctx.Value(txEnvKey).(*app); ok && txEnv.currentTx != nil {
+	if txEnv := a.txEnvFromCtx(ctx); txEnv != nil {
 		return txEnv.WriteQueries.UpsertAPIKeyLogAction(ctx, name)
 	}
 	return a.WriteQueries.UpsertAPIKeyLogAction(ctx, name)
 }
 
 func (a *app) UpsertAPIKeyLogIP(ctx context.Context, ip string) error {
-	if txEnv, ok := ctx.Value(txEnvKey).(*app); ok && txEnv.currentTx != nil {
+	if txEnv := a.txEnvFromCtx(ctx); txEnv != nil {
 		return txEnv.WriteQueries.UpsertAPIKeyLogIP(ctx, ip)
 	}
 	return a.WriteQueries.UpsertAPIKeyLogIP(ctx, ip)

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"time"
+	"trip2g/internal/appreq"
 	"trip2g/internal/case/admin/deletesecret"
 	"trip2g/internal/case/admin/getsecret"
 	"trip2g/internal/case/admin/setsecret"
@@ -44,9 +45,36 @@ func (a *app) CurrentTx() *sql.Tx {
 	return a.currentTx
 }
 
+// txEnvFromCtx returns the transaction-scoped env visible from ctx or the
+// receiver, or nil when no write transaction is open. It checks the same
+// three channels the tx-aware call sites use: the explicit txEnvKey set by
+// WithTransaction, the request env swapped in by AcquireTxEnvInRequest, and
+// the receiver itself.
+func (a *app) txEnvFromCtx(ctx context.Context) *app {
+	if txEnv, ok := ctx.Value(txEnvKey).(*app); ok && txEnv.currentTx != nil {
+		return txEnv
+	}
+	if req, err := appreq.FromCtx(ctx); err == nil {
+		if env, ok := req.Env.(*app); ok && env.currentTx != nil {
+			return env
+		}
+	}
+	if a.currentTx != nil {
+		return a
+	}
+	return nil
+}
+
 // WithTransaction runs the given function within a database transaction.
 // fn should return true to commit the transaction, false to rollback.
 func (a *app) WithTransaction(ctx context.Context, fn func(context.Context, *app) (bool, error)) error {
+	// The write pool has a single connection (db.Setup), so beginning a second
+	// transaction inside an open one blocks forever waiting for the connection
+	// the outer scope holds. Fail loudly instead.
+	if txEnv := a.txEnvFromCtx(ctx); txEnv != nil {
+		return errors.New("nested WithTransaction: a write transaction is already open")
+	}
+
 	// not sure but I guess transactions should run on writeConn
 	tx, err := a.writeConn.BeginTx(ctx, nil)
 	if err != nil {

--- a/cmd/server/graphql.go
+++ b/cmd/server/graphql.go
@@ -3,12 +3,10 @@ package main
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 	"trip2g/internal/appreq"
 	"trip2g/internal/case/listactiveusersubgraphs"
 	"trip2g/internal/db"
@@ -28,11 +26,6 @@ type txEnvKeyType struct{}
 //nolint:gochecknoglobals // Context key for transactional env
 var txEnvKey = txEnvKeyType{}
 
-type graphTransactions struct {
-	sync.Mutex
-	EnvMap map[*app]*sql.Tx
-}
-
 func (a *app) ListActiveUserSubgraphs(ctx context.Context, userID int64) ([]string, error) {
 	// TODO: add caching for this method
 	return listactiveusersubgraphs.Resolve(ctx, a, userID)
@@ -42,6 +35,12 @@ func (a *app) AcquireTxEnvInRequest(ctx context.Context, label string) error {
 	req, err := appreq.FromCtx(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get request from context: %w", err)
+	}
+
+	// The single write connection is held for the tx lifetime, so a second
+	// acquire on the same request would block forever waiting for it.
+	if txEnv := a.txEnvFromCtx(ctx); txEnv != nil {
+		return errors.New("nested transaction: request already has an open write transaction")
 	}
 
 	tx, err := a.writeConn.BeginTx(ctx, nil)
@@ -61,11 +60,6 @@ func (a *app) AcquireTxEnvInRequest(ctx context.Context, label string) error {
 	// override the context with the new tx env
 	req.Env = &newEnv
 
-	a.graphTxs.Lock()
-	defer a.graphTxs.Unlock()
-
-	a.graphTxs.EnvMap[&newEnv] = tx
-
 	return nil
 }
 
@@ -75,20 +69,19 @@ func (a *app) ReleaseTxEnvInRequest(ctx context.Context, commit bool) error {
 		return fmt.Errorf("failed to get request from context: %w", err)
 	}
 
-	a.graphTxs.Lock()
-	defer a.graphTxs.Unlock()
-
 	envPtr, ok := req.Env.(*app)
 	if !ok {
 		return errors.New("failed to cast env to *app")
 	}
-	tx, ok := a.graphTxs.EnvMap[envPtr]
-	if !ok {
-		return fmt.Errorf("transactioned env not found for request: %v", req.Env)
+
+	tx := envPtr.currentTx
+	if tx == nil {
+		return errors.New("no open transaction on request env")
 	}
 
-	// Clean up the map entry regardless of commit/rollback
-	delete(a.graphTxs.EnvMap, envPtr)
+	// Restore the base env so nothing keeps using the finished tx scope and a
+	// later acquire on the same request sees a clean state.
+	req.Env = a
 
 	if commit {
 		commitErr := tx.Commit()

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -88,10 +88,27 @@ var _ replicareload.Env = (*app)(nil)
 // A longer interval reduces reload churn (bleve IO + note-loader work) on resource-constrained hosts.
 const replicaNoteReloadInterval = 5 * time.Second
 
+// app is the composition root behind every Env interface in the system. It
+// carries only the per-transaction scope: the query handles and tx swapped
+// when a tx env is created (`newEnv := *a` in AcquireTxEnvInRequest and
+// WithTransaction). Everything process-lifetime lives in the embedded
+// *appState and is shared by reference across all copies.
 type app struct {
+	*appState
+
 	*db.Queries
 	*db.WriteQueries
 
+	queries *db.Queries
+
+	currentTx *sql.Tx
+}
+
+// appState holds all process-lifetime state. It is embedded in app by
+// pointer, so per-transaction app copies share every field here by reference:
+// mutexes and atomics are safe as plain values, and adding a field cannot
+// reintroduce the copied-lock / copied-map bug class.
+type appState struct {
 	Storage
 	*dataencryption.Manager
 	*patreonjobs.PatreonJobs
@@ -121,48 +138,35 @@ type app struct {
 	fedHTTPClient     *fasthttp.Client
 
 	webhookTestCalls []webhookTestCall
-	webhookTestMu    *sync.Mutex
+	webhookTestMu    sync.Mutex
 
 	debugJobLog []debugJobRecord
-	debugJobMu  *sync.Mutex
+	debugJobMu  sync.Mutex
 
-	// noteWriteMu is a POINTER, not a value: app is shallow-copied per request
-	// (`newEnv := *a` in AcquireTxEnvInRequest/WithTransaction). A value mutex
-	// would be copied — defeating cross-request serialization and, worse,
-	// deadlocking if copied while locked. A pointer makes every copy share the
-	// one real mutex so plugin pushNotes and git apply/materialize truly serialize.
-	noteWriteMu *sync.Mutex
+	// noteWriteMu serializes plugin pushNotes and git apply/materialize.
+	noteWriteMu sync.Mutex
 
 	openaiClient *openai.Client
 
 	sigChan     chan os.Signal
 	shutdownCtx context.Context
 	shutdown    context.CancelFunc
-	// Pointer so the per-request shallow copy (newEnv := *a) shares the one flag
-	// rather than copying a noCopy atomic value.
-	stopped *atomic.Bool
+	stopped     atomic.Bool
 	// ready reports whether the instance can fully serve, including writes. It
 	// flips true only after the writer slot is acquired and writer subsystems
 	// (queues, cron, patreon/boosty refresh) have started. /readyz returns 503
 	// until then so Nomad/Traefik route traffic only to fully-ready instances.
-	// Pointer for the same reason as stopped (shared across per-request copies).
-	ready          *atomic.Bool
+	ready          atomic.Bool
 	internalServer *fasthttp.Server
 	// appHandler holds the full public request handler once startServer has
 	// built it. The internal server's leader-side replica intake reads it to run
 	// forwarded writes through the real pipeline; nil (→ 503) until ready.
-	// Pointer (like stopped/ready) so per-request app copies share one atomic.
-	appHandler *atomic.Pointer[fasthttp.RequestHandler]
+	appHandler atomic.Pointer[fasthttp.RequestHandler]
 	ctx        context.Context
 
-	graphTxs *graphTransactions
-
-	queries   *db.Queries
 	conn      *sql.DB
 	writeConn *sql.DB
 	queueConn *sql.DB // separate connection for goqite so queue polling never blocks app writes
-
-	currentTx *sql.Tx
 
 	noteBus *notebus.Bus
 
@@ -203,10 +207,8 @@ type app struct {
 	// localAssetsFS serves note assets from the local-storage dir via the
 	// /_assets/ route. nil unless the local storage backend is active.
 	localAssetsFS *fasthttp.FS
-	// Pointer, not value: app is shallow-copied per request (newEnv := *a), and
-	// assetHashes is shared by reference. A copied value mutex would not guard
-	// the shared map, risking a fatal concurrent map write. See noteWriteMu.
-	assetsMu *sync.Mutex
+	// assetsMu guards assetHashes rebuilds.
+	assetsMu sync.Mutex
 
 	*configregistry.SiteConfigBuilder
 
@@ -314,48 +316,38 @@ func main() {
 	log.Info("using storage prefix", "prefix", config.Storage.Prefix)
 
 	a := &app{
-		Queries:      queries,
-		WriteQueries: writeQueries,
+		appState: &appState{
+			Storage: fileStorage,
+			Manager: initDataEncryptionManager(config),
 
-		Storage: fileStorage,
-		Manager: initDataEncryptionManager(config),
+			config: config,
 
-		config: config,
+			tokenManager: tokenManager,
 
-		tokenManager: tokenManager,
+			hotAuthTokenManager: hotauthtoken.NewManager(config.HotAuthToken),
+			tgAuthTokenManager:  tgauthtoken.NewManager(config.TgAuthToken),
 
-		graphTxs: &graphTransactions{
-			EnvMap: make(map[*app]*sql.Tx),
+			purchaseTokenManager: purchasetoken.NewManager(config.PurchaseToken),
+
+			log:     log,
+			noteBus: notebus.New(log),
+			conn:    conn,
+			// mail:    mailyak.New(mailAddr, mailAuth),
+
+			writeConn: writeConn,
+			queueConn: queueConn,
+
+			UserBans: userbans.New(queries),
+
+			nowpaymentsClient: nowpaymentsClient,
+
+			Client:        turnstile.New(config.Turnstile),
+			signinCounter: &requestemailsignin.SignInCounter{},
 		},
 
-		noteWriteMu:   &sync.Mutex{},
-		assetsMu:      &sync.Mutex{},
-		webhookTestMu: &sync.Mutex{},
-		debugJobMu:    &sync.Mutex{},
-		stopped:       &atomic.Bool{},
-		ready:         &atomic.Bool{},
-		appHandler:    &atomic.Pointer[fasthttp.RequestHandler]{},
-
-		hotAuthTokenManager: hotauthtoken.NewManager(config.HotAuthToken),
-		tgAuthTokenManager:  tgauthtoken.NewManager(config.TgAuthToken),
-
-		purchaseTokenManager: purchasetoken.NewManager(config.PurchaseToken),
-
-		log:     log,
-		noteBus: notebus.New(log),
-		queries: queries,
-		conn:    conn,
-		// mail:    mailyak.New(mailAddr, mailAuth),
-
-		writeConn: writeConn,
-		queueConn: queueConn,
-
-		UserBans: userbans.New(queries),
-
-		nowpaymentsClient: nowpaymentsClient,
-
-		Client:        turnstile.New(config.Turnstile),
-		signinCounter: &requestemailsignin.SignInCounter{},
+		Queries:      queries,
+		WriteQueries: writeQueries,
+		queries:      queries,
 	}
 
 	if config.IsReadReplica() {

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"database/sql"
 	"path/filepath"
-	"sync"
 	"testing"
 	"trip2g/internal/appreq"
 	"trip2g/internal/db"
@@ -36,17 +35,14 @@ func TestWithTransaction(t *testing.T) {
 
 	// set app
 	a := &app{
-		log:          log,
-		conn:         conn,
-		writeConn:    conn,
+		appState: &appState{
+			log:       log,
+			conn:      conn,
+			writeConn: conn,
+		},
 		queries:      queries,
 		Queries:      queries,
 		WriteQueries: writeQueries,
-		graphTxs: &graphTransactions{
-			EnvMap: make(map[*app]*sql.Tx),
-		},
-		noteWriteMu: &sync.Mutex{},
-		assetsMu:    &sync.Mutex{},
 	}
 
 	// Create properly initialized fasthttp context

--- a/cmd/server/pagecache_wiring_test.go
+++ b/cmd/server/pagecache_wiring_test.go
@@ -53,7 +53,7 @@ func (emptyNoteLoaderEnv) ListAllSubgraphs(context.Context) ([]db.Subgraph, erro
 // appWithEmptyLoaders builds an app whose note loaders load nothing and whose
 // page cache holds one entry. Calling a Prepare* method must empty the cache.
 func appWithEmptyLoaders() *app {
-	a := &app{pageCache: pagecache.New()}
+	a := &app{appState: &appState{pageCache: pagecache.New()}}
 	a.latestNoteLoader = noteloader.New("latest", emptyNoteLoaderEnv{}, mdloader.Config{})
 	a.liveNoteLoader = noteloader.New("live", emptyNoteLoaderEnv{}, mdloader.Config{})
 	return a

--- a/cmd/server/queue.go
+++ b/cmd/server/queue.go
@@ -3,13 +3,11 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
 	"sync"
 	"time"
-	"trip2g/internal/appreq"
 	"trip2g/internal/logger"
 	"trip2g/internal/model"
 
@@ -302,35 +300,12 @@ func (a *app) enqueueJobToQ(ctx context.Context, aq *appQueue, job model.Backgro
 		Priority: job.Priority,
 	}
 
-	// First check context for transactional env (works for both HTTP and background jobs)
-	if txEnv, ok := ctx.Value(txEnvKey).(*app); ok && txEnv.currentTx != nil {
-		a.log.Debug("enqueueing in context tx env", "job_id", job.ID, "data", string(rawData), "queue", aq.name)
+	// Enqueue inside the open write transaction if one is visible from ctx
+	// (WithTransaction env, GraphQL request env) or the receiver itself.
+	if txEnv := a.txEnvFromCtx(ctx); txEnv != nil {
+		a.log.Debug("enqueueing in tx env", "job_id", job.ID, "data", string(rawData), "queue", aq.name)
 
 		_, err = jobs.CreateTx(ctx, txEnv.currentTx, aq.q, job.ID, gqMsg)
-		return err
-	}
-
-	// Fallback: check request context (for HTTP requests)
-	req, err := appreq.FromCtx(ctx)
-	if err != nil && !errors.Is(err, appreq.ErrNotFound) {
-		return fmt.Errorf("failed to get request from context: %w", err)
-	}
-
-	if req != nil {
-		env, ok := req.Env.(*app)
-		if ok && env.CurrentTx() != nil {
-			a.log.Debug("enqueueing in request env", "job_id", job.ID, "data", string(rawData), "queue", aq.name)
-
-			_, err = jobs.CreateTx(ctx, env.currentTx, aq.q, job.ID, gqMsg)
-			return err
-		}
-	}
-
-	// Fallback: check global app (should rarely be used now)
-	if a.currentTx != nil {
-		a.log.Debug("enqueueing in app.currentTx", "job_id", job.ID, "data", string(rawData), "queue", aq.name)
-
-		_, err = jobs.CreateTx(ctx, a.currentTx, aq.q, job.ID, gqMsg)
 		return err
 	}
 

--- a/cmd/server/ready_test.go
+++ b/cmd/server/ready_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -25,10 +24,7 @@ func TestIsReady(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			a := &app{
-				stopped: &atomic.Bool{},
-				ready:   &atomic.Bool{},
-			}
+			a := &app{appState: &appState{}}
 			a.stopped.Store(tc.stopped)
 			a.ready.Store(tc.ready)
 

--- a/cmd/server/tx_env_test.go
+++ b/cmd/server/tx_env_test.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+	"trip2g/internal/appreq"
+	"trip2g/internal/db"
+	"trip2g/internal/logger"
+
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+// newTxTestApp builds a minimal app wired to a real SQLite file, the same way
+// TestWithTransaction does. The single connection serves as both read and
+// write pool (db.Setup caps a non-read-only pool at 1 open connection, like
+// production), so transaction-scoping bugs surface as blocked BeginTx calls.
+func newTxTestApp(t *testing.T) *app {
+	t.Helper()
+
+	dbFile := filepath.Join(t.TempDir(), "test.db")
+
+	conn, err := db.Setup(db.SetupConfig{
+		SkipDump:     true,
+		DatabaseFile: dbFile,
+		Logger:       &logger.TestLogger{Prefix: "[test]"},
+	})
+	require.NoError(t, err, "failed to setup test database")
+	t.Cleanup(func() { conn.Close() })
+
+	log := &logger.TestLogger{}
+	queries := db.New(db.WithLogger(conn, logger.WithPrefix(log, "read: no tx:")))
+	writeQueries := db.NewWriteQueries(db.WithLogger(conn, logger.WithPrefix(log, "write: no tx:")))
+
+	return &app{
+		appState: &appState{
+			log:       log,
+			conn:      conn,
+			writeConn: conn,
+		},
+		queries:      queries,
+		Queries:      queries,
+		WriteQueries: writeQueries,
+	}
+}
+
+// newTestRequest stores a fresh appreq bound to a in a fasthttp context, the
+// way the HTTP server does before dispatching (server.go: req.Env = a).
+func newTestRequest(t *testing.T, a *app) *fasthttp.RequestCtx {
+	t.Helper()
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Init(&fasthttp.Request{}, nil, nil)
+
+	req := appreq.Acquire()
+	req.Env = a
+	req.Req = fctx
+	req.StoreInContext()
+	t.Cleanup(func() { appreq.Release(req) })
+
+	return fctx
+}
+
+// Nested WithTransaction must fail loudly. The write pool has a single
+// connection, so silently beginning a second transaction inside an open one
+// blocks forever waiting for the connection the outer scope holds.
+func TestWithTransactionNestedFails(t *testing.T) {
+	a := newTxTestApp(t)
+
+	err := a.WithTransaction(context.Background(), func(txCtx context.Context, env *app) (bool, error) {
+		done := make(chan error, 1)
+		go func() {
+			done <- env.WithTransaction(txCtx, func(context.Context, *app) (bool, error) {
+				return true, nil
+			})
+		}()
+
+		select {
+		case nestedErr := <-done:
+			require.Error(t, nestedErr, "nested WithTransaction must not silently open a second write transaction")
+			require.Contains(t, nestedErr.Error(), "nested")
+		case <-time.After(2 * time.Second):
+			t.Error("nested WithTransaction deadlocked waiting for the single write connection")
+		}
+
+		return false, nil
+	})
+	require.NoError(t, err)
+}
+
+// A nested call on the base env (not the tx copy) must also be detected: the
+// tx env travels in ctx under txEnvKey, and the write connection is still held.
+func TestWithTransactionNestedViaCtxFails(t *testing.T) {
+	a := newTxTestApp(t)
+
+	err := a.WithTransaction(context.Background(), func(txCtx context.Context, _ *app) (bool, error) {
+		done := make(chan error, 1)
+		go func() {
+			done <- a.WithTransaction(txCtx, func(context.Context, *app) (bool, error) {
+				return true, nil
+			})
+		}()
+
+		select {
+		case nestedErr := <-done:
+			require.Error(t, nestedErr)
+			require.Contains(t, nestedErr.Error(), "nested")
+		case <-time.After(2 * time.Second):
+			t.Error("nested WithTransaction via ctx deadlocked waiting for the single write connection")
+		}
+
+		return false, nil
+	})
+	require.NoError(t, err)
+}
+
+// Acquiring a second tx env on a request that already has one must fail
+// loudly instead of blocking on the held write connection.
+func TestAcquireTxEnvInRequestDoubleAcquireFails(t *testing.T) {
+	a := newTxTestApp(t)
+	fctx := newTestRequest(t, a)
+
+	require.NoError(t, a.AcquireTxEnvInRequest(fctx, "first"))
+	defer func() { _ = a.ReleaseTxEnvInRequest(fctx, false) }()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- a.AcquireTxEnvInRequest(fctx, "second")
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "second acquire on the same request must fail")
+	case <-time.After(2 * time.Second):
+		t.Fatal("double AcquireTxEnvInRequest deadlocked waiting for the single write connection")
+	}
+}
+
+// Release must restore the base env on the request so nothing keeps using the
+// dead transaction scope after commit/rollback.
+func TestReleaseTxEnvInRequestRestoresBaseEnv(t *testing.T) {
+	a := newTxTestApp(t)
+	fctx := newTestRequest(t, a)
+
+	require.NoError(t, a.AcquireTxEnvInRequest(fctx, "tx"))
+
+	req, err := appreq.FromCtx(fctx)
+	require.NoError(t, err)
+	require.NotSame(t, a, req.Env, "acquire must swap in a tx-scoped env")
+
+	require.NoError(t, a.ReleaseTxEnvInRequest(fctx, true))
+	require.Same(t, a, req.Env, "release must restore the base env on the request")
+}
+
+// Releasing without an open transaction must return an error, not panic or
+// silently succeed.
+func TestReleaseTxEnvInRequestWithoutAcquireFails(t *testing.T) {
+	a := newTxTestApp(t)
+	fctx := newTestRequest(t, a)
+
+	require.Error(t, a.ReleaseTxEnvInRequest(fctx, true))
+}

--- a/docs/dev/2026-07-02_architecture_smell_review.md
+++ b/docs/dev/2026-07-02_architecture_smell_review.md
@@ -1,0 +1,122 @@
+# Architecture Smell Review (2026-07-02)
+
+Skeptical pass over `main` against the project's own stated principles (`app_patterns.md`, `principles.md`) and Go idiom. Read-only analysis, every claim grounded in file:line.
+
+## TL;DR
+
+The weakest part of the architecture is the `app` god object in `cmd/server` combined with the shallow-copy transaction mechanism: a ~70-field, 25-embed struct with 272 methods whose correctness depends on Go struct-copy semantics (`newEnv := *a`). Every synchronization primitive on it must be a pointer or the system deadlocks or races, and the struct carries multi-paragraph warning comments to keep contributors from stepping on that mine. The top Go-idiom problem is the same pattern seen from the interface side: `graph.Env` is a roughly 340-method mega-interface that only `*app` can satisfy, which inverts the codebase's otherwise excellent small-Env-per-consumer discipline at exactly the point where it matters most.
+
+Verdict up front: the leaf-level architecture (use-case packages, per-case Env, moq tests, SQLite R/W split, service packages) is genuinely good. The rot is concentrated in one place, the composition root, and it is fixable incrementally.
+
+## The weakest link: `app` plus shallow-copy tx envs
+
+### What it is
+
+`cmd/server/main.go:91-247` defines `type app struct` with:
+
+- 2 embedded query facades (`*db.Queries`, `*db.WriteQueries`, main.go:92-93)
+- ~20 embedded job types (`*sendtelegrampost.SendTelegramPostJob` and friends, main.go:97-119)
+- ~45 named fields covering queues, caches, loaders, clients, token managers, mutexes, atomics, contexts
+- 272 methods spread over 20 files in `cmd/server` (`grep -c 'func (a \*app)'`)
+
+`app` is the single concrete type behind every Env interface in the system (196 `type Env interface` declarations across `internal/`). That part is by design and mostly fine. The problem is how transactions are scoped:
+
+```go
+// cmd/server/graphql.go:55-59 (same shape in config.go:65-69)
+newEnv := *a
+newEnv.queries = queries.Queries
+newEnv.Queries = queries.Queries
+newEnv.WriteQueries = queries
+newEnv.currentTx = tx
+```
+
+A per-request or per-transaction env is a shallow copy of the entire 70-field struct with three fields swapped. This has three consequences:
+
+1. **Copy semantics become a systemwide invariant.** Any field that must be shared across copies has to be a pointer. The struct itself documents the failure modes: `noteWriteMu` "A value mutex would be copied, defeating cross-request serialization and, worse, deadlocking if copied while locked" (main.go:129-134); `stopped`, `ready`, `appHandler` all repeat the same warning (main.go:141-155); `assetsMu` warns about "a fatal concurrent map write" (main.go:206-209). Four separate defensive comments exist because the pattern was bitten four separate times. The next contributor who adds `mu sync.Mutex` instead of `mu *sync.Mutex` reintroduces the bug class silently; no linter catches it.
+
+2. **A side registry duplicates state already in the copy.** `graphTransactions` at `cmd/server/graphql.go:31-34` is `map[*app]*sql.Tx` keyed by the address of each copied env, populated at graphql.go:67 and drained at graphql.go:91. But the tx is already stored in the copy itself (`newEnv.currentTx`, graphql.go:59, readable via `CurrentTx()` at config.go:42-44). The map exists only so `ReleaseTxEnvInRequest` can find the tx again from the request env. If any code path skips release (a panic that gqlgen recovers past the `handler.go:174-184` commit/rollback hooks, a future second call site), the map entry and the open write transaction leak forever, and on SQLite an orphaned write tx blocks the single writer. The map is also unbounded growth waiting for a bug.
+
+3. **Nested transactions are silently wrong.** `WithTransaction` (config.go:48-88) begins a fresh tx on `a.writeConn` unconditionally. Because the copied env still carries `writeConn`, calling `env.WithTransaction` from inside an already-transactional env opens a second, independent SQLite write transaction rather than a savepoint or an error. Nothing prevents a use case from doing this; the invariant lives in developers' heads.
+
+### Why this is #1
+
+Blast radius: every request, every mutation, every background job flows through this object; `cmd/server` is where all 63 use-case packages, all queues, and all service packages meet. Churn: `case_methods.go`, `note_loader_envs.go`, `config.go` etc. grow with every feature. Testability: `cmd/server/main_test.go:38` constructs a hand-picked partial `app` literal, which works only because tests know which of the 70 fields a code path touches; there is no compiler help.
+
+### Refactor direction
+
+Keep the Env idea, kill the copy trick:
+
+- Replace the shallow copy with a small explicit scope type, e.g. `type txScope struct { *app; q *db.Queries; wq *db.WriteQueries; tx *sql.Tx }` whose method set overrides only the query accessors. The compiler then guarantees the rest of `app` is shared by reference, all mutex/atomic footguns disappear, and the warning comments can be deleted.
+- Delete `graphTxs.EnvMap`; `ReleaseTxEnvInRequest` can read the tx from the scope it already holds via `req.Env`.
+- Make `WithTransaction` detect an existing tx (`currentTx != nil`) and either reuse it or fail loudly.
+- Longer term, group `app` fields into 5-6 domain structs (telegram, payments, notes/loaders, auth/tokens, infra) embedded once, shrinking the flat field list and giving the boot sequence in `main()` natural phases.
+
+## Top smells (ranked)
+
+| # | Smell | Location | Severity | Why it hurts |
+|---|-------|----------|----------|--------------|
+| 1 | God object + shallow-copy tx env | cmd/server/main.go:91-247, graphql.go:55, config.go:65 | High | Copy-semantics correctness invariant, tx leak vector, nested-tx hazard |
+| 2 | `graph.Env` mega-interface | internal/graph/resolver.go:156-497 | High | ~340 methods, only `*app` satisfies it; small-Env discipline inverted |
+| 3 | sqlc row types leak through all layers | 137 of the case `resolve.go` files import `internal/db`; graph.Env returns `db.*` rows | Medium-high | Schema change ripples to resolvers and frontend contract |
+| 4 | No context in the markdown pipeline | internal/mdloader/loader.go:111 `func Load(options Options)` | Medium-high | Hottest CPU path (full reload per push) is non-cancellable |
+| 5 | Hidden IO in innocent getters | cmd/server/config.go:31-35 (`SiteTitleTemplate`), config.go:89-101 (`Now()`) | Medium | `Now()` performs a DB config read with a fresh `context.Background()` per call |
+| 6 | Fire-and-forget goroutine per page view | internal/case/rendernotepage/resolve.go:449-454 | Medium | Unbounded, unsupervised, error swallowed, no shutdown coordination |
+| 7 | Copy-paste duplication | cmd/server/graphql.go:181-271; internal/case/backjob (12 telegram job clones); case_methods.go `*WithTx` pairs | Medium | Fix-in-one-forget-the-other class of bugs |
+| 8 | `appreq.Request` god context + panics on env access | internal/appreq/request.go:28-84; internal/graph/resolver.go:142-154 | Medium | Service-locator with `Env interface{}`; resolver `panic(err)` on missing/mistyped env |
+| 9 | Complexity exclusions are un-refactored, not irreducible | internal/case/rendernotepage/resolve.go:192 (Resolve), internal/noteloader/loader.go:139 (228-line Load) | Low-medium | Orchestration functions doing sequential phases inline |
+| 10 | `internal/model` as secondary dumping ground | internal/model (5.6k lines), note.go (1472 lines), `RawMeta map[string]interface{}` at note.go:198 | Low | NoteView mixes parsing, rendering, routing, JSON-LD, telegram concerns |
+
+### 2. The `graph.Env` mega-interface
+
+`internal/graph/resolver.go:156-497` embeds roughly 150 use-case `Env` interfaces plus ~190 direct method declarations into one interface. The per-case Env pattern is supposed to produce small consumer-defined interfaces, and at the leaf it does. But the GraphQL layer aggregates them all back into one interface that only `*app` can ever satisfy, so the abstraction buys nothing at that boundary: no alternative implementation is possible, no test can stub it (the wiring test at handler_wiring_test.go stubs a tiny 2-method subset instead, which is telling: the real seam is small). Meanwhile `Resolver.env()` at resolver.go:142-154 panics twice on the happy-path lookup (`panic(err)`, `panic("request env is not of type Env")`), turning a wiring mistake into a process-level recover instead of a 500 with context. Direction: gqlgen's resolver root can hold several domain-scoped interfaces (`AdminEnv`, `TelegramEnv`, `NotesEnv`, ...) as fields; the aggregation then lives in the struct literal at wiring time, not in one unreviewable interface.
+
+### 3. sqlc rows as the de facto domain model
+
+Env methods across the codebase traffic in `db.User`, `db.Offer`, `db.CreateNoteAssetParams`, `db.GetFormStringValuesBySubmitIDRow` (resolver.go:161-210 is a wall of them). This is a deliberate pragmatic choice (sqlc rows are cheap, and `principles.md` never promised hexagonal purity), but the cost is real: renaming a column or reshaping a query type touches use cases, graph resolvers, and via gqlgen bindings potentially the schema. The `Row`-suffixed types leaking into `graph.Env` (e.g. `AllWaitListEmailRequestsRow`, resolver.go:185) are query-shape artifacts appearing in an API-layer contract. Not worth a big-bang fix, but new subsystems should prefer `model` types at Env boundaries, which `noteloader.Env` (loader.go:51-76) already does well.
+
+### 4. Context stops at the markdown pipeline
+
+`mdloader.Load(options Options)` (loader.go:111) and everything below it take no `context.Context`. This is the exact path prior perf work identified as the hot one (full `noteloader.Load` per push, ~45% CPU in GC under load, `docs/dev/sync_perf_memory_2026-06-29.md`). A slow reload cannot be cancelled on shutdown or superseded when a newer push arrives; `noteloader.Load` (loader.go:139, 228 lines, cyclop/gocyclo excluded) holds the loader mutex throughout. Threading ctx through mdloader is mechanical and unlocks cancellation, deadline, and per-phase tracing.
+
+### 5. `Now()` reads the database
+
+`func (a *app) Now() time.Time` (config.go:89-101) calls `a.SiteConfig(ctx)` with a fresh `context.Background()` and 5-second timeout to fetch the configured timezone, then `time.LoadLocation` per call. A function named `Now()` sitting in dozens of Env contracts looks free and pure; it is neither. `SiteTitleTemplate()` (config.go:31-35) has the same shape. Under the covers SiteConfig is presumably cached, but the pattern violates the project's own "IO on the app layer, explicit ctx" discipline and least surprise. Direction: cache the `*time.Location` on config reload and make `Now()` a pure read; getters that can do IO should take ctx.
+
+### 6. Unsupervised goroutine per authenticated page view
+
+rendernotepage/resolve.go:449-454 spawns a goroutine per logged-in view to `RecordUserNoteView` with `context.Background()`, ignoring the returned state entirely. Under a crawl or hot page this is unbounded goroutine creation all funneling writes at SQLite's single writer, with no error visibility and no shutdown drain (a SIGTERM can lose views mid-flight, acceptable, or worse interleave with the writer-slot handoff). Direction: a small buffered channel plus one consumer goroutine owned by `app`, dropping on overflow, closed on shutdown.
+
+### 7. Duplication
+
+`GraphQLRequest` and `GraphQLRequestScoped` (graphql.go:181-223 vs 229-271) are ~45 identical lines differing in one token-stamping line; extract the shared body. The `internal/case/backjob` telegram family (send/update x post/message x bot/account = 12 packages, 43-1200 lines each) plus the paired `X` / `XWithTx` proxies in case_methods.go:22-70 are structural clones; a parameterized job runner or shared core would collapse most of it. gochecknoglobals exclusions, by contrast, are clean: nearly all are immutable lookup tables with honest justifications.
+
+### 8. `appreq.Request` as service locator
+
+`internal/appreq/request.go:28-84` is a pooled, mutable struct carrying `Env interface{}`, the fasthttp ctx, token state, webhook scoping, federation identity, and delivery attribution in one bag, reset field-by-field at request.go:86-106 (forget a field on Reset when adding one and you get cross-request state bleed from the pool; the `mu sync.Mutex` on a pooled struct at least survives reuse). Fetching the env from it with a type assertion is the classic service-locator anti-pattern Go's Env idiom exists to avoid; here both live side by side, and the assertion failure path panics (resolver.go:150). This is load-bearing plumbing for the tx-env swap, so fixing smell #1 shrinks this too.
+
+### 9 and 10, briefly
+
+The golangci complexity exclusions map to long sequential-phase orchestrators, not irreducible algorithms: `rendernotepage.Resolve` (resolve.go:192, ~140 lines) is note lookup, paywall, banner, token, telegram links, sidebars in one function and would split cleanly along those phases. `russkayalatinica` is the exception: a genuinely complex transliteration algorithm where the exclusion is honest. `model/note.go` (1472 lines) accretes routing, JSON-LD, og-image, telegram, and chart concerns onto `NoteView` with `map[string]interface{}` frontmatter (note.go:198); the sibling `note_*.go` split shows the right instinct, it just needs to keep going.
+
+## What's actually good
+
+Calibration matters, and most of this codebase holds up:
+
+- **The per-case Env + moq pattern works.** 63 use-case packages with minimal package-local Env interfaces, 115 `moq` generate directives, table-driven tests. `noteloader.Env` (loader.go:51-76) is a textbook consumer-defined interface with documented methods.
+- **Error handling is consistent.** `%w` wrapping with descriptive prefixes everywhere sampled (pushnotes/resolve.go:77-99), sentinel helpers like `db.IsNoFound`, and the ErrorPayload vs system-error split is followed.
+- **SQLite discipline is real engineering.** Read/write/queue connection split (main.go:283-284), prepared-statement cache on the read pool with a correct note about why tx paths must not use it (main.go:290-295), and the Block A / writer-slot / Block B boot sequence (main.go:375-520) is well designed and unusually well commented.
+- **Service packages follow their own doc.** `gitapi`, `chartdata`, `notebus`, `pagecache` each declare a minimal Env, are named after the domain, embed into `app` without proxy methods, and keep state off package level. `var _ mcp.Env = (*app)(nil)` compile checks are present (main.go:83-84).
+- **Globals are almost all justified.** The gochecknoglobals nolints are immutable lookup tables and context keys, each with a reason.
+- **The lint config is strict** (golden config, cyclop 30, funlen 150) and the exclusion list is narrow and explained rather than a blanket mute.
+
+## Prioritized remediation
+
+1. **Replace `newEnv := *a` with an explicit tx scope type and delete `graphTxs.EnvMap`** (graphql.go:31-109, config.go:48-88). Highest leverage: removes the copy-semantics invariant, the tx-leak vector, and the nested-tx hazard in one move. Effort: 1-2 days plus careful review of the ~30 `WithTransaction` call sites.
+2. **Thread `context.Context` through mdloader and bound the reload path** (mdloader/loader.go:111 downward). Mechanical, unlocks cancellation on the known hot path. Effort: half a day.
+3. **Make `Now()` and `SiteTitleTemplate()` pure** by caching the timezone/location on config reload (config.go:31-35, 89-101). Effort: hours.
+4. **Supervise `RecordUserNoteView`** with a bounded channel and single writer owned by `app` (rendernotepage/resolve.go:449-454). Effort: hours.
+5. **Deduplicate `GraphQLRequest`/`GraphQLRequestScoped`** and then the telegram backjob clones behind a parameterized core. Effort: hours for the first, 2-3 days for the jobs.
+6. **Split `graph.Env` into domain-scoped interfaces on the resolver root** and turn the `env()` panics into errors. Effort: 2-4 days, purely mechanical after deciding the grouping; do it after item 1 so the scope type is what gets asserted.
+7. **Background, opportunistic:** prefer `model` types over `db.*Row` types in new Env contracts; keep splitting `model/note.go` by concern; phase-split `rendernotepage.Resolve` next time it changes and drop its lint exclusion.
+
+Items 1-4 remove the actual hazards. Items 5-7 are hygiene that pays down churn cost. Nothing here requires a rewrite; the composition root is the only place where the architecture fights its own principles.


### PR DESCRIPTION
Implements item 1 of the prioritized remediation in `docs/dev/2026-07-02_architecture_smell_review.md` ("The weakest link: `app` plus shallow-copy tx envs").

## Chosen approach: hollow out `app` into a shared `*appState`

`app` now carries only the per-transaction scope; everything process-lifetime moved into an embedded `*appState`:

```go
type app struct {
    *appState          // all ~65 process-lifetime fields, shared by reference

    *db.Queries        // swapped per tx
    *db.WriteQueries   // swapped per tx
    queries   *db.Queries
    currentTx *sql.Tx
}
```

`newEnv := *a` still exists, but it now copies five pointers and nothing else — the copy is provably safe by construction. Field and method promotion through the embedded pointer keeps every one of the 272 `(a *app)` methods and all ~196 per-case `Env` interfaces working unchanged: zero use-case packages touched, zero call sites migrated.

## Alternatives considered

- **`txScope` wrapper type embedding `*app`** (the direction sketched in the smell review). Rejected after tracing receiver binding: ~60 methods on `*app` dereference `a.Queries`/`a.WriteQueries`/`a.currentTx` directly, and ~28 pass `a` itself into `Resolve(ctx, a, ...)`. With a wrapper, those methods keep the base-app receiver and would silently run **outside** the transaction — the worst possible failure mode, and undetectable. Method promotion satisfies the interfaces; it does not rebind receivers.
- **Threading a querier through `context`/rewriting use cases.** Correct long-term but a big-bang migration across 63 use-case packages; not one reviewable PR.
- The `appState` split gets the same safety guarantee as the wrapper with none of the receiver-binding hazard, and the compiler enforced the whole migration (struct literal + tests were the only fallout).

## How each hazard dies

1. **Copy-semantics invariant** (main.go:129-155, 206-209): mutexes and atomics moved into `appState` are now plain values (`sync.Mutex`, `atomic.Bool`, `atomic.Pointer`) — they are never copied because `appState` is shared by pointer. The four defensive "must be a pointer" comments are deleted; the next contributor adding `mu sync.Mutex` to `appState` gets correct behavior for free.
2. **`graphTxs.EnvMap` leak vector** (graphql.go:31-34): deleted entirely, along with its mutex. `ReleaseTxEnvInRequest` reads the tx from the scope it already holds (`req.Env.(*app).currentTx`). No side registry, no unbounded map, no leaked SQLite write tx when release is skipped — there is nothing left to leak. Release now also restores the base env on the request, so nothing can keep using a finished tx scope.
3. **Silent nested transactions** (config.go:48-88): `WithTransaction` and `AcquireTxEnvInRequest` now fail loudly when a write transaction is already visible (new `txEnvFromCtx` helper checks `txEnvKey`, the request env, and the receiver — the same three channels `enqueueJobToQ` used; that triplicated lookup is now unified behind the helper, also in `auth.go`). Fail-loud is safe by construction: the write pool is `SetMaxOpenConns(1)` (internal/db/setup.go:84), so any live nested path today does not "silently open a second tx" — it **deadlocks**. The new tests reproduce that deadlock on the old code (2s timeout guard) and prove the guard converts it into an immediate error.

## Tests (written first, red on old code)

`cmd/server/tx_env_test.go`:
- `TestWithTransactionNestedFails` / `TestWithTransactionNestedViaCtxFails` — deadlocked before (reproduced), error now
- `TestAcquireTxEnvInRequestDoubleAcquireFails` — deadlocked before, error now
- `TestReleaseTxEnvInRequestRestoresBaseEnv` — failed before (stale tx env left on request), passes now
- `TestReleaseTxEnvInRequestWithoutAcquireFails` — regression pin

Existing `TestWithTransaction` (acquire/commit/rollback/re-acquire round trip) passes unchanged and pins the EnvMap deletion.

## Blast radius

`cmd/server` only: main.go (struct split + literal), graphql.go, config.go, auth.go, queue.go, plus three test files' literals. No changes under `internal/`, no Env interface changes, no GraphQL schema/resolver changes. Behavior change surface: paths that previously deadlocked now return an error; `ReleaseTxEnvInRequest` restores the base env after commit/rollback.

Verified: `go build ./...`, `go test ./cmd/server/... ./internal/graph/... ./internal/appreq/... ./internal/db/...`, `go test -race` on the tx tests, `golangci-lint run cmd/server/...` — all clean.

## Follow-ups (out of scope, from the smell review)

- Group `appState`'s flat field list into domain structs (telegram, payments, notes, auth, infra)
- Split `graph.Env` into domain-scoped resolver interfaces (item 6) — easier now that the copy trick is contained

🤖 Generated with [Claude Code](https://claude.com/claude-code)
