### PR TITLE
feat(docs): GitHub star CTA in docs footers + transcludable star-cta note

### DIFF
--- a/docs/_footer.md
+++ b/docs/_footer.md
@@ -28,3 +28,5 @@ free: true
 
 - [Open Source](https://github.com/trip2g/trip2g)
 - [alexes.dev@gmail.com](mailto:alexes.dev@gmail.com)
+
+![[star-cta]]

--- a/docs/ru/_footer.md
+++ b/docs/ru/_footer.md
@@ -28,3 +28,5 @@ free: true
 
 - [Open Source](https://github.com/trip2g/trip2g)
 - [alexes.dev@gmail.com](mailto:alexes.dev@gmail.com)
+
+![[ru/star-cta]]

--- a/docs/ru/star-cta.md
+++ b/docs/ru/star-cta.md
@@ -1,0 +1,7 @@
+---
+free: true
+---
+
+**trip2g — открытый код (MIT).** Если проект вам помог, [звезда на GitHub](https://github.com/trip2g/trip2g) поможет другим его найти.
+
+[![Звёзды на GitHub](https://img.shields.io/github/stars/trip2g/trip2g?style=social)](https://github.com/trip2g/trip2g)

--- a/docs/star-cta.md
+++ b/docs/star-cta.md
@@ -1,0 +1,7 @@
+---
+free: true
+---
+
+**trip2g is open source (MIT).** If it helped you, [a star on GitHub](https://github.com/trip2g/trip2g) helps others find it.
+
+[![GitHub stars](https://img.shields.io/github/stars/trip2g/trip2g?style=social)](https://github.com/trip2g/trip2g)


### PR DESCRIPTION
Adds a soft, non-incentivized GitHub-star CTA to the docs site.

## Mechanism 1: footer CTA (site-wide, primary)
The default template falls back to the `_footer` note on every page (`internal/defaulttemplate/template.go` `FooterRef`), and `docs/patches/ru.md` already wires `footer: [[ru/_footer]]` for all `ru/**` pages. So the CTA is added to both footer notes — every docs page gets it with zero per-note markup, language-correct:
- `docs/_footer.md` → `![[star-cta]]`
- `docs/ru/_footer.md` → `![[ru/star-cta]]`

No Jet layout was touched (the mesh landing layout is separate); the footer is plain markdown rendered by the default template, so existing pages are unaffected.

## Mechanism 2: transcludable `star-cta` note
Note-transclusion IS supported: `renderEmbed` in `internal/mdloader/link_renderer.go` embeds a target note's rendered HTML in `<div class="embedded-note">` (not just images/assets). New notes for optional per-note placement via `![[star-cta]]` (EN) / `![[ru/star-cta]]` (RU):
- `docs/star-cta.md` — "trip2g is open source (MIT). If it helped you, a star on GitHub helps others find it." + live `img.shields.io` star badge linking to https://github.com/trip2g/trip2g
- `docs/ru/star-cta.md` — parallel Russian copy

The footer wiring itself uses these embeds, so the copy is single-sourced.

## Verification
- `go run -tags dev ./cmd/server lint docs` → exit 0 (only pre-existing demo info warnings)
- Booted an isolated dev server (temp SQLite, local storage backend, :28081), synced the branch docs vault via obsidian-sync CLI, and curled rendered pages:
  - `/en/user/getting_started` footer shows the EN CTA + shields star badge inside `embedded-note`
  - `/ru/user/advanced` footer shows the RU CTA + badge
- CTA renders at the bottom of the footer's Contact column (which already carries the Open Source link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)