### PR TITLE
fix(e2e): load fleet/krisp specs + resync sync snapshot

### DIFF
--- a/e2e/fleet-kanban.spec.js
+++ b/e2e/fleet-kanban.spec.js
@@ -19,14 +19,13 @@
 import { test, expect } from '@playwright/test';
 import { spawn } from 'child_process';
 import path from 'path';
-import { fileURLToPath } from 'url';
 import { signInAsAdmin } from './helpers/auth.js';
 import { startStubLLM } from './helpers/stub-llm.js';
 
 const APP_URL = process.env.APP_URL || 'http://localhost:20081';
 const GRAPHQL_URL = `${APP_URL}/_system/graphql`;
 // REPO_ROOT is the worktree root — where go run ./cmd/fleet will be executed.
-const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const REPO_ROOT = process.cwd();
 
 // FLEET_CALLBACK_HOST controls the callback URL the fleet registers with trip2g.
 // Pure-host run: 127.0.0.1 (default). Docker compose run (app in container,

--- a/e2e/krisp-ingest.spec.js
+++ b/e2e/krisp-ingest.spec.js
@@ -26,7 +26,6 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
 import { graphqlSignIn } from './helpers/auth.js';
 
 const APP_URL = process.env.APP_URL || 'http://localhost:20081';
@@ -73,7 +72,7 @@ async function gqlApi(request, apiKey, query, variables = {}) {
 // had: double-quoted Python vs the doc's single quotes).
 // ---------------------------------------------------------------------------
 
-const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const REPO_ROOT = process.cwd();
 const roleSeed = fs.readFileSync(
   path.join(REPO_ROOT, 'docs/fleet/krisp/roles/transcript-ingest.md'),
   'utf8',

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -489,7 +489,9 @@ fi
 # Screenshot regression tests
 echo ""
 echo "📸 Running screenshot tests..."
-npx playwright test e2e/screenshots.spec.js || {
+SCREENSHOT_ARGS=()
+[ "$UPDATE_SNAPSHOTS" = "1" ] && SCREENSHOT_ARGS+=(--update-snapshots)
+npx playwright test e2e/screenshots.spec.js "${SCREENSHOT_ARGS[@]}" || {
   echo -e "${RED}✗ Screenshot tests failed${NC}"
   exit 1
 }

--- a/testdata/sync-updates/01-testvault0.json
+++ b/testdata/sync-updates/01-testvault0.json
@@ -156,6 +156,14 @@
     "url": "http://localhost:20081/federation_kb_semi"
   },
   {
+    "path": "fleet/boards/sprint.md",
+    "url": "http://localhost:20081/fleet/boards/sprint"
+  },
+  {
+    "path": "fleet/roles/triage.md",
+    "url": "http://localhost:20081/fleet/roles/triage"
+  },
+  {
     "path": "folder/_banner.md",
     "url": "http://localhost:20081/folder/_banner"
   },
@@ -316,10 +324,6 @@
     "url": "http://localhost:20081/patch_tests/_vault_patch_free"
   },
   {
-    "path": "patch_tests/_vault-patch-malformed.md",
-    "url": "http://localhost:20081/patch_tests/_vault_patch_malformed"
-  },
-  {
     "path": "patch_tests/_vault-patch-multi.md",
     "url": "http://localhost:20081/patch_tests/_vault_patch_multi"
   },
@@ -450,6 +454,10 @@
   {
     "path": "software.md",
     "url": "http://localhost:20081/software"
+  },
+  {
+    "path": "tasklist.md",
+    "url": "http://localhost:20081/tasklist"
   },
   {
     "path": "team-status.md",


### PR DESCRIPTION
## What

Running the full local e2e suite on `main` surfaced three pre-existing breakages (CI's `e2e` job is `if: false`, so none were gated). This PR lands the two clearly-correct fixes; the remaining three runtime failures are reported below for a decision.

### Fixed here
- **`fleet-kanban.spec.js` + `krisp-ingest.spec.js` never loaded.** They are the only two specs using `import.meta.url`; with no `"type": "module"` in `package.json`, Playwright's CJS transform turns `import.meta` into a `require` call → `ReferenceError: require is not defined in ES module scope`. Verified the original commits fail identically — these never ran green in this harness. Switched to `process.cwd()` (the pattern `gitsync`/`updatenotes`/`renderlayout` already use; the harness runs from repo root).
- **Resynced `testdata/sync-updates/01-testvault0.json`.** Golden sync snapshot had drifted from `docs/demo`: `+fleet/boards/sprint.md`, `+fleet/roles/triage.md` (tracked fixtures), `-patch_tests/_vault-patch-malformed.md` (removed file), `+tasklist.md` (new demo note).
- **`--update-snapshots` now also refreshes Playwright screenshots** (previously only CLI golden snapshots).

## Still red on main — needs a decision (not in this PR)
1. **`vault.spec.js:203` "duplicate filename priority (root wins)"** — stale test. PR #91 (`972120c8 feat(wikilink): scoped bare-link resolution ladder`) changed bare-link resolution to folder→lang→shallowest, so `[[dup]]` on `/folder/source` now resolves to `/folder/dup`, not `/dup`. The new behavior is intended (see `docs/dev/2026-07-02_wikilink_multilang_resolution.md`); the test should be updated to assert folder-wins.
2. **`fleet.spec.js:172`** — `beforeAll` hook timeout (dockerized fleet didn't come up in 30s). Infra/timing.
3. **`fleet-kanban.spec.js:244`** — agent didn't add `@triaged` within the 30s test window (board unchanged). Fleet runtime/timing.

Because the suite exits on the first Playwright failure, the screenshot-update step is never reached — home screenshots remain unverified until 1–3 are resolved.

## Test
- `npx playwright test e2e/{fleet-kanban,krisp-ingest}.spec.js --list` — both now load (previously errored).
- Full run: 256 passed, 3 failed (the three above).