### PR TITLE
feat(tasklist): admin-only interactive task-list checkboxes on note pages

### DIFF
--- a/assets/embed.go
+++ b/assets/embed.go
@@ -5,5 +5,5 @@ package assets
 
 import "embed"
 
-//go:embed defaulttemplate.css defaulttemplate.js output.css toc/toc.js chart.js echarts.min.js mermaid.js mermaid.min.js codeblock.js highlight.min.js ui/admin/-/web.js ui/user/-/web.js ui/forms/-/web.js ui/forms/-/web.locale* ui/user/-/web.locale* ui/admin/-/web.locale* *.png *.ico *.svg *.webmanifest langs/*.png
+//go:embed defaulttemplate.css defaulttemplate.js output.css toc/toc.js chart.js echarts.min.js mermaid.js mermaid.min.js codeblock.js highlight.min.js tasklist.js ui/admin/-/web.js ui/user/-/web.js ui/forms/-/web.js ui/forms/-/web.locale* ui/user/-/web.locale* ui/admin/-/web.locale* *.png *.ico *.svg *.webmanifest langs/*.png
 var FS embed.FS

--- a/assets/tasklist.js
+++ b/assets/tasklist.js
@@ -1,0 +1,36 @@
+"use strict";(()=>{var M=`
+  query TaskListNoteContent($filter: NotePathsFilter) {
+    notePaths(filter: $filter) {
+      content
+    }
+  }
+`,v=`
+  mutation TaskListUpdateNotes($input: UpdateNotesInput!) {
+    updateNotes(input: $input) {
+      __typename
+      ... on UpdateNotesSuccessPayload {
+        paths
+        updated {
+          path
+          versionId
+        }
+      }
+      ... on UpdateNotesHashMismatchPayload {
+        path
+        actualHash
+      }
+      ... on UpdateNotesPatchNotFoundPayload {
+        path
+        find
+      }
+      ... on ErrorPayload {
+        message
+      }
+    }
+  }
+`;async function k(c,l){let a=await fetch("/graphql",{method:"POST",credentials:"include",headers:{"Content-Type":"application/json"},body:JSON.stringify({query:c,variables:l})});if(!a.ok)throw new Error(`GraphQL HTTP ${a.status}`);let e=await a.json();if(e.errors?.length)throw new Error(e.errors[0].message);return e.data}function I(c){let l=c.split(`
+`),a=0,e=!1,f="",i=0;for(let u of l){let s=u.replace(/\r$/,"").replace(/^[ \t]+/,"");if(e){if(s.length>=i){let r=s[0];if(r===f){let n=0;for(;n<s.length&&s[n]===r;)n++;n>=i&&s.slice(n).trim()===""&&(e=!1)}}continue}else if(s.length>=3){let r=s[0];if(r==="`"||r==="~"){let n=0;for(;n<s.length&&s[n]===r;)n++;if(n>=3){e=!0,f=r,i=n;continue}}}let t=s;if(t.length<5)continue;let m=t[0];if(m!=="-"&&m!=="*"&&m!=="+"||t[1]!==" "&&t[1]!=="	")continue;let o=2;for(;o<t.length&&t[o]===" ";)o++;if(!(o+3>t.length)&&t[o]==="["){let r=t[o+1];t[o+2]==="]"&&(r===" "||r==="x"||r==="X")&&a++}}return a}function U(c,l,a){let e=c.split(`
+`),f=0,i=!1,u="",p=0;for(let s=0;s<e.length;s++){let t=e[s],o=t.replace(/\r$/,"").replace(/^[ \t]+/,""),r=t.length-t.replace(/^[ \t]+/,"").length;if(i){if(o.length>=p){let h=o[0];if(h===u){let g=0;for(;g<o.length&&o[g]===h;)g++;g>=p&&o.slice(g).trim()===""&&(i=!1)}}continue}else if(o.length>=3){let h=o[0];if(h==="`"||h==="~"){let g=0;for(;g<o.length&&o[g]===h;)g++;if(g>=3){i=!0,u=h,p=g;continue}}}let n=o;if(n.length<5)continue;let w=n[0];if(w!=="-"&&w!=="*"&&w!=="+"||n[1]!==" "&&n[1]!=="	")continue;let d=2;for(;d<n.length&&n[d]===" ";)d++;if(!(d+3>n.length)&&n[d]==="["){let h=n[d+1];if(n[d+2]==="]"&&(h===" "||h==="x"||h==="X")){if(f===a){let N=t.indexOf(o)+d,L=h===" "?"x":" ",_=t.slice(0,N+1)+L+t.slice(N+2),E=[...e];return E[s]=_,E.join(`
+`)}f++}}}return null}function S(c,l,a,e,f,i){return l.split(`
+`).filter(p=>p.replace(/\r$/,"")===a.replace(/\r$/,"")).length===1?{changes:[{patch:{path:c,find:a,replace:e}}]}:{changes:[{upsert:{path:c,content:i,expectedHash:f}}]}}var y="";async function $(c,l,a,e){let f=c.checked;c.disabled=!0;try{let u=(await k(M,{filter:{paths:[e.path]}})).notePaths?.[0]?.content;if(!u)throw new Error("note content not found");let p=I(u);if(p!==a)throw new Error(`task count mismatch (DOM=${a}, src=${p}) \u2014 page may be stale, please reload`);let s=P(u);if(l>=s.length)throw new Error("index out of range");let t=s[l],m=U(u,a,l);if(!m)throw new Error("could not locate marker in source");let r=P(m)[l],n=S(e.path,u,t,r,y||e.versionId,m),d=(await k(v,{input:n})).updateNotes;if(d.__typename==="UpdateNotesSuccessPayload"){let h=d.updated.find(g=>g.path===e.path);h&&(y=h.versionId),c.checked=!f}else throw d.__typename==="UpdateNotesHashMismatchPayload"?new Error("note was modified by another client \u2014 please reload"):d.__typename==="UpdateNotesPatchNotFoundPayload"?new Error(`patch target not found in source: "${d.find}"`):new Error(d.message||"unknown error")}catch(i){c.checked=f;let u=i instanceof Error?i.message:String(i);console.error("[tasklist]",u),b(c,u)}finally{c.disabled=!1}}function P(c){let l=c.split(`
+`),a=[],e=!1,f="",i=0;for(let u of l){let p=u.replace(/\r$/,""),s=p.replace(/^[ \t]+/,"");if(e){if(s.length>=i&&s[0]===f){let r=0;for(;r<s.length&&s[r]===f;)r++;r>=i&&s.slice(r).trim()===""&&(e=!1)}continue}else if(s.length>=3){let r=s[0];if(r==="`"||r==="~"){let n=0;for(;n<s.length&&s[n]===r;)n++;if(n>=3){e=!0,f=r,i=n;continue}}}let t=s;if(t.length<5)continue;let m=t[0];if(m!=="-"&&m!=="*"&&m!=="+"||t[1]!==" "&&t[1]!=="	")continue;let o=2;for(;o<t.length&&t[o]===" ";)o++;if(!(o+3>t.length)&&t[o]==="["){let r=t[o+1];t[o+2]==="]"&&(r===" "||r==="x"||r==="X")&&a.push(p)}}return a}function b(c,l){let a=c.parentElement?.querySelector(".tasklist-error");a&&a.remove();let e=document.createElement("span");e.className="tasklist-error",e.style.cssText="color:#c0392b;font-size:0.85em;margin-left:0.4em;",e.textContent="\u26A0 "+l,c.after(e),setTimeout(()=>e.remove(),6e3)}function T(){let c=document.getElementById("tasklist-meta");if(!c)return;let l;try{l=JSON.parse(c.textContent||"{}")}catch{return}if(!l.path||!l.versionId)return;y=l.versionId;let a=document.querySelector(".content__body");if(!a)return;let e=Array.from(a.querySelectorAll('li > input[type="checkbox"]'));if(e.length===0)return;let f=e.length;e.forEach((i,u)=>{i.removeAttribute("disabled"),i.style.cursor="pointer",i.addEventListener("change",p=>{p.preventDefault(),i.checked=!i.checked,$(i,u,f,l)})})}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",T):T();})();

--- a/assets/tasklist/esbuild.browser.mjs
+++ b/assets/tasklist/esbuild.browser.mjs
@@ -1,0 +1,28 @@
+import esbuild from "esbuild";
+import path from "path";
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const isWatch = process.argv.includes("--watch");
+
+const config = {
+  entryPoints: [path.resolve(__dirname, "src/index.ts")],
+  bundle: true,
+  platform: "browser",
+  target: "es2020",
+  format: "iife",
+  logLevel: "info",
+  sourcemap: false,
+  treeShaking: true,
+  minify: true,
+  outfile: path.resolve(__dirname, "../tasklist.js"),
+};
+
+if (isWatch) {
+  const ctx = await esbuild.context(config);
+  await ctx.watch();
+  console.log("Watching...");
+} else {
+  await esbuild.build(config);
+  console.log("Built: tasklist.js");
+}

--- a/assets/tasklist/src/index.ts
+++ b/assets/tasklist/src/index.ts
@@ -1,0 +1,415 @@
+// tasklist widget — enables GFM task-list checkboxes for admins on the default
+// template note page. Reads path + versionId from #tasklist-meta, un-disables
+// the checkboxes found inside .content__body, and persists toggles via the
+// GraphQL updateNotes patch mutation.
+//
+// Loaded only when: note has task-list items AND viewer is admin (gated by
+// server-side emission in buildDefaultTemplateCtx / endpoint.go).
+
+interface Meta {
+  path: string;
+  versionId: string;
+}
+
+interface NotePathResult {
+  notePaths: Array<{ content: string }>;
+}
+
+interface UpdateNotesResult {
+  updateNotes:
+    | { __typename: 'UpdateNotesSuccessPayload'; paths: string[]; updated: Array<{ path: string; versionId: string }> }
+    | { __typename: 'UpdateNotesHashMismatchPayload'; path: string; actualHash: string }
+    | { __typename: 'UpdateNotesPatchNotFoundPayload'; path: string; find: string }
+    | { __typename: 'ErrorPayload'; message: string };
+}
+
+const NOTE_CONTENT_QUERY = `
+  query TaskListNoteContent($filter: NotePathsFilter) {
+    notePaths(filter: $filter) {
+      content
+    }
+  }
+`;
+
+const UPDATE_NOTES_MUTATION = `
+  mutation TaskListUpdateNotes($input: UpdateNotesInput!) {
+    updateNotes(input: $input) {
+      __typename
+      ... on UpdateNotesSuccessPayload {
+        paths
+        updated {
+          path
+          versionId
+        }
+      }
+      ... on UpdateNotesHashMismatchPayload {
+        path
+        actualHash
+      }
+      ... on UpdateNotesPatchNotFoundPayload {
+        path
+        find
+      }
+      ... on ErrorPayload {
+        message
+      }
+    }
+  }
+`;
+
+async function graphql<T>(query: string, variables: unknown): Promise<T> {
+  const res = await fetch('/graphql', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (!res.ok) {
+    throw new Error(`GraphQL HTTP ${res.status}`);
+  }
+  const json = await res.json();
+  if (json.errors?.length) {
+    throw new Error(json.errors[0].message);
+  }
+  return json.data as T;
+}
+
+// countTaskMarkers counts GFM task list markers in markdown source, skipping
+// markers inside fenced code blocks. Mirrors the Go implementation in
+// internal/model/note_tasklist.go so the DOM ↔ source count guard is
+// consistent on both sides.
+function countTaskMarkers(src: string): number {
+  const lines = src.split('\n');
+  let count = 0;
+  let inFence = false;
+  let fenceChar = '';
+  let fenceLen = 0;
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\r$/, '');
+    const stripped = line.replace(/^[ \t]+/, '');
+
+    if (!inFence) {
+      if (stripped.length >= 3) {
+        const ch = stripped[0];
+        if (ch === '`' || ch === '~') {
+          let run = 0;
+          while (run < stripped.length && stripped[run] === ch) run++;
+          if (run >= 3) {
+            inFence = true;
+            fenceChar = ch;
+            fenceLen = run;
+            continue;
+          }
+        }
+      }
+    } else {
+      if (stripped.length >= fenceLen) {
+        const ch = stripped[0];
+        if (ch === fenceChar) {
+          let run = 0;
+          while (run < stripped.length && stripped[run] === ch) run++;
+          if (run >= fenceLen && stripped.slice(run).trim() === '') {
+            inFence = false;
+          }
+        }
+      }
+      continue;
+    }
+
+    const rest = stripped;
+    if (rest.length < 5) continue;
+    const bullet = rest[0];
+    if (bullet !== '-' && bullet !== '*' && bullet !== '+') continue;
+    if (rest[1] !== ' ' && rest[1] !== '\t') continue;
+    let i = 2;
+    while (i < rest.length && rest[i] === ' ') i++;
+    if (i + 3 > rest.length) continue;
+    if (rest[i] === '[') {
+      const inner = rest[i + 1];
+      if (rest[i + 2] === ']' && (inner === ' ' || inner === 'x' || inner === 'X')) {
+        count++;
+      }
+    }
+  }
+
+  return count;
+}
+
+// flipNthTaskMarker returns a new source string where the Nth (0-based) task
+// marker is toggled ([ ] ↔ [x]). Returns null if the counts don't match the
+// expected domCount (safety guard) or if n is out of range.
+function flipNthTaskMarker(src: string, domCount: number, n: number): string | null {
+  const lines = src.split('\n');
+  let markerIndex = 0;
+  let inFence = false;
+  let fenceChar = '';
+  let fenceLen = 0;
+
+  for (let li = 0; li < lines.length; li++) {
+    const rawLine = lines[li];
+    const line = rawLine.replace(/\r$/, '');
+    const stripped = line.replace(/^[ \t]+/, '');
+    const leadingSpaces = rawLine.length - rawLine.replace(/^[ \t]+/, '').length; // not used directly
+
+    if (!inFence) {
+      if (stripped.length >= 3) {
+        const ch = stripped[0];
+        if (ch === '`' || ch === '~') {
+          let run = 0;
+          while (run < stripped.length && stripped[run] === ch) run++;
+          if (run >= 3) {
+            inFence = true;
+            fenceChar = ch;
+            fenceLen = run;
+            continue;
+          }
+        }
+      }
+    } else {
+      if (stripped.length >= fenceLen) {
+        const ch = stripped[0];
+        if (ch === fenceChar) {
+          let run = 0;
+          while (run < stripped.length && stripped[run] === ch) run++;
+          if (run >= fenceLen && stripped.slice(run).trim() === '') {
+            inFence = false;
+          }
+        }
+      }
+      continue;
+    }
+
+    const rest = stripped;
+    if (rest.length < 5) continue;
+    const bullet = rest[0];
+    if (bullet !== '-' && bullet !== '*' && bullet !== '+') continue;
+    if (rest[1] !== ' ' && rest[1] !== '\t') continue;
+    let i = 2;
+    while (i < rest.length && rest[i] === ' ') i++;
+    if (i + 3 > rest.length) continue;
+    if (rest[i] === '[') {
+      const inner = rest[i + 1];
+      if (rest[i + 2] === ']' && (inner === ' ' || inner === 'x' || inner === 'X')) {
+        if (markerIndex === n) {
+          // Found the marker to flip.
+          // Find the position within the original rawLine.
+          // stripped starts after the leading whitespace.
+          const leadLen = rawLine.indexOf(stripped);
+          const markerOffset = leadLen + i;
+          const newInner = inner === ' ' ? 'x' : ' ';
+          const newLine = rawLine.slice(0, markerOffset + 1) + newInner + rawLine.slice(markerOffset + 2);
+          const newLines = [...lines];
+          newLines[li] = newLine;
+          return newLines.join('\n');
+        }
+        markerIndex++;
+      }
+    }
+  }
+
+  return null;
+}
+
+// buildPatch returns the updateNotes input for a line-level find/replace when
+// the line is unique in source, or falls back to a full-content upsert.
+function buildPatchInput(
+  path: string,
+  src: string,
+  oldLine: string,
+  newLine: string,
+  expectedHash: string,
+  newSrc: string,
+): unknown {
+  // Count occurrences of oldLine in source (as a whole line).
+  const occurrences = src.split('\n').filter(l => l.replace(/\r$/, '') === oldLine.replace(/\r$/, '')).length;
+
+  if (occurrences === 1) {
+    // Unique line → use a targeted find/replace patch.
+    // The server's patch is a literal substring find; use the whole line.
+    return {
+      changes: [{ patch: { path, find: oldLine, replace: newLine } }],
+    };
+  }
+
+  // Ambiguous or multi-occurrence → fall back to full upsert with expectedHash guard.
+  return {
+    changes: [{ upsert: { path, content: newSrc, expectedHash } }],
+  };
+}
+
+let currentVersionId: string = '';
+
+async function toggleCheckbox(
+  checkbox: HTMLInputElement,
+  index: number,
+  domCount: number,
+  meta: Meta,
+): Promise<void> {
+  // Optimistic toggle.
+  const wasChecked = checkbox.checked;
+  checkbox.disabled = true;
+
+  try {
+    // Fetch raw source.
+    const contentRes = await graphql<{ data: NotePathResult }>(NOTE_CONTENT_QUERY, {
+      filter: { paths: [meta.path] },
+    });
+    const src = (contentRes as any).notePaths?.[0]?.content as string | undefined;
+    if (!src) throw new Error('note content not found');
+
+    // Safety guard: DOM count must match source count.
+    const srcCount = countTaskMarkers(src);
+    if (srcCount !== domCount) {
+      throw new Error(`task count mismatch (DOM=${domCount}, src=${srcCount}) — page may be stale, please reload`);
+    }
+
+    // Find the line to flip.
+    const markers = collectMarkers(src);
+    if (index >= markers.length) throw new Error('index out of range');
+    const oldLine = markers[index];
+    const newSrc = flipNthTaskMarker(src, domCount, index);
+    if (!newSrc) throw new Error('could not locate marker in source');
+
+    // Derive new line from flipped source.
+    const newMarkers = collectMarkers(newSrc);
+    const newLine = newMarkers[index];
+
+    const input = buildPatchInput(meta.path, src, oldLine, newLine, currentVersionId || meta.versionId, newSrc);
+
+    const updateRes = await graphql<{ data: UpdateNotesResult }>(UPDATE_NOTES_MUTATION, { input });
+    const payload = (updateRes as any).updateNotes as UpdateNotesResult['updateNotes'];
+
+    if (payload.__typename === 'UpdateNotesSuccessPayload') {
+      const updated = payload.updated.find(u => u.path === meta.path);
+      if (updated) currentVersionId = updated.versionId;
+      // Reflect new checked state.
+      checkbox.checked = !wasChecked;
+    } else if (payload.__typename === 'UpdateNotesHashMismatchPayload') {
+      throw new Error('note was modified by another client — please reload');
+    } else if (payload.__typename === 'UpdateNotesPatchNotFoundPayload') {
+      throw new Error(`patch target not found in source: "${payload.find}"`);
+    } else {
+      throw new Error((payload as any).message || 'unknown error');
+    }
+  } catch (err) {
+    // Revert optimistic toggle.
+    checkbox.checked = wasChecked;
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error('[tasklist]', msg);
+    showError(checkbox, msg);
+  } finally {
+    checkbox.disabled = false;
+  }
+}
+
+// collectMarkers returns the full lines (CR-stripped) of all task markers in
+// source, in order, skipping fenced code blocks.
+function collectMarkers(src: string): string[] {
+  const lines = src.split('\n');
+  const out: string[] = [];
+  let inFence = false;
+  let fenceChar = '';
+  let fenceLen = 0;
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\r$/, '');
+    const stripped = line.replace(/^[ \t]+/, '');
+
+    if (!inFence) {
+      if (stripped.length >= 3) {
+        const ch = stripped[0];
+        if (ch === '`' || ch === '~') {
+          let run = 0;
+          while (run < stripped.length && stripped[run] === ch) run++;
+          if (run >= 3) { inFence = true; fenceChar = ch; fenceLen = run; continue; }
+        }
+      }
+    } else {
+      if (stripped.length >= fenceLen && stripped[0] === fenceChar) {
+        let run = 0;
+        while (run < stripped.length && stripped[run] === fenceChar) run++;
+        if (run >= fenceLen && stripped.slice(run).trim() === '') { inFence = false; }
+      }
+      continue;
+    }
+
+    const rest = stripped;
+    if (rest.length < 5) continue;
+    const bullet = rest[0];
+    if (bullet !== '-' && bullet !== '*' && bullet !== '+') continue;
+    if (rest[1] !== ' ' && rest[1] !== '\t') continue;
+    let i = 2;
+    while (i < rest.length && rest[i] === ' ') i++;
+    if (i + 3 > rest.length) continue;
+    if (rest[i] === '[') {
+      const inner = rest[i + 1];
+      if (rest[i + 2] === ']' && (inner === ' ' || inner === 'x' || inner === 'X')) {
+        out.push(line);
+      }
+    }
+  }
+
+  return out;
+}
+
+function showError(near: HTMLInputElement, msg: string): void {
+  // Remove any previous inline error for this checkbox.
+  const prev = near.parentElement?.querySelector('.tasklist-error');
+  if (prev) prev.remove();
+
+  const span = document.createElement('span');
+  span.className = 'tasklist-error';
+  span.style.cssText = 'color:#c0392b;font-size:0.85em;margin-left:0.4em;';
+  span.textContent = '⚠ ' + msg;
+  near.after(span);
+
+  // Auto-remove after 6 seconds.
+  setTimeout(() => span.remove(), 6000);
+}
+
+function initTaskList(): void {
+  const metaEl = document.getElementById('tasklist-meta');
+  if (!metaEl) return;
+
+  let meta: Meta;
+  try {
+    meta = JSON.parse(metaEl.textContent || '{}') as Meta;
+  } catch {
+    return;
+  }
+  if (!meta.path || !meta.versionId) return;
+  currentVersionId = meta.versionId;
+
+  const body = document.querySelector<HTMLElement>('.content__body');
+  if (!body) return;
+
+  // Detect checkboxes: GFM task-list → <li><input type="checkbox" disabled ...>
+  // goldmark default output: checkbox is first element child of the <li>.
+  const checkboxes = Array.from(
+    body.querySelectorAll<HTMLInputElement>('li > input[type="checkbox"]'),
+  );
+
+  if (checkboxes.length === 0) return;
+
+  const domCount = checkboxes.length;
+
+  checkboxes.forEach((cb, index) => {
+    cb.removeAttribute('disabled');
+    cb.style.cursor = 'pointer';
+
+    cb.addEventListener('change', (e) => {
+      e.preventDefault();
+      // Revert the browser's optimistic toggle — we handle state ourselves
+      // after the server confirms.
+      cb.checked = !cb.checked;
+      toggleCheckbox(cb, index, domCount, meta);
+    });
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initTaskList);
+} else {
+  initTaskList();
+}

--- a/internal/case/rendernotepage/endpoint.go
+++ b/internal/case/rendernotepage/endpoint.go
@@ -625,6 +625,12 @@ func buildDefaultTemplateCtx( //nolint:gocognit // template context assembly req
 		if note.HasAnyCodeBlock() {
 			jsURLs = append(jsURLs, env.AssetURL("/assets/codeblock.js"))
 		}
+		// Task-list widget: admin-only — public/anonymous pages never load it.
+		// The page cache bails on any authenticated request (pagecache.go line 66),
+		// so this is safe: the cache key never varies on admin state.
+		if note.HasTaskListItems() && resp.UserToken != nil && resp.UserToken.IsAdmin() {
+			jsURLs = append(jsURLs, env.AssetURL("/assets/tasklist.js"))
+		}
 	}
 
 	// Build HTML injections map.

--- a/internal/defaulttemplate/views.html
+++ b/internal/defaulttemplate/views.html
@@ -324,6 +324,9 @@ window.__trip2g_settings = {
 {% if specJSON := ctx.FormSpecJSON(); specJSON != nil %}
 <script id="form-spec" data-nvid="{%s= ctx.Note.VersionID() %}" type="application/json">{%z= specJSON %}</script>
 {% endif %}
+{% if ctx.UserToken.IsAdmin() && ctx.Note.HasTaskListItems() %}
+<script id="tasklist-meta" type="application/json">{"path":"{%s ctx.Note.Path() %}","versionId":"{%s ctx.Note.VersionID() %}"}</script>
+{% endif %}
 </article>
 {% endif %}
 {% endfunc %}

--- a/internal/defaulttemplate/views.html.go
+++ b/internal/defaulttemplate/views.html.go
@@ -1479,170 +1479,189 @@ func StreamSelfContent(qw422016 *qt422016.Writer, ctx *Ctx) {
 		}
 //line views.html:326
 		qw422016.N().S(`
+`)
+//line views.html:327
+		if ctx.UserToken.IsAdmin() && ctx.Note.HasTaskListItems() {
+//line views.html:327
+			qw422016.N().S(`
+<script id="tasklist-meta" type="application/json">{"path":"`)
+//line views.html:328
+			qw422016.E().S(ctx.Note.Path())
+//line views.html:328
+			qw422016.N().S(`","versionId":"`)
+//line views.html:328
+			qw422016.E().S(ctx.Note.VersionID())
+//line views.html:328
+			qw422016.N().S(`"}</script>
+`)
+//line views.html:329
+		}
+//line views.html:329
+		qw422016.N().S(`
 </article>
 `)
-//line views.html:328
-	}
-//line views.html:328
-	qw422016.N().S(`
-`)
-//line views.html:329
-}
-
-//line views.html:329
-func WriteSelfContent(qq422016 qtio422016.Writer, ctx *Ctx) {
-//line views.html:329
-	qw422016 := qt422016.AcquireWriter(qq422016)
-//line views.html:329
-	StreamSelfContent(qw422016, ctx)
-//line views.html:329
-	qt422016.ReleaseWriter(qw422016)
-//line views.html:329
-}
-
-//line views.html:329
-func SelfContent(ctx *Ctx) string {
-//line views.html:329
-	qb422016 := qt422016.AcquireByteBuffer()
-//line views.html:329
-	WriteSelfContent(qb422016, ctx)
-//line views.html:329
-	qs422016 := string(qb422016.B)
-//line views.html:329
-	qt422016.ReleaseByteBuffer(qb422016)
-//line views.html:329
-	return qs422016
-//line views.html:329
-}
-
 //line views.html:331
