### PR TITLE
docs: README hero rewrite + CONTRIBUTING for star conversion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to trip2g
+
+Thanks for considering a contribution. This guide gets you from a fresh clone to a running dev server and a mergeable PR.
+
+## TL;DR
+
+```bash
+git clone https://github.com/trip2g/trip2g && cd trip2g
+go mod download && npm install
+make db-up          # apply SQLite migrations
+make air            # dev server with hot reload (starts MinIO via docker)
+```
+
+Open an issue or comment on an existing one before starting anything non-trivial, so we agree on the approach before you write code.
+
+## Prerequisites
+
+- Go 1.26+
+- Node.js 20+
+- Make
+- Docker (for MinIO, the local S3-compatible asset store)
+
+## Project layout
+
+Go monolith + $mol frontend + SQLite + GraphQL (gqlgen).
+
+| Path | What lives there |
+|---|---|
+| `cmd/server` | main binary |
+| `internal/case/` | one package per GraphQL mutation/query (the use case pattern) |
+| `internal/` | services: gitapi, noteloader, defaulttemplate, router, db (sqlc) |
+| `assets/ui/` | $mol frontend (`.view.tree` structure + `.view.ts` behavior) |
+| `docs/dev/` | developer docs; start with `app_patterns.md`, `architecture.md`, `source-tree.md` |
+| `docs/en/user/`, `docs/ru/user/` | user docs, always in EN + RU pairs |
+
+## Build and generate commands
+
+Generated code is committed. After editing a source of generated code, run the matching generator and commit both together.
+
+| Command | When |
+|---|---|
+| `make air` | dev server with hot reload |
+| `make test` / `go test ./...` | run tests |
+| `make lint` | golangci-lint + SQL query checks |
+| `make gqlgen` | after editing `schema.graphqls` |
+| `make sqlc` | after editing `queries.read.sql` / `queries.write.sql` |
+| `make db-new name=...` / `make db-up` | create / apply a migration (dbmate) |
+| `go generate ./internal/defaulttemplate/...` | after editing `views.html` or `langs/*.toml` (quicktemplate, not Go templates) |
+| `go generate ./internal/router/...` | after adding HTTP endpoints |
+| `npm run build` | TypeScript + Vite build |
+| `npm run graphqlgen` | frontend GraphQL types (needs the server running on :8081) |
+| `npm run test:e2e` | Playwright E2E tests |
+| `go run -tags dev ./cmd/server lint docs` | check doc links after editing anything under `docs/` |
+
+## Testing
+
+- Write tests first when practical (red, green, refactor).
+- Table-driven tests with `testify/require`; mocks are generated with `moq` (`//go:generate go tool github.com/matryer/moq -out mocks_test.go . Env`).
+- `make test` must pass before you open a PR.
+
+## PR conventions
+
+- **Language:** everything in English (code, comments, commits, PR text).
+- **Commits:** short one-liners, conventional format: `feat(scope): description`, `fix(scope): ...`, `docs: ...`. No commit body, no co-author trailers.
+- **Match the existing style.** Read the neighboring code before adding anything new. Comments only where the code is non-obvious, and no decorative banner comments.
+- **Small PRs merge faster.** One concern per PR.
+- **Generated files** (`views.html.go`, `internal/db/`, gqlgen output) belong in the same commit as their source.
+- SQL migrations get extra scrutiny; call them out in the PR description.
+
+## Where to start
+
+- Issues labeled [`good first issue`](https://github.com/trip2g/trip2g/labels/good%20first%20issue).
+- Docs fixes: the bilingual user docs under `docs/en/user/` and `docs/ru/user/` always welcome corrections (keep the EN/RU pair in sync).
+- Read `docs/dev/app_patterns.md` before proposing backend changes; it explains the Env interface and service package patterns the codebase is built on.
+
+## Questions
+
+Open a [GitHub issue](https://github.com/trip2g/trip2g/issues) or a discussion. For security issues, please do not open a public issue; contact the maintainer directly.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,50 @@
 # trip2g
 
+**Publish your Obsidian vault as a website. Self-hosted MCP memory for AI agents.**
+
+Write in Obsidian, press Sync, your notes are live. The same self-hosted hub serves readers a website and serves agents an MCP endpoint, publishes to Telegram, and gates paid content. Under the hood it is a Markdown Operating System: every note is a file, and one note is both a web page for a human and a tool call for an agent.
+
+[![CI](https://github.com/trip2g/trip2g/actions/workflows/ci.yml/badge.svg)](https://github.com/trip2g/trip2g/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/trip2g/trip2g)](https://github.com/trip2g/trip2g/releases)
+[![GitHub stars](https://img.shields.io/github/stars/trip2g/trip2g?style=flat)](https://github.com/trip2g/trip2g/stargazers)
 [![Go](https://img.shields.io/badge/go-1.26-blue.svg)](https://golang.org)
 
-**Markdown Operating System.** A self-hosted server where every note is a file, the shared knowledge base is the kernel, and the same note is served two ways: to a human as a web page, to an agent as an MCP call. Obsidian vaults and Telegram channels go in; a website, an MCP endpoint, hub-to-hub federation, and note-triggered agents come out.
+**Why trip2g**
 
-trip2g is a live, multi-tenant server for markdown (Go, SQLite, MIT, no SaaS in the middle), not a local editor like Obsidian or a static build like Quartz.
+- **Your notes work twice.** One markdown file renders as a page for readers and answers `search` / `note_html` calls from any MCP client. No export step, no copy of your knowledge locked in a vector store you can't read.
+- **Your data stays yours.** Plain markdown, a git-cloneable vault, every edit a readable diff. No SaaS in the middle, and you can move out any time with `git clone`.
+- **One process to run.** A single Go binary on SQLite. It starts the same on a laptop, a small VM, or a container. MIT licensed.
 
-[Try the public hub →](#try-it-now) · [Self-host](#self-host) · [Docs](https://trip2g.com/en/user)
-
+<!-- DEMO GIF placeholder: ~15 seconds, edit a note in Obsidian, press Sync, refresh the page, then ask an MCP client about the change.
+     Drop the recording at docs/assets/demo.gif and replace this comment with:
+     ![15 second demo: edit in Obsidian, sync, the page and the agent both see it](docs/assets/demo.gif) -->
 ![trip2g landing](docs/assets/screenshot.webp)
+
+## Quickstart
+
+**See it work in 30 seconds.** Add the public knowledge hub to any MCP client and ask it a question. It searches all connected bases and answers with sources:
+
+```json
+{
+  "mcpServers": {
+    "trip2g": {
+      "url": "https://trip2g.com/_system/mcp"
+    }
+  }
+}
+```
+
+**Run your own hub:**
+
+```bash
+git clone https://github.com/trip2g/trip2g && cd trip2g
+docker compose up
+```
+
+Prefer no terminal? Get a [free cloud instance](https://simplecloud.2pub.me). All the options (single binary, Docker Compose, fly.io) are in the [self-host guide](https://trip2g.com/en/user/selfhosted).
+
+[Docs](https://trip2g.com/en/user) · [Getting started](https://trip2g.com/en/user/getting-started) · [MCP tools](https://trip2g.com/en/user/mcp) · [Self-host](#self-host) · [Contributing](CONTRIBUTING.md)
 
 ---
 
@@ -68,26 +103,6 @@ trip2g borrows the operating-system vocabulary because the primitives line up. E
 | Process executor | internal LLM run loop (`agentruntime`), tool allowlist + caps | branch |
 | Package manager | role-as-note: drop a note, `fleet` registers the agent | branch |
 | Resource limits | non-overridable token + step caps per run | branch |
-
----
-
-## Try it now
-
-Add the public knowledge hub to your MCP client:
-
-```json
-{
-  "mcpServers": {
-    "trip2g": {
-      "url": "https://trip2g.com/_system/mcp"
-    }
-  }
-}
-```
-
-Ask it a question. It searches all connected bases and returns answers with sources.
-
-Want your own? [Free cloud instance](https://simplecloud.2pub.me), no terminal needed.
 
 ---
 


### PR DESCRIPTION
## What

Repo-surface pass for star conversion. Two files: `README.md` hero rewrite + new `CONTRIBUTING.md`. Plus, in this PR body: a draft of good-first-issues (for approval, none created) and a prepared submission checklist for awesome lists and MCP directories (no external PRs opened).

## 1. README hero rewrite

- First two lines are now the plain promise with the primary keywords: "Publish your Obsidian vault as a website. Self-hosted MCP memory for AI agents." The "Markdown Operating System" framing moves to the second beat, per the positioning verdict in `docs/dev/2026-07-02_user_docs_humanization_plan.md`.
- Above the fold: what it is, a 3-bullet why, badges (CI build, license, release, stars, Go), screenshot, quickstart (public-hub MCP config + `docker compose up`), links row.
- Demo GIF placeholder added as an HTML comment right above the screenshot, with instructions: record ~15s of "edit in Obsidian, Sync, page refresh, MCP query", drop it at `docs/assets/demo.gif`, swap the comment for the image tag. No binary fabricated.
- Removed the old mid-page "Try it now" section (folded into Quickstart). Body sections (OS map, federation, fleet, etc.) untouched.
- No em dashes anywhere in the README now.

Structure modeled on these high-star OSS READMEs:

| Reference | What was borrowed |
|---|---|
| [usememos/memos](https://github.com/usememos/memos) (~40k stars) | one-line plain promise, 3-4 bold-lead feature bullets, docker quickstart right after the screenshot |
| [immich-app/immich](https://github.com/immich-app/immich) (~80k) | badge row + tagline + full-width screenshot before any prose |
| [jackyzha0/quartz](https://github.com/jackyzha0/quartz) (~9k, closest domain) | job-to-be-done as the literal first sentence |
| [outline/outline](https://github.com/outline/outline) (~35k) | contributing section that routes newcomers to good-first-issue and asks for discussion before code |
| [siyuan-note/siyuan](https://github.com/siyuan-note/siyuan) (~40k) | badge selection (build, release, license) without the badge-wall excess |

## 2. CONTRIBUTING.md

New file: prerequisites, TL;DR clone-to-running-server, project layout table, the full build/generate command table (from Makefile + CLAUDE.md), testing conventions (TDD, moq, testify), PR conventions (English, conventional one-liner commits, generated files committed with their source), where to start.

## 3. Good-first-issues draft (NEEDS APPROVAL, none created)

All grounded in verified findings from the 2026-07-02 docs audit. Approve and I (or anyone) can `gh issue create` them with the `good first issue` label.

1. **docs: remove screenshot art-direction placeholders shipped in live-editing.md and editor.md**
   `docs/en/user/live-editing.md:20-21` and `docs/en/user/editor.md` ship a `> 🖼️ Screenshot ...` placeholder plus art-direction notes in the published body. Either add the real screenshot or cut the block (and mirror the fix in the RU pair).

2. **docs: remove TODO comments shipped in en/user/advanced.md**
   `docs/en/user/advanced.md:51` and `:97` contain `<!-- TODO: verify with product -->` in published prose. Verify against `frontmatter-patches.md` / `oauth.md` and delete the comments.

3. **docs: hosting.md pins ghcr image to :0.2 while every other doc uses :latest**
   `docs/en/user/hosting.md:26` pins `ghcr.io/trip2g/trip2g:0.2`. Align with the rest of the docs (`:latest`) or state why the pin exists.

4. **docs: publishing.md ships an empty slug example code block**
   `docs/en/user/publishing.md:68-69` has an empty code block where a `slug` frontmatter example should be. Restore the example (check the RU pair too).

5. **docs: backup.md and backups.md both claim the title "Backups"**
   `backup.md` (server SQLite DB) is orphaned from `_sidebar.md`; `backups.md` (Obsidian vault) is linked. Retitle both to disambiguate and either link or merge the orphan.

6. **docs(ru): unify Obsidian vault terminology to "хранилище"**
   RU docs drift between `хранилище` (dominant, 133 uses), transliterated `волт` (`local-quickstart.md`, `okf.md`, `fly.md`) and English `vault` in prose (`agent_admin.md`, `mcp.md`). Unify prose to `хранилище`; `vault` inside code/CLI stays.

7. **docs(ru): fix two grammar slips in forms.md**
   `docs/ru/user/forms.md:36` "собирает свой вёрстку" should be "свою вёрстку"; `:7` needs a comma: "ввод, привязанный". Two-line fix, good first PR.

8. **README: record the 15-second demo GIF**
   README has a placeholder comment above the screenshot describing the exact shot: edit a note in Obsidian, press Sync, refresh the page, ask an MCP client about the change. Record it, drop it at `docs/assets/demo.gif`, swap the comment for the image tag.

## 4. Awesome-list / MCP-directory submissions (PREPARED, none opened)

Reusable one-liner: *"Self-hosted markdown knowledge hub with a built-in MCP server: publish an Obsidian vault as a website and let AI agents search and read the same notes over MCP, with hub-to-hub federation."*

- [ ] **awesome-mcp-servers** ([punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers)) — category **Knowledge & Memory**. Entry (their emoji legend: Go, cloud/self-hosted):
  `- [trip2g/trip2g](https://github.com/trip2g/trip2g) 🏎️ ☁️ 🏠 - Self-hosted markdown knowledge hub: publish an Obsidian vault as a website and query it over MCP (hybrid search, note reading, similarity, federation across hubs).`
- [ ] **awesome-selfhosted** ([awesome-selfhosted/awesome-selfhosted](https://github.com/awesome-selfhosted/awesome-selfhosted)) — category **Note-taking & Editors** (or **Knowledge Management Tools**). Entry:
  `- [trip2g](https://trip2g.com) - Publish Obsidian vaults as websites with paid subscriptions, Telegram publishing and a built-in MCP server for AI agents. ([Source Code](https://github.com/trip2g/trip2g)) ``MIT`` ``Go/Docker``  `
  Note: they require projects to be at least 4 months old with real activity and releases; check the checklist in their CONTRIBUTING before opening.
- [ ] **awesome-obsidian** ([kmaasrud/awesome-obsidian](https://github.com/kmaasrud/awesome-obsidian)) — category **Publishing**. Entry:
  `- [trip2g](https://github.com/trip2g/trip2g) - Self-hosted server that publishes your vault as a website: two-way sync, Telegram publishing, paid subscriptions, and an MCP endpoint for AI agents.`
- [ ] **awesome-ai-agents** ([e2b-dev/awesome-ai-agents](https://github.com/e2b-dev/awesome-ai-agents)) — section **Open-source projects**. Entry:
  `- [trip2g](https://github.com/trip2g/trip2g) - Self-hosted MCP memory and event bus for agents: notes trigger webhooks, agents read and write the same markdown humans browse as a website.`
- [ ] **mcp.so** — submit via the on-site form (https://mcp.so, "Submit") with name `trip2g`, repo URL, the reusable one-liner, category **Knowledge & Memory**, server URL pattern `https://<your-hub>/_system/mcp` (public demo: `https://trip2g.com/_system/mcp`).
- [ ] **mcpservers.org** — submissions go through the site's Submit flow / PR (wong2's directory). Same one-liner, category **Knowledge**; mark as remote/streamable-HTTP server, demo endpoint `https://trip2g.com/_system/mcp`.
- [ ] **pulsemcp.com** — submit via https://www.pulsemcp.com/submit with repo URL and the one-liner; classification: remote-capable, self-hostable, Go.

All seven are a human/approval step; no external PRs or form submissions were made from this task.

## Verify

- Nothing under `docs/` was touched, so the docs link lint gate does not apply to this diff.
- README markdown renders clean; zero em dashes; all internal anchors (`#self-host`) and `CONTRIBUTING.md` link resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
