### PR TITLE
docs(mcp): docs-base initialize/instructions notes, fix demo prompt leak

### DIFF
--- a/docs/_mcp_initialize.md
+++ b/docs/_mcp_initialize.md
@@ -1,0 +1,42 @@
+---
+mcp_method: initialize
+free: true
+---
+
+You are connected to the trip2g documentation base (trip2g.com). trip2g is a Markdown publishing platform: it turns an Obsidian vault into a website with subscriptions, Telegram publishing, and this MCP server for AI agents. This base holds the trip2g user guides (`en/user/`, `ru/user/`), the changelog, developer docs (`dev/`), and design plans (`plans/`).
+
+Answer from retrieved sources, not memory. Follow the loop below: it keeps every read to one section (~300 tokens) instead of a whole note (3,000+).
+
+## The retrieval loop
+
+1. `search(query)` — up to 6 results; the top 3 carry `matches[]`, each with a `snippet` and a `toc_path` (breadcrumb to the matching section).
+2. Read only that section: `note_html(pid=<note_id>, toc_path=<match.toc_path>)`.
+3. Pointer looks off, or you want to survey the note first? `expand(pid=N)` lists its top-level sections; `expand(pid=N, toc_path=["Section"])` lists that section's subsections. Descend to a leaf, then read it with `note_html(toc_path=...)`.
+4. Read a whole note (`note_html(pid=N)` with no `toc_path`) only when `expand` shows it has no sections.
+
+Worked example — the user asks "how do I connect a private federation peer?":
+
+```
+search("private federation peer HMAC secret")
+→ 1. MCP Federation, note_id=658,
+     match toc_path=["Adding a private peer (two-step exchange)"]
+note_html(pid=658, toc_path=["Adding a private peer (two-step exchange)"])
+→ one section; answer from it, cite https://trip2g.com/en/user/federation
+```
+
+## Other tools — one-line triggers
+
+- `similar(pid=N)` — you found one good note and want its neighbors. Example: after the federation guide, `similar(pid=658)` surfaces the protocol guide and the RU twin.
+- `federated_search(query)` — local `search` found nothing relevant, or a result had `kind: "federation_kb"` (a pointer to a connected base). It fans the query out across all connected bases; pass `kb_id="..."` to target one. Follow-up reads go through `federated_note_html` / `federated_expand` / `federated_similar`, and each of those requires the `kb_id`.
+
+Call the `instructions` tool for the full argument reference.
+
+## Guardrails
+
+- Never open a note without `toc_path` (or `match_id`) on the first read. A section is ~10x cheaper and lands at the top of your context, where recall is best.
+- A wrong `toc_path` does not error — it silently returns the whole note. If a `note_html` response is much longer than one section, your pointer missed: stop, call `expand(pid=N)` to see the real headings, and re-read with an exact title from that list.
+- `toc_path` entries must match headings exactly, punctuation included. Copy them from `search` matches or `expand` children; never guess or translate them.
+- Prefer `toc_path` over `match_id`. A `match_id` gives a focused chunk window only in its `pN:cM` form; `pN:mM` ids do not resolve.
+- Ignore `demo/` notes — that is a Marcus Aurelius / Meditations showcase, not trip2g documentation — unless the user asks about the demo itself.
+- Ground answers only in sections you actually read, and cite the note URL. If the docs do not cover something, say so briefly.
+- Answer in the user's language. Guides exist as `en/user/` and `ru/user/` mirrors; prefer the one matching the user.

