### PR TITLE
fix(e2e): fleet spec beforeAll timeouts and go run cold-compile

### DIFF
--- a/e2e/fleet-kanban.spec.js
+++ b/e2e/fleet-kanban.spec.js
@@ -18,6 +18,7 @@
 
 import { test, expect } from '@playwright/test';
 import { spawn } from 'child_process';
+import { unlinkSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { signInAsAdmin } from './helpers/auth.js';
@@ -76,6 +77,8 @@ async function waitJobs(request) {
 // ---------------------------------------------------------------------------
 
 test.describe.serial('Fleet kanban vertical slice', () => {
+  // go build + fleet reconcile + agent triage: needs more than the default 30 s.
+  test.setTimeout(120000);
   /** @type {string} Admin session cookie (trip2g_e2e=...). */
   let cookie;
   /** @type {string} Full-admin API key value (for X-Api-Key header). */
@@ -84,6 +87,8 @@ test.describe.serial('Fleet kanban vertical slice', () => {
   let stub;
   /** @type {import('child_process').ChildProcess} */
   let fleetProc;
+  /** @type {string} Path to the pre-built fleet binary. */
+  let fleetBin;
 
   // Seeded board content — card is already @status:doing so the stub's find
   // matches immediately when the fleet fires on the user edit.
@@ -122,6 +127,8 @@ test.describe.serial('Fleet kanban vertical slice', () => {
   ].join('\n');
 
   test.beforeAll(async ({ browser, request }) => {
+    // Extend this hook's timeout to cover go build + fleet reconcile.
+    test.setTimeout(120000);
     // signInAsAdmin needs a Page, not a Browser — create one and close after.
     const page = await browser.newPage();
     cookie = await signInAsAdmin(page);
@@ -182,6 +189,23 @@ test.describe.serial('Fleet kanban vertical slice', () => {
     await waitJobs(request);
 
     // -----------------------------------------------------------------------
+    // Pre-build the fleet binary so `go run` cold-compile time (~10-30 s) does
+    // not eat into the reconcile poll budget.
+    // -----------------------------------------------------------------------
+    fleetBin = `/tmp/fleet-e2e-${process.pid}`;
+    await new Promise((resolve, reject) => {
+      const proc = spawn('go', ['build', '-o', fleetBin, './cmd/fleet'], {
+        cwd: REPO_ROOT,
+        stdio: 'pipe',
+      });
+      proc.stderr?.pipe(process.stderr);
+      proc.on('close', (code) => {
+        if (code !== 0) reject(new Error(`go build ./cmd/fleet exited ${code}`));
+        else resolve();
+      });
+    });
+
+    // -----------------------------------------------------------------------
     // Start the deterministic stub LLM.
     // Call 1 → patch_note({path, find: '@status:doing', replace: '@status:doing @triaged'})
     // Call 2+ → finish({answer: 'triaged'})
@@ -199,9 +223,8 @@ test.describe.serial('Fleet kanban vertical slice', () => {
     // stdio: 'pipe' keeps fleet output out of the test runner unless debugging.
     // -----------------------------------------------------------------------
     fleetProc = spawn(
-      'go',
+      fleetBin,
       [
-        'run', './cmd/fleet',
         '-fleet-id', 'e2e',
         '-listen', '127.0.0.1:9099',
         '-callback-url', `http://${FLEET_CALLBACK_HOST}:9099`,
@@ -240,6 +263,7 @@ test.describe.serial('Fleet kanban vertical slice', () => {
   test.afterAll(async () => {
     if (fleetProc) fleetProc.kill('SIGTERM');
     if (stub) stub.server.close();
+    if (fleetBin) try { unlinkSync(fleetBin); } catch {}
   });
 
   test('user edit → agent triage → one delivery, board updated, no re-trigger', async ({ request }) => {
@@ -278,7 +302,7 @@ test.describe.serial('Fleet kanban vertical slice', () => {
           `, { f: { paths: [BOARD_PATH] } });
           return d.notePaths[0]?.content ?? '';
         },
-        { timeout: 30000, intervals: [1000] },
+        { timeout: 60000, intervals: [1000] },
       )
       .toContain('@status:doing @triaged');
 

--- a/e2e/fleet.spec.js
+++ b/e2e/fleet.spec.js
@@ -110,7 +110,9 @@ test.describe.serial('Fleet LLM pipeline (dockerized)', () => {
     'Write your analysis to segments/sample.md.',
   ].join('\n');
 
-  test.beforeAll({ timeout: 90000 }, async ({ request }) => {
+  test.beforeAll(async ({ request }) => {
+    // Extend this hook's timeout (beforeAll requires test.setTimeout, not options arg).
+    test.setTimeout(90000);
     // Use the API-based sign-in (faster than browser UI, no locator waiting).
     // graphqlSignIn returns a raw JWT; construct the cookie header from it.
     const token = await graphqlSignIn(request, 'hello@example.com', '111111', { useCache: false });


### PR DESCRIPTION
## Root cause per spec

### fleet.spec.js — invalid beforeAll timeout option

`test.beforeAll({ timeout: 90000 }, fn)` is not a valid Playwright API. Playwright 1.56
only accepts `(fn)` or `(title: string, fn)`. The object `{ timeout: 90000 }` was silently
treated as the title string `"[object Object]"` and the hook ran with the default 30 s
timeout. When the dockerized fleet service took slightly longer to reconcile the seeded
role, the hook timed out at 30 s.

Fix: replace the options-first call with `test.setTimeout(90000)` as the first statement
inside the hook body — the correct Playwright API for overriding a `beforeAll`/`afterAll`
timeout (per the Playwright docs example at line 5667 of types/test.d.ts).

Verdict: **timing/harness bug** (no fleet functional issue).

### fleet-kanban.spec.js — go run cold-compile eats the reconcile budget

`go run ./cmd/fleet` compiles the fleet binary from scratch every run (~10–30 s). The
`beforeAll` had no timeout override (defaulted to 30 s) and spawned the fleet via `go run`,
leaving almost no time for the reconcile `expect.poll({ timeout: 30000 })`. The test body
also had no `test.setTimeout`, so the default 30 s applied there too.

Fixes:
- `test.setTimeout(120000)` in the describe body (tests) and `test.setTimeout(120000)` inside
  `beforeAll` (hook) — using the correct Playwright API in both places.
- Pre-build `./cmd/fleet` with `go build -o /tmp/fleet-e2e-<pid>` inside `beforeAll` (awaited)
  before spawning; then spawn the binary directly instead of via `go run`. Binary is cleaned
  up in `afterAll`.
- `expect.poll` timeout in the test body raised from 30 s → 60 s to match the new test
  timeout and give headroom for any residual delivery latency.

Verdict: **timing/harness bug** (no fleet functional issue).