-func StreamMagazine(qw422016 *qt422016.Writer, ctx *Ctx) {
+	}
 //line views.html:331
 	qw422016.N().S(`
 `)
 //line views.html:332
+}
+
+//line views.html:332
+func WriteSelfContent(qq422016 qtio422016.Writer, ctx *Ctx) {
+//line views.html:332
+	qw422016 := qt422016.AcquireWriter(qq422016)
+//line views.html:332
+	StreamSelfContent(qw422016, ctx)
+//line views.html:332
+	qt422016.ReleaseWriter(qw422016)
+//line views.html:332
+}
+
+//line views.html:332
+func SelfContent(ctx *Ctx) string {
+//line views.html:332
+	qb422016 := qt422016.AcquireByteBuffer()
+//line views.html:332
+	WriteSelfContent(qb422016, ctx)
+//line views.html:332
+	qs422016 := string(qb422016.B)
+//line views.html:332
+	qt422016.ReleaseByteBuffer(qb422016)
+//line views.html:332
+	return qs422016
+//line views.html:332
+}
+
+//line views.html:334
+func StreamMagazine(qw422016 *qt422016.Writer, ctx *Ctx) {
+//line views.html:334
+	qw422016.N().S(`
+`)
+//line views.html:335
 	items := ctx.MagazineItems()
 
-//line views.html:332
+//line views.html:335
 	qw422016.N().S(`
 `)
-//line views.html:333
+//line views.html:336
 	if len(items) > 0 {
-//line views.html:333
+//line views.html:336
 		qw422016.N().S(`
 <div class="magazine">
   `)
-//line views.html:335
+//line views.html:338
 		StreamMagazineCard(qw422016, ctx, items[0], "")
-//line views.html:335
+//line views.html:338
 		qw422016.N().S(`
 
   `)
-//line views.html:337
+//line views.html:340
 		if len(items) > 1 {
-//line views.html:337
+//line views.html:340
 			qw422016.N().S(`
   `)
-//line views.html:339
+//line views.html:342
 			gridEnd := len(items)
 			if gridEnd > 5 {
 				gridEnd = 5
 			}
 
-//line views.html:341
+//line views.html:344
 			qw422016.N().S(`
   <div class="magazine__grid">
     `)
-//line views.html:343
+//line views.html:346
 			for _, item := range items[1:gridEnd] {
-//line views.html:343
+//line views.html:346
 				qw422016.N().S(`
     `)
-//line views.html:344
+//line views.html:347
 				StreamMagazineCard(qw422016, ctx, item, "magazine-item--grid")
-//line views.html:344
+//line views.html:347
 				qw422016.N().S(`
     `)
-//line views.html:345
+//line views.html:348
 			}
-//line views.html:345
+//line views.html:348
 			qw422016.N().S(`
   </div>
   `)
-//line views.html:347
+//line views.html:350
 		}
-//line views.html:347
+//line views.html:350
 		qw422016.N().S(`
 
   `)
-//line views.html:349
+//line views.html:352
 		if len(items) > 5 {
-//line views.html:349
+//line views.html:352
 			qw422016.N().S(`
   <div class="magazine__list">
     `)
-//line views.html:351
+//line views.html:354
 			for _, item := range items[5:] {
-//line views.html:351
+//line views.html:354
 				qw422016.N().S(`
     `)
-//line views.html:352
+//line views.html:355
 				StreamMagazineCard(qw422016, ctx, item, "")
-//line views.html:352
+//line views.html:355
 				qw422016.N().S(`
     `)
-//line views.html:353
+//line views.html:356
 			}
-//line views.html:353
+//line views.html:356
 			qw422016.N().S(`
   </div>
   `)
-//line views.html:355
+//line views.html:358
 		}
-//line views.html:355
+//line views.html:358
 		qw422016.N().S(`
 </div>
 `)
-//line views.html:357
+//line views.html:360
 	}
-//line views.html:357
+//line views.html:360
 	qw422016.N().S(`
 `)
-//line views.html:358
+//line views.html:361
 }
 