--- a/docs/_mcp_instructions.md
+++ b/docs/_mcp_instructions.md
@@ -1,0 +1,65 @@
+---
+mcp_method: instructions
+mcp_description: Full tool reference for the trip2g documentation base
+free: true
+---
+
+# trip2g docs — MCP tool reference
+
+This base is the trip2g documentation: user guides under `en/user/` and `ru/user/`, changelog, developer docs under `dev/`, design plans under `plans/`. The `demo/` folder is a Meditations showcase, not trip2g docs.
+
+Core loop: `search` → read one section with `note_html(toc_path=...)` → navigate structure with `expand` when the pointer misses. Details per tool below.
+
+## search
+
+`search(query, limit?, detail_limit?)` — hybrid (keyword + vector) search over this base.
+
+- `limit`: max results, default 6, cap 20.
+- `detail_limit`: how many results include `matches[]` snippets, default 3; the rest are lightweight previews (title, path, score).
+- Each result: `title`, `note_id`, `note_path`, `href`, `url`, `kind`, `score`.
+- Each match: `match_id`, `chunk_index`, `snippet`, `toc_path` — the breadcrumb of the section that matched, e.g. `["Adding a private peer (two-step exchange)"]`.
+- `note_id` is the stable id; `note_html`, `expand`, and `similar` accept it as either `pid` or `note_id`.
+- A result with `kind: "federation_kb"` is a pointer to a connected base — switch to `federated_search` with the `kb_id` it names.
+
+Query tips: use content words from the question ("private federation peer HMAC secret"), not full sentences. If nothing relevant comes back, rephrase once with synonyms before reaching for `federated_search`.
+
+## note_html
+
+`note_html(pid | note_id | path | href, toc_path?, match_id?)` — read a note or one section of it.
+
+- With `toc_path`: returns only that section's HTML. This is the default way to read.
+- With `match_id` (form `pN:cM` only): returns a focused text window around that chunk. Ids in the `pN:mM` form do not resolve — use the `toc_path` instead.
+- With neither: returns the whole note. Do this only for notes `expand` shows to be sectionless.
+- Failure mode: a `toc_path` that matches no heading silently falls back to the whole note. A response far longer than one section means the pointer missed — recover via `expand`, do not retry blind.
+
+## expand
+
+`expand(pid | note_id | path | href, toc_path?)` — progressive disclosure of a note's table of contents.
+
+- No `toc_path` (or `[]`): the top-level sections.
+- With `toc_path`: that section's direct subsections.
+- Each child: `title`, `level`, `path` (ready to pass on), `has_children`.
+- Descend until a leaf (`has_children: false`), then `note_html(toc_path=child.path)`.
+- Use it to survey a note's structure before reading, and to recover from a `toc_path` miss.
+
+## similar
+
+`similar(pid | note_id | path | href, limit?)` — related notes for a known note (vector similarity). Default limit 10.
+
+Trigger: you have one good note and want its neighbors — related guides, the other-language twin, follow-up material.
+
+## Federated tools
+
+This base can be connected to peer knowledge bases. The federated variants mirror the local ones, with a `kb_id` targeting a peer:
+
+- `federated_search(query, kb_id?, kb_ids?, limit?, detail_limit?)` — omit `kb_id` to fan out across all connected bases in parallel; pass `kb_id` for one base, `kb_ids` for a chosen set.
+- `federated_note_html(kb_id, ...)`, `federated_expand(kb_id, ...)`, `federated_similar(kb_id, ...)` — same arguments as their local twins, `kb_id` required.
+
+Trigger: local `search` came up empty after one rephrase, or a local result had `kind: "federation_kb"`. Results from a peer name their `kb_id` — keep passing it on every follow-up call.
+
+## Efficiency rules
+
+1. Section reads first: `search` → `note_html(toc_path=...)`. One section is ~300 tokens; a full note is 3,000+.
+2. `toc_path` values are exact heading titles. Copy, never guess or translate.
+3. Whole-note reads are the last resort, not the fallback.
+4. Cite the `url` of every note you answer from.

--- a/docs/_mcp_instructions.md
+++ b/docs/_mcp_instructions.md
@@ -57,6 +57,8 @@ This base can be connected to peer knowledge bases. The federated variants mirro
 
 Trigger: local `search` came up empty after one rephrase, or a local result had `kind: "federation_kb"`. Results from a peer name their `kb_id` — keep passing it on every follow-up call.
 
+**Discovering connected bases.** For a browsable directory of the peers instead of blind fan-out, read the hub index: `search("hub")` or `note_html(path="en/hub/_index.md")`. It links one note per base (e.g. `en/hub/foragent.md`), and each of those names its `kb_id` in the frontmatter. Use that to pick a target for `federated_search(kb_id="foragent")` deliberately, rather than fanning out to every peer or waiting for a `kind: "federation_kb"` pointer to surface.
+
 ## Efficiency rules
 
 1. Section reads first: `search` → `note_html(toc_path=...)`. One section is ~300 tokens; a full note is 3,000+.

