### PR TITLE
test(agentruntime): close sandbox test-coverage gaps — CI-skip guard, no-new-privs, rlimits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,18 @@ jobs:
       - name: Run tests
         run: go test -tags dev ./...
 
+      # The sandbox enforcement tests self-skip on kernels without unprivileged
+      # userns/Landlock, so a plain run can go green without executing them.
+      # This privileged lane sets SANDBOX_TESTS_REQUIRED=1: unsupported → FAIL.
+      - name: Sandbox enforcement tests (privileged, skip forbidden)
+        run: >
+          docker run --rm --privileged
+          -v "$PWD":/src -w /src
+          -v "$(go env GOMODCACHE)":/go/pkg/mod
+          -e SANDBOX_TESTS_REQUIRED=1
+          -e GOFLAGS=-buildvcs=false
+          golang:1.26 go test ./internal/agentruntime/ -run TestSandbox -v
+
   e2e:
     runs-on: ubuntu-latest
     needs: [lint, test]

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -507,5 +507,22 @@ services:
       retries: 10
       start_period: 15s
 
+  # Sandbox enforcement tests under a privileged container where userns +
+  # Landlock are guaranteed: SANDBOX_TESTS_REQUIRED=1 turns kernel-support
+  # skips into failures. Not part of the default e2e stack — run explicitly:
+  #   docker compose -f docker-compose.test.yml run --rm sandbox-test
+  sandbox-test:
+    image: golang:1.26
+    container_name: trip2g-test-sandbox
+    privileged: true
+    profiles: ["sandbox"]
+    working_dir: /src
+    volumes:
+      - .:/src
+    environment:
+      - SANDBOX_TESTS_REQUIRED=1
+      - GOFLAGS=-buildvcs=false
+    command: ["go", "test", "./internal/agentruntime/", "-run", "TestSandbox", "-v"]
+
 volumes:
   test-data:

--- a/internal/agentruntime/sandbox_linux.go
+++ b/internal/agentruntime/sandbox_linux.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 
 	"github.com/landlock-lsm/go-landlock/landlock"
+	llsys "github.com/landlock-lsm/go-landlock/landlock/syscall"
 	"golang.org/x/sys/unix"
 )
 
@@ -78,8 +79,10 @@ func runSandboxChild(encoded string) error {
 	}
 
 	// go-landlock also sets NO_NEW_PRIVS internally, but keep it explicit so
-	// the guarantee holds even when Landlock degrades to a no-op.
-	if pErr := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); pErr != nil {
+	// the guarantee holds even when Landlock degrades to a no-op. Must be the
+	// all-threads variant: prctl is per-thread and the Go runtime may exec
+	// from a different OS thread than the one that ran a plain prctl.
+	if pErr := llsys.AllThreadsPrctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); pErr != nil {
 		return fmt.Errorf("prctl no_new_privs: %w", pErr)
 	}
 

--- a/internal/agentruntime/sandbox_linux_test.go
+++ b/internal/agentruntime/sandbox_linux_test.go
@@ -7,13 +7,26 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	llsys "github.com/landlock-lsm/go-landlock/landlock/syscall"
 	"github.com/stretchr/testify/require"
 )
+
+// skipOrFatal skips by default (dev kernels without userns/Landlock stay
+// green) but fails under SANDBOX_TESTS_REQUIRED=1 — the privileged CI lane
+// sets it so "sandbox unsupported" can never masquerade as a passing run.
+func skipOrFatal(t *testing.T, format string, args ...any) {
+	t.Helper()
+	if os.Getenv("SANDBOX_TESTS_REQUIRED") == "1" {
+		t.Fatalf("SANDBOX_TESTS_REQUIRED=1 but "+format, args...)
+	}
+	t.Skipf(format, args...)
+}
 
 // requireSandboxSupport skips the test when the kernel refuses the sandbox's
 // namespaces (e.g. unprivileged user namespaces disabled) — the production
@@ -27,7 +40,7 @@ func requireSandboxSupport(t *testing.T) {
 	cmd.Dir = dir
 	cmd.Env = []string{"PATH=" + os.Getenv("PATH")}
 	if runErr := cmd.Run(); runErr != nil {
-		t.Skipf("sandbox namespaces unavailable on this kernel: %v", runErr)
+		skipOrFatal(t, "sandbox namespaces unavailable on this kernel: %v", runErr)
 	}
 }
 