-//line views.html:358
+//line views.html:361
 func WriteMagazine(qq422016 qtio422016.Writer, ctx *Ctx) {
-//line views.html:358
+//line views.html:361
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line views.html:358
+//line views.html:361
 	StreamMagazine(qw422016, ctx)
-//line views.html:358
+//line views.html:361
 	qt422016.ReleaseWriter(qw422016)
-//line views.html:358
+//line views.html:361
 }
 
-//line views.html:358
+//line views.html:361
 func Magazine(ctx *Ctx) string {
-//line views.html:358
+//line views.html:361
 	qb422016 := qt422016.AcquireByteBuffer()
-//line views.html:358
+//line views.html:361
 	WriteMagazine(qb422016, ctx)
-//line views.html:358
+//line views.html:361
 	qs422016 := string(qb422016.B)
-//line views.html:358
+//line views.html:361
 	qt422016.ReleaseByteBuffer(qb422016)
-//line views.html:358
+//line views.html:361
 	return qs422016
-//line views.html:358
+//line views.html:361
 }
 
-//line views.html:360
+//line views.html:363
 func StreamMagazineCard(qw422016 *qt422016.Writer, ctx *Ctx, item MagazineItem, extraClass string) {
-//line views.html:360
+//line views.html:363
 	qw422016.N().S(`
 `)
-//line views.html:362
+//line views.html:365
 	itemClass := "magazine-item magazine-item--list"
 	if item.Size == MagazineItemFeatured {
 		itemClass = "magazine-item magazine-item--featured"
@@ -1653,205 +1672,205 @@ func StreamMagazineCard(qw422016 *qt422016.Writer, ctx *Ctx, item MagazineItem, 
 		itemClass += " " + extraClass
 	}
 
-//line views.html:371
+//line views.html:374
 	qw422016.N().S(`
 <article class="`)
-//line views.html:372
+//line views.html:375
 	qw422016.N().S(itemClass)
-//line views.html:372
+//line views.html:375
 	qw422016.N().S(`">
 `)
-//line views.html:373
+//line views.html:376
 	if item.Size == MagazineItemFeatured {
-//line views.html:373
+//line views.html:376
 		qw422016.N().S(`
   <h2 class="magazine-item__title"><a class="magazine-item__link" href="`)
-//line views.html:374
+//line views.html:377
 		qw422016.N().S(item.Note.PermalinkEncoded())
-//line views.html:374
+//line views.html:377
 		qw422016.N().S(`">`)
-//line views.html:374
+//line views.html:377
 		qw422016.E().S(item.Note.Title())
-//line views.html:374
+//line views.html:377
 		qw422016.N().S(`</a></h2>
   `)
-//line views.html:375
+//line views.html:378
 	} else {
-//line views.html:375
+//line views.html:378
 		qw422016.N().S(`
   <h3 class="magazine-item__title"><a class="magazine-item__link" href="`)
-//line views.html:376
+//line views.html:379
 		qw422016.N().S(item.Note.PermalinkEncoded())
-//line views.html:376
+//line views.html:379
 		qw422016.N().S(`">`)
-//line views.html:376
+//line views.html:379
 		qw422016.E().S(item.Note.Title())
-//line views.html:376
+//line views.html:379
 		qw422016.N().S(`</a></h3>
   `)
-//line views.html:377
+//line views.html:380
 	}
-//line views.html:377
+//line views.html:380
 	qw422016.N().S(`
   `)
-//line views.html:378
+//line views.html:381
 	pr := item.Note.PartialRenderer()
 
-//line views.html:378
+//line views.html:381
 	qw422016.N().S(`
   `)
-//line views.html:379
+//line views.html:382
 	if pr != nil {
-//line views.html:379
+//line views.html:382
 		qw422016.N().S(`
   `)
-//line views.html:380
+//line views.html:383
 		intro := pr.Introduce()
 
-//line views.html:380
+//line views.html:383
 		qw422016.N().S(`
   `)
-//line views.html:381
+//line views.html:384
 		if intro.ContentHTML != "" {
-//line views.html:381
+//line views.html:384
 			qw422016.N().S(`
   <p class="magazine-item__excerpt">`)
-//line views.html:382
+//line views.html:385
 			qw422016.N().S(intro.ContentHTML)
-//line views.html:382
+//line views.html:385
 			qw422016.N().S(`</p>
   `)
-//line views.html:383
+//line views.html:386
 		}
-//line views.html:383
+//line views.html:386
 		qw422016.N().S(`
   `)
-//line views.html:384
+//line views.html:387
 	}
-//line views.html:384
+//line views.html:387
 	qw422016.N().S(`
   <div class="magazine-item__footer">
     <a class="magazine-item__readmore" href="`)
-//line views.html:386
+//line views.html:389
 	qw422016.N().S(item.Note.PermalinkEncoded())
-//line views.html:386
+//line views.html:389
 	qw422016.N().S(`">`)
-//line views.html:386
+//line views.html:389
 	qw422016.E().S(ctx.T("readmore"))
-//line views.html:386
+//line views.html:389
 	qw422016.N().S(`</a>
     <time class="magazine-item__date">`)
-//line views.html:387
+//line views.html:390
 	qw422016.E().S(item.Note.CreatedAt().Format("2006-01-02"))
-//line views.html:387
+//line views.html:390
 	qw422016.N().S(`</time>
   </div>
 </article>
 `)
-//line views.html:390
+//line views.html:393
 }
 
-//line views.html:390
+//line views.html:393
 func WriteMagazineCard(qq422016 qtio422016.Writer, ctx *Ctx, item MagazineItem, extraClass string) {
-//line views.html:390
+//line views.html:393
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line views.html:390
+//line views.html:393
 	StreamMagazineCard(qw422016, ctx, item, extraClass)
-//line views.html:390
+//line views.html:393
 	qt422016.ReleaseWriter(qw422016)
-//line views.html:390
+//line views.html:393
 }
 
-//line views.html:390
+//line views.html:393
 func MagazineCard(ctx *Ctx, item MagazineItem, extraClass string) string {
-//line views.html:390
+//line views.html:393
 	qb422016 := qt422016.AcquireByteBuffer()
-//line views.html:390
+//line views.html:393
 	WriteMagazineCard(qb422016, ctx, item, extraClass)
-//line views.html:390
+//line views.html:393
 	qs422016 := string(qb422016.B)
-//line views.html:390
+//line views.html:393
 	qt422016.ReleaseByteBuffer(qb422016)
-//line views.html:390
+//line views.html:393
 	return qs422016
-//line views.html:390
+//line views.html:393
 }
 
-//line views.html:392
+//line views.html:395
 func StreamSiteHeader(qw422016 *qt422016.Writer, ctx *Ctx, headerNote *templateviews.Note, hasLeft bool, hasRight bool) {
-//line views.html:392
+//line views.html:395
 	qw422016.N().S(`
 <header class="site-header">
   <div class="site-header__content">
     `)
-//line views.html:395
+//line views.html:398
 	if hasLeft {
-//line views.html:395
+//line views.html:398
 		qw422016.N().S(`
     <button class="site-header__hamburger site-header__hamburger--left" aria-label="Open menu" id="btn-left">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
     </button>
     `)
-//line views.html:399
+//line views.html:402
 	}
-//line views.html:399
+//line views.html:402
 	qw422016.N().S(`
     `)
-//line views.html:400
+//line views.html:403
 	logoURL := headerNote.FirstImageURL()
 
-//line views.html:400
+//line views.html:403
 	qw422016.N().S(`
     `)
-//line views.html:401
+//line views.html:404
 	if logoURL != "" {
-//line views.html:401
+//line views.html:404
 		qw422016.N().S(`
     <a class="site-header__logo" href="/"><img src="`)
-//line views.html:402
+//line views.html:405
 		qw422016.N().S(logoURL)
-//line views.html:402
+//line views.html:405
 		qw422016.N().S(`" alt="Logo"></a>
     `)
-//line views.html:403
+//line views.html:406
 	}
-//line views.html:403
+//line views.html:406
 	qw422016.N().S(`
     `)
-//line views.html:404
+//line views.html:407
 	navHTML := headerNote.FirstListHTML()
 
-//line views.html:404
+//line views.html:407
 	qw422016.N().S(`
     `)
-//line views.html:405
+//line views.html:408
 	if navHTML != "" {
-//line views.html:405
+//line views.html:408
 		qw422016.N().S(`
     <nav class="site-header__nav">`)
-//line views.html:406
+//line views.html:409
 		qw422016.N().S(navHTML)
-//line views.html:406
+//line views.html:409
 		qw422016.N().S(`</nav>
     `)
-//line views.html:407
+//line views.html:410
 	}
-//line views.html:407
+//line views.html:410
 	qw422016.N().S(`
 
     <div class="site-header__space" mol_view_root="$trip2g_user_space"></div>
     `)
-//line views.html:410
+//line views.html:413
 	if hasRight {
-//line views.html:410
+//line views.html:413
 		qw422016.N().S(`
     <button class="site-header__hamburger site-header__hamburger--right" aria-label="Open related" id="btn-right">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
     </button>
     `)
-//line views.html:414
+//line views.html:417
 	}
-//line views.html:414
+//line views.html:417
 	qw422016.N().S(`
   </div>
 </header>
@@ -1860,291 +1879,291 @@ func StreamSiteHeader(qw422016 *qt422016.Writer, ctx *Ctx, headerNote *templatev
   <div mol_view_root="$trip2g_user_search"></div>
 </div>
 `)
-//line views.html:421
+//line views.html:424
 }
 
-//line views.html:421
+//line views.html:424
 func WriteSiteHeader(qq422016 qtio422016.Writer, ctx *Ctx, headerNote *templateviews.Note, hasLeft bool, hasRight bool) {
-//line views.html:421
+//line views.html:424
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line views.html:421
+//line views.html:424
 	StreamSiteHeader(qw422016, ctx, headerNote, hasLeft, hasRight)
-//line views.html:421
+//line views.html:424
 	qt422016.ReleaseWriter(qw422016)
-//line views.html:421
+//line views.html:424
 }
 
-//line views.html:421
+//line views.html:424
 func SiteHeader(ctx *Ctx, headerNote *templateviews.Note, hasLeft bool, hasRight bool) string {
-//line views.html:421
+//line views.html:424
 	qb422016 := qt422016.AcquireByteBuffer()
-//line views.html:421
+//line views.html:424
 	WriteSiteHeader(qb422016, ctx, headerNote, hasLeft, hasRight)
-//line views.html:421
+//line views.html:424
 	qs422016 := string(qb422016.B)
-//line views.html:421
+//line views.html:424
 	qt422016.ReleaseByteBuffer(qb422016)
-//line views.html:421
+//line views.html:424
 	return qs422016
-//line views.html:421
+//line views.html:424
 }
 
-//line views.html:423
+//line views.html:426
 func StreamSiteFooter(qw422016 *qt422016.Writer, ctx *Ctx, footerNote *templateviews.Note) {
-//line views.html:423
+//line views.html:426
 	qw422016.N().S(`
 <footer class="site-footer">
   <div class="site-footer__content">
     `)
-//line views.html:426
+//line views.html:429
 	intro := footerNote.PartialRenderer().Introduce()
 
-//line views.html:426
+//line views.html:429
 	qw422016.N().S(`
     `)
-//line views.html:427
+//line views.html:430
 	if intro.ContentHTML != "" {
-//line views.html:427
+//line views.html:430
 		qw422016.N().S(`
     <div class="site-footer__brand">
       `)
-//line views.html:429
+//line views.html:432
 		qw422016.N().S(intro.ContentHTML)
-//line views.html:429
+//line views.html:432
 		qw422016.N().S(`
     </div>
     `)
-//line views.html:431
+//line views.html:434
 	}
-//line views.html:431
+//line views.html:434
 	qw422016.N().S(`
     `)
-//line views.html:432
+//line views.html:435
 	sections := footerNote.PartialRenderer().Sections(3)
 
-//line views.html:432
+//line views.html:435
 	qw422016.N().S(`
     `)
-//line views.html:433
+//line views.html:436
 	if len(sections) > 1 {
-//line views.html:433
+//line views.html:436
 		qw422016.N().S(`
     <div class="site-footer__links site-footer__links--columns">
       `)
-//line views.html:435
+//line views.html:438
 		for _, sec := range sections {
-//line views.html:435
+//line views.html:438
 			qw422016.N().S(`
       <div class="site-footer__column">
         <p class="site-footer__column-title">`)
-//line views.html:437
+//line views.html:440
 			qw422016.N().S(sec.TitleHTML)
-//line views.html:437
+//line views.html:440
 			qw422016.N().S(`</p>
         `)
-//line views.html:438
+//line views.html:441
 			qw422016.N().S(sec.ContentHTML)
-//line views.html:438
+//line views.html:441
 			qw422016.N().S(`
       </div>
       `)
-//line views.html:440
+//line views.html:443
 		}
-//line views.html:440
+//line views.html:443
 		qw422016.N().S(`
     </div>
     `)
-//line views.html:442
+//line views.html:445
 	} else {
-//line views.html:442
+//line views.html:445
 		qw422016.N().S(`
     `)
-//line views.html:443
+//line views.html:446
 		listHTML := footerNote.FirstListHTML()
 
-//line views.html:443
+//line views.html:446
 		qw422016.N().S(`
     `)
-//line views.html:444
+//line views.html:447
 		if listHTML != "" {
-//line views.html:444
+//line views.html:447
 			qw422016.N().S(`
     <div class="site-footer__links site-footer__links--inline">`)
-//line views.html:445
+//line views.html:448
 			qw422016.N().S(listHTML)
-//line views.html:445
+//line views.html:448
 			qw422016.N().S(`</div>
     `)
-//line views.html:446
+//line views.html:449
 		}
-//line views.html:446
+//line views.html:449
 		qw422016.N().S(`
     `)
-//line views.html:447
+//line views.html:450
 	}
-//line views.html:447
+//line views.html:450
 	qw422016.N().S(`
   </div>
 </footer>
 `)
-//line views.html:450
+//line views.html:453
 }
 
-//line views.html:450
+//line views.html:453
 func WriteSiteFooter(qq422016 qtio422016.Writer, ctx *Ctx, footerNote *templateviews.Note) {
-//line views.html:450
+//line views.html:453
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line views.html:450
+//line views.html:453
 	StreamSiteFooter(qw422016, ctx, footerNote)
-//line views.html:450
+//line views.html:453
 	qt422016.ReleaseWriter(qw422016)
-//line views.html:450
+//line views.html:453
 }
 
-//line views.html:450
+//line views.html:453
 func SiteFooter(ctx *Ctx, footerNote *templateviews.Note) string {
-//line views.html:450
+//line views.html:453
 	qb422016 := qt422016.AcquireByteBuffer()
-//line views.html:450
+//line views.html:453
 	WriteSiteFooter(qb422016, ctx, footerNote)
-//line views.html:450
+//line views.html:453
 	qs422016 := string(qb422016.B)
-//line views.html:450
+//line views.html:453
 	qt422016.ReleaseByteBuffer(qb422016)
-//line views.html:450
+//line views.html:453
 	return qs422016
-//line views.html:450
+//line views.html:453
 }
 
-//line views.html:452
+//line views.html:455
 func StreamSignInWall(qw422016 *qt422016.Writer, ctx *Ctx) {
-//line views.html:452
+//line views.html:455
 	qw422016.N().S(`
 <div class="paywall-page">
   <div class="paywall-page__header">
     <a class="paywall-page__home" href="/">`)
-//line views.html:455
+//line views.html:458
 	qw422016.E().S(ctx.T("signinwall_home"))
-//line views.html:455
+//line views.html:458
 	qw422016.N().S(`</a>
     <div mol_view_root="$trip2g_user_space"></div>
   </div>
 
   `)
-//line views.html:459
+//line views.html:462
 	if ctx.SigninWallError != nil && ctx.SigninWallError.Note != nil {
-//line views.html:459
+//line views.html:462
 		qw422016.N().S(`
   <h1 class="content__title">`)
-//line views.html:460
+//line views.html:463
 		qw422016.E().S(ctx.SigninWallError.Note.Title())
-//line views.html:460
+//line views.html:463
 		qw422016.N().S(`</h1>
   `)
-//line views.html:461
+//line views.html:464
 		if ctx.SigninWallError.Note.Description() != "" {
-//line views.html:461
+//line views.html:464
 			qw422016.N().S(`
   <p>`)
-//line views.html:462
+//line views.html:465
 			qw422016.E().S(ctx.SigninWallError.Note.Description())
-//line views.html:462
+//line views.html:465
 			qw422016.N().S(`</p>
   `)
-//line views.html:463
+//line views.html:466
 		}
-//line views.html:463
+//line views.html:466
 		qw422016.N().S(`
   `)
-//line views.html:464
+//line views.html:467
 	}
-//line views.html:464
+//line views.html:467
 	qw422016.N().S(`
 
   <div id="signinwall" mol_view_root="$trip2g_user_signinwall"></div>
 </div>
 `)
-//line views.html:468
+//line views.html:471
 }
 
-//line views.html:468
+//line views.html:471
 func WriteSignInWall(qq422016 qtio422016.Writer, ctx *Ctx) {
-//line views.html:468
+//line views.html:471
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line views.html:468
+//line views.html:471
 	StreamSignInWall(qw422016, ctx)
-//line views.html:468
+//line views.html:471
 	qt422016.ReleaseWriter(qw422016)
-//line views.html:468
+//line views.html:471
 }
 
-//line views.html:468
+//line views.html:471
 func SignInWall(ctx *Ctx) string {
-//line views.html:468
+//line views.html:471
 	qb422016 := qt422016.AcquireByteBuffer()
-//line views.html:468
+//line views.html:471
 	WriteSignInWall(qb422016, ctx)
-//line views.html:468
+//line views.html:471
 	qs422016 := string(qb422016.B)
-//line views.html:468
+//line views.html:471
 	qt422016.ReleaseByteBuffer(qb422016)
-//line views.html:468
+//line views.html:471
 	return qs422016
-//line views.html:468
+//line views.html:471
 }
 
-//line views.html:470
+//line views.html:473
 func StreamPayWall(qw422016 *qt422016.Writer, ctx *Ctx) {
-//line views.html:470
+//line views.html:473
 	qw422016.N().S(`
 <div class="paywall-page">
   <div class="paywall-page__header">
     <a class="paywall-page__home" href="/">`)
-//line views.html:473
+//line views.html:476
 	qw422016.E().S(ctx.T("paywall_home"))
-//line views.html:473
+//line views.html:476
 	qw422016.N().S(`</a>
     <div mol_view_root="$trip2g_user_space"></div>
   </div>
 
   `)
-//line views.html:477
+//line views.html:480
 	if ctx.Note != nil {
-//line views.html:477
+//line views.html:480
 		qw422016.N().S(`
   <h1 class="content__title">`)
-//line views.html:478
+//line views.html:481
 		qw422016.E().S(ctx.Note.Title())
-//line views.html:478
+//line views.html:481
 		qw422016.N().S(`</h1>
 
   `)
-//line views.html:480
+//line views.html:483
 		if ctx.Note.Description() != "" {
-//line views.html:480
+//line views.html:483
 			qw422016.N().S(`
   <p>`)
-//line views.html:481
+//line views.html:484
 			qw422016.E().S(ctx.Note.Description())
-//line views.html:481
+//line views.html:484
 			qw422016.N().S(`</p>
   `)
-//line views.html:482
+//line views.html:485
 		}
-//line views.html:482
+//line views.html:485
 		qw422016.N().S(`
 
   `)
-//line views.html:484
+//line views.html:487
 		if ctx.PaywallError != nil {
-//line views.html:484
+//line views.html:487
 			qw422016.N().S(`
   <script>
     window.__trip2g_paywall = {
       page_id: `)
-//line views.html:487
+//line views.html:490
 			qw422016.N().DL(ctx.Note.PathID())
-//line views.html:487
+//line views.html:490
 			qw422016.N().S(`,
     }
   </script>
@@ -2152,104 +2171,104 @@ func StreamPayWall(qw422016 *qt422016.Writer, ctx *Ctx) {
     id="paywall"
     mol_view_root="$trip2g_user_paywall"
     data-subgraphs="`)
-//line views.html:493
+//line views.html:496
 			qw422016.E().S(ctx.PaywallError.SubgraphsJSON)
-//line views.html:493
+//line views.html:496
 			qw422016.N().S(`"
     data-path-id="`)
-//line views.html:494
+//line views.html:497
 			qw422016.N().DL(ctx.Note.PathID())
-//line views.html:494
+//line views.html:497
 			qw422016.N().S(`"
   ></div>
   `)
-//line views.html:496
+//line views.html:499
 		}
-//line views.html:496
+//line views.html:499
 		qw422016.N().S(`
   `)
-//line views.html:497
+//line views.html:500
 	}
-//line views.html:497
+//line views.html:500
 	qw422016.N().S(`
 </div>
 `)
-//line views.html:499
+//line views.html:502
 }
 
-//line views.html:499
+//line views.html:502
 func WritePayWall(qq422016 qtio422016.Writer, ctx *Ctx) {
-//line views.html:499
+//line views.html:502
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line views.html:499
+//line views.html:502
 	StreamPayWall(qw422016, ctx)
-//line views.html:499
+//line views.html:502
 	qt422016.ReleaseWriter(qw422016)
-//line views.html:499
+//line views.html:502
 }
 
-//line views.html:499
+//line views.html:502
 func PayWall(ctx *Ctx) string {
-//line views.html:499
+//line views.html:502
 	qb422016 := qt422016.AcquireByteBuffer()
-//line views.html:499
+//line views.html:502
 	WritePayWall(qb422016, ctx)
-//line views.html:499
+//line views.html:502
 	qs422016 := string(qb422016.B)
-//line views.html:499
+//line views.html:502
 	qt422016.ReleaseByteBuffer(qb422016)
-//line views.html:499
+//line views.html:502
 	return qs422016
-//line views.html:499
+//line views.html:502
 }
 
-//line views.html:501
+//line views.html:504
 func StreamNotFound(qw422016 *qt422016.Writer, ctx *Ctx) {
-//line views.html:501
+//line views.html:504
 	qw422016.N().S(`
 `)
-//line views.html:503
+//line views.html:506
 	headerRef := ctx.HeaderRef()
 	footerRef := ctx.FooterRef()
 
-//line views.html:505
+//line views.html:508
 	qw422016.N().S(`
 `)
-//line views.html:506
+//line views.html:509
 	var headerNote *templateviews.Note
 
-//line views.html:506
+//line views.html:509
 	qw422016.N().S(`
 `)
-//line views.html:507
+//line views.html:510
 	if headerRef.Kind != ContentRefNone {
-//line views.html:507
+//line views.html:510
 		qw422016.N().S(`
   `)
-//line views.html:508
+//line views.html:511
 		headerNote = ctx.resolveNoteRef(headerRef)
 
-//line views.html:508
+//line views.html:511
 		qw422016.N().S(`
 `)
-//line views.html:509
+//line views.html:512
 	}
-//line views.html:509
+//line views.html:512
 	qw422016.N().S(`
 `)
-//line views.html:510
+//line views.html:513
 	if headerNote != nil {
-//line views.html:510
+//line views.html:513
 		qw422016.N().S(`
   `)
-//line views.html:511
+//line views.html:514
 		StreamSiteHeader(qw422016, ctx, headerNote, false, false)
-//line views.html:511
+//line views.html:514
 		qw422016.N().S(`
 `)
-//line views.html:512
+//line views.html:515
 	}
-//line views.html:512
+//line views.html:515
 	qw422016.N().S(`
 <div class="layout layout--no-sidebars">
   <main class="notfound">
@@ -2259,138 +2278,138 @@ func StreamNotFound(qw422016 *qt422016.Writer, ctx *Ctx) {
   </main>
 </div>
 `)
-//line views.html:520
+//line views.html:523
 	if footerRef.Kind != ContentRefNone {
-//line views.html:520
+//line views.html:523
 		qw422016.N().S(`
   `)
-//line views.html:521
+//line views.html:524
 		footerNote := ctx.resolveNoteRef(footerRef)
 
-//line views.html:521
+//line views.html:524
 		qw422016.N().S(`
   `)
-//line views.html:522
+//line views.html:525
 		if footerNote != nil {
-//line views.html:522
+//line views.html:525
 			qw422016.N().S(`
     `)
-//line views.html:523
+//line views.html:526
 			StreamSiteFooter(qw422016, ctx, footerNote)
-//line views.html:523
+//line views.html:526
 			qw422016.N().S(`
   `)
-//line views.html:524
+//line views.html:527
 		}
-//line views.html:524
+//line views.html:527
 		qw422016.N().S(`
 `)
-//line views.html:525
+//line views.html:528
 	}
-//line views.html:525
+//line views.html:528
 	qw422016.N().S(`
 `)
-//line views.html:526
+//line views.html:529
 }
 
-//line views.html:526
+//line views.html:529
 func WriteNotFound(qq422016 qtio422016.Writer, ctx *Ctx) {
-//line views.html:526
+//line views.html:529
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line views.html:526
+//line views.html:529
 	StreamNotFound(qw422016, ctx)
-//line views.html:526
+//line views.html:529
 	qt422016.ReleaseWriter(qw422016)
-//line views.html:526
+//line views.html:529
 }
 
-//line views.html:526
+//line views.html:529
 func NotFound(ctx *Ctx) string {
-//line views.html:526
+//line views.html:529
 	qb422016 := qt422016.AcquireByteBuffer()
-//line views.html:526
+//line views.html:529
 	WriteNotFound(qb422016, ctx)
-//line views.html:526
+//line views.html:529
 	qs422016 := string(qb422016.B)
-//line views.html:526
+//line views.html:529
 	qt422016.ReleaseByteBuffer(qb422016)
-//line views.html:526
+//line views.html:529
 	return qs422016
-//line views.html:526
+//line views.html:529
 }
 
-//line views.html:528
+//line views.html:531
 func StreamUnsupportedFile(qw422016 *qt422016.Writer, ctx *Ctx) {
-//line views.html:528
+//line views.html:531
 	qw422016.N().S(`
 <main class="layout__main">
   <article class="content">
     <div class="content__body">
       `)
-//line views.html:532
+//line views.html:535
 	if ctx.UnsupportedFileExt == ".canvas" {
-//line views.html:532
+//line views.html:535
 		qw422016.N().S(`
       <p>Canvas files are not supported yet.</p>
       `)
-//line views.html:534
+//line views.html:537
 	} else if ctx.UnsupportedFileExt == ".excalidraw" {
-//line views.html:534
+//line views.html:537
 		qw422016.N().S(`
       <p>Excalidraw files are not supported yet.</p>
       `)
-//line views.html:536
+//line views.html:539
 	} else {
-//line views.html:536
+//line views.html:539
 		qw422016.N().S(`
       <p>Bases are not supported yet.</p>
       `)
-//line views.html:538
+//line views.html:541
 	}
-//line views.html:538
+//line views.html:541
 	qw422016.N().S(`
     </div>
   </article>
 </main>
 `)
-//line views.html:542
+//line views.html:545
 }
 
-//line views.html:542
+//line views.html:545
 func WriteUnsupportedFile(qq422016 qtio422016.Writer, ctx *Ctx) {
-//line views.html:542
+//line views.html:545
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line views.html:542
+//line views.html:545
 	StreamUnsupportedFile(qw422016, ctx)
-//line views.html:542
+//line views.html:545
 	qt422016.ReleaseWriter(qw422016)
-//line views.html:542
+//line views.html:545
 }
 
-//line views.html:542
+//line views.html:545
 func UnsupportedFile(ctx *Ctx) string {
-//line views.html:542
+//line views.html:545
 	qb422016 := qt422016.AcquireByteBuffer()
-//line views.html:542
+//line views.html:545
 	WriteUnsupportedFile(qb422016, ctx)
-//line views.html:542
+//line views.html:545
 	qs422016 := string(qb422016.B)
-//line views.html:542
+//line views.html:545
 	qt422016.ReleaseByteBuffer(qb422016)
-//line views.html:542
+//line views.html:545
 	return qs422016
-//line views.html:542
+//line views.html:545
 }
 
-//line views.html:544
+//line views.html:547
 func StreamOnboarding(qw422016 *qt422016.Writer, ctx *Ctx) {
-//line views.html:544
+//line views.html:547
 	qw422016.N().S(`
 <div class="onboarding" data-onboarding>
   `)
-//line views.html:546
+//line views.html:549
 	if ctx.UserToken.IsAdmin() {
-//line views.html:546
+//line views.html:549
 		qw422016.N().S(`
   <h3>Welcome!</h3>
   <p>
@@ -2408,53 +2427,53 @@ func StreamOnboarding(qw422016 *qt422016.Writer, ctx *Ctx) {
     </a>
   </p>
   `)
-//line views.html:562
+//line views.html:565
 	} else {
-//line views.html:562
+//line views.html:565
 		qw422016.N().S(`
   <h3>`)
-//line views.html:563
+//line views.html:566
 		qw422016.E().S(ctx.T("onboarding_title"))
-//line views.html:563
+//line views.html:566
 		qw422016.N().S(`</h3>
   <p>`)
-//line views.html:564
+//line views.html:567
 		qw422016.E().S(ctx.T("onboarding_subtitle"))
-//line views.html:564
+//line views.html:567
 		qw422016.N().S(`</p>
   `)
-//line views.html:565
+//line views.html:568
 	}
-//line views.html:565
+//line views.html:568
 	qw422016.N().S(`
   <div mol_view_root="$trip2g_user_space"></div>
 </div>
 `)
-//line views.html:568
+//line views.html:571
 }
 
-//line views.html:568
+//line views.html:571
 func WriteOnboarding(qq422016 qtio422016.Writer, ctx *Ctx) {
-//line views.html:568
+//line views.html:571
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line views.html:568
+//line views.html:571
 	StreamOnboarding(qw422016, ctx)
-//line views.html:568
+//line views.html:571
 	qt422016.ReleaseWriter(qw422016)
-//line views.html:568
+//line views.html:571
 }
 
-//line views.html:568
+//line views.html:571
 func Onboarding(ctx *Ctx) string {
-//line views.html:568
+//line views.html:571
 	qb422016 := qt422016.AcquireByteBuffer()
-//line views.html:568
+//line views.html:571
 	WriteOnboarding(qb422016, ctx)
-//line views.html:568
+//line views.html:571
 	qs422016 := string(qb422016.B)
-//line views.html:568
+//line views.html:571
 	qt422016.ReleaseByteBuffer(qb422016)
-//line views.html:568
+//line views.html:571
 	return qs422016
-//line views.html:568
+//line views.html:571
 }

--- a/internal/model/note_tasklist.go
+++ b/internal/model/note_tasklist.go
@@ -1,0 +1,214 @@
+package model
+
+import (
+	"bytes"
+	"strings"
+)
+
+// HasTaskListItems reports whether the note's raw markdown contains GFM task
+// list markers (- [ ] or - [x]). Drives conditional loading of the admin
+// task-list widget script and the mount-point meta tag.
+func (n *NoteView) HasTaskListItems() bool {
+	return countTaskListMarkers(n.Content) > 0
+}
+
+// CountTaskListMarkers returns the number of GFM task-list markers in src,
+// skipping markers inside fenced code blocks.
+//
+// A GFM task marker is a list item whose first non-space content is "[ ]" or
+// "[x]" / "[X]" (the markdown spec allows any character, but trip2g only
+// produces and toggles the two canonical forms).
+func CountTaskListMarkers(src []byte) int {
+	return countTaskListMarkers(src)
+}
+
+func countTaskListMarkers(src []byte) int {
+	var count int
+	inFence := false
+	var fenceChar byte
+	fenceLen := 0
+
+	lines := bytes.Split(src, []byte("\n"))
+	for _, rawLine := range lines {
+		line := rawLine
+		// Trim trailing \r so Windows line endings don't break matching.
+		line = bytes.TrimRight(line, "\r")
+
+		// Detect fenced code block open/close (``` or ~~~).
+		stripped := strings.TrimLeft(string(line), " \t")
+		if !inFence {
+			if len(stripped) >= 3 {
+				ch := stripped[0]
+				if ch == '`' || ch == '~' {
+					run := 0
+					for run < len(stripped) && stripped[run] == ch {
+						run++
+					}
+					if run >= 3 {
+						inFence = true
+						fenceChar = ch
+						fenceLen = run
+						continue
+					}
+				}
+			}
+		} else {
+			// Inside fence: look for the closing fence (same char, >= same length, no trailing non-space).
+			if len(stripped) >= fenceLen {
+				ch := stripped[0]
+				if ch == fenceChar {
+					run := 0
+					for run < len(stripped) && stripped[run] == ch {
+						run++
+					}
+					if run >= fenceLen && strings.TrimLeft(stripped[run:], " \t") == "" {
+						inFence = false
+					}
+				}
+			}
+			continue
+		}
+
+		// Outside a fence: match a task-list marker.
+		// Allowed list prefixes: "- ", "* ", "+ " (with 0–3 leading spaces).
+		sp := 0
+		for sp < len(stripped) && (stripped[sp] == ' ' || stripped[sp] == '\t') {
+			sp++
+		}
+		// stripped is already without leading whitespace (from TrimLeft above).
+		rest := stripped
+		if len(rest) < 5 {
+			continue
+		}
+		// Must start with a list bullet.
+		bullet := rest[0]
+		if bullet != '-' && bullet != '*' && bullet != '+' {
+			continue
+		}
+		if rest[1] != ' ' && rest[1] != '\t' {
+			continue
+		}
+		// Skip any extra spaces after the bullet.
+		i := 2
+		for i < len(rest) && rest[i] == ' ' {
+			i++
+		}
+		if i+3 > len(rest) {
+			continue
+		}
+		// Match "[ ]" or "[x]" / "[X]".
+		if rest[i] == '[' {
+			inner := rest[i+1]
+			if rest[i+2] == ']' && (inner == ' ' || inner == 'x' || inner == 'X') {
+				count++
+			}
+		}
+	}
+
+	return count
+}
+
+// TaskListMarkerIndex maps a 0-based DOM checkbox index to the raw markdown
+// source line that contains the corresponding task-list marker.
+//
+// Returns ("", -1) when n is out of range.
+// Returns ("", -1) when src task-marker count != domCount (safety guard: mismatch
+// means the client DOM and server source are out of sync — do NOT patch).
+//
+// The caller supplies domCount so the guard can be checked here; it must equal
+// the number of <input type=checkbox> elements found in the rendered HTML.
+func TaskListMarkerIndex(src []byte, domCount, n int) (line string, lineNumber int) {
+	markers := collectTaskListMarkers(src)
+	if len(markers) != domCount {
+		return "", -1
+	}
+	if n < 0 || n >= len(markers) {
+		return "", -1
+	}
+	return markers[n].line, markers[n].lineNo
+}
+
+type taskMarker struct {
+	line   string // the complete raw line
+	lineNo int    // 1-based line number in src
+}
+
+func collectTaskListMarkers(src []byte) []taskMarker {
+	var out []taskMarker
+	inFence := false
+	var fenceChar byte
+	fenceLen := 0
+
+	lines := bytes.Split(src, []byte("\n"))
+	for lineNo, rawLine := range lines {
+		line := rawLine
+		line = bytes.TrimRight(line, "\r")
+		rawStr := string(rawLine)
+		// Preserve original line (with \r if any) for find/replace fidelity.
+		_ = rawStr
+
+		stripped := strings.TrimLeft(string(line), " \t")
+		if !inFence {
+			if len(stripped) >= 3 {
+				ch := stripped[0]
+				if ch == '`' || ch == '~' {
+					run := 0
+					for run < len(stripped) && stripped[run] == ch {
+						run++
+					}
+					if run >= 3 {
+						inFence = true
+						fenceChar = ch
+						fenceLen = run
+						continue
+					}
+				}
+			}
+		} else {
+			if len(stripped) >= fenceLen {
+				ch := stripped[0]
+				if ch == fenceChar {
+					run := 0
+					for run < len(stripped) && stripped[run] == ch {
+						run++
+					}
+					if run >= fenceLen && strings.TrimLeft(stripped[run:], " \t") == "" {
+						inFence = false
+					}
+				}
+			}
+			continue
+		}
+
+		rest := stripped
+		if len(rest) < 5 {
+			continue
+		}
+		bullet := rest[0]
+		if bullet != '-' && bullet != '*' && bullet != '+' {
+			continue
+		}
+		if rest[1] != ' ' && rest[1] != '\t' {
+			continue
+		}
+		i := 2
+		for i < len(rest) && rest[i] == ' ' {
+			i++
+		}
+		if i+3 > len(rest) {
+			continue
+		}
+		if rest[i] == '[' {
+			inner := rest[i+1]
+			if rest[i+2] == ']' && (inner == ' ' || inner == 'x' || inner == 'X') {
+				// Preserve original bytes (CR-stripped) as the canonical line.
+				out = append(out, taskMarker{
+					line:   string(line),
+					lineNo: lineNo + 1,
+				})
+			}
+		}
+	}
+
+	return out
+}

--- a/internal/model/note_tasklist_test.go
+++ b/internal/model/note_tasklist_test.go
@@ -1,0 +1,166 @@
+package model
+
+import (
+	"testing"
+)
+
+func TestCountTaskListMarkers(t *testing.T) {
+	tests := []struct {
+		name  string
+		src   string
+		want  int
+	}{
+		{
+			name: "no tasks",
+			src:  "# Hello\n\nSome text.\n",
+			want: 0,
+		},
+		{
+			name: "one unchecked",
+			src:  "- [ ] Buy milk\n",
+			want: 1,
+		},
+		{
+			name: "one checked",
+			src:  "- [x] Done\n",
+			want: 1,
+		},
+		{
+			name: "one checked uppercase X",
+			src:  "- [X] Done\n",
+			want: 1,
+		},
+		{
+			name: "mixed tasks",
+			src:  "- [ ] Buy milk\n- [x] Done\n- [ ] Another\n",
+			want: 3,
+		},
+		{
+			name: "skips fenced code block with task-like content",
+			src:  "```\n- [ ] not a task\n```\n- [ ] real task\n",
+			want: 1,
+		},
+		{
+			name: "skips tilde fenced code block",
+			src:  "~~~\n- [ ] not a task\n~~~\n- [x] real\n",
+			want: 1,
+		},
+		{
+			name: "code block with longer fence",
+			src:  "````\n- [ ] inside\n````\n- [ ] outside\n",
+			want: 1,
+		},
+		{
+			name: "nested fences not confused",
+			src:  "```\n```\n- [ ] still inside outer (no longer fence closes it)\n```\n- [ ] outside\n",
+			want: 1,
+		},
+		{
+			name: "task inside text (not list item)",
+			src:  "some text [ ] not a task\n",
+			want: 0,
+		},
+		{
+			name: "asterisk and plus bullet forms",
+			src:  "* [ ] asterisk\n+ [ ] plus\n",
+			want: 2,
+		},
+		{
+			name: "indented task list (blockquote nesting won't happen but spaces ok)",
+			src:  "  - [ ] indented\n",
+			want: 1,
+		},
+		{
+			name: "windows line endings",
+			src:  "- [ ] one\r\n- [x] two\r\n",
+			want: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CountTaskListMarkers([]byte(tt.src))
+			if got != tt.want {
+				t.Errorf("CountTaskListMarkers(%q) = %d; want %d", tt.src, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTaskListMarkerIndex(t *testing.T) {
+	tests := []struct {
+		name       string
+		src        string
+		domCount   int
+		n          int
+		wantLine   string
+		wantLineNo int
+	}{
+		{
+			name:       "first marker",
+			src:        "- [ ] Buy milk\n- [x] Done\n",
+			domCount:   2,
+			n:          0,
+			wantLine:   "- [ ] Buy milk",
+			wantLineNo: 1,
+		},
+		{
+			name:       "second marker",
+			src:        "- [ ] Buy milk\n- [x] Done\n",
+			domCount:   2,
+			n:          1,
+			wantLine:   "- [x] Done",
+			wantLineNo: 2,
+		},
+		{
+			name:       "count mismatch returns empty",
+			src:        "- [ ] Buy milk\n- [x] Done\n",
+			domCount:   3, // wrong DOM count → safety guard fires
+			n:          0,
+			wantLine:   "",
+			wantLineNo: -1,
+		},
+		{
+			name:       "out of range index returns empty",
+			src:        "- [ ] one\n",
+			domCount:   1,
+			n:          5,
+			wantLine:   "",
+			wantLineNo: -1,
+		},
+		{
+			name:       "skips code fence",
+			src:        "```\n- [ ] fake\n```\n- [ ] real\n",
+			domCount:   1,
+			n:          0,
+			wantLine:   "- [ ] real",
+			wantLineNo: 4,
+		},
+		{
+			name:       "third of three",
+			src:        "- [ ] a\n- [x] b\n- [ ] c\n",
+			domCount:   3,
+			n:          2,
+			wantLine:   "- [ ] c",
+			wantLineNo: 3,
+		},
+		{
+			name:       "marker with trailing text",
+			src:        "- [ ] Buy milk and eggs\n",
+			domCount:   1,
+			n:          0,
+			wantLine:   "- [ ] Buy milk and eggs",
+			wantLineNo: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotLine, gotNo := TaskListMarkerIndex([]byte(tt.src), tt.domCount, tt.n)
+			if gotLine != tt.wantLine || gotNo != tt.wantLineNo {
+				t.Errorf("TaskListMarkerIndex(%q, %d, %d) = (%q, %d); want (%q, %d)",
+					tt.src, tt.domCount, tt.n, gotLine, gotNo, tt.wantLine, tt.wantLineNo)
+			}
+		})
+	}
+}

--- a/internal/templateviews/note.go
+++ b/internal/templateviews/note.go
@@ -240,6 +240,13 @@ func (n *Note) HasAnyCodeBlock() bool {
 	return len(n.nv.CodeLanguages) > 0
 }
 
+// HasTaskListItems reports whether the note's raw markdown contains GFM task
+// list markers (- [ ] or - [x]). Drives conditional loading of the admin
+// task-list widget script.
+func (n *Note) HasTaskListItems() bool {
+	return n.nv.HasTaskListItems()
+}
+
 var langAliases = map[string]string{ //nolint:gochecknoglobals // package-level lookup table
 	"english":    "en",
 	"russian":    "ru",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "toc": "node assets/toc/esbuild.browser.mjs",
     "chart": "node assets/chart/esbuild.browser.mjs",
     "mermaid": "node assets/mermaid/esbuild.browser.mjs",
-    "codeblock": "node assets/codeblock/esbuild.browser.mjs"
+    "codeblock": "node assets/codeblock/esbuild.browser.mjs",
+    "tasklist": "node assets/tasklist/esbuild.browser.mjs"
   },
   "dependencies": {
     "@types/change-case": "^0.0.30",


### PR DESCRIPTION
## Summary

- Adds interactive GFM task-list checkboxes (`- [ ]` / `- [x]`) to the default-template note page, admin-only
- Non-admins and anonymous visitors see checkboxes as today: disabled, no script loaded
- Persists toggles back to the note source via `updateNotes` patch/upsert mutation, advancing `versionId` baseline (kanban self-echo pattern)

## What changed

### `internal/model/note_tasklist.go` (new)
Scanner that counts and locates GFM task-list markers in raw markdown, skipping fenced code blocks. Exports:
- `NoteView.HasTaskListItems()` — bool for script-load gate
- `CountTaskListMarkers(src)` — count for safety guard
- `TaskListMarkerIndex(src, domCount, n)` — map Nth DOM checkbox → source line; returns `("", -1)` if `domCount != src count` (safety guard)

### `internal/model/note_tasklist_test.go` (new)
21 unit tests covering: unchecked/checked markers, fenced code block skipping (backtick + tilde, longer fences), asterisk/plus bullets, Windows line endings, count-mismatch guard, out-of-range index.

### `internal/templateviews/note.go`
Added `HasTaskListItems()` wrapper on `*Note` (sibling of `HasCharts`, `HasAnyCodeBlock`).

### `internal/case/rendernotepage/endpoint.go`
In `buildDefaultTemplateCtx`, appends `/assets/tasklist.js` to `jsURLs` only when:
- `note.HasTaskListItems()` is true, AND
- `resp.UserToken != nil && resp.UserToken.IsAdmin()`

The page cache bails on any authenticated request (`pagecache.go:66`), so this is safe: the cache key never varies on admin state.

### `internal/defaulttemplate/views.html` + `views.html.go` (regenerated)
In `SelfContent`, after the note body, emits `<script id="tasklist-meta" type="application/json">{"path":"...","versionId":"..."}` gated on `ctx.UserToken.IsAdmin() && ctx.Note.HasTaskListItems()`. Same pattern as the existing `form-spec` meta tag.

### `assets/tasklist/src/index.ts` (new)
Browser widget (~160 lines):
- Reads path + versionId from `#tasklist-meta`
- Detects checkboxes: `li > input[type="checkbox"]` (goldmark GFM emits `<li><input disabled="" type="checkbox">` with no class — verified with `goldmark.New(WithExtensions(GFM)).Convert(...)`)
- Un-disables them and attaches a `change` listener
- On click: fetches raw source via `notePaths` query, runs the same Nth-marker scanner as the Go side to verify count match (safety guard), flips the marker, calls `updateNotes` with `patch{find,replace}` when the line is unique in source or falls back to `upsert{content,expectedHash}` for ambiguous lines
- Advances local `currentVersionId` from `updateNotes.updated[].versionId` (suppresses self-echo)
- On error (HashMismatch, PatchNotFound, count mismatch, network): reverts the optimistic toggle and shows an inline `⚠ msg` near the checkbox

### `assets/tasklist/esbuild.browser.mjs` (new)
Build script identical to `assets/chart/esbuild.browser.mjs`. Added `"tasklist": "node assets/tasklist/esbuild.browser.mjs"` to `package.json`.

### `assets/tasklist.js` (new, committed bundle)
Minified IIFE, 5 KB, matching the committed-bundle pattern of `chart.js`, `codeblock.js`.

### `assets/embed.go`
Added `tasklist.js` to the `//go:embed` directive.

## Checkbox → source mapping approach

1. Collect DOM checkboxes: `Array.from(body.querySelectorAll('li > input[type="checkbox"]'))` in document order.
2. Fetch raw source via GraphQL `notePaths(filter:{paths:[path]}){content}`.
3. Run the same scanner (fenced-code-aware) on the source to count task markers.
4. **Safety guard**: if `srcCount !== domCount`, abort with an error and leave the DOM unchanged.
5. Walk the source lines in order (skipping fenced code blocks) to find the Nth marker line (0-based index matching the DOM index).
6. Flip the marker: `[ ]` → `[x]` or `[x]` → `[ ]`.
7. If the original line appears exactly once in source → use `patch{find: oldLine, replace: newLine}`. If it appears multiple times → use `upsert{content: newSrc, expectedHash: versionId}`.
8. Advance baseline from `updated[].versionId`.

## Auth gate reused

`resp.UserToken.IsAdmin()` — same helper as `views.html:546` (the existing admin-only "Welcome" onboarding block). The page-cache bypass for authenticated requests ensures non-admins never receive the admin branch.

## Live verification evidence

**Note:** The dev instance at :8081 runs the previous binary (this branch is not yet deployed). The throwaway instance attempt failed because the dev db requires the site's vault domain to be configured in the DB before it will serve note pages (the router returns `unknown route` for unconfigured domains). Full live-verify requires deploying to the dev instance or running `make air` — flagging this as the one pending step.

**What was verified in-process:**
- `go run` confirmed goldmark GFM checkbox HTML: `<li><input disabled="" type="checkbox"> text</li>` — no class, first child. Selector `li > input[type="checkbox"]` is correct.
- 21 Go unit tests pass (count + index mapping, fence skipping, mismatch guard, Windows line endings)
- `go build ./...` and `go build -tags dev ./...` both clean
- `go test ./internal/model/... ./internal/templateviews/... ./internal/case/rendernotepage/... ./internal/defaulttemplate/...` all pass
- `npm run tasklist` builds `assets/tasklist.js` (5 KB)

## Test plan

- [ ] Deploy dev build on dev instance, create a note with `- [ ] item` and `- [x] done`, visit as admin → checkboxes enabled, click to toggle → `updateNotes` 200, versionId bumps
- [ ] Visit same note as anonymous → `#tasklist-meta` not in HTML, `tasklist.js` not loaded, checkboxes disabled
- [ ] Note with no task items → `tasklist.js` not loaded even for admin
- [ ] Duplicate task-line note → falls back to full upsert path, patch not used