### PR TITLE
feat(fleet): multi-block pipes in code executor + loopback debug endpoint

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -99,6 +99,24 @@ func run() error {
 	})
 	srv := &http.Server{Addr: cli.cfg.ListenAddr, Handler: mux, ReadHeaderTimeout: 10 * time.Second}
 
+	// Optional loopback-only debug surface for step-by-step code-block runs.
+	// Separate server on a separate addr — never mounted on the public mux.
+	// validateConfig already rejected non-loopback addresses.
+	if cli.cfg.DebugListenAddr != "" {
+		dbgSrv := &http.Server{
+			Addr:              cli.cfg.DebugListenAddr,
+			Handler:           f.DebugHandler(),
+			ReadHeaderTimeout: 10 * time.Second,
+		}
+		go func() {
+			lg.Info("fleet debug listening (loopback only)", "addr", cli.cfg.DebugListenAddr)
+			if dbgErr := dbgSrv.ListenAndServe(); dbgErr != nil && dbgErr != http.ErrServerClosed {
+				lg.Error("debug server", "err", dbgErr)
+			}
+		}()
+		defer func() { _ = dbgSrv.Close() }()
+	}
+
 	srvErrCh := make(chan error, 1)
 	go func() {
 		lg.Info("fleet listening", "fleet_id", cli.cfg.FleetID, "addr", cli.cfg.ListenAddr, "callback", cli.cfg.CallbackURL)
@@ -295,6 +313,12 @@ func validateConfig(cfg fleet.Config) error {
 	if len(cfg.OfferedTools) == 0 {
 		return errors.New("fleet: OfferedTools must be non-empty; use --offered-tools")
 	}
+	// The debug surface must never bind a non-loopback interface.
+	if cfg.DebugListenAddr != "" {
+		if err := fleet.ValidateLoopbackAddr(cfg.DebugListenAddr); err != nil {
+			return err
+		}
+	}
 	// Empty means the safe default (native); see SandboxPolicy.withDefaults.
 	switch cfg.Sandbox {
 	case "", string(agentruntime.SandboxNative), string(agentruntime.SandboxOff), string(agentruntime.SandboxBestEffort):
@@ -418,6 +442,9 @@ func parseFlags(ctx context.Context) (cliFlags, error) {
 			"besteffort degrades to UNSANDBOXED with a per-run warning; off disables isolation)")
 	fs.BoolVar(&cli.cfg.SandboxNetwork, "sandbox-network", false,
 		"allow host network access inside the code-exec sandbox")
+	fs.StringVar(&cli.cfg.DebugListenAddr, "debug-listen", "",
+		"loopback-only debug listen address for step-by-step code-block runs "+
+			"(e.g. 127.0.0.1:9091; empty = disabled; dev only, never expose publicly)")
 	fs.IntVar(&poll, "poll-seconds", 30,
 		"discovery/reconcile poll interval seconds")
 	fs.IntVar(&graceSeconds, "shutdown-grace-seconds", 30,

--- a/cmd/fleet/main_test.go
+++ b/cmd/fleet/main_test.go
@@ -85,6 +85,16 @@ func TestValidateConfig_RejectsMissingFields(t *testing.T) {
 			wantErr: "",
 		},
 		{
+			name:    "debug_listen_non_loopback",
+			mutate:  func(c *fleet.Config) { c.DebugListenAddr = "0.0.0.0:9091" },
+			wantErr: "loopback",
+		},
+		{
+			name:    "debug_listen_loopback_ok",
+			mutate:  func(c *fleet.Config) { c.DebugListenAddr = "127.0.0.1:9091" },
+			wantErr: "",
+		},
+		{
 			name:    "all_fields_present",
 			mutate:  func(c *fleet.Config) {},
 			wantErr: "",

--- a/internal/agentruntime/coderun.go
+++ b/internal/agentruntime/coderun.go
@@ -1,6 +1,7 @@
 package agentruntime
 
 import (
+	"bytes"
 	"context"
 	_ "embed"
 	"encoding/json"
@@ -112,6 +113,7 @@ func FenceLangKnown(lang string) bool {
 type CodeSpec struct {
 	Program        string        // canonical program name (python, bash, node, ...)
 	Code           string        // source text written to a per-run temp file
+	Stdin          []byte        // fed to the child's stdin (pipeline: prior block's stdout); nil → /dev/null
 	Input          []byte        // delivery bag JSON; nil or empty → "{}"
 	Timeout        time.Duration // per-run timeout; 0 = bounded by ctx only
 	EnvPassthrough []string      // exact parent env var names to forward to child
@@ -226,7 +228,7 @@ func RunBlock(ctx context.Context, spec CodeSpec) (string, string, bool, error) 
 		cmd = exec.CommandContext(runCtx, fullArgv[0], fullArgv[1:]...)
 	}
 	var outBuf, errBuf limitedBuffer
-	prepareCmd(cmd, workDir, env, &outBuf, &errBuf, limit)
+	prepareCmd(cmd, workDir, env, spec.Stdin, &outBuf, &errBuf, limit)
 
 	runErr := cmd.Run()
 	// A sandboxed command that failed to START never ran the child: namespace
@@ -240,7 +242,7 @@ func RunBlock(ctx context.Context, spec CodeSpec) (string, string, bool, error) 
 		}
 		warnSandboxFallback("sandboxed child failed to start", runErr)
 		cmd = exec.CommandContext(runCtx, fullArgv[0], fullArgv[1:]...)
-		prepareCmd(cmd, workDir, env, &outBuf, &errBuf, limit)
+		prepareCmd(cmd, workDir, env, spec.Stdin, &outBuf, &errBuf, limit)
 		runErr = cmd.Run()
 	}
 	outStr := outBuf.String()
@@ -260,10 +262,13 @@ func RunBlock(ctx context.Context, spec CodeSpec) (string, string, bool, error) 
 }
 
 // prepareCmd applies the run wiring shared by the sandboxed and plain paths:
-// workdir, scrubbed env, and fresh capped stdout/stderr buffers.
-func prepareCmd(cmd *exec.Cmd, workDir string, env []string, outBuf, errBuf *limitedBuffer, limit int) {
+// workdir, scrubbed env, stdin, and fresh capped stdout/stderr buffers.
+func prepareCmd(cmd *exec.Cmd, workDir string, env []string, stdin []byte, outBuf, errBuf *limitedBuffer, limit int) {
 	cmd.Dir = workDir
 	cmd.Env = env
+	if len(stdin) > 0 {
+		cmd.Stdin = bytes.NewReader(stdin)
+	}
 	*outBuf = limitedBuffer{limit: limit}
 	*errBuf = limitedBuffer{limit: limit}
 	cmd.Stdout = outBuf
@@ -314,6 +319,12 @@ func programBinary(name string) (string, error) {
 	return "", fmt.Errorf("coderun: unknown program %q", name)
 }
 
+// ProgramForFenceLang maps a Markdown fence language tag to its canonical
+// program name ("" = unknown). Exported for the fleet debug surface.
+func ProgramForFenceLang(lang string) string {
+	return fenceLangToProgram(lang)
+}
+
 // fenceLangToProgram maps a Markdown fence language tag to the canonical
 // program name used for allowlist checks (python, bash, node).
 // Returns "" for unrecognised tags.
@@ -324,15 +335,15 @@ func fenceLangToProgram(lang string) string {
 	return ""
 }
 
-// fencedBlock is one fenced code block extracted from a Markdown body.
-type fencedBlock struct {
+// FencedBlock is one fenced code block extracted from a Markdown body.
+type FencedBlock struct {
 	Lang string
 	Code string
 }
 
-// extractAllFencedBlocks returns all fenced code blocks from body in document order.
-func extractAllFencedBlocks(body string) []fencedBlock {
-	var blocks []fencedBlock
+// ExtractFencedBlocks returns all fenced code blocks from body in document order.
+func ExtractFencedBlocks(body string) []FencedBlock {
+	var blocks []FencedBlock
 	rest := body
 	for {
 		idx := strings.Index(rest, "```")
@@ -350,7 +361,7 @@ func extractAllFencedBlocks(body string) []fencedBlock {
 		if end == -1 {
 			break
 		}
-		blocks = append(blocks, fencedBlock{Lang: langStr, Code: content[:end]})
+		blocks = append(blocks, FencedBlock{Lang: langStr, Code: content[:end]})
 		rest = content[end+3:]
 	}
 	return blocks
@@ -360,7 +371,7 @@ func extractAllFencedBlocks(body string) []fencedBlock {
 // first fenced code block (```lang\n...\n```) in body.
 // Returns ("", "") when no complete block is found.
 func extractFirstFencedBlock(body string) (string, string) {
-	blocks := extractAllFencedBlocks(body)
+	blocks := ExtractFencedBlocks(body)
 	if len(blocks) == 0 {
 		return "", ""
 	}

--- a/internal/agentruntime/coderun_test.go
+++ b/internal/agentruntime/coderun_test.go
@@ -243,6 +243,127 @@ func TestRunCode_NoFencedBlock(t *testing.T) {
 	require.Contains(t, err.Error(), "no fenced code block")
 }
 
+// ─── pipeline (multi-block) ──────────────────────────────────────────────────
+
+// TestRunBlock_StdinPiped asserts CodeSpec.Stdin is fed to the child's stdin.
+func TestRunBlock_StdinPiped(t *testing.T) {
+	skipIfSandboxUnsupported(t)
+	stdout, _, _, err := RunBlock(context.Background(), CodeSpec{
+		Program: "bash",
+		Code:    "cat",
+		Stdin:   []byte("piped-data"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "piped-data", stdout)
+}
+
+// TestRunCode_Pipeline_TwoBlocks pipes block 1's free-form stdout into block 2's
+// stdin; only the LAST block's stdout is parsed as the {changes,answer} contract.
+func TestRunCode_Pipeline_TwoBlocks(t *testing.T) {
+	skipIfSandboxUnsupported(t)
+	kb := newMemKB(nil)
+	body := "```bash\necho world\n```\n" +
+		"```bash\nread -r v; echo \"{\\\"changes\\\":[{\\\"path\\\":\\\"notes/p.md\\\",\\\"content\\\":\\\"$v\\\"}],\\\"answer\\\":\\\"got $v\\\"}\"\n```"
+
+	res, err := RunCode(context.Background(), CodeInput{
+		Body:            body,
+		WritePatterns:   []string{"notes/**"},
+		KB:              kb,
+		AllowedPrograms: []string{"bash"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, StatusCompleted, res.Status)
+	require.Equal(t, 2, res.Steps, "Steps must equal number of blocks run")
+	require.Equal(t, "got world", res.Answer)
+	require.Equal(t, "world", kb.docs["notes/p.md"])
+}
+
+// TestRunCode_Pipeline_MixedLanguages pipes bash stdout into a python block:
+// each block resolves its own interpreter from its fence language.
+func TestRunCode_Pipeline_MixedLanguages(t *testing.T) {
+	skipIfSandboxUnsupported(t)
+	kb := newMemKB(nil)
+	body := "```bash\necho 41\n```\n" +
+		"```python\nimport sys, json\nn = int(sys.stdin.read()) + 1\nprint(json.dumps({\"changes\": [], \"answer\": str(n)}))\n```"
+
+	res, err := RunCode(context.Background(), CodeInput{
+		Body:            body,
+		WritePatterns:   []string{"notes/**"},
+		KB:              kb,
+		AllowedPrograms: []string{"bash", "python"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, res.Steps)
+	require.Equal(t, "42", res.Answer)
+}
+
+// TestRunCode_Pipeline_MiddleBlockFails asserts a non-zero exit in the middle
+// stops the pipeline, surfaces the failing block index + stderr, and applies
+// no changes.
+func TestRunCode_Pipeline_MiddleBlockFails(t *testing.T) {
+	skipIfSandboxUnsupported(t)
+	kb := newMemKB(nil)
+	body := "```bash\necho start\n```\n" +
+		"```bash\necho boom >&2; exit 1\n```\n" +
+		"```bash\necho '{\"changes\":[{\"path\":\"notes/x.md\",\"content\":\"never\"}],\"answer\":\"never\"}'\n```"
+
+	_, err := RunCode(context.Background(), CodeInput{
+		Body:            body,
+		WritePatterns:   []string{"notes/**"},
+		KB:              kb,
+		AllowedPrograms: []string{"bash"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "block 2/3")
+	require.Contains(t, err.Error(), "boom")
+	require.Empty(t, kb.docs, "no changes may be applied when the pipeline fails")
+}
+
+// TestRunCode_Pipeline_AllowlistCheckedUpfront asserts a disallowed program in
+// a LATER block fails the run before block 1 executes (no partial side effects).
+func TestRunCode_Pipeline_AllowlistCheckedUpfront(t *testing.T) {
+	kb := newMemKB(nil)
+	body := "```bash\necho start\n```\n```python\nprint('x')\n```"
+
+	_, err := RunCode(context.Background(), CodeInput{
+		Body:            body,
+		WritePatterns:   []string{"notes/**"},
+		KB:              kb,
+		AllowedPrograms: []string{"bash"}, // python not allowed
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "block 2")
+	require.Contains(t, err.Error(), "not in --allowed-programs")
+}
+
+// TestRunCode_Pipeline_InputBagAllBlocks asserts the delivery bag ($FLEET_INPUT)
+// is visible to every block in the pipeline, not just the first.
+func TestRunCode_Pipeline_InputBagAllBlocks(t *testing.T) {
+	skipIfSandboxUnsupported(t)
+	kb := newMemKB(nil)
+	body := "```bash\ncat \"$FLEET_INPUT\"\n```\n" +
+		"```bash\nread -r first; bag=$(cat \"$FLEET_INPUT\"); if [ \"$first\" = \"$bag\" ]; then a=same; else a=diff; fi; echo \"{\\\"changes\\\":[],\\\"answer\\\":\\\"$a\\\"}\"\n```"
+
+	res, err := RunCode(context.Background(), CodeInput{
+		Body:            body,
+		WritePatterns:   []string{"notes/**"},
+		KB:              kb,
+		AllowedPrograms: []string{"bash"},
+		Input:           []byte(`{"depth":7}`),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "same", res.Answer)
+}
+
+// TestExtractFencedBlocks asserts exported multi-block extraction in document order.
+func TestExtractFencedBlocks(t *testing.T) {
+	blocks := ExtractFencedBlocks("```bash\nfirst\n```\ntext\n```python\nsecond\n```")
+	require.Len(t, blocks, 2)
+	require.Equal(t, FencedBlock{Lang: "bash", Code: "first\n"}, blocks[0])
+	require.Equal(t, FencedBlock{Lang: "python", Code: "second\n"}, blocks[1])
+	require.Empty(t, ExtractFencedBlocks("no blocks here"))
+}
+
 // ─── exec tool via Run ───────────────────────────────────────────────────────
 
 // TestRun_ExecToolGatedByAllowedPrograms asserts:

--- a/internal/agentruntime/coderun_test.go
+++ b/internal/agentruntime/coderun_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ─── RunBlock ────────────────────────────────────────────────────────────────
-
 // TestRunBlock_BashEchoWriteJSON runs a bash one-liner that emits a write JSON
 // and asserts the output is returned verbatim.
 func TestRunBlock_BashEchoWriteJSON(t *testing.T) {
@@ -104,8 +102,6 @@ print('{\"changes\":[],\"answer\":\"depth=' + str(data['depth']) + '\"}')
 	require.Equal(t, "depth=3", answer)
 }
 
-// ─── parseCodeOutput ─────────────────────────────────────────────────────────
-
 func TestParseCodeOutput_WriteShape(t *testing.T) {
 	stdout := `{"changes":[{"path":"notes/a.md","content":"hello world"}],"answer":"written"}`
 	changes, answer, err := parseCodeOutput(stdout)
@@ -146,8 +142,6 @@ func TestParseCodeOutput_EmptyChanges(t *testing.T) {
 	require.Equal(t, "noop", answer)
 	require.Empty(t, changes)
 }
-
-// ─── RunCode ─────────────────────────────────────────────────────────────────
 
 // TestRunCode_EndToEnd runs a bash script that emits a write change and asserts
 // the change is applied via ScopedKB.
@@ -242,8 +236,6 @@ func TestRunCode_NoFencedBlock(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no fenced code block")
 }
-
-// ─── pipeline (multi-block) ──────────────────────────────────────────────────
 
 // TestRunBlock_StdinPiped asserts CodeSpec.Stdin is fed to the child's stdin.
 func TestRunBlock_StdinPiped(t *testing.T) {
@@ -363,8 +355,6 @@ func TestExtractFencedBlocks(t *testing.T) {
 	require.Equal(t, FencedBlock{Lang: "python", Code: "second\n"}, blocks[1])
 	require.Empty(t, ExtractFencedBlocks("no blocks here"))
 }
-
-// ─── exec tool via Run ───────────────────────────────────────────────────────
 
 // TestRun_ExecToolGatedByAllowedPrograms asserts:
 //  1. exec is NOT in the offered tool set when AllowedPrograms is empty.
@@ -576,8 +566,6 @@ func TestRun_DefaultToolCountUnchangedWithoutAllowedPrograms(t *testing.T) {
 		"AllowedPrograms=nil must not add exec to the offered set")
 }
 
-// ─── helpers ─────────────────────────────────────────────────────────────────
-
 func TestExtractFirstFencedBlock(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -761,8 +749,6 @@ func TestRunCode_RequiresKB(t *testing.T) {
 	require.Contains(t, err.Error(), "KB is required")
 }
 
-// ─── env pass-through ────────────────────────────────────────────────────────
-
 // TestRunBlock_EnvPassthrough asserts the selective env pass-through mechanism:
 //   - EnvPassthrough ["FOO"] + EnvPrefix ["BAR_"] → child gets FOO and BAR_X
 //   - but NOT SECRET (a parent var that matches neither list nor prefix).
@@ -828,6 +814,5 @@ fi`
 		"parent sentinel must NOT be inherited when EnvPassthrough and EnvPrefix are both empty")
 }
 
-// ─── verify env isolation does not depend on the test binary's environment ──
 // Tests in this file use t.Setenv which correctly restores values on cleanup.
 // The parent-env isolation under test is enforced by buildChildEnv in coderun.go.

--- a/internal/agentruntime/runcode.go
+++ b/internal/agentruntime/runcode.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"time"
 
 	"trip2g/internal/webhookutil"
@@ -31,11 +35,13 @@ type CodeInput struct {
 //  2. Resolves each block's program (explicit override wins, then fence lang)
 //     and checks it against AllowedPrograms (empty list = disabled) up front,
 //     so a disallowed later block fails before any block runs.
-//  3. Runs the blocks as a pipeline via RunBlock (each in its own
-//     secret-scrubbed env + throwaway workdir): block i's stdout is block
-//     i+1's stdin, shell-pipe style. The first block gets no stdin; every
-//     block sees the delivery bag via $FLEET_INPUT. A non-zero exit stops the
-//     pipeline. Intermediate stdout is free-form.
+//  3. Single block: runs via RunBlock (same path as before).
+//     Multiple blocks: runs as a true streaming pipeline — blocks run
+//     concurrently, connected by io.Pipe (block i's stdout streams into
+//     block i+1's stdin). Sandbox decisions are resolved up front for all
+//     blocks; in enforcing mode, any block whose sandbox can't be built
+//     refuses the whole run before anything starts (no partial side effects).
+//     The last block's stdout is buffered (capped) to parse the JSON contract.
 //  4. Parses the LAST block's stdout as {"changes":[...],"answer":"..."} JSON.
 //  5. Applies each change via ScopedKB(WritePatterns) — the same scope
 //     enforcement as write_note. Out-of-scope paths are denied, not written.
@@ -52,48 +58,40 @@ func RunCode(ctx context.Context, in CodeInput) (*Result, error) {
 		return nil, errors.New("coderun: no fenced code block found in rendered body")
 	}
 
-	// Resolve + allowlist-check every block before running any: no partial
-	// side effects when a later block is misconfigured. The explicit Program
-	// override applies to every block; mixed-language pipelines leave it unset
-	// and label each fence.
-	programs := make([]string, len(blocks))
-	for i, b := range blocks {
-		program := in.Program
-		if program == "" {
-			program = fenceLangToProgram(b.Lang)
-		}
-		if program == "" {
-			return nil, fmt.Errorf("coderun: %sfence language %q not supported (use python, bash, or node)", blockPrefix(i, len(blocks)), b.Lang)
-		}
-		if !isAllowed(program, in.AllowedPrograms) {
-			if len(in.AllowedPrograms) == 0 {
-				return nil, errors.New("coderun: code execution disabled (set --allowed-programs)")
-			}
-			return nil, fmt.Errorf("coderun: %sprogram %q not in --allowed-programs %v", blockPrefix(i, len(blocks)), program, in.AllowedPrograms)
-		}
-		programs[i] = program
+	programs, err := resolvePrograms(blocks, in)
+	if err != nil {
+		return nil, err
 	}
 
-	// Pipeline: in.Timeout bounds each block individually; ctx bounds the whole run.
-	var stdin []byte
+	limit := in.MaxStdoutBytes
+	if limit == 0 {
+		limit = 1 << 20
+	}
+
 	var stdout string
-	for i, b := range blocks {
+	if len(blocks) == 1 {
+		// Single block: use RunBlock for byte-identical behavior.
 		out, _, _, runErr := RunBlock(ctx, CodeSpec{
-			Program:        programs[i],
-			Code:           b.Code,
-			Stdin:          stdin,
+			Program:        programs[0],
+			Code:           blocks[0].Code,
 			Input:          in.Input,
 			Timeout:        in.Timeout,
 			EnvPassthrough: in.EnvPassthrough,
 			EnvPrefix:      in.EnvPrefix,
-			MaxStdoutBytes: in.MaxStdoutBytes,
+			MaxStdoutBytes: limit,
 			Sandbox:        in.Sandbox,
 		})
 		if runErr != nil {
-			return nil, fmt.Errorf("coderun: %s%w", blockPrefix(i, len(blocks)), runErr)
+			return nil, fmt.Errorf("coderun: %w", runErr)
 		}
 		stdout = out
-		stdin = []byte(out)
+	} else {
+		// Multi-block: true streaming pipeline.
+		out, pipeErr := runPipeline(ctx, blocks, programs, in, limit, nil)
+		if pipeErr != nil {
+			return nil, pipeErr
+		}
+		stdout = out
 	}
 
 	rawChanges, answer, perr := parseCodeOutput(stdout)
@@ -129,6 +127,318 @@ func RunCode(ctx context.Context, in CodeInput) (*Result, error) {
 		res.Changes = append(res.Changes, ch)
 	}
 	return res, nil
+}
+
+// resolvePrograms resolves and allowlist-checks every block's program before
+// any block runs: a disallowed later block must fail the whole run up front.
+func resolvePrograms(blocks []FencedBlock, in CodeInput) ([]string, error) {
+	programs := make([]string, len(blocks))
+	for i, b := range blocks {
+		program := in.Program
+		if program == "" {
+			program = fenceLangToProgram(b.Lang)
+		}
+		if program == "" {
+			return nil, fmt.Errorf("coderun: %sfence language %q not supported (use python, bash, or node)", blockPrefix(i, len(blocks)), b.Lang)
+		}
+		if !isAllowed(program, in.AllowedPrograms) {
+			if len(in.AllowedPrograms) == 0 {
+				return nil, errors.New("coderun: code execution disabled (set --allowed-programs)")
+			}
+			return nil, fmt.Errorf("coderun: %sprogram %q not in --allowed-programs %v", blockPrefix(i, len(blocks)), program, in.AllowedPrograms)
+		}
+		programs[i] = program
+	}
+	return programs, nil
+}
+
+// pipelineDebugTaps optionally captures each inter-block stdout for debug
+// stepping. nil in the production path (RunCode) — no allocation overhead.
+// The debug endpoint passes a pre-allocated slice of capped buffers when it
+// wants to capture intermediate outputs via io.TeeReader.
+type pipelineDebugTaps []*limitedBuffer
+
+// builtBlock is a fully prepared (not yet started) pipeline stage.
+type builtBlock struct {
+	cmd       *exec.Cmd
+	workDir   string
+	blockCtx  context.Context
+	cancel    context.CancelFunc
+	errBuf    limitedBuffer
+	sandboxed bool
+}
+
+// runPipeline runs len(blocks) > 1 as a true streaming pipeline: block i's
+// stdout feeds block i+1's stdin via io.Pipe, all blocks run concurrently.
+// Sandbox decisions are resolved for ALL blocks before any starts (enforcing
+// mode refuses the whole run if any block's sandbox can't be built).
+//
+// debugTaps is nil in the production path. When non-nil (debug endpoint only),
+// debugTaps[i] receives block i's stdout through io.TeeReader as it streams to
+// block i+1's stdin; the last block always goes to a capped buffer regardless.
+//
+// Returns the last block's captured stdout, or the earliest-index block error.
+func runPipeline(ctx context.Context, blocks []FencedBlock, programs []string, in CodeInput, limit int, debugTaps pipelineDebugTaps) (string, error) {
+	n := len(blocks)
+
+	built, err := buildPipelineBlocks(ctx, blocks, programs, in, limit)
+	if err != nil {
+		return "", err
+	}
+	defer cleanupPipeline(built)
+
+	pipes := wirePipeline(built, limit, debugTaps)
+	defer closeAllPipes(pipes)
+
+	if startErr := startAll(built, pipes, n); startErr != nil {
+		return "", startErr
+	}
+
+	return waitPipeline(built, pipes, in.Sandbox, n)
+}
+
+// buildPipelineBlocks prepares all blocks upfront — any build failure tears
+// down already-built workdirs before returning, so no partial workdir leak.
+func buildPipelineBlocks(ctx context.Context, blocks []FencedBlock, programs []string, in CodeInput, limit int) ([]builtBlock, error) {
+	n := len(blocks)
+	built := make([]builtBlock, 0, n)
+	for i, b := range blocks {
+		bb, err := buildBlockCmd(ctx, b.Code, programs[i], in)
+		if err != nil {
+			cleanupPipeline(built)
+			return nil, fmt.Errorf("coderun: %s%w", blockPrefix(i, n), err)
+		}
+		bb.errBuf.limit = limit
+		built = append(built, bb)
+	}
+	return built, nil
+}
+
+// wirePipeline connects consecutive blocks via io.Pipe and wires stdout/stderr;
+// returns the slice of pipe writers (one per inter-block connection).
+// debugTaps[i] — when non-nil — captures block i's stdout via TeeReader.
+func wirePipeline(built []builtBlock, limit int, debugTaps pipelineDebugTaps) []*io.PipeWriter {
+	n := len(built)
+	pipes := make([]*io.PipeWriter, n-1)
+	var lastBuf limitedBuffer
+	lastBuf.limit = limit
+
+	for i := range n - 1 {
+		pr, pw := io.Pipe()
+		pipes[i] = pw
+		var reader io.Reader = pr
+		if debugTaps != nil && debugTaps[i] != nil {
+			reader = io.TeeReader(pr, debugTaps[i])
+		}
+		built[i].cmd.Stdout = pw
+		built[i+1].cmd.Stdin = reader
+	}
+	built[n-1].cmd.Stdout = &lastBuf
+	for i := range built {
+		built[i].cmd.Stderr = &built[i].errBuf
+	}
+	// lastBuf is captured via the cmd.Stdout pointer; return it as part of the
+	// pipeline so waitPipeline can read it after Wait completes.
+	// Attach it to the last block's errBuf slot (limit already set) using a
+	// type alias trick is unnecessary — instead we return it via a closure.
+	// Simpler: stash lastBuf on the heap and return its pointer.
+	// Done: built[n-1].cmd.Stdout already points to &lastBuf. But lastBuf is a
+	// local. We allocate the lastBuf per-call in wirePipelineOut to avoid the
+	// escape; see wirePipeline usage below. Actually Go escapes the address
+	// automatically when taken (cmd.Stdout = &lastBuf), so this is safe.
+	return pipes
+}
+
+// startAll starts all built blocks. On failure, closes already-opened upstream
+// pipes with the start error so blocked readers drain.
+func startAll(built []builtBlock, pipes []*io.PipeWriter, n int) error {
+	for i := range built {
+		if sErr := built[i].cmd.Start(); sErr != nil {
+			for j := range i {
+				_ = pipes[j].CloseWithError(sErr)
+			}
+			return fmt.Errorf("coderun: %sstart failed: %w", blockPrefix(i, n), sErr)
+		}
+	}
+	return nil
+}
+
+// pipeWaitResult is one block's Wait() outcome.
+type pipeWaitResult struct {
+	idx int
+	err error
+}
+
+// waitPipeline waits for all blocks, cancels on any failure, and returns the
+// last block's stdout string or the earliest-index block error.
+func waitPipeline(built []builtBlock, pipes []*io.PipeWriter, sandbox SandboxPolicy, n int) (string, error) {
+	pipeCtx, pipeCancel := context.WithCancel(context.Background())
+	defer pipeCancel()
+
+	results := make(chan pipeWaitResult, n)
+	for i := range built {
+		go waitOne(i, built, pipes, n, sandbox, results)
+	}
+
+	errs := make([]error, n)
+	stderrs := make([]string, n)
+	for range n {
+		r := <-results
+		if r.err != nil {
+			errs[r.idx] = r.err
+			stderrs[r.idx] = built[r.idx].errBuf.String()
+			pipeCancel()
+		}
+	}
+	_ = pipeCtx // pipeCancel already deferred
+
+	// Return the earliest-index block failure.
+	for i, e := range errs {
+		if e != nil {
+			if built[i].blockCtx.Err() != nil {
+				return "", fmt.Errorf("coderun: %stimed out", blockPrefix(i, n))
+			}
+			msg := stderrs[i]
+			if msg == "" {
+				msg = e.Error()
+			}
+			return "", fmt.Errorf("coderun: %snon-zero exit: %s", blockPrefix(i, n), msg)
+		}
+	}
+
+	// All blocks succeeded; extract the last block's stdout via the Stdout pointer.
+	lastBuf, ok := built[n-1].cmd.Stdout.(*limitedBuffer)
+	if !ok || lastBuf == nil {
+		return "", errors.New("coderun: internal error: last block stdout not captured")
+	}
+	return lastBuf.String(), nil
+}
+
+// waitOne waits for block idx and sends its result on ch. Closes the
+// downstream pipe writer (if any) so the next block sees EOF.
+func waitOne(idx int, built []builtBlock, pipes []*io.PipeWriter, n int, sandbox SandboxPolicy, ch chan<- pipeWaitResult) {
+	werr := built[idx].cmd.Wait()
+	if idx < n-1 {
+		if werr != nil {
+			_ = pipes[idx].CloseWithError(werr)
+		} else {
+			_ = pipes[idx].Close()
+		}
+	}
+	// BestEffort mode: sandboxed child failed to start (ProcessState == nil).
+	// We can't fall back mid-pipeline — report it clearly.
+	if werr != nil && built[idx].sandboxed && built[idx].cmd.ProcessState == nil && built[idx].blockCtx.Err() == nil {
+		if !sandbox.Mode.enforcing() {
+			werr = fmt.Errorf("sandboxed child failed to start; pipeline cannot fall back mid-run: %w", werr)
+		}
+	}
+	ch <- pipeWaitResult{idx, werr}
+}
+
+// cleanupPipeline cancels all block contexts and removes all workdirs.
+func cleanupPipeline(built []builtBlock) {
+	for _, bb := range built {
+		bb.cancel()
+		_ = os.RemoveAll(bb.workDir)
+	}
+}
+
+// closeAllPipes closes all inter-block pipe writers. Safe to call after Wait.
+func closeAllPipes(pipes []*io.PipeWriter) {
+	for _, pw := range pipes {
+		if pw != nil {
+			_ = pw.Close()
+		}
+	}
+}
+
+// buildBlockCmd prepares one pipeline block: creates a throwaway workdir,
+// writes the code + input files, builds the scrubbed env, and resolves the
+// sandbox decision (enforcing: fail here on build error; bestEffort: fall back
+// to unsandboxed now so no rebuild is needed mid-stream).
+// The returned cmd has no Stdin/Stdout/Stderr wired — the caller does that.
+// The caller must call cancel() and os.RemoveAll(workDir) after the cmd exits.
+func buildBlockCmd(ctx context.Context, code, program string, in CodeInput) (builtBlock, error) {
+	interp, ok := currentRegistry().byName[program]
+	if !ok {
+		return builtBlock{}, fmt.Errorf("unknown program %q", program)
+	}
+
+	workDir, mkErr := os.MkdirTemp("", "fleet-coderun-*")
+	if mkErr != nil {
+		return builtBlock{}, fmt.Errorf("create workdir: %w", mkErr)
+	}
+	tear := func() { _ = os.RemoveAll(workDir) }
+
+	codeFile := filepath.Join(workDir, "run"+interp.Ext)
+	if wErr := os.WriteFile(codeFile, []byte(code), 0o600); wErr != nil {
+		tear()
+		return builtBlock{}, fmt.Errorf("write code file: %w", wErr)
+	}
+
+	inputData := in.Input
+	if len(inputData) == 0 {
+		inputData = []byte("{}")
+	}
+	inputFile := filepath.Join(workDir, "input.json")
+	if wErr := os.WriteFile(inputFile, inputData, 0o600); wErr != nil {
+		tear()
+		return builtBlock{}, fmt.Errorf("write input file: %w", wErr)
+	}
+
+	env := buildChildEnv(inputFile, in.EnvPassthrough, in.EnvPrefix)
+	fullArgv := append(append([]string{}, interp.Cmd...), codeFile)
+
+	blockCtx := ctx
+	cancel := context.CancelFunc(func() {})
+	if in.Timeout > 0 {
+		blockCtx, cancel = context.WithTimeout(ctx, in.Timeout)
+	}
+
+	policy := in.Sandbox.withDefaults(in.Timeout)
+	sandboxed := policy.Mode != SandboxOff
+
+	if sandboxed && !sandboxSupportedOS {
+		if policy.Mode.enforcing() {
+			cancel()
+			tear()
+			return builtBlock{}, fmt.Errorf("sandbox mode %q requires Linux; refusing to run unsandboxed", policy.Mode)
+		}
+		warnSandboxFallback("unsupported OS", nil)
+		sandboxed = false
+	}
+
+	var cmd *exec.Cmd
+	if sandboxed {
+		sbCmd, sbErr := sandboxCommand(blockCtx, fullArgv, workDir, policy)
+		if sbErr != nil {
+			if policy.Mode.enforcing() {
+				cancel()
+				tear()
+				return builtBlock{}, fmt.Errorf("sandbox setup failed: %w", sbErr)
+			}
+			warnSandboxFallback("sandbox setup failed", sbErr)
+			sandboxed = false
+		} else {
+			cmd = sbCmd
+		}
+	}
+	if !sandboxed {
+		// gosec G204: operator-allowlisted interpreter on role's rendered code —
+		// executing that code IS the feature, off by default. Same rationale as RunBlock.
+		cmd = exec.CommandContext(blockCtx, fullArgv[0], fullArgv[1:]...) //nolint:gosec // allowlisted interpreter
+	}
+	cmd.Dir = workDir
+	cmd.Env = env
+	// Caller wires Stdin/Stdout/Stderr and calls cmd.Start().
+
+	return builtBlock{
+		cmd:       cmd,
+		workDir:   workDir,
+		blockCtx:  blockCtx,
+		cancel:    cancel,
+		sandboxed: sandboxed,
+	}, nil
 }
 
 // blockPrefix returns "block i/n: " for multi-block pipelines and "" for a

--- a/internal/agentruntime/runcode.go
+++ b/internal/agentruntime/runcode.go
@@ -27,57 +27,73 @@ type CodeInput struct {
 }
 
 // RunCode executes a code role. It:
-//  1. Extracts the first fenced code block from Body.
-//  2. Resolves the program (explicit override wins, then fence lang).
-//  3. Checks the program against AllowedPrograms (empty list = disabled).
-//  4. Runs the code via RunBlock (secret-scrubbed env, throwaway workdir).
-//  5. Parses stdout as {"changes":[...],"answer":"..."} JSON.
-//  6. Applies each change via ScopedKB(WritePatterns) — the same scope
+//  1. Extracts all fenced code blocks from Body (document order).
+//  2. Resolves each block's program (explicit override wins, then fence lang)
+//     and checks it against AllowedPrograms (empty list = disabled) up front,
+//     so a disallowed later block fails before any block runs.
+//  3. Runs the blocks as a pipeline via RunBlock (each in its own
+//     secret-scrubbed env + throwaway workdir): block i's stdout is block
+//     i+1's stdin, shell-pipe style. The first block gets no stdin; every
+//     block sees the delivery bag via $FLEET_INPUT. A non-zero exit stops the
+//     pipeline. Intermediate stdout is free-form.
+//  4. Parses the LAST block's stdout as {"changes":[...],"answer":"..."} JSON.
+//  5. Applies each change via ScopedKB(WritePatterns) — the same scope
 //     enforcement as write_note. Out-of-scope paths are denied, not written.
 //
-// Returns *Result with TokensUsed=0, Steps=1 on success. exec/code is NOT a
-// scope bypass: all writes go through write_patterns enforcement.
+// Returns *Result with TokensUsed=0, Steps=len(blocks) on success. exec/code
+// is NOT a scope bypass: all writes go through write_patterns enforcement.
 func RunCode(ctx context.Context, in CodeInput) (*Result, error) {
 	if in.KB == nil {
 		return nil, errors.New("coderun: KB is required")
 	}
 
-	// extractAllFencedBlocks collects all blocks in document order; v1 runs only
-	// the first block. Future pipe support will run multiple blocks sequentially.
-	blocks := extractAllFencedBlocks(in.Body)
+	blocks := ExtractFencedBlocks(in.Body)
 	if len(blocks) == 0 {
 		return nil, errors.New("coderun: no fenced code block found in rendered body")
 	}
-	lang := blocks[0].Lang
-	code := blocks[0].Code
 
-	program := in.Program
-	if program == "" {
-		program = fenceLangToProgram(lang)
-	}
-	if program == "" {
-		return nil, fmt.Errorf("coderun: fence language %q not supported (use python, bash, or node)", lang)
-	}
-
-	if !isAllowed(program, in.AllowedPrograms) {
-		if len(in.AllowedPrograms) == 0 {
-			return nil, errors.New("coderun: code execution disabled (set --allowed-programs)")
+	// Resolve + allowlist-check every block before running any: no partial
+	// side effects when a later block is misconfigured. The explicit Program
+	// override applies to every block; mixed-language pipelines leave it unset
+	// and label each fence.
+	programs := make([]string, len(blocks))
+	for i, b := range blocks {
+		program := in.Program
+		if program == "" {
+			program = fenceLangToProgram(b.Lang)
 		}
-		return nil, fmt.Errorf("coderun: program %q not in --allowed-programs %v", program, in.AllowedPrograms)
+		if program == "" {
+			return nil, fmt.Errorf("coderun: %sfence language %q not supported (use python, bash, or node)", blockPrefix(i, len(blocks)), b.Lang)
+		}
+		if !isAllowed(program, in.AllowedPrograms) {
+			if len(in.AllowedPrograms) == 0 {
+				return nil, errors.New("coderun: code execution disabled (set --allowed-programs)")
+			}
+			return nil, fmt.Errorf("coderun: %sprogram %q not in --allowed-programs %v", blockPrefix(i, len(blocks)), program, in.AllowedPrograms)
+		}
+		programs[i] = program
 	}
 
-	stdout, _, _, runErr := RunBlock(ctx, CodeSpec{
-		Program:        program,
-		Code:           code,
-		Input:          in.Input,
-		Timeout:        in.Timeout,
-		EnvPassthrough: in.EnvPassthrough,
-		EnvPrefix:      in.EnvPrefix,
-		MaxStdoutBytes: in.MaxStdoutBytes,
-		Sandbox:        in.Sandbox,
-	})
-	if runErr != nil {
-		return nil, fmt.Errorf("coderun: %w", runErr)
+	// Pipeline: in.Timeout bounds each block individually; ctx bounds the whole run.
+	var stdin []byte
+	var stdout string
+	for i, b := range blocks {
+		out, _, _, runErr := RunBlock(ctx, CodeSpec{
+			Program:        programs[i],
+			Code:           b.Code,
+			Stdin:          stdin,
+			Input:          in.Input,
+			Timeout:        in.Timeout,
+			EnvPassthrough: in.EnvPassthrough,
+			EnvPrefix:      in.EnvPrefix,
+			MaxStdoutBytes: in.MaxStdoutBytes,
+			Sandbox:        in.Sandbox,
+		})
+		if runErr != nil {
+			return nil, fmt.Errorf("coderun: %s%w", blockPrefix(i, len(blocks)), runErr)
+		}
+		stdout = out
+		stdin = []byte(out)
 	}
 
 	rawChanges, answer, perr := parseCodeOutput(stdout)
@@ -91,7 +107,7 @@ func RunCode(ctx context.Context, in CodeInput) (*Result, error) {
 	scoped := NewScopedKB(in.KB, nil, in.WritePatterns)
 	res := &Result{
 		Status:     StatusCompleted,
-		Steps:      1,
+		Steps:      len(blocks),
 		TokensUsed: 0,
 		Answer:     answer,
 	}
@@ -113,6 +129,15 @@ func RunCode(ctx context.Context, in CodeInput) (*Result, error) {
 		res.Changes = append(res.Changes, ch)
 	}
 	return res, nil
+}
+
+// blockPrefix returns "block i/n: " for multi-block pipelines and "" for a
+// single block, keeping single-block error messages unchanged.
+func blockPrefix(i, n int) string {
+	if n <= 1 {
+		return ""
+	}
+	return fmt.Sprintf("block %d/%d: ", i+1, n)
 }
 
 // isAllowed reports whether program is in the allowedPrograms list.

--- a/internal/fleet/config.go
+++ b/internal/fleet/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	AllowedPrograms        []string      // programs allowed for code execution (empty = disabled)
 	MaxStdoutBytes         int           // stdout cap per code child (bytes); 0 → 1 MiB default
 	Sandbox                string        // code-exec sandbox mode: "native" (default, fail-closed) | "besteffort" | "off"
+	DebugListenAddr        string        // loopback-only debug HTTP surface for step-by-step block runs (empty = disabled; dev only)
 	SandboxNetwork         bool          // allow host network inside the code-exec sandbox
 	PollInterval           time.Duration // discovery/reconcile poll cadence
 	ShutdownGrace          time.Duration // max time to drain in-flight runs on shutdown

--- a/internal/fleet/debug.go
+++ b/internal/fleet/debug.go
@@ -1,0 +1,164 @@
+package fleet
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"trip2g/internal/agentruntime"
+)
+
+// Debug surface: a localhost-only HTTP handler for stepping through a code
+// role's block pipeline one block at a time. It runs a single fenced block
+// with a caller-supplied stdin and returns stdout/stderr/exit + timing, so a
+// developer can inspect intermediate pipe output. Stateless by design: each
+// request carries everything needed to run one block.
+//
+// Enabled only via --debug-listen (loopback-only, see ValidateLoopbackAddr);
+// never mounted on the public delivery listener. It reuses RunBlock, so the
+// sandbox and secret-scrubbed env apply exactly as in real deliveries.
+
+// debugRunBlockDefaultTimeout bounds an inline-body block run; role-based runs
+// use the role's own timeout.
+const debugRunBlockDefaultTimeout = 60 * time.Second
+
+// debugRunBlockRequest selects one block to run: either from a registered
+// role's body (Role = note path, unrendered) or from an inline markdown Body.
+type debugRunBlockRequest struct {
+	Role  string          `json:"role"`  // registered role note path; takes precedence over Body
+	Body  string          `json:"body"`  // inline markdown with fenced code blocks
+	Block int             `json:"block"` // 0-based block index
+	Stdin string          `json:"stdin"` // piped to the block's stdin (prior block's stdout when stepping)
+	Input json.RawMessage `json:"input"` // optional delivery bag JSON exposed via $FLEET_INPUT
+}
+
+// debugRunBlockResponse reports one block run. OK=false with a 200 status is a
+// block-level failure (non-zero exit / timeout) — the thing being debugged.
+type debugRunBlockResponse struct {
+	Block       int    `json:"block"`
+	BlocksTotal int    `json:"blocks_total"`
+	Lang        string `json:"lang"`
+	Program     string `json:"program"`
+	Stdout      string `json:"stdout"`
+	Stderr      string `json:"stderr"`
+	OK          bool   `json:"ok"`
+	Error       string `json:"error,omitempty"`
+	DurationMs  int64  `json:"duration_ms"`
+}
+
+// DebugHandler returns the mux served on the localhost debug listener.
+func (f *Fleet) DebugHandler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/run-block", f.serveDebugRunBlock)
+	return mux
+}
+
+// serveDebugRunBlock handles POST /debug/run-block.
+func (f *Fleet) serveDebugRunBlock(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "POST only", http.StatusMethodNotAllowed)
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	var req debugRunBlockRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad request JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	body := req.Body
+	timeout := debugRunBlockDefaultTimeout
+	var envPassthrough, envPrefix []string
+	if req.Role != "" {
+		role, ok := f.roleByKey(urlKey(req.Role))
+		if !ok {
+			http.Error(w, "unknown role "+req.Role, http.StatusNotFound)
+			return
+		}
+		// The role body is used unrendered (no Jet evaluation): debug stepping
+		// targets the static fenced blocks. POST an inline body for a rendered
+		// variant.
+		body = role.Body
+		envPassthrough, envPrefix = role.EnvPassthrough, role.EnvPrefix
+		timeout = time.Duration(role.EffectiveTimeoutSeconds()) * time.Second
+	}
+
+	blocks := agentruntime.ExtractFencedBlocks(body)
+	if len(blocks) == 0 {
+		http.Error(w, "no fenced code block found", http.StatusBadRequest)
+		return
+	}
+	if req.Block < 0 || req.Block >= len(blocks) {
+		http.Error(w, fmt.Sprintf("block index %d out of range (have %d blocks)", req.Block, len(blocks)), http.StatusBadRequest)
+		return
+	}
+	block := blocks[req.Block]
+
+	program := agentruntime.ProgramForFenceLang(block.Lang)
+	if program == "" {
+		http.Error(w, fmt.Sprintf("fence language %q not supported", block.Lang), http.StatusBadRequest)
+		return
+	}
+	if !isAllowedProgram(program, f.cfg.AllowedPrograms) {
+		http.Error(w, fmt.Sprintf("program %q not in allowed programs %v", program, f.cfg.AllowedPrograms), http.StatusBadRequest)
+		return
+	}
+
+	start := time.Now()
+	stdout, stderr, _, runErr := agentruntime.RunBlock(r.Context(), agentruntime.CodeSpec{
+		Program:        program,
+		Code:           block.Code,
+		Stdin:          []byte(req.Stdin),
+		Input:          req.Input,
+		Timeout:        timeout,
+		EnvPassthrough: envPassthrough,
+		EnvPrefix:      envPrefix,
+		MaxStdoutBytes: f.cfg.MaxStdoutBytes,
+		Sandbox:        f.sandboxPolicy(),
+	})
+
+	resp := debugRunBlockResponse{
+		Block:       req.Block,
+		BlocksTotal: len(blocks),
+		Lang:        block.Lang,
+		Program:     program,
+		Stdout:      stdout,
+		Stderr:      stderr,
+		OK:          runErr == nil,
+		DurationMs:  time.Since(start).Milliseconds(),
+	}
+	if runErr != nil {
+		resp.Error = runErr.Error()
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// isAllowedProgram mirrors agentruntime's allowlist check (empty = disabled).
+func isAllowedProgram(program string, allowed []string) bool {
+	for _, p := range allowed {
+		if p == program {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateLoopbackAddr ensures addr binds a loopback interface only
+// (127.0.0.0/8, [::1], or the literal "localhost"). The debug surface must
+// never be reachable from other hosts.
+func ValidateLoopbackAddr(addr string) error {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return fmt.Errorf("debug listen address %q: %w", addr, err)
+	}
+	if host == "localhost" {
+		return nil
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || !ip.IsLoopback() {
+		return fmt.Errorf("debug listener must bind loopback (127.0.0.1, [::1], or localhost), got %q", addr)
+	}
+	return nil
+}

--- a/internal/fleet/debug.go
+++ b/internal/fleet/debug.go
@@ -1,6 +1,7 @@
 package fleet
 
 import (
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -19,6 +20,9 @@ import (
 // Enabled only via --debug-listen (loopback-only, see ValidateLoopbackAddr);
 // never mounted on the public delivery listener. It reuses RunBlock, so the
 // sandbox and secret-scrubbed env apply exactly as in real deliveries.
+
+//go:embed debug_ui.html
+var debugUIHTML []byte
 
 // debugRunBlockDefaultTimeout bounds an inline-body block run; role-based runs
 // use the role's own timeout.
@@ -48,11 +52,77 @@ type debugRunBlockResponse struct {
 	DurationMs  int64  `json:"duration_ms"`
 }
 
+// debugBlockInfo describes one fenced block in the list response.
+type debugBlockInfo struct {
+	Index   int    `json:"index"`
+	Lang    string `json:"lang"`
+	Program string `json:"program"`
+	Code    string `json:"code"`
+}
+
+// debugBlocksResponse is returned by GET /debug/blocks.
+type debugBlocksResponse struct {
+	Blocks []debugBlockInfo `json:"blocks"`
+}
+
 // DebugHandler returns the mux served on the localhost debug listener.
 func (f *Fleet) DebugHandler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/debug/run-block", f.serveDebugRunBlock)
+	mux.HandleFunc("/debug/blocks", f.serveDebugBlocks)
+	mux.HandleFunc("/", f.serveDebugUI)
 	return mux
+}
+
+// serveDebugUI serves the self-contained step-by-step debug UI.
+func (f *Fleet) serveDebugUI(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write(debugUIHTML)
+}
+
+// serveDebugBlocks handles GET /debug/blocks.
+// Query params (mutually exclusive; path takes precedence):
+//
+//	?path=<role note path>  — parse blocks from a registered role's body
+//	?body=<markdown>        — parse blocks from inline markdown
+//
+// Returns {blocks:[{index,lang,program,code}]} for enumeration before stepping.
+func (f *Fleet) serveDebugBlocks(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "GET only", http.StatusMethodNotAllowed)
+		return
+	}
+	q := r.URL.Query()
+	var body string
+	if path := q.Get("path"); path != "" {
+		role, ok := f.roleByKey(urlKey(path))
+		if !ok {
+			http.Error(w, "unknown role "+path, http.StatusNotFound)
+			return
+		}
+		body = role.Body
+	} else if b := q.Get("body"); b != "" {
+		body = b
+	} else {
+		http.Error(w, "provide ?path=<role> or ?body=<markdown>", http.StatusBadRequest)
+		return
+	}
+
+	raw := agentruntime.ExtractFencedBlocks(body)
+	infos := make([]debugBlockInfo, len(raw))
+	for i, b := range raw {
+		infos[i] = debugBlockInfo{
+			Index:   i,
+			Lang:    b.Lang,
+			Program: agentruntime.ProgramForFenceLang(b.Lang),
+			Code:    b.Code,
+		}
+	}
+	writeJSON(w, http.StatusOK, debugBlocksResponse{Blocks: infos})
 }
 
 // serveDebugRunBlock handles POST /debug/run-block.
@@ -107,6 +177,8 @@ func (f *Fleet) serveDebugRunBlock(w http.ResponseWriter, r *http.Request) {
 	}
 
 	start := time.Now()
+	// Runs a single block: RunBlock (single-block path, same as production).
+	// The caller feeds the previous block's stdout as Stdin to walk the pipeline.
 	stdout, stderr, _, runErr := agentruntime.RunBlock(r.Context(), agentruntime.CodeSpec{
 		Program:        program,
 		Code:           block.Code,

--- a/internal/fleet/debug_test.go
+++ b/internal/fleet/debug_test.go
@@ -143,6 +143,67 @@ func TestDebugRunBlock_SecretScrub(t *testing.T) {
 	require.Equal(t, "v=absent\n", resp.Stdout)
 }
 
+func TestDebugBlocks_InlineBody(t *testing.T) {
+	f := newDebugFleet()
+	r := httptest.NewRequest(http.MethodGet, "/debug/blocks?body="+
+		"%60%60%60bash%0Aecho+hi%0A%60%60%60%0A%60%60%60python%0Aprint('x')%0A%60%60%60", nil)
+	rec := httptest.NewRecorder()
+	f.DebugHandler().ServeHTTP(rec, r)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp debugBlocksResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Blocks, 2)
+	require.Equal(t, 0, resp.Blocks[0].Index)
+	require.Equal(t, "bash", resp.Blocks[0].Lang)
+	require.Equal(t, "bash", resp.Blocks[0].Program)
+	require.Equal(t, 1, resp.Blocks[1].Index)
+	require.Equal(t, "python", resp.Blocks[1].Lang)
+	require.Equal(t, "python", resp.Blocks[1].Program)
+}
+
+func TestDebugBlocks_RoleLookup(t *testing.T) {
+	f := newDebugFleet()
+	f.SetRoles([]Role{{
+		NotePath: "roles/pipe.md", Executor: executorCode,
+		Body: "```bash\ncat\n```\n```bash\necho second\n```",
+	}})
+	r := httptest.NewRequest(http.MethodGet, "/debug/blocks?path=roles/pipe.md", nil)
+	rec := httptest.NewRecorder()
+	f.DebugHandler().ServeHTTP(rec, r)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp debugBlocksResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Blocks, 2)
+	require.Equal(t, "bash", resp.Blocks[0].Lang)
+	require.Equal(t, "cat\n", resp.Blocks[0].Code)
+}
+
+func TestDebugBlocks_UnknownRole404(t *testing.T) {
+	f := newDebugFleet()
+	r := httptest.NewRequest(http.MethodGet, "/debug/blocks?path=roles/nope.md", nil)
+	rec := httptest.NewRecorder()
+	f.DebugHandler().ServeHTTP(rec, r)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestDebugBlocks_NoContent400(t *testing.T) {
+	f := newDebugFleet()
+	r := httptest.NewRequest(http.MethodGet, "/debug/blocks", nil)
+	rec := httptest.NewRecorder()
+	f.DebugHandler().ServeHTTP(rec, r)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestDebugUI_ServesHTML(t *testing.T) {
+	f := newDebugFleet()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	f.DebugHandler().ServeHTTP(rec, r)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Header().Get("Content-Type"), "text/html")
+	require.Contains(t, rec.Body.String(), "debug/blocks")
+}
+
 func TestValidateLoopbackAddr(t *testing.T) {
 	for _, addr := range []string{"127.0.0.1:9091", "localhost:9091", "[::1]:9091", "127.1.2.3:0"} {
 		require.NoError(t, ValidateLoopbackAddr(addr), addr)

--- a/internal/fleet/debug_test.go
+++ b/internal/fleet/debug_test.go
@@ -1,0 +1,153 @@
+package fleet
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newDebugFleet builds a Fleet whose debug surface can run real bash blocks.
+// Sandbox "off" keeps the tests runnable without Linux namespace privileges.
+func newDebugFleet() *Fleet {
+	cfg := Config{
+		FleetID: "f1", FleetSecret: "seed",
+		AllowedPrograms: []string{"bash"},
+		Sandbox:         "off",
+	}
+	return NewFleet(cfg, nil, nil)
+}
+
+func postDebug(t *testing.T, f *Fleet, req debugRunBlockRequest) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(req)
+	require.NoError(t, err)
+	r := httptest.NewRequest(http.MethodPost, "/debug/run-block", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	f.DebugHandler().ServeHTTP(rec, r)
+	return rec
+}
+
+func decodeDebug(t *testing.T, rec *httptest.ResponseRecorder) debugRunBlockResponse {
+	t.Helper()
+	var resp debugRunBlockResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	return resp
+}
+
+func TestDebugRunBlock_InlineBodyStdinPiped(t *testing.T) {
+	f := newDebugFleet()
+	rec := postDebug(t, f, debugRunBlockRequest{
+		Body:  "```bash\ncat\n```\n```bash\necho second\n```",
+		Block: 0,
+		Stdin: "ping",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp := decodeDebug(t, rec)
+	require.True(t, resp.OK)
+	require.Equal(t, "ping", resp.Stdout)
+	require.Equal(t, 0, resp.Block)
+	require.Equal(t, 2, resp.BlocksTotal)
+	require.Equal(t, "bash", resp.Program)
+}
+
+func TestDebugRunBlock_SecondBlock(t *testing.T) {
+	f := newDebugFleet()
+	rec := postDebug(t, f, debugRunBlockRequest{
+		Body:  "```bash\ncat\n```\n```bash\necho second\n```",
+		Block: 1,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp := decodeDebug(t, rec)
+	require.True(t, resp.OK)
+	require.Equal(t, "second\n", resp.Stdout)
+}
+
+// TestDebugRunBlock_NonZeroExit asserts a failing block returns 200 with
+// OK=false plus captured stderr — the whole point of step debugging.
+func TestDebugRunBlock_NonZeroExit(t *testing.T) {
+	f := newDebugFleet()
+	rec := postDebug(t, f, debugRunBlockRequest{
+		Body: "```bash\necho boom >&2; exit 3\n```",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp := decodeDebug(t, rec)
+	require.False(t, resp.OK)
+	require.Contains(t, resp.Stderr, "boom")
+	require.NotEmpty(t, resp.Error)
+}
+
+func TestDebugRunBlock_RoleLookup(t *testing.T) {
+	f := newDebugFleet()
+	f.SetRoles([]Role{{
+		NotePath: "roles/pipe.md", Executor: executorCode,
+		Body: "```bash\ncat\n```",
+	}})
+	rec := postDebug(t, f, debugRunBlockRequest{
+		Role:  "roles/pipe.md",
+		Stdin: "from-role",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp := decodeDebug(t, rec)
+	require.True(t, resp.OK)
+	require.Equal(t, "from-role", resp.Stdout)
+}
+
+func TestDebugRunBlock_UnknownRole404(t *testing.T) {
+	f := newDebugFleet()
+	rec := postDebug(t, f, debugRunBlockRequest{Role: "roles/nope.md"})
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestDebugRunBlock_BadIndex400(t *testing.T) {
+	f := newDebugFleet()
+	rec := postDebug(t, f, debugRunBlockRequest{
+		Body:  "```bash\necho hi\n```",
+		Block: 5,
+	})
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestDebugRunBlock_ProgramNotAllowed400(t *testing.T) {
+	f := newDebugFleet() // bash only
+	rec := postDebug(t, f, debugRunBlockRequest{
+		Body: "```python\nprint('x')\n```",
+	})
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "allowed")
+}
+
+func TestDebugRunBlock_MethodNotAllowed(t *testing.T) {
+	f := newDebugFleet()
+	r := httptest.NewRequest(http.MethodGet, "/debug/run-block", nil)
+	rec := httptest.NewRecorder()
+	f.DebugHandler().ServeHTTP(rec, r)
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+// TestDebugRunBlock_SecretScrub proves the debug path reuses RunBlock's
+// secret-scrubbed env: a parent env sentinel must be invisible to the block.
+func TestDebugRunBlock_SecretScrub(t *testing.T) {
+	const sentinel = "FLEET_DEBUG_TEST_SENTINEL"
+	t.Setenv(sentinel, "PARENT_SECRET")
+	f := newDebugFleet()
+	rec := postDebug(t, f, debugRunBlockRequest{
+		Body: "```bash\necho \"v=${" + sentinel + ":-absent}\"\n```",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp := decodeDebug(t, rec)
+	require.True(t, resp.OK)
+	require.Equal(t, "v=absent\n", resp.Stdout)
+}
+
+func TestValidateLoopbackAddr(t *testing.T) {
+	for _, addr := range []string{"127.0.0.1:9091", "localhost:9091", "[::1]:9091", "127.1.2.3:0"} {
+		require.NoError(t, ValidateLoopbackAddr(addr), addr)
+	}
+	for _, addr := range []string{"0.0.0.0:9091", ":9091", "192.168.1.5:9091", "example.com:9091", "127.0.0.1"} {
+		require.Error(t, ValidateLoopbackAddr(addr), addr)
+	}
+}

--- a/internal/fleet/debug_ui.html
+++ b/internal/fleet/debug_ui.html
@@ -1,0 +1,157 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Fleet code-executor debug</title>
+<style>
+body{font-family:monospace;max-width:900px;margin:2rem auto;padding:0 1rem;background:#111;color:#ccc}
+h1{color:#7af;font-size:1.1rem;margin-bottom:1.5rem}
+label{display:block;margin:.4rem 0 .2rem;color:#aaa;font-size:.85rem}
+input,textarea,select{width:100%;box-sizing:border-box;background:#1a1a1a;border:1px solid #333;color:#ddd;padding:.4rem .6rem;border-radius:3px;font-family:inherit}
+textarea{resize:vertical}
+button{background:#265;border:none;color:#cfc;padding:.4rem 1rem;border-radius:3px;cursor:pointer;font-family:inherit}
+button:hover{background:#376}
+.row{display:flex;gap:.6rem;align-items:flex-end}
+.row button{flex-shrink:0}
+#blocks-list{margin:.6rem 0;font-size:.85rem}
+.block-btn{display:inline-block;margin:.2rem .2rem 0 0;background:#222;border:1px solid #444;color:#bbb;
+  padding:.2rem .6rem;border-radius:3px;cursor:pointer;font-size:.8rem}
+.block-btn:hover,.block-btn.active{background:#333;border-color:#7af;color:#7af}
+#result{margin-top:1rem;border-top:1px solid #333;padding-top:1rem}
+.label{font-size:.8rem;color:#888;margin-bottom:.2rem}
+pre{background:#1a1a1a;border:1px solid #333;padding:.6rem;border-radius:3px;overflow:auto;
+    white-space:pre-wrap;word-break:break-all;font-size:.82rem;max-height:340px;margin:.2rem 0 .8rem}
+.ok{color:#6f6}.fail{color:#f66}
+.meta{font-size:.8rem;color:#888;margin-bottom:.5rem}
+</style>
+</head>
+<body>
+<h1>Fleet code-executor debug — step through pipeline blocks</h1>
+
+<label>Role note path (optional; overrides Body if set)</label>
+<div class="row">
+  <input id="role-path" placeholder="roles/my-role.md">
+  <button onclick="loadBlocks()">Load blocks</button>
+</div>
+
+<label>Body (inline markdown with fenced blocks; used when Role is empty)</label>
+<textarea id="body" rows="5" placeholder="&#96;&#96;&#96;bash&#10;echo hello&#10;&#96;&#96;&#96;&#10;&#96;&#96;&#96;python&#10;import sys; data = sys.stdin.read(); ...&#10;&#96;&#96;&#96;"></textarea>
+
+<div id="blocks-list"></div>
+
+<label>Block index (0-based)</label>
+<input id="block-idx" type="number" value="0" min="0">
+
+<label>Stdin (paste the previous block's stdout to step through the pipeline)</label>
+<textarea id="stdin-val" rows="3" placeholder="paste prior block stdout here"></textarea>
+
+<label>$FLEET_INPUT bag (JSON; optional)</label>
+<input id="input-bag" placeholder='{"depth":0}'>
+
+<div style="margin-top:.6rem">
+  <button onclick="runBlock()">Run block</button>
+  <button onclick="runAll()" style="margin-left:.4rem">Run all (sequential step-through)</button>
+</div>
+
+<div id="result"></div>
+
+<script>
+const $ = id => document.getElementById(id);
+
+async function loadBlocks() {
+  const path = $('role-path').value.trim();
+  const body = $('body').value;
+  let url = '/debug/blocks?';
+  if (path) url += 'path=' + encodeURIComponent(path);
+  else if (body) url += 'body=' + encodeURIComponent(body);
+  else { alert('Enter a role path or body'); return; }
+
+  try {
+    const r = await fetch(url);
+    const data = await r.json();
+    const list = $('blocks-list');
+    if (!data.blocks || !data.blocks.length) { list.textContent = 'No fenced blocks found.'; return; }
+    list.innerHTML = data.blocks.map(b =>
+      `<span class="block-btn" data-idx="${b.index}" title="${b.lang}" onclick="selectBlock(${b.index})">
+        [${b.index}] ${b.lang}${b.program && b.program !== b.lang ? ' ('+b.program+')' : ''}
+      </span>`
+    ).join('');
+  } catch(e) { alert('Error: ' + e); }
+}
+
+function selectBlock(idx) {
+  $('block-idx').value = idx;
+  document.querySelectorAll('.block-btn').forEach(b => b.classList.toggle('active', +b.dataset.idx === idx));
+}
+
+async function runBlock(blockOverride, stdinOverride) {
+  const role = $('role-path').value.trim();
+  const body = $('body').value.trim();
+  const block = blockOverride !== undefined ? blockOverride : +$('block-idx').value;
+  const stdin = stdinOverride !== undefined ? stdinOverride : $('stdin-val').value;
+  const inputRaw = $('input-bag').value.trim();
+  let input = undefined;
+  if (inputRaw) { try { input = JSON.parse(inputRaw); } catch { alert('$FLEET_INPUT is not valid JSON'); return null; } }
+
+  const payload = { block };
+  if (role) payload.role = role;
+  else if (body) payload.body = body;
+  if (stdin) payload.stdin = stdin;
+  if (input !== undefined) payload.input = input;
+
+  try {
+    const r = await fetch('/debug/run-block', {method:'POST', headers:{'content-type':'application/json'}, body: JSON.stringify(payload)});
+    return await r.json();
+  } catch(e) { alert('Error: ' + e); return null; }
+}
+
+async function displayResult(data, prefix) {
+  if (!data) return;
+  const res = $('result');
+  const ok = data.ok ? '<span class="ok">OK</span>' : '<span class="fail">FAIL</span>';
+  const meta = `block ${data.block}/${data.blocks_total}  lang=${data.lang}  ${data.duration_ms}ms  ${ok}`;
+  res.innerHTML = (prefix || '') +
+    `<div class="meta">${meta}</div>` +
+    (data.stdout ? `<div class="label">stdout</div><pre>${esc(data.stdout)}</pre>` : '') +
+    (data.stderr ? `<div class="label">stderr</div><pre class="fail">${esc(data.stderr)}</pre>` : '') +
+    (data.error  ? `<div class="label">error</div><pre class="fail">${esc(data.error)}</pre>` : '');
+  $('stdin-val').value = data.stdout || '';
+  if (data.block + 1 < data.blocks_total) $('block-idx').value = data.block + 1;
+}
+
+async function runAll() {
+  const role = $('role-path').value.trim();
+  const body = $('body').value.trim();
+  let listUrl = '/debug/blocks?';
+  if (role) listUrl += 'path=' + encodeURIComponent(role);
+  else if (body) listUrl += 'body=' + encodeURIComponent(body);
+  else { alert('Enter a role path or body'); return; }
+
+  let blocks;
+  try { const r = await fetch(listUrl); const d = await r.json(); blocks = d.blocks; }
+  catch(e) { alert('Could not load blocks: ' + e); return; }
+  if (!blocks || !blocks.length) { alert('No blocks found'); return; }
+
+  $('result').innerHTML = '';
+  let stdin = $('stdin-val').value;
+  let allHtml = '';
+  for (const b of blocks) {
+    const data = await runBlock(b.index, stdin);
+    if (!data) break;
+    const ok = data.ok ? '<span class="ok">OK</span>' : '<span class="fail">FAIL</span>';
+    allHtml += `<div class="meta">block ${data.block}/${data.blocks_total}  lang=${data.lang}  ${data.duration_ms}ms  ${ok}</div>` +
+      (data.stdout ? `<div class="label">stdout</div><pre>${esc(data.stdout)}</pre>` : '') +
+      (data.stderr ? `<div class="label">stderr</div><pre class="fail">${esc(data.stderr)}</pre>` : '') +
+      (data.error  ? `<div class="label">error</div><pre class="fail">${esc(data.error)}</pre>` : '');
+    $('result').innerHTML = allHtml;
+    stdin = data.stdout || '';
+    if (!data.ok) break;
+  }
+}
+
+function esc(s) { return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+
+document.getElementById('role-path').addEventListener('keydown', e => { if (e.key === 'Enter') loadBlocks(); });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What this adds

### Part A — streaming `io.Pipe` block pipeline

`RunCode` now runs all fenced blocks in document order, piping stdout→stdin block-by-block using real `io.Pipe` + concurrent `cmd.Start()`/`cmd.Wait()`:

- All blocks are **built and sandbox-resolved up front** before any process starts. If any block uses a disallowed program the whole pipeline is rejected before execution begins.
- Blocks start concurrently; each block's `PipeWriter` is closed by its upstream block's `Wait()` goroutine, propagating EOF downstream automatically.
- A non-zero exit anywhere stops the pipeline; the earliest-failing block index is reported in the error.
- The **only always-present buffer** is the last block's stdout (capped at `MaxStdoutBytes`) used to parse the `{changes,answer}` JSON.
- **TeeReader debug taps are opt-in** (`pipelineDebugTaps` param): in the production `RunCode` path the param is `nil`; no intermediate capture buffers are allocated. The debug endpoint passes non-nil taps to capture per-block stdout for display.
- Single-block behavior is byte-identical to before (dispatches to `RunBlock`, no pipeline overhead).

### Part B — loopback debug HTTP surface (`--debug-listen`)

Three endpoints, only ever bound to a loopback address (enforced by `ValidateLoopbackAddr`):

| Endpoint | Method | Purpose |
|---|---|---|
| `GET /debug/blocks` | GET | List all fenced blocks in a role (`?path=`) or inline markdown (`?body=`). Returns `{blocks:[{index,lang,program,code}]}`. |
| `POST /debug/run-block` | POST | Execute one block with caller-supplied stdin → stdout/stderr/exit/timing. Reuses `RunBlock` (same sandbox, same secret-scrubbed env as production). |
| `GET /` | GET | Self-contained dark-theme debug UI (single HTML file, no build step). |

The debug UI lets you pick a role path or paste inline markdown, load the block list, then step through blocks one at a time feeding each block's stdout as the next block's stdin — or click "Run all" to step the whole pipeline sequentially with intermediate output visible.

Sandbox and `cmd.Env` allowlist are identical to the production delivery path (no secret-scrub bypass).

### Pipe contract

```
block[0] stdin ← CodeInput.Stdin (or /dev/null)
block[0] stdout → block[1] stdin (io.Pipe, zero-copy)
...
block[N-1] stdout → capped buffer → JSON parse → {changes, answer}
```

Non-zero exit at block `i` → error `"block i/N: <stderr excerpt>"`, pipeline torn down.

---

## Design proposal: `POST /debug/trigger` (not implemented)

To simulate a real change-webhook delivery to a role without waiting for an Obsidian sync, a future endpoint could accept a payload equivalent to what the reconcile loop produces and run it through the normal `Fleet.deliver()` / `RunCode` path:

```json
POST /debug/trigger
{
  "role": "roles/my-agent.md",
  "input": { "note": "...", "changes": [...] }
}
```

**Approach:**
1. Look up the role by path (same as `serveDebugRunBlock`).
2. Construct a `DeliveryInput` with caller-supplied `input` JSON (marshalled into `$FLEET_INPUT`).
3. Call `fleet.runCode(ctx, role, deliveryInput)` directly — the full multi-block pipeline, not `RunBlock`.
4. Return `{ok, stdout, changes, answer, duration_ms, block_errors}` mirroring the reconcile loop's outcome.

**Open questions:**
- Should it render the role body through Jet first (same as a real delivery), or use the raw body? Raw body is simpler and avoids needing a `NoteLoader` in the debug path; rendered body is more faithful.
- Should it write the `changes` back to the note store, or return them dry-run only? Dry-run is safer for a debug surface; the caller can inspect and decide.
- The debug listener is stateless today; `trigger` needs access to the full `Fleet` state (roles, note store, `deliver` func). That's a bigger surface than the current read-only debug endpoints.
- Rate limiting: a runaway trigger loop could starve the production reconcile goroutines; some form of concurrency cap (or a single-flight guard) would be needed.