--- a/docs/dev/mcp_instructions_guide.md
+++ b/docs/dev/mcp_instructions_guide.md
@@ -1,0 +1,57 @@
+# How to write good MCP instructions for your base
+
+**TL;DR:** every base needs its own `mcp_method: initialize` note, or agents get the wrong identity (trip2g.com served the demo's Marcus Aurelius prompt for months). Write it for the weakest model that will connect: identity in 2-3 sentences, the retrieval loop as numbered steps, one worked example with real values, one-line triggers for the other tools, and guardrails built from the actual failure paths. The reference example is `docs/_mcp_initialize.md` + `docs/_mcp_instructions.md`.
+
+## The mechanism
+
+Two frontmatter keys, both handled in `internal/case/mcp/resolve.go`:
+
+- `mcp_method: initialize` — the note body (frontmatter stripped) is injected as the `instructions` field of the MCP `initialize` response. Every client sees it at connect time. This is the note that matters.
+- `mcp_method: <name>` (any non-reserved name, e.g. `instructions`) — the note becomes a callable tool named `<name>` that returns its body. Use it for the longer reference the initialize note points to. `mcp_description` sets the tool description in `tools/list`.
+
+Both need `free: true` to be visible to anonymous MCP callers.
+
+**Shadowing gotcha:** when several notes share an `mcp_method`, the first one in path-sorted order wins (`handleInitialize` / `handleDynamicMethod` iterate `LatestNoteViews().List`, which `ExtractNoteList` sorts by path). That is why root-level `_mcp_initialize.md` shadows `demo/_mcp_initialize.md` (`_` < `d`) — and why the leak happened in the first place: with no root note, the demo's was the only match. Don't rely on shadowing across sibling folders; keep one authoritative note per method.
+
+## The recipe
+
+Order matters — a weak model weights the top of the prompt heaviest:
+
+1. **Identity, 2-3 sentences.** What this base is and what topics live here. The agent uses it to decide whether a question is even answerable locally.
+2. **The retrieval loop, as numbered steps.** For trip2g bases: `search` → `note_html(toc_path=match.toc_path)` → `expand` when the pointer misses → whole-note read only for sectionless notes. State the payoff in numbers ("one section ~300 tokens, full note 3,000+") so the model has a reason to comply.
+3. **One worked example with real values.** A real query, a real `note_id`, a real `toc_path` from your base. Weak models copy examples far more reliably than they follow abstract rules.
+4. **One-line triggers for the other tools.** "`similar` — you found one good note and want its neighbors. `federated_search` — local search came up empty, or a result had `kind: federation_kb`." One trigger per tool; no essays.
+5. **Guardrails from the failure paths.** Write these from how the system actually fails, not how it should work. For trip2g: a wrong `toc_path` silently returns the *whole note* (no error), so teach the recovery — "response much longer than a section = pointer miss; call `expand`, re-read with an exact heading"; `toc_path` must match headings exactly; `pN:mM` match_ids don't resolve.
+
+## Weak-model rules
+
+- **Tight beats complete.** A haiku-class model degrades with wall-of-text; the initialize note should fit in ~50 lines. Push the full argument reference into a callable `instructions` tool-note.
+- **Exact names only.** The tool is `expand`, not "extend"; the argument is `toc_path`, not "section". Copy names from `handleToolsList` in `resolve.go` — if the note and the schema disagree, the agent flips a coin.
+- **Imperative, not descriptive.** "Never open a note without `toc_path` on the first read", not "it is generally more efficient to…".
+- **Don't document fields that no longer exist.** The docs taught a removed `toc` search field for months (see `2026-07-02_vector_search_token_economy.md`, finding 3); an agent hunting for a phantom field burns a turn and then falls back to the expensive path.
+
+## Validate against the live endpoint
+
+Don't ship instructions you haven't run:
+
+```sh
+# identity: does initialize return YOUR note?
+curl -s https://your-base/_system/mcp -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"initialize","id":1}'
+
+# names: does tools/list match what your note claims?
+curl -s https://your-base/_system/mcp -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
+
+# the loop itself: search -> expand -> note_html(toc_path) on a real term
+curl -s https://your-base/_system/mcp -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"tools/call","id":2,"params":{"name":"search","arguments":{"query":"<real docs term>","limit":3}}}'
+```
+
+Then walk one drill-down by hand: take a `toc_path` from the search result, `note_html` it, and compare the section length to the full note. If you can, point a cheap model at the endpoint and watch whether it follows the loop; every place it stumbles is a line your note is missing.
+
+## Related
+
+- `docs/dev/mcp.md` — endpoint and dynamic-method basics (predates `note_html`/`expand`/federation; the tool list there is stale)
+- `docs/en/user/Token Economy.md`, `Fuzzy Pointer.md`, `expand.md` — the drill-down pattern the instructions teach
+- `docs/dev/2026-07-02_vector_search_token_economy.md` — the failure-path audit the guardrails are built from

--- a/docs/dev/mcp_instructions_guide.md
+++ b/docs/dev/mcp_instructions_guide.md
@@ -29,6 +29,7 @@ Order matters — a weak model weights the top of the prompt heaviest:
 - **Exact names only.** The tool is `expand`, not "extend"; the argument is `toc_path`, not "section". Copy names from `handleToolsList` in `resolve.go` — if the note and the schema disagree, the agent flips a coin.
 - **Imperative, not descriptive.** "Never open a note without `toc_path` on the first read", not "it is generally more efficient to…".
 - **Don't document fields that no longer exist.** The docs taught a removed `toc` search field for months (see `2026-07-02_vector_search_token_economy.md`, finding 3); an agent hunting for a phantom field burns a turn and then falls back to the expensive path.
+- **Link a browsable peer directory if you federate.** Blind `federated_search` fan-out and `kind: "federation_kb"` pointers only surface peers reactively. If your base has a `free: true` hub index (one note per peer, each carrying its `mcp_federation_kb_id`), point the instructions at it so the agent can look up a `kb_id` and target one base deliberately. trip2g's own note does this via `en/hub/_index.md`.
 
 ## Validate against the live endpoint
 


### PR DESCRIPTION
## What

trip2g.com's MCP `initialize` currently returns the DEMO base's Marcus Aurelius / Meditations prompt, because the docs root had no `mcp_method: initialize` note of its own and `docs/demo/_mcp_initialize.md` was the only match. This PR gives the docs base its own identity and agent manual:

- `docs/_mcp_initialize.md` (`mcp_method: initialize`, `free: true`) — injected into the MCP `initialize` response. Tight, weak-model-friendly: base identity, the drill-down loop (`search` → `note_html(toc_path=...)` → `expand` on a miss), a worked example with real live values (note_id 658, the federation guide), one-line triggers for `similar` / `federated_search`, and guardrails built from the actual failure paths (silent full-note fallback on a bad `toc_path`, unusable `pN:mM` match_ids).
- `docs/_mcp_instructions.md` (`mcp_method: instructions`) — callable tool with the full per-tool argument reference, matching the schemas in `internal/case/mcp/resolve.go` exactly.
- `docs/dev/mcp_instructions_guide.md` — "How to write good MCP instructions for your base": the mechanism (initialize vs dynamic tool notes, path-sort shadowing gotcha), the recipe, weak-model rules, live validation checklist. This is the template for other bases.

Root notes shadow the demo ones because `ExtractNoteList` sorts by path (`_` < `d`); the demo notes stay untouched as showcase content.

## Validation (live, read-only)

- `initialize` on trip2g.com currently returns the Marcus prompt (bug reproduced).
- `tools/list` confirmed tool names: `search`, `similar`, `note_html`, `expand`, `federated_*`, plus dynamic `wiki`/`instructions`.
- Walked the loop live: `search("federation setup HMAC secret")` → match `toc_path=["Adding a private peer (two-step exchange)"]` on note_id 658 → `expand(pid=658)` (11 sections) → `note_html(pid=658, toc_path=["Core concepts"])` = 720 chars vs 15,283 for the bad-toc_path full-note fallback — exactly the failure the guardrails teach recovery from.
- `federated_search` fan-out reaches a live peer (`nicksenin_journal`); `similar(pid=658)` returns the RU twin first.
- `go run -tags dev ./cmd/server lint docs` — clean except the three pre-existing demo/canvas info items.

## Doc/behavior mismatches found (not fixed here)

- `docs/dev/mcp.md` is stale: documents `similar(text=...)`, no `note_html`/`expand`/federated tools (flagged in the new guide).
- `Token Economy.md` / `Fuzzy Pointer.md` still teach the removed per-result `toc` field (audit finding 3).
- `note_html` silently returns the whole note on a `toc_path`/`match_id` miss (audit finding 1) — the instructions teach agents to detect and recover; a code-side loud failure is still worth doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)