@@ -94,7 +107,7 @@ fi`, port)
 func TestSandbox_FSConfinedToWorkdir(t *testing.T) {
 	requireSandboxSupport(t)
 	if landlockABI() < 1 {
-		t.Skip("kernel has no Landlock support (needs >= 5.13 with landlock LSM enabled)")
+		skipOrFatal(t, "kernel has no Landlock support (needs >= 5.13 with landlock LSM enabled)")
 	}
 
 	outside := t.TempDir()
@@ -158,6 +171,163 @@ func TestSandbox_RlimitCPUTrips(t *testing.T) {
 	require.Error(t, runErr, "busy loop must be killed by RLIMIT_CPU")
 	require.False(t, timedOut, "the rlimit, not the wall-clock timeout, must trip")
 	require.Less(t, time.Since(start), 15*time.Second, "SIGXCPU must fire near the 1s CPU limit")
+}
+
+// TestSandbox_NoNewPrivs proves the NO_NEW_PRIVS bit: setuid/setcap binaries
+// cannot re-elevate the sandboxed child. A real setuid escalation needs root
+// and a setuid file, so the honest portable assertion is the kernel-reported
+// NoNewPrivs status bit. The child cannot introspect itself (Landlock denies
+// /proc), so the unsandboxed parent reads /proc/<pid>/status of the running
+// child: 0 in the control run, 1 sandboxed.
+func TestSandbox_NoNewPrivs(t *testing.T) {
+	requireSandboxSupport(t)
+
+	run := func(t *testing.T, sandboxed bool) string {
+		t.Helper()
+		dir := t.TempDir()
+		script := filepath.Join(dir, "run.sh")
+		// The ready-file signals that bash is exec'd (post-confinement).
+		require.NoError(t, os.WriteFile(script, []byte("echo >ready; exec sleep 30"), 0o600))
+		argv := []string{"bash", script}
+
+		var cmd *exec.Cmd
+		if sandboxed {
+			var err error
+			cmd, err = sandboxCommand(context.Background(), argv, dir, SandboxPolicy{}.withDefaults(0))
+			require.NoError(t, err)
+		} else {
+			cmd = exec.Command(argv[0], argv[1:]...)
+		}
+		cmd.Dir = dir
+		cmd.Env = []string{"PATH=" + os.Getenv("PATH")}
+		require.NoError(t, cmd.Start())
+		defer func() {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}()
+
+		require.Eventually(t, func() bool {
+			_, err := os.Stat(filepath.Join(dir, "ready"))
+			return err == nil
+		}, 10*time.Second, 10*time.Millisecond, "probe never signalled readiness")
+
+		data, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", cmd.Process.Pid))
+		require.NoError(t, err)
+		for _, line := range strings.Split(string(data), "\n") {
+			if v, ok := strings.CutPrefix(line, "NoNewPrivs:"); ok {
+				return strings.TrimSpace(v)
+			}
+		}
+		return "0" // pre-3.5 kernels omit the line; treat absent as unset
+	}
+
+	require.Equal(t, "0", run(t, false), "control child must not have NO_NEW_PRIVS set")
+	require.Equal(t, "1", run(t, true), "sandboxed child must have NO_NEW_PRIVS set")
+}
+
+// TestSandbox_RlimitFSizeTrips proves RLIMIT_FSIZE: writing a file past the
+// limit gets the writer killed by SIGXFSZ only when sandboxed.
+func TestSandbox_RlimitFSizeTrips(t *testing.T) {
+	requireSandboxSupport(t)
+
+	probe := `if dd if=/dev/zero of=big.bin bs=1M count=2 2>/dev/null; then
+  echo '{"changes":[],"answer":"wrote"}'
+else
+  echo '{"changes":[],"answer":"denied"}'
+fi`
+
+	stdout, _, _, runErr := RunBlock(context.Background(), CodeSpec{
+		Program: "bash",
+		Code:    probe,
+		Sandbox: SandboxPolicy{Mode: SandboxOff},
+	})
+	require.NoError(t, runErr)
+	_, answer, perr := parseCodeOutput(stdout)
+	require.NoError(t, perr)
+	require.Equal(t, "wrote", answer, "control run must write a 2 MiB file")
+
+	stdout, _, _, runErr = RunBlock(context.Background(), CodeSpec{
+		Program: "bash",
+		Code:    probe,
+		Sandbox: SandboxPolicy{FileSizeBytes: 1 << 20},
+	})
+	require.NoError(t, runErr)
+	_, answer, perr = parseCodeOutput(stdout)
+	require.NoError(t, perr)
+	require.Equal(t, "denied", answer, "sandboxed child must not write past RLIMIT_FSIZE")
+}
+
+// TestSandbox_RlimitNoFileTrips proves RLIMIT_NOFILE: fd numbers >= the limit
+// cannot be opened. The probe opens fd 100 in a subshell — fine under the
+// usual >=1024 default, impossible under a limit of 64.
+func TestSandbox_RlimitNoFileTrips(t *testing.T) {
+	requireSandboxSupport(t)
+
+	probe := `if (exec 100>/dev/null) 2>/dev/null; then
+  echo '{"changes":[],"answer":"opened"}'
+else
+  echo '{"changes":[],"answer":"denied"}'
+fi`
+
+	stdout, _, _, runErr := RunBlock(context.Background(), CodeSpec{
+		Program: "bash",
+		Code:    probe,
+		Sandbox: SandboxPolicy{Mode: SandboxOff},
+	})
+	require.NoError(t, runErr)
+	_, answer, perr := parseCodeOutput(stdout)
+	require.NoError(t, perr)
+	require.Equal(t, "opened", answer, "control run must open fd 100")
+
+	stdout, _, _, runErr = RunBlock(context.Background(), CodeSpec{
+		Program: "bash",
+		Code:    probe,
+		Sandbox: SandboxPolicy{MaxOpenFiles: 64},
+	})
+	require.NoError(t, runErr)
+	_, answer, perr = parseCodeOutput(stdout)
+	require.NoError(t, perr)
+	require.Equal(t, "denied", answer, "sandboxed child must not open fds past RLIMIT_NOFILE")
+}
+
+// TestSandbox_RlimitsApplied proves every rlimit the policy sets reaches the
+// child as its soft limit, including the two without a cheap enforcement
+// probe: RLIMIT_AS (a tight limit crashes the Go child stub before exec) and
+// RLIMIT_NPROC (per-UID accounting makes a fork probe environment-dependent).
+// Deliberately odd values so a coincidental match with ambient limits is
+// implausible; bash ulimit units: -t seconds, -f 1024-byte blocks, -v KiB.
+func TestSandbox_RlimitsApplied(t *testing.T) {
+	requireSandboxSupport(t)
+
+	policy := SandboxPolicy{
+		CPUSeconds:    137,
+		MemoryBytes:   3 << 30,
+		FileSizeBytes: 2 << 20,
+		MaxProcs:      311,
+		MaxOpenFiles:  487,
+	}
+	want := "cpu=137 fsize=2048 nproc=311 nofile=487 as=3145728"
+	probe := `echo "{\"changes\":[],\"answer\":\"cpu=$(ulimit -t) fsize=$(ulimit -f) nproc=$(ulimit -u) nofile=$(ulimit -n) as=$(ulimit -v)\"}"`
+
+	stdout, _, _, runErr := RunBlock(context.Background(), CodeSpec{
+		Program: "bash",
+		Code:    probe,
+		Sandbox: SandboxPolicy{Mode: SandboxOff},
+	})
+	require.NoError(t, runErr)
+	_, answer, perr := parseCodeOutput(stdout)
+	require.NoError(t, perr)
+	require.NotEqual(t, want, answer, "control run must keep the ambient limits")
+
+	stdout, _, _, runErr = RunBlock(context.Background(), CodeSpec{
+		Program: "bash",
+		Code:    probe,
+		Sandbox: policy,
+	})
+	require.NoError(t, runErr)
+	_, answer, perr = parseCodeOutput(stdout)
+	require.NoError(t, perr)
+	require.Equal(t, want, answer, "sandboxed child must run under exactly the policy's rlimits")
 }
 
 // TestSandbox_FallbackWhenChildCannotStart exercises graceful degradation: a


### PR DESCRIPTION
Closes the test-coverage gaps a review found in the Tier-0 code-exec sandbox (#85/#84). Every new test follows the existing control+sandboxed pattern: an unsandboxed run proves the probe works, a sandboxed run proves enforcement.

## 1. CI-skip blindness → `SANDBOX_TESTS_REQUIRED=1` guard

Investigation: CI runs `go test -tags dev ./...` directly on `ubuntu-latest` (no privileged container), the e2e job is `if: false`, and `docker-compose.test.yml` had no go-test lane at all — so the sandbox enforcement tests could silently skip in every CI environment and still show green.

- `skipOrFatal` helper: `requireSandboxSupport` and the Landlock-ABI check now `t.Fatal` instead of `t.Skip` when `SANDBOX_TESTS_REQUIRED=1`. Unset (dev boxes) keeps skipping, so plain `go test ./...` stays green on unsupported kernels.
- New CI step in the `test` job: runs `go test ./internal/agentruntime/ -run TestSandbox` inside `docker run --privileged golang:1.26` with `SANDBOX_TESTS_REQUIRED=1` — userns + Landlock guaranteed there, and "unsupported" now fails the build instead of skipping.
- New `sandbox-test` compose service (profile `sandbox`, not part of the default e2e stack) for the same privileged run locally: `docker compose -f docker-compose.test.yml run --rm sandbox-test`.

Verified the guard both ways with a compiled test binary and a broken PATH to force the support probe to fail: unset → `--- SKIP`, `SANDBOX_TESTS_REQUIRED=1` → `--- FAIL` with `SANDBOX_TESTS_REQUIRED=1 but sandbox namespaces unavailable...`.

## 2. `TestSandbox_NoNewPrivs`

Proves the NO_NEW_PRIVS bit: control child shows `NoNewPrivs: 0`, sandboxed child shows `1`. Two honest caveats:
- The child cannot read `/proc/self/status` itself — Landlock denies `/proc` (found while writing the test; itself a nice confinement property). So the unsandboxed parent reads `/proc/<pid>/status` of the running child, synchronized via a ready-file written after exec.
- This asserts the kernel-reported status bit, not a full setuid-binary escalation (which needs root + a setuid file and is flaky). The bit is what the kernel consults on execve, so it is the honest portable assertion.

**Bonus production fix the test motivated:** `runSandboxChild` set NO_NEW_PRIVS via `unix.Prctl`, which is per-thread — the Go runtime may exec from a different OS thread, so the explicit guarantee could silently not hold exactly on kernels where Landlock (which sets it on all threads itself) is absent. Switched to go-landlock's `AllThreadsPrctl` (one line).

## 3. rlimit coverage

The policy sets 5 rlimits: CPU (already tested), AS, FSIZE, NPROC, NOFILE.

- `TestSandbox_RlimitFSizeTrips` — enforcement: `dd` writing 2 MiB succeeds in control, is SIGXFSZ-killed under `FileSizeBytes: 1MiB`.
- `TestSandbox_RlimitNoFileTrips` — enforcement: opening fd 100 succeeds in control (ambient limit ≥1024), fails under `MaxOpenFiles: 64`.
- `TestSandbox_RlimitsApplied` — all five limits (incl. AS and NPROC) verified as the child's exact soft limits via `ulimit -t/-f/-u/-n/-v`, using deliberately odd values (137/2048/311/487/3 GiB) that cannot coincide with ambient limits; the control run asserts the ambient limits differ.
- Skipped direct enforcement probes for AS and NPROC, deliberately: a tight RLIMIT_AS can crash the Go child stub between setrlimit and exec (Go runtime mmaps), and RLIMIT_NPROC is per-UID so a fork probe depends on how many processes the invoking user already has (and bash's fork-retry loop makes failure take ~30 s). The applied-limits test covers that both reach the child.

## Verification (dev box, kernel supports the sandbox — tests genuinely executed, no skips)

- `go build -tags dev ./...`, `go vet -tags dev ./internal/agentruntime/...`, golangci-lint: clean
- `go test -tags dev ./internal/agentruntime/...`: ok (all 9 sandbox tests PASS, executed not skipped)
- `SANDBOX_TESTS_REQUIRED=1 go test ./internal/agentruntime/ -run TestSandbox`: PASS (kernel supported, so nothing to convert; the Fatal path was verified separately via the forced-failure run above)
- Not run here: docker lanes (no docker in this environment); the privileged CI step will exercise them on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)