### PR TITLE
fix(fleet): harden Tier-0 code-exec sandbox (fail-closed + PID/mount ns + Landlock probe + enforcing CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,32 +50,29 @@ jobs:
       - name: Run tests
         run: go test -tags dev ./...
 
-  # Sandbox enforcement lane: runs the code-exec isolation tests on a runner
-  # that supports unprivileged user namespaces + Landlock. FLEET_SANDBOX_MUST_ENFORCE=1
-  # turns the tests' t.Skip guards into HARD FAILURES, so if a runner lacks
-  # userns/Landlock the job fails loudly instead of reporting a false "green"
-  # for tests that never actually ran. bash + python3 (the interpreters the
-  # probes use) ship on ubuntu-latest. Network is left BLOCKED here on purpose
-  # (no TRIP2G_FLEET_SANDBOX_NETWORK): TestSandbox_NetworkBlocked must enforce.
+  # Sandbox enforcement lane: runs the code-exec isolation tests inside a
+  # privileged Docker container so MS_REC|MS_PRIVATE remount of / is permitted.
+  # FLEET_SANDBOX_MUST_ENFORCE=1 turns the tests' t.Skip guards into HARD
+  # FAILURES, so a runner without userns/Landlock fails the build instead of
+  # quietly reporting "green" for tests that never ran. Network is left BLOCKED
+  # here on purpose (no TRIP2G_FLEET_SANDBOX_NETWORK): TestSandbox_NetworkBlocked
+  # must enforce. python3 is installed explicitly because the golang image is
+  # minimal; bash is already present.
   sandbox:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.26'
-          cache: true
-
-      - name: Prepare generated files
-        run: go generate ./...
-
-      - name: Run sandbox enforcement tests (must actually enforce)
-        env:
-          FLEET_SANDBOX_MUST_ENFORCE: "1"
-        run: go test -tags dev -race -run TestSandbox ./internal/agentruntime/...
+      - name: Run sandbox enforcement tests in privileged container
+        run: |
+          docker run --rm --privileged \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            -e FLEET_SANDBOX_MUST_ENFORCE=1 \
+            -e CGO_ENABLED=0 \
+            golang:1.26 \
+            sh -c "apt-get update -q && apt-get install -y -q python3 && go test -race -tags dev -count=1 -timeout 120s ./internal/agentruntime/..."
 
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
             -e FLEET_SANDBOX_MUST_ENFORCE=1 \
             -e CGO_ENABLED=0 \
             golang:1.26 \
-            sh -c "apt-get update -q && apt-get install -y -q python3 && go test -race -tags dev -count=1 -timeout 120s ./internal/agentruntime/..."
+            sh -c "apt-get update -q && apt-get install -y -q python3 && go test -tags dev -count=1 -timeout 120s ./internal/agentruntime/..."
 
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,33 @@ jobs:
       - name: Run tests
         run: go test -tags dev ./...
 
+  # Sandbox enforcement lane: runs the code-exec isolation tests on a runner
+  # that supports unprivileged user namespaces + Landlock. FLEET_SANDBOX_MUST_ENFORCE=1
+  # turns the tests' t.Skip guards into HARD FAILURES, so if a runner lacks
+  # userns/Landlock the job fails loudly instead of reporting a false "green"
+  # for tests that never actually ran. bash + python3 (the interpreters the
+  # probes use) ship on ubuntu-latest. Network is left BLOCKED here on purpose
+  # (no TRIP2G_FLEET_SANDBOX_NETWORK): TestSandbox_NetworkBlocked must enforce.
+  sandbox:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+          cache: true
+
+      - name: Prepare generated files
+        run: go generate ./...
+
+      - name: Run sandbox enforcement tests (must actually enforce)
+        env:
+          FLEET_SANDBOX_MUST_ENFORCE: "1"
+        run: go test -tags dev -race -run TestSandbox ./internal/agentruntime/...
+
   e2e:
     runs-on: ubuntu-latest
     needs: [lint, test]

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -296,9 +296,11 @@ func validateConfig(cfg fleet.Config) error {
 		return errors.New("fleet: OfferedTools must be non-empty; use --offered-tools")
 	}
 	// Empty means the safe default (native); see SandboxPolicy.withDefaults.
-	if cfg.Sandbox != "" && cfg.Sandbox != string(agentruntime.SandboxNative) && cfg.Sandbox != string(agentruntime.SandboxOff) {
-		return fmt.Errorf("fleet: Sandbox must be %q or %q (got %q); use --sandbox",
-			agentruntime.SandboxNative, agentruntime.SandboxOff, cfg.Sandbox)
+	switch cfg.Sandbox {
+	case "", string(agentruntime.SandboxNative), string(agentruntime.SandboxOff), string(agentruntime.SandboxBestEffort):
+	default:
+		return fmt.Errorf("fleet: Sandbox must be %q, %q or %q (got %q); use --sandbox",
+			agentruntime.SandboxNative, agentruntime.SandboxBestEffort, agentruntime.SandboxOff, cfg.Sandbox)
 	}
 	return nil
 }
@@ -411,8 +413,9 @@ func parseFlags(ctx context.Context) (cliFlags, error) {
 	fs.IntVar(&cli.cfg.MaxStdoutBytes, "max-stdout-bytes", 1<<20,
 		"stdout cap per code child (bytes)")
 	fs.StringVar(&cli.cfg.Sandbox, "sandbox", "native",
-		"code-exec sandbox mode: native|off (native = no network + Landlock FS confinement + rlimits + "+
-			"no-new-privs; Linux-only, falls back with a warning when unsupported)")
+		"code-exec sandbox mode: native|besteffort|off (native = PID+mount+net namespaces + private /proc + "+
+			"Landlock FS confinement + rlimits + no-new-privs, Linux-only, FAILS CLOSED when unsupported; "+
+			"besteffort degrades to UNSANDBOXED with a per-run warning; off disables isolation)")
 	fs.BoolVar(&cli.cfg.SandboxNetwork, "sandbox-network", false,
 		"allow host network access inside the code-exec sandbox")
 	fs.IntVar(&poll, "poll-seconds", 30,

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -507,5 +507,35 @@ services:
       retries: 10
       start_period: 15s
 
+  # Local sandbox enforcement lane: runs the code-exec isolation tests with
+  # FLEET_SANDBOX_MUST_ENFORCE=1 (skip guards become hard failures) so you can
+  # reproduce the CI `sandbox` job locally:
+  #   docker compose -f docker-compose.test.yml run --rm sandbox-tests
+  # privileged grants the CAP_SYS_ADMIN + relaxed seccomp/apparmor the sandbox
+  # child needs to create user/PID/mount namespaces and mount a private /proc
+  # inside the container (default Docker containers drop CAP_SYS_ADMIN, so
+  # namespace creation returns EPERM). python3 is installed for the no-new-privs
+  # probe (golang image ships bash, not python). The agentruntime package has no
+  # generated deps, so no `go generate` is needed. Network is intentionally left
+  # BLOCKED (no TRIP2G_FLEET_SANDBOX_NETWORK).
+  sandbox-tests:
+    image: golang:1.26
+    working_dir: /src
+    volumes:
+      - .:/src
+      - fleet-sandbox-gomod:/go/pkg/mod # persist module cache across runs
+      - fleet-sandbox-gocache:/root/.cache/go-build
+    environment:
+      - FLEET_SANDBOX_MUST_ENFORCE=1
+    privileged: true
+    command:
+      - bash
+      - -c
+      - >
+        apt-get update -qq && apt-get install -y -qq python3 >/dev/null &&
+        go test -tags dev -race -run TestSandbox ./internal/agentruntime/...
+
 volumes:
   test-data:
+  fleet-sandbox-gomod:
+  fleet-sandbox-gocache:

--- a/internal/agentruntime/coderun.go
+++ b/internal/agentruntime/coderun.go
@@ -197,18 +197,29 @@ func RunBlock(ctx context.Context, spec CodeSpec) (string, string, bool, error) 
 
 	policy := spec.Sandbox.withDefaults(spec.Timeout)
 	sandboxed := policy.Mode != SandboxOff
+
+	// Fail-closed: when the enforcing mode is requested but the OS cannot
+	// sandbox at all, REFUSE the run — never run untrusted code unconfined.
 	if sandboxed && !sandboxSupportedOS {
+		if policy.Mode.enforcing() {
+			return "", "", false, fmt.Errorf("coderun: sandbox mode %q requires Linux; refusing to run unsandboxed", policy.Mode)
+		}
 		warnSandboxFallback("unsupported OS", nil)
 		sandboxed = false
 	}
 
 	var cmd *exec.Cmd
 	if sandboxed {
-		var sbErr error
-		cmd, sbErr = sandboxCommand(runCtx, fullArgv, workDir, policy)
+		sbCmd, sbErr := sandboxCommand(runCtx, fullArgv, workDir, policy)
 		if sbErr != nil {
+			// Enforcing mode: a sandbox that cannot be built refuses the run.
+			if policy.Mode.enforcing() {
+				return "", "", false, fmt.Errorf("coderun: sandbox setup failed: %w", sbErr)
+			}
 			warnSandboxFallback("sandbox setup failed", sbErr)
 			sandboxed = false
+		} else {
+			cmd = sbCmd
 		}
 	}
 	if !sandboxed {
@@ -219,9 +230,14 @@ func RunBlock(ctx context.Context, spec CodeSpec) (string, string, bool, error) 
 
 	runErr := cmd.Run()
 	// A sandboxed command that failed to START never ran the child: namespace
-	// creation was denied (e.g. unprivileged userns disabled). Degrade to the
-	// pre-sandbox behavior with a warning instead of failing every code run.
+	// creation was denied (e.g. unprivileged userns disabled) or a confinement
+	// step failed. Enforcing mode REFUSES the run (the code never ran, so this
+	// is a clean failure, not a partial one). BestEffort degrades to plain
+	// execution with a per-run warning.
 	if runErr != nil && sandboxed && cmd.ProcessState == nil && runCtx.Err() == nil {
+		if policy.Mode.enforcing() {
+			return "", "", false, fmt.Errorf("coderun: sandboxed child failed to start; refusing to run unsandboxed: %w", runErr)
+		}
 		warnSandboxFallback("sandboxed child failed to start", runErr)
 		cmd = exec.CommandContext(runCtx, fullArgv[0], fullArgv[1:]...)
 		prepareCmd(cmd, workDir, env, &outBuf, &errBuf, limit)

--- a/internal/agentruntime/coderun_test.go
+++ b/internal/agentruntime/coderun_test.go
@@ -17,6 +17,7 @@ import (
 // TestRunBlock_BashEchoWriteJSON runs a bash one-liner that emits a write JSON
 // and asserts the output is returned verbatim.
 func TestRunBlock_BashEchoWriteJSON(t *testing.T) {
+	skipIfSandboxUnsupported(t)
 	code := `echo '{"changes":[{"path":"notes/a.md","content":"hello"}],"answer":"done"}'`
 	stdout, stderr, timedOut, err := RunBlock(context.Background(), CodeSpec{
 		Program: "bash",
@@ -31,6 +32,7 @@ func TestRunBlock_BashEchoWriteJSON(t *testing.T) {
 
 // TestRunBlock_NonZeroExit asserts a failing script returns an error with stderr.
 func TestRunBlock_NonZeroExit(t *testing.T) {
+	skipIfSandboxUnsupported(t)
 	code := `echo "oops" >&2; exit 1`
 	_, stderr, timedOut, err := RunBlock(context.Background(), CodeSpec{
 		Program: "bash",
@@ -44,6 +46,7 @@ func TestRunBlock_NonZeroExit(t *testing.T) {
 // TestRunBlock_TimeoutKills asserts a long-running script is killed when the
 // per-spec timeout fires.
 func TestRunBlock_TimeoutKills(t *testing.T) {
+	skipIfSandboxUnsupported(t)
 	_, _, timedOut, err := RunBlock(context.Background(), CodeSpec{
 		Program: "bash",
 		Code:    "sleep 60",
@@ -58,6 +61,7 @@ func TestRunBlock_TimeoutKills(t *testing.T) {
 // secret-scrub guarantee: cmd.Env is an explicit minimal allowlist
 // (PATH + FLEET_INPUT only), never nil (inherits parent) or os.Environ().
 func TestRunBlock_SecretScrub(t *testing.T) {
+	skipIfSandboxUnsupported(t)
 	const sentinel = "FLEET_CODERUN_TEST_SENTINEL"
 	t.Setenv(sentinel, "PARENT_SECRET_VALUE")
 
@@ -82,6 +86,7 @@ fi`
 // TestRunBlock_FleetInputWritten asserts the delivery bag is accessible via
 // $FLEET_INPUT in the child (the bag JSON is written to a temp file).
 func TestRunBlock_FleetInputWritten(t *testing.T) {
+	skipIfSandboxUnsupported(t)
 	bag := []byte(`{"depth":3}`)
 	code := `python3 -c "
 import json, os
@@ -147,6 +152,7 @@ func TestParseCodeOutput_EmptyChanges(t *testing.T) {
 // TestRunCode_EndToEnd runs a bash script that emits a write change and asserts
 // the change is applied via ScopedKB.
 func TestRunCode_EndToEnd(t *testing.T) {
+	skipIfSandboxUnsupported(t)
 	kb := newMemKB(nil)
 	body := "```bash\necho '{\"changes\":[{\"path\":\"notes/a.md\",\"content\":\"generated\"}],\"answer\":\"ok\"}'\n```"
 
@@ -169,6 +175,7 @@ func TestRunCode_EndToEnd(t *testing.T) {
 // TestRunCode_ScopeEnforcement asserts writes outside write_patterns are denied
 // and not applied — exec/code is NOT a scope bypass.
 func TestRunCode_ScopeEnforcement(t *testing.T) {
+	skipIfSandboxUnsupported(t)
 	kb := newMemKB(nil)
 	// Script tries to write two files: one in scope and one out of scope.
 	script := `echo '{"changes":[{"path":"notes/in.md","content":"in"},{"path":"other/out.md","content":"out"}],"answer":"tried"}'`
@@ -302,6 +309,7 @@ func TestRun_ExecToolGatedByAllowedPrograms(t *testing.T) {
 // with a bash one-liner, then finishes. Asserts the write is applied via
 // ScopedKB and recorded in res.Changes.
 func TestRun_ExecToolRunsAndApplies(t *testing.T) {
+	skipIfSandboxUnsupported(t)
 	kb := newMemKB(nil)
 	bashCode := `echo '{"changes":[{"path":"notes/exec.md","content":"from exec"}],"answer":"wrote"}'`
 
@@ -342,6 +350,7 @@ func TestRun_ExecToolRunsAndApplies(t *testing.T) {
 // with a write targeting a path outside write_patterns. The write must be
 // denied (recorded in res.Denials) and not reach the KB.
 func TestRun_ExecToolDeniedOutOfScope(t *testing.T) {
+	skipIfSandboxUnsupported(t)
 	kb := newMemKB(nil)
 	bashCode := `echo '{"changes":[{"path":"secret/x.md","content":"leak"}],"answer":"tried"}'`
 
@@ -556,6 +565,7 @@ func TestInterpreterRegistry_ConcurrentAccess(t *testing.T) {
 }
 
 func TestMaxStdoutBytesFromConfig(t *testing.T) {
+	skipIfSandboxUnsupported(t)
 	code := `printf '%0.s1234567890' {1..10}` // writes 100 bytes
 	stdout, _, _, err := RunBlock(context.Background(), CodeSpec{
 		Program:        "bash",
@@ -569,6 +579,7 @@ func TestMaxStdoutBytesFromConfig(t *testing.T) {
 // TestRunBlock_WorkdirIsolation asserts each RunBlock call gets a clean working
 // directory with no files from a previous run.
 func TestRunBlock_WorkdirIsolation(t *testing.T) {
+	skipIfSandboxUnsupported(t)
 	// First run creates a file in its workdir.
 	code1 := `echo '{"changes":[],"answer":"run1"}'`
 	_, _, _, err := RunBlock(context.Background(), CodeSpec{Program: "bash", Code: code1})
@@ -590,6 +601,7 @@ func TestRunBlock_WorkdirIsolation(t *testing.T) {
 // complements TestRunBlock_SecretScrub with a differently-named sentinel to
 // rule out any pattern-matching false negatives.
 func TestRunBlock_ParentSecretAbsent(t *testing.T) {
+	skipIfSandboxUnsupported(t)
 	t.Setenv("FLEET_SECRET_LEAK_TEST", "must-not-appear-in-child")
 
 	code := `if [ -z "${FLEET_SECRET_LEAK_TEST}" ]; then
@@ -637,6 +649,7 @@ func TestRunCode_RequiresKB(t *testing.T) {
 // This proves the deny-by-default + explicit-opt-in contract: secrets not
 // declared in env_passthrough or env_prefix do NOT reach the child.
 func TestRunBlock_EnvPassthrough(t *testing.T) {
+	skipIfSandboxUnsupported(t)
 	t.Setenv("FLEET_ENVTEST_FOO", "1")
 	t.Setenv("FLEET_ENVTEST_BAR_X", "2")
 	t.Setenv("FLEET_ENVTEST_SECRET", "should-not-appear")
@@ -673,6 +686,7 @@ print(json.dumps({'changes':[],'answer':json.dumps(got)}))
 // from the child. (bash injects a few vars of its own like SHLVL, so we check
 // for the sentinel specifically rather than asserting zero extra vars.)
 func TestRunBlock_EnvPassthroughBaseOnly(t *testing.T) {
+	skipIfSandboxUnsupported(t)
 	t.Setenv("FLEET_ENVTEST_EXTRA", "should-not-appear")
 
 	code := `if [ -z "${FLEET_ENVTEST_EXTRA}" ]; then

--- a/internal/agentruntime/sandbox.go
+++ b/internal/agentruntime/sandbox.go
@@ -2,7 +2,6 @@ package agentruntime
 
 import (
 	"log/slog"
-	"sync"
 	"time"
 )
 
@@ -11,15 +10,28 @@ type SandboxMode string
 
 const (
 	// SandboxOff disables OS-level isolation (pre-sandbox behavior: scrubbed
-	// env + throwaway workdir + timeout only).
+	// env + throwaway workdir + timeout only). Untrusted code runs unconfined —
+	// only choose this for fully trusted code.
 	SandboxOff SandboxMode = "off"
-	// SandboxNative is the Tier-0 posture (see docs/dev/process_isolation.md
-	// and the 2026-07-02 sandbox research): empty network namespace, Landlock
+	// SandboxNative is the enforcing Tier-0 posture (see
+	// docs/dev/process_isolation.md and the 2026-07-02 sandbox research):
+	// empty network + PID + mount namespaces, a private /proc, Landlock
 	// filesystem confinement to the run workdir, rlimits, NO_NEW_PRIVS, and a
-	// drop to an unprivileged uid when the daemon runs as root. Pure-Go,
-	// Linux-only; unsupported platforms/kernels fall back with a warning.
+	// drop to an unprivileged uid. Pure-Go, Linux-only. FAIL-CLOSED: if the
+	// sandbox cannot be built or the child fails to start, the run is REFUSED —
+	// untrusted code is never executed unconfined.
 	SandboxNative SandboxMode = "native"
+	// SandboxBestEffort attempts the native posture but degrades to UNSANDBOXED
+	// execution (with a per-run warning) when the sandbox cannot be built or
+	// started. This runs untrusted code without isolation on unsupported
+	// kernels — it is NEVER the default and must be opted into explicitly.
+	SandboxBestEffort SandboxMode = "besteffort"
 )
+
+// enforcing reports whether the mode refuses to run when the sandbox cannot be
+// applied (fail-closed). Only SandboxNative enforces; SandboxBestEffort falls
+// back and SandboxOff never sandboxes.
+func (m SandboxMode) enforcing() bool { return m == SandboxNative }
 
 // SandboxPolicy configures the sandbox applied around one code run. The zero
 // value means the safe default (SandboxNative where supported, network off).
@@ -81,6 +93,7 @@ type sandboxChildSpec struct {
 	Argv          []string `json:"argv"`
 	WorkDir       string   `json:"workdir"`
 	RODirs        []string `json:"ro_dirs"`
+	ROFiles       []string `json:"ro_files"`
 	RWDirs        []string `json:"rw_dirs"`
 	RWFiles       []string `json:"rw_files"`
 	CPUSeconds    int      `json:"cpu_seconds"`
@@ -88,15 +101,14 @@ type sandboxChildSpec struct {
 	FileSizeBytes int64    `json:"file_size_bytes"`
 	MaxProcs      int      `json:"max_procs"`
 	MaxOpenFiles  int      `json:"max_open_files"`
+	DropUID       int      `json:"drop_uid"` // >0 → setuid to this uid after mounts (root path)
+	DropGID       int      `json:"drop_gid"` // >0 → setgid to this gid after mounts (root path)
 }
 
-//nolint:gochecknoglobals // one-shot warning gate; package-level by design
-var sandboxWarnOnce sync.Once
-
-// warnSandboxFallback logs (once per process) that code execution is running
-// WITHOUT the sandbox so operators see the degraded posture in the logs.
+// warnSandboxFallback logs (per run, NOT once) that a SandboxBestEffort run is
+// executing WITHOUT OS-level isolation so operators see every degraded run in
+// the logs. SandboxNative never reaches this path — it fails closed.
 func warnSandboxFallback(reason string, err error) {
-	sandboxWarnOnce.Do(func() {
-		slog.Warn("coderun: sandbox unavailable, executing without OS-level isolation", "reason", reason, "err", err)
-	})
+	//nolint:sloglint // pure helper with no scoped logger; operator-facing degraded-posture warning
+	slog.Warn("coderun: sandbox unavailable, executing WITHOUT OS-level isolation (besteffort mode)", "reason", reason, "err", err)
 }

--- a/internal/agentruntime/sandbox_linux.go
+++ b/internal/agentruntime/sandbox_linux.go
@@ -4,10 +4,10 @@ package agentruntime
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -15,6 +15,7 @@ import (
 	"syscall"
 
 	"github.com/landlock-lsm/go-landlock/landlock"
+	llsys "github.com/landlock-lsm/go-landlock/landlock/syscall"
 	"golang.org/x/sys/unix"
 )
 
@@ -24,6 +25,13 @@ const sandboxSupportedOS = true
 // sandboxChildArg is the hidden argv[1] marking a re-exec'd sandbox child.
 const sandboxChildArg = "__fleet-coderun-child"
 
+// sandboxSpecFD is the inherited pipe fd (via cmd.ExtraFiles) the parent uses to
+// hand the child its spec. The re-exec child branch activates ONLY when this fd
+// carries a valid spec, so the confined-child launcher can never be driven by
+// argv alone (a stray `binary __fleet-coderun-child` with no inherited pipe
+// simply errors out instead of exec'ing an attacker-chosen command).
+const sandboxSpecFD = 3
+
 // sandboxNobodyID is the uid/gid the child drops to when the daemon is root.
 const sandboxNobodyID = 65534
 
@@ -31,30 +39,65 @@ const sandboxNobodyID = 65534
 // test binary exercising the sandbox): when the process was re-exec'd as the
 // confined child it applies its limits and execs the interpreter, never
 // returning. In the normal parent process it is a no-op.
+//
+// The child spec arrives on the inherited pipe (sandboxSpecFD), not argv: the
+// argv sentinel alone is not enough to trigger the launcher.
 func MaybeRunSandboxChild() {
-	if len(os.Args) != 3 || os.Args[1] != sandboxChildArg {
+	if len(os.Args) != 2 || os.Args[1] != sandboxChildArg {
 		return
 	}
-	if err := runSandboxChild(os.Args[2]); err != nil {
-		fmt.Fprintln(os.Stderr, "coderun sandbox child:", err)
+	spec, err := readChildSpec()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "coderun sandbox child: read spec:", err)
+		os.Exit(125)
+	}
+	if runErr := runSandboxChild(spec); runErr != nil {
+		fmt.Fprintln(os.Stderr, "coderun sandbox child:", runErr)
 		os.Exit(125)
 	}
 }
 
-// runSandboxChild applies rlimits, Landlock (BestEffort — no-op on kernels
-// without it), and NO_NEW_PRIVS, then execs the interpreter. The namespaces
-// and credential drop were already applied by the parent via SysProcAttr.
-func runSandboxChild(encoded string) error {
-	raw, err := base64.StdEncoding.DecodeString(encoded)
+// readChildSpec reads and parses the spec from the inherited handshake pipe.
+// A missing/closed fd (i.e. not launched by the parent) is an error, not an
+// exec — this is the handshake that keeps the child off the argv-only path.
+func readChildSpec() (sandboxChildSpec, error) {
+	f := os.NewFile(uintptr(sandboxSpecFD), "sandbox-spec")
+	if f == nil {
+		return sandboxChildSpec{}, errors.New("no handshake pipe on fd 3")
+	}
+	defer f.Close()
+	raw, err := io.ReadAll(io.LimitReader(f, 1<<20))
 	if err != nil {
-		return fmt.Errorf("decode spec: %w", err)
+		return sandboxChildSpec{}, fmt.Errorf("read handshake pipe: %w", err)
+	}
+	if len(raw) == 0 {
+		return sandboxChildSpec{}, errors.New("empty handshake pipe")
 	}
 	var spec sandboxChildSpec
 	if uerr := json.Unmarshal(raw, &spec); uerr != nil {
-		return fmt.Errorf("parse spec: %w", uerr)
+		return sandboxChildSpec{}, fmt.Errorf("parse spec: %w", uerr)
 	}
+	return spec, nil
+}
+
+// runSandboxChild confines the re-exec'd child, then execs the interpreter.
+// Order matters: private /proc (while still privileged) → drop uid → rlimits →
+// NO_NEW_PRIVS (all threads) → Landlock (fail-closed) → exec. Namespaces and
+// uid mappings were already applied by the parent via SysProcAttr.
+func runSandboxChild(spec sandboxChildSpec) error {
 	if len(spec.Argv) == 0 {
 		return errors.New("empty argv")
+	}
+
+	// Fresh private /proc so the child sees ONLY its own PID namespace: no
+	// /proc/<fleet>/environ, no host process list. Must run before the uid drop
+	// (mounting needs CAP_SYS_ADMIN). MS_REC|MS_PRIVATE detaches propagation and
+	// unlocks the mount so the fresh procfs can shadow the inherited one.
+	if err := unix.Mount("", "/", "", unix.MS_REC|unix.MS_PRIVATE, ""); err != nil {
+		return fmt.Errorf("remount / private: %w", err)
+	}
+	if err := unix.Mount("proc", "/proc", "proc", unix.MS_NOSUID|unix.MS_NODEV|unix.MS_NOEXEC, ""); err != nil {
+		return fmt.Errorf("mount private /proc: %w", err)
 	}
 
 	limits := []struct {
@@ -77,15 +120,62 @@ func runSandboxChild(encoded string) error {
 		}
 	}
 
-	// go-landlock also sets NO_NEW_PRIVS internally, but keep it explicit so
-	// the guarantee holds even when Landlock degrades to a no-op.
-	if pErr := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); pErr != nil {
+	// NO_NEW_PRIVS across ALL OS threads: a single-thread prctl can be lost when
+	// Go execs from a different thread, so a setuid binary could still elevate.
+	if pErr := llsys.AllThreadsPrctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); pErr != nil {
 		return fmt.Errorf("prctl no_new_privs: %w", pErr)
 	}
 
+	// Apply Landlock while still privileged so it can open every granted path
+	// (notably the RW workdir) regardless of ownership; the ruleset is inherited
+	// across the uid drop and the exec below.
+	if err := applyLandlock(spec); err != nil {
+		return err
+	}
+
+	// Root path: drop to an unprivileged uid LAST — after the privileged mount,
+	// rlimits, NO_NEW_PRIVS and Landlock are in place. (In the unprivileged
+	// userns path DropUID is 0 and the child already runs as a mapped
+	// non-privileged identity.) NO_NEW_PRIVS still permits dropping privilege.
+	if spec.DropUID > 0 {
+		if err := syscall.Setgroups([]int{}); err != nil {
+			return fmt.Errorf("setgroups: %w", err)
+		}
+		if err := syscall.Setgid(spec.DropGID); err != nil {
+			return fmt.Errorf("setgid: %w", err)
+		}
+		if err := syscall.Setuid(spec.DropUID); err != nil {
+			return fmt.Errorf("setuid: %w", err)
+		}
+	}
+
+	bin, err := exec.LookPath(spec.Argv[0])
+	if err != nil {
+		return fmt.Errorf("lookup %s: %w", spec.Argv[0], err)
+	}
+	return unix.Exec(bin, spec.Argv, os.Environ())
+}
+
+// applyLandlock enforces filesystem confinement, failing CLOSED when Landlock
+// is unavailable: BestEffort silently no-ops on kernels without the Landlock
+// LSM, leaving the FS unconfined while the code looks confined. We probe the
+// ABI first and refuse the run when it reports 0 (unavailable). With Landlock
+// present, BestEffort still enforces at the highest supported ABI. Everything
+// not granted here — including /proc, /sys and /dev — is denied by default.
+func applyLandlock(spec sandboxChildSpec) error {
+	abi, err := llsys.LandlockGetABIVersion()
+	if err != nil {
+		return fmt.Errorf("landlock probe failed; refusing to run without FS confinement: %w", err)
+	}
+	if abi < 1 {
+		return errors.New("landlock unavailable (abi 0); refusing to run without FS confinement")
+	}
 	var rules []landlock.Rule
 	if len(spec.RODirs) > 0 {
 		rules = append(rules, landlock.RODirs(spec.RODirs...).IgnoreIfMissing())
+	}
+	if len(spec.ROFiles) > 0 {
+		rules = append(rules, landlock.ROFiles(spec.ROFiles...).IgnoreIfMissing())
 	}
 	if len(spec.RWDirs) > 0 {
 		rules = append(rules, landlock.RWDirs(spec.RWDirs...).IgnoreIfMissing())
@@ -96,27 +186,25 @@ func runSandboxChild(encoded string) error {
 	if llErr := landlock.V5.BestEffort().RestrictPaths(rules...); llErr != nil {
 		return fmt.Errorf("landlock: %w", llErr)
 	}
-
-	bin, err := exec.LookPath(spec.Argv[0])
-	if err != nil {
-		return fmt.Errorf("lookup %s: %w", spec.Argv[0], err)
-	}
-	return unix.Exec(bin, spec.Argv, os.Environ())
+	return nil
 }
 
-// sandboxCommand builds the re-exec child command implementing the Tier-0
-// posture: the parent contributes the namespaces + credential drop through
-// SysProcAttr; the child stub (runSandboxChild) applies rlimits, Landlock and
-// NO_NEW_PRIVS before exec'ing the interpreter.
+// sandboxCommand builds the re-exec child command implementing the enforcing
+// Tier-0 posture. The parent contributes the namespaces + credential mapping
+// through SysProcAttr and hands the spec over the inherited handshake pipe; the
+// child stub (runSandboxChild) mounts a private /proc, drops privileges, and
+// applies rlimits, NO_NEW_PRIVS and Landlock before exec'ing the interpreter.
 func sandboxCommand(ctx context.Context, argv []string, workDir string, p SandboxPolicy) (*exec.Cmd, error) {
 	self, err := os.Executable()
 	if err != nil {
 		return nil, fmt.Errorf("sandbox: resolve self: %w", err)
 	}
+	roDirs, roFiles := sandboxROPaths(argv[0])
 	spec := sandboxChildSpec{
 		Argv:          argv,
 		WorkDir:       workDir,
-		RODirs:        sandboxRODirs(argv[0]),
+		RODirs:        roDirs,
+		ROFiles:       roFiles,
 		RWDirs:        []string{workDir},
 		RWFiles:       []string{"/dev/null", "/dev/zero", "/dev/urandom", "/dev/random", "/dev/full"},
 		CPUSeconds:    p.CPUSeconds,
@@ -125,46 +213,78 @@ func sandboxCommand(ctx context.Context, argv []string, workDir string, p Sandbo
 		MaxProcs:      p.MaxProcs,
 		MaxOpenFiles:  p.MaxOpenFiles,
 	}
-	raw, err := json.Marshal(spec)
-	if err != nil {
-		return nil, fmt.Errorf("sandbox: marshal spec: %w", err)
-	}
 
-	cmd := exec.CommandContext(ctx, self, sandboxChildArg, base64.StdEncoding.EncodeToString(raw))
 	attr := &syscall.SysProcAttr{}
+	// PID + mount namespaces isolate the process table and give us a private
+	// /proc; the (optional) network namespace blocks host network access.
+	attr.Cloneflags |= syscall.CLONE_NEWPID | syscall.CLONE_NEWNS
 	if !p.Network {
 		attr.Cloneflags |= syscall.CLONE_NEWNET
 	}
 	if os.Geteuid() == 0 {
-		// Root can create the netns directly; drop the child to an
-		// unprivileged uid. The workdir must follow the ownership change.
-		attr.Credential = &syscall.Credential{Uid: sandboxNobodyID, Gid: sandboxNobodyID}
+		// Real root: create the namespaces directly and drop the child to a
+		// distinct unprivileged uid (done in the child after the /proc mount).
+		// The workdir must follow the ownership change so the dropped child can
+		// still write it.
+		spec.DropUID = sandboxNobodyID
+		spec.DropGID = sandboxNobodyID
 		if chErr := chownTree(workDir, sandboxNobodyID, sandboxNobodyID); chErr != nil {
 			return nil, fmt.Errorf("sandbox: chown workdir: %w", chErr)
 		}
-	} else if !p.Network {
-		// Unprivileged netns creation requires a user namespace
-		// (the unshare --map-root-user pattern).
+	} else {
+		// Unprivileged: a user namespace grants the caps needed to create the
+		// other namespaces and mount /proc. The kernel only lets an unprivileged
+		// writer map a single id whose host side is its own uid, so container 0
+		// maps to the caller's uid; the PID + mount namespaces (private /proc)
+		// are what actually close the /proc secret leak here.
 		attr.Cloneflags |= syscall.CLONE_NEWUSER
 		attr.UidMappings = []syscall.SysProcIDMap{{ContainerID: 0, HostID: os.Getuid(), Size: 1}}
 		attr.GidMappings = []syscall.SysProcIDMap{{ContainerID: 0, HostID: os.Getgid(), Size: 1}}
 	}
+
+	raw, err := json.Marshal(spec)
+	if err != nil {
+		return nil, fmt.Errorf("sandbox: marshal spec: %w", err)
+	}
+	specR, specW, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("sandbox: handshake pipe: %w", err)
+	}
+	// The spec is small (well under the pipe buffer); write and close the write
+	// end now so the child reads to EOF. The parent's copy of the read end is
+	// closed by os/exec once the child inherits it as fd 3.
+	if _, werr := specW.Write(raw); werr != nil {
+		_ = specW.Close()
+		_ = specR.Close()
+		return nil, fmt.Errorf("sandbox: write spec: %w", werr)
+	}
+	_ = specW.Close()
+
+	cmd := exec.CommandContext(ctx, self, sandboxChildArg)
+	cmd.ExtraFiles = []*os.File{specR} // → fd 3 in the child
 	cmd.SysProcAttr = attr
 	return cmd, nil
 }
 
-// sandboxRODirs returns the read-only system paths the interpreter needs
-// (missing ones are ignored via IgnoreIfMissing), plus the resolved directory
-// of the interpreter binary for non-standard installs.
-func sandboxRODirs(program string) []string {
-	dirs := []string{"/usr", "/bin", "/sbin", "/lib", "/lib32", "/lib64", "/etc", "/opt"}
+// sandboxROPaths returns the read-only paths the interpreter needs: the
+// resolved interpreter directory, the core executable and library dirs, and the
+// dynamic-linker cache. Everything else (notably the blanket /etc, /opt and the
+// rest of /usr) is denied so a compromised interpreter cannot read host config.
+func sandboxROPaths(program string) ([]string, []string) {
+	dirs := []string{
+		"/bin", "/sbin",
+		"/usr/bin", "/usr/sbin",
+		"/lib", "/lib32", "/lib64",
+		"/usr/lib", "/usr/lib32", "/usr/lib64",
+	}
+	files := []string{"/etc/ld.so.cache"} // dynamic linker cache only, not all of /etc
 	if bin, err := exec.LookPath(program); err == nil {
 		if resolved, rerr := filepath.EvalSymlinks(bin); rerr == nil {
 			bin = resolved
 		}
 		dirs = append(dirs, filepath.Dir(bin))
 	}
-	return dirs
+	return dirs, files
 }
 
 // chownTree recursively chowns a directory tree (the per-run temp workdir).

--- a/internal/agentruntime/sandbox_linux_test.go
+++ b/internal/agentruntime/sandbox_linux_test.go
@@ -292,6 +292,7 @@ func TestSandbox_RlimitsApplied(t *testing.T) {
 // an environment where the probe already failed — covered indirectly: an OFF
 // policy and a NATIVE policy must both produce a working run end-to-end.
 func TestSandbox_ModesBothExecute(t *testing.T) {
+	requireSandboxSupport(t)
 	for _, mode := range []SandboxMode{SandboxOff, SandboxNative} {
 		stdout, stderr, _, runErr := RunBlock(context.Background(), CodeSpec{
 			Program: "bash",

--- a/internal/agentruntime/sandbox_linux_test.go
+++ b/internal/agentruntime/sandbox_linux_test.go
@@ -7,7 +7,10 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,19 +18,42 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// mustEnforce reports whether the CI enforcement lane demands that the sandbox
+// actually run: when FLEET_SANDBOX_MUST_ENFORCE=1 the skip guards below become
+// hard failures, so a runner without userns/Landlock support fails the build
+// instead of quietly reporting "green" for tests that never executed.
+func mustEnforce() bool { return os.Getenv("FLEET_SANDBOX_MUST_ENFORCE") == "1" }
+
+// skipOrFail skips normally but fails hard under FLEET_SANDBOX_MUST_ENFORCE.
+func skipOrFail(t *testing.T, format string, args ...any) {
+	t.Helper()
+	if mustEnforce() {
+		t.Fatalf("FLEET_SANDBOX_MUST_ENFORCE=1 but "+format, args...)
+	}
+	t.Skipf(format, args...)
+}
+
 // requireSandboxSupport skips the test when the kernel refuses the sandbox's
-// namespaces (e.g. unprivileged user namespaces disabled) — the production
-// path falls back to unsandboxed execution there, so the isolation assertions
-// below would be meaningless.
+// namespaces (e.g. unprivileged user namespaces disabled). The enforcing
+// production path REFUSES to run there, so the isolation assertions below would
+// have nothing to assert. Under FLEET_SANDBOX_MUST_ENFORCE the missing support
+// is a hard failure instead of a skip.
 func requireSandboxSupport(t *testing.T) {
 	t.Helper()
-	dir := t.TempDir()
+	// Use a /tmp workdir (world-traversable, like RunBlock's os.MkdirTemp), NOT
+	// t.TempDir(): the latter is a 0700 root-owned nested path the root-path uid
+	// drop cannot traverse, which would misreport support as unavailable.
+	dir, err := os.MkdirTemp("", "fleet-sbprobe-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
 	cmd, err := sandboxCommand(context.Background(), []string{"true"}, dir, SandboxPolicy{}.withDefaults(0))
 	require.NoError(t, err)
 	cmd.Dir = dir
 	cmd.Env = []string{"PATH=" + os.Getenv("PATH")}
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
 	if runErr := cmd.Run(); runErr != nil {
-		t.Skipf("sandbox namespaces unavailable on this kernel: %v", runErr)
+		skipOrFail(t, "sandbox namespaces unavailable on this kernel: %v (child: %s)", runErr, strings.TrimSpace(stderr.String()))
 	}
 }
 
@@ -94,7 +120,7 @@ fi`, port)
 func TestSandbox_FSConfinedToWorkdir(t *testing.T) {
 	requireSandboxSupport(t)
 	if landlockABI() < 1 {
-		t.Skip("kernel has no Landlock support (needs >= 5.13 with landlock LSM enabled)")
+		skipOrFail(t, "kernel has no Landlock support (needs >= 5.13 with landlock LSM enabled)")
 	}
 
 	outside := t.TempDir()
@@ -158,6 +184,106 @@ func TestSandbox_RlimitCPUTrips(t *testing.T) {
 	require.Error(t, runErr, "busy loop must be killed by RLIMIT_CPU")
 	require.False(t, timedOut, "the rlimit, not the wall-clock timeout, must trip")
 	require.Less(t, time.Since(start), 15*time.Second, "SIGXCPU must fire near the 1s CPU limit")
+}
+
+// TestSandbox_NoProcLeak proves the PID + mount namespace: a host process is
+// visible in /proc without the sandbox but absent inside it, so the child can
+// never reach /proc/<fleet>/environ to steal JWT_SECRET/FLEET_SECRET/etc.
+func TestSandbox_NoProcLeak(t *testing.T) {
+	requireSandboxSupport(t)
+
+	sleeper := exec.Command("sleep", "30")
+	sleeper.Env = []string{"SECRET=LEAKED-SECRET-VALUE"}
+	require.NoError(t, sleeper.Start())
+	t.Cleanup(func() {
+		_ = sleeper.Process.Kill()
+		_, _ = sleeper.Process.Wait()
+	})
+	pid := sleeper.Process.Pid
+
+	probe := fmt.Sprintf(`if [ -e /proc/%d ]; then
+  echo '{"changes":[],"answer":"visible"}'
+else
+  echo '{"changes":[],"answer":"hidden"}'
+fi`, pid)
+
+	// Control: without the sandbox the host process is visible in /proc.
+	stdout, _, _, runErr := RunBlock(context.Background(), CodeSpec{
+		Program: "bash",
+		Code:    probe,
+		Sandbox: SandboxPolicy{Mode: SandboxOff},
+	})
+	require.NoError(t, runErr)
+	_, answer, perr := parseCodeOutput(stdout)
+	require.NoError(t, perr)
+	require.Equal(t, "visible", answer, "control run must see the host process in /proc")
+
+	// Sandboxed: the private PID namespace + fresh /proc hide every host process.
+	stdout, _, _, runErr = RunBlock(context.Background(), CodeSpec{
+		Program: "bash",
+		Code:    probe,
+	})
+	require.NoError(t, runErr)
+	_, answer, perr = parseCodeOutput(stdout)
+	require.NoError(t, perr)
+	require.Equal(t, "hidden", answer, "sandboxed child must not see host processes in /proc")
+}
+
+// TestSandbox_NoNewPrivs proves NO_NEW_PRIVS is set (across all OS threads):
+// with the bit set a setuid binary can never gain privilege via execve. The
+// child reads the flag with prctl(PR_GET_NO_NEW_PRIVS) rather than /proc, which
+// the sandbox correctly denies. Uses python (ctypes) since /proc/self/status is
+// out of the Landlock grant.
+func TestSandbox_NoNewPrivs(t *testing.T) {
+	requireSandboxSupport(t)
+
+	// PR_GET_NO_NEW_PRIVS == 39; returns 1 when the bit is set.
+	code := `import ctypes, json
+libc = ctypes.CDLL(None, use_errno=True)
+print(json.dumps({"changes": [], "answer": str(libc.prctl(39, 0, 0, 0, 0))}))`
+	stdout, stderr, _, runErr := RunBlock(context.Background(), CodeSpec{
+		Program: "python",
+		Code:    code,
+	})
+	require.NoError(t, runErr, "stderr: %s", stderr)
+	_, answer, perr := parseCodeOutput(stdout)
+	require.NoError(t, perr)
+	require.Equal(t, "1", answer, "sandboxed child must have NO_NEW_PRIVS set")
+}
+
+// TestSandbox_RlimitsApplied proves RLIMIT_AS, RLIMIT_FSIZE, RLIMIT_NPROC and
+// RLIMIT_NOFILE reach the child (only RLIMIT_CPU was previously covered). It
+// reads them back via bash's ulimit and compares to the requested policy.
+func TestSandbox_RlimitsApplied(t *testing.T) {
+	requireSandboxSupport(t)
+
+	const (
+		memBytes   = int64(512) << 20 // ulimit -v is in KiB
+		fsizeBytes = int64(32) << 20  // ulimit -f is in 1024-byte blocks
+		maxProcs   = 128              // ulimit -u count
+		maxFiles   = 256              // ulimit -n count
+	)
+	code := `printf '{"changes":[],"answer":"%s|%s|%s|%s"}\n' "$(ulimit -v)" "$(ulimit -f)" "$(ulimit -u)" "$(ulimit -n)"`
+	stdout, stderr, _, runErr := RunBlock(context.Background(), CodeSpec{
+		Program: "bash",
+		Code:    code,
+		Sandbox: SandboxPolicy{
+			MemoryBytes:   memBytes,
+			FileSizeBytes: fsizeBytes,
+			MaxProcs:      maxProcs,
+			MaxOpenFiles:  maxFiles,
+		},
+	})
+	require.NoError(t, runErr, "stderr: %s", stderr)
+	_, answer, perr := parseCodeOutput(stdout)
+	require.NoError(t, perr)
+
+	fields := strings.Split(answer, "|")
+	require.Len(t, fields, 4, "want v|f|u|n, got %q", answer)
+	require.Equal(t, strconv.FormatInt(memBytes/1024, 10), fields[0], "RLIMIT_AS (ulimit -v, KiB)")
+	require.Equal(t, strconv.FormatInt(fsizeBytes/1024, 10), fields[1], "RLIMIT_FSIZE (ulimit -f, 1024-byte blocks)")
+	require.Equal(t, strconv.Itoa(maxProcs), fields[2], "RLIMIT_NPROC (ulimit -u)")
+	require.Equal(t, strconv.Itoa(maxFiles), fields[3], "RLIMIT_NOFILE (ulimit -n)")
 }
 
 // TestSandbox_FallbackWhenChildCannotStart exercises graceful degradation: a

--- a/internal/agentruntime/sandbox_main_test.go
+++ b/internal/agentruntime/sandbox_main_test.go
@@ -1,16 +1,56 @@
 package agentruntime
 
 import (
+	"context"
 	"os"
+	"strings"
 	"testing"
 )
+
+// sandboxAvailable is set once in TestMain before any test runs.
+var sandboxAvailable bool
 
 // TestMain hooks the sandbox re-exec protocol: sandboxed RunBlock re-execs
 // this test binary as the confined child, so the child branch must run before
 // the test framework takes over.
 func TestMain(m *testing.M) {
 	MaybeRunSandboxChild()
+	sandboxAvailable = probeSandbox()
 	os.Exit(m.Run())
+}
+
+// probeSandbox returns true when the current kernel supports the native sandbox
+// (user namespaces + MS_REC|MS_PRIVATE remount). Used to gate tests that call
+// RunBlock/RunCode with the default SandboxNative policy.
+func probeSandbox() bool {
+	dir, err := os.MkdirTemp("", "fleet-sbprobe-*")
+	if err != nil {
+		return false
+	}
+	defer os.RemoveAll(dir)
+	cmd, err := sandboxCommand(context.Background(), []string{"true"}, dir, SandboxPolicy{}.withDefaults(0))
+	if err != nil {
+		return false
+	}
+	cmd.Dir = dir
+	cmd.Env = []string{"PATH=" + os.Getenv("PATH")}
+	var sb strings.Builder
+	cmd.Stderr = &sb
+	return cmd.Run() == nil
+}
+
+// skipIfSandboxUnsupported skips t when the native sandbox cannot be used on
+// this kernel. Tests that call RunBlock or RunCode with the default
+// SandboxNative policy must call this at their top so the regular test job
+// (no FLEET_SANDBOX_MUST_ENFORCE) gets clean skips on non-privileged runners.
+func skipIfSandboxUnsupported(t *testing.T) {
+	t.Helper()
+	if !sandboxAvailable {
+		if mustEnforce() {
+			t.Fatal("FLEET_SANDBOX_MUST_ENFORCE=1 but sandbox is unavailable on this kernel")
+		}
+		t.Skip("sandbox unavailable on this kernel (mount namespace or MS_PRIVATE not permitted)")
+	}
 }
 
 // TestSandboxDefaultIsEnforcing guards the fail-closed invariant: the zero

--- a/internal/agentruntime/sandbox_main_test.go
+++ b/internal/agentruntime/sandbox_main_test.go
@@ -12,3 +12,21 @@ func TestMain(m *testing.M) {
 	MaybeRunSandboxChild()
 	os.Exit(m.Run())
 }
+
+// TestSandboxDefaultIsEnforcing guards the fail-closed invariant: the zero
+// policy resolves to the enforcing native mode, and only native enforces —
+// besteffort (degrade-to-unsandboxed) must never be the default.
+func TestSandboxDefaultIsEnforcing(t *testing.T) {
+	if got := (SandboxPolicy{}).withDefaults(0).Mode; got != SandboxNative {
+		t.Fatalf("default sandbox mode = %q, want %q (fail-closed default)", got, SandboxNative)
+	}
+	if !SandboxNative.enforcing() {
+		t.Fatal("SandboxNative must be enforcing (fail-closed)")
+	}
+	if SandboxBestEffort.enforcing() {
+		t.Fatal("SandboxBestEffort must NOT be enforcing (it degrades to unsandboxed)")
+	}
+	if SandboxOff.enforcing() {
+		t.Fatal("SandboxOff must NOT be enforcing")
+	}
+}

--- a/internal/agentruntime/sandbox_main_test.go
+++ b/internal/agentruntime/sandbox_main_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // sandboxAvailable is set once in TestMain before any test runs.
-var sandboxAvailable bool
+var sandboxAvailable bool //nolint:gochecknoglobals // probed once before test suite; shared across all tests in the package
 
 // TestMain hooks the sandbox re-exec protocol: sandboxed RunBlock re-execs
 // this test binary as the confined child, so the child branch must run before

--- a/internal/fleet/config.go
+++ b/internal/fleet/config.go
@@ -28,7 +28,7 @@ type Config struct {
 	OfferedTools           []string      // a role's tools must be a subset of these
 	AllowedPrograms        []string      // programs allowed for code execution (empty = disabled)
 	MaxStdoutBytes         int           // stdout cap per code child (bytes); 0 → 1 MiB default
-	Sandbox                string        // code-exec sandbox mode: "native" (default) | "off"
+	Sandbox                string        // code-exec sandbox mode: "native" (default, fail-closed) | "besteffort" | "off"
 	SandboxNetwork         bool          // allow host network inside the code-exec sandbox
 	PollInterval           time.Duration // discovery/reconcile poll cadence
 	ShutdownGrace          time.Duration // max time to drain in-flight runs on shutdown


### PR DESCRIPTION
Hardens the Tier-0 code-exec sandbox from PR #85 (`internal/agentruntime`) against the findings from the adversarial security review. Supersedes #87 (which added coverage/CI but did **not** fix the two CRITICALs); #87's real finding — per-thread `NO_NEW_PRIVS` — is folded in here.

Code-exec stays **off by default** (`--allowed-programs` empty), `CGO_ENABLED=0`, non-Linux graceful via build tags.

## Findings → fixes

| # | Sev | Finding | Fix |
|---|-----|---------|-----|
| 1 | CRITICAL | On sandbox build/start failure `RunBlock` warned once and **re-ran the code with NO sandbox** | **Fail-closed.** `SandboxNative` now REFUSES the run on unsupported OS, build failure, or child-start failure — no path runs untrusted code unconfined. Degrade-to-unsandboxed moved behind an explicit, non-default `SandboxBestEffort` mode that logs **per-run** (removed the `sync.Once`). `coderun.go` |
| 2 | CRITICAL | Child in host PID+mount ns; non-root path mapped container-root to the fleet's own uid → `/proc/<fleet>/environ` leaked `JWT_SECRET`/`FLEET_SECRET`/`KRISP_TOKEN` | Added `CLONE_NEWPID` + `CLONE_NEWNS` and a fresh private `/proc` mounted in the child (`MS_REC\|MS_PRIVATE` then `mount proc`) so it sees only its own namespace. Root path drops to a **distinct** unprivileged uid (65534). Composes with the existing `CLONE_NEWNET`. `sandbox_linux.go` |
| 3 | High | `landlock.V5.BestEffort()` silently no-ops without the Landlock LSM → FS unconfined while looking confined | `applyLandlock` probes `LandlockGetABIVersion()` and **fails closed** when ABI 0. `/proc`, `/sys`, `/dev` are denied by default (allowlist model; only granted paths pass). |
| 4 | High | Blanket `/etc`,`/usr`,`/opt` read grant | `sandboxROPaths` drops `/etc` (keeps only `/etc/ld.so.cache` as an ROFile), `/opt`, and the `/usr` blanket — grants only exec/lib dirs + the resolved interpreter dir. |
| 5 | High | Enforcement tests `t.Skip` on `ubuntu-latest` and e2e disabled → "green" == "never ran" | New CI `sandbox` job runs the enforcement tests with `FLEET_SANDBOX_MUST_ENFORCE=1`, which turns the `t.Skip` guards into **hard failures** when userns/Landlock is absent. Matching `docker-compose.test.yml` `sandbox-tests` service for local runs. Network left **blocked** in that lane. |
| 6/7 | High/Med | Only RLIMIT_CPU tested; no NNP-escalation test | Added `TestSandbox_NoNewPrivs` (prctl `PR_GET_NO_NEW_PRIVS`), `TestSandbox_NoProcLeak` (host PID invisible in child `/proc`), and `TestSandbox_RlimitsApplied` (AS/FSIZE/NPROC/NOFILE). |
| 9 | Med | `__fleet-coderun-child` re-exec driven purely by `argv[1]` | Spec now arrives over an **inherited handshake pipe** (fd 3 via `ExtraFiles`), not argv; the child branch errors out unless a valid spec is present on the pipe → can't be driven by argv alone. |
| (#87) | High | `NO_NEW_PRIVS` set per-thread (lost if Go execs from another thread) | Uses go-landlock's `AllThreadsPrctl` so it applies across all OS threads. |

## Deferred / noted
- **Userns-path subuid remap (part of #2):** the kernel only lets an *unprivileged* writer put a single uid_map line whose host side is its own uid, so mapping container-root to a distinct host subuid needs `newuidmap`/`/etc/subuid` delegation (a setuid helper, not pure-Go). The **PID+mount namespace + private /proc** closes the actual `/proc` secret leak in that path regardless of uid; the **root deployment path** does drop to a distinct uid (65534). Documented in code.

## Verification (host: Linux 6.8, userns + Landlock)
- `go build -tags dev ./...` → OK (ran `go generate ./onboarding-vault/` first).
- `FLEET_SANDBOX_MUST_ENFORCE=1 go test -race ./internal/agentruntime/...` → **ok**, all enforcement tests **RUN, not skip**:
```
--- PASS: TestSandbox_NetworkBlocked
--- PASS: TestSandbox_FSConfinedToWorkdir
--- PASS: TestSandbox_WorkdirStaysWritable
--- PASS: TestSandbox_RlimitCPUTrips
--- PASS: TestSandbox_NoProcLeak
--- PASS: TestSandbox_NoNewPrivs
--- PASS: TestSandbox_RlimitsApplied
--- PASS: TestSandbox_ModesBothExecute
--- PASS: TestSandboxDefaultIsEnforcing
```
  proving net-blocked / FS-confined / no-proc-leak / no-new-privs / rlimits all **enforce**.
- Root-path lane also verified green in a privileged Docker container (all 9 tests PASS) — exercises the uid-drop path the host userns lane doesn't. `FLEET_SANDBOX_MUST_ENFORCE=1` correctly hard-failed when run in a cap-dropped container (proves the guard works).
- `golangci-lint run --build-tags dev ./internal/agentruntime/... ./cmd/fleet/... ./internal/fleet/...` → **0 issues**.
- `go test ./internal/fleet/... ./cmd/fleet/...` → ok.

Note: `docker-compose.test.yml sandbox-tests` needs module download on first run; a transient proxy.golang.org TLS timeout on the build host is environmental (the suite passes once modules are cached).
