### PR TITLE
fix(db): stop write-pool exhaustion warning flood + dev write-holder diagnostic

### DIFF
--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -81,6 +81,9 @@ func (a *app) WithTransaction(ctx context.Context, fn func(context.Context, *app
 		return fmt.Errorf("failed to BeginTx: %w", err)
 	}
 
+	releaseHolder := a.writeHolder.Acquire("WithTransaction")
+	defer releaseHolder()
+
 	defer func() {
 		rollbackErr := tx.Rollback()
 		if rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {

--- a/cmd/server/debug_writeholder.go
+++ b/cmd/server/debug_writeholder.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// handleDebugWriteHolder reports who currently occupies the single write
+// connection: open write transactions and in-flight write statements, oldest
+// first (the oldest is the actual holder; younger ones queue behind it).
+// Dev-only: registered on the internal debug mux only when DevMode is set,
+// and the underlying WriteHolder captures nothing otherwise.
+func (a *app) handleDebugWriteHolder(w http.ResponseWriter, _ *http.Request) {
+	type holderJSON struct {
+		Label   string `json:"label"`
+		HeldFor string `json:"held_for"`
+		Stack   string `json:"stack"`
+	}
+	type response struct {
+		Held    bool         `json:"held"`
+		Holders []holderJSON `json:"holders,omitempty"`
+	}
+
+	infos := a.writeHolder.Snapshot()
+	resp := response{Held: len(infos) > 0}
+	for _, info := range infos {
+		resp.Holders = append(resp.Holders, holderJSON{
+			Label:   info.Label,
+			HeldFor: info.HeldFor.String(),
+			Stack:   info.Stack,
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		a.log.Error("failed to encode write-holder response", "error", err)
+	}
+}

--- a/cmd/server/debug_writeholder_test.go
+++ b/cmd/server/debug_writeholder_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -31,7 +32,7 @@ func TestHandleDebugWriteHolder(t *testing.T) {
 
 	get := func() response {
 		rec := httptest.NewRecorder()
-		a.handleDebugWriteHolder(rec, httptest.NewRequest("GET", "/debug/write-holder", nil))
+		a.handleDebugWriteHolder(rec, httptest.NewRequest(http.MethodGet, "/debug/write-holder", nil))
 		require.Equal(t, 200, rec.Code)
 		var resp response
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))

--- a/cmd/server/debug_writeholder_test.go
+++ b/cmd/server/debug_writeholder_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"trip2g/internal/db"
+	"trip2g/internal/logger"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleDebugWriteHolder(t *testing.T) {
+	holder := db.NewWriteHolder(true)
+	a := &app{
+		appState: &appState{
+			log:         &logger.TestLogger{},
+			writeHolder: holder,
+		},
+	}
+
+	type response struct {
+		Held    bool `json:"held"`
+		Holders []struct {
+			Label   string `json:"label"`
+			HeldFor string `json:"held_for"`
+			Stack   string `json:"stack"`
+		} `json:"holders"`
+	}
+
+	get := func() response {
+		rec := httptest.NewRecorder()
+		a.handleDebugWriteHolder(rec, httptest.NewRequest("GET", "/debug/write-holder", nil))
+		require.Equal(t, 200, rec.Code)
+		var resp response
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		return resp
+	}
+
+	resp := get()
+	require.False(t, resp.Held)
+	require.Empty(t, resp.Holders)
+
+	release := holder.Acquire("tx pushNotes")
+	resp = get()
+	require.True(t, resp.Held)
+	require.Len(t, resp.Holders, 1)
+	require.Equal(t, "tx pushNotes", resp.Holders[0].Label)
+	require.NotEmpty(t, resp.Holders[0].HeldFor)
+	require.Contains(t, resp.Holders[0].Stack, "TestHandleDebugWriteHolder")
+
+	release()
+	resp = get()
+	require.False(t, resp.Held)
+}

--- a/cmd/server/graphql.go
+++ b/cmd/server/graphql.go
@@ -56,6 +56,7 @@ func (a *app) AcquireTxEnvInRequest(ctx context.Context, label string) error {
 	newEnv.Queries = queries.Queries
 	newEnv.WriteQueries = queries
 	newEnv.currentTx = tx
+	newEnv.txHolderRelease = a.writeHolder.Acquire("tx " + label)
 
 	// override the context with the new tx env
 	req.Env = &newEnv
@@ -77,6 +78,10 @@ func (a *app) ReleaseTxEnvInRequest(ctx context.Context, commit bool) error {
 	tx := envPtr.currentTx
 	if tx == nil {
 		return errors.New("no open transaction on request env")
+	}
+
+	if envPtr.txHolderRelease != nil {
+		envPtr.txHolderRelease()
 	}
 
 	// Restore the base env so nothing keeps using the finished tx scope and a

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -102,6 +102,9 @@ type app struct {
 	queries *db.Queries
 
 	currentTx *sql.Tx
+	// txHolderRelease clears this tx's write-holder entry (dev diagnostic);
+	// set together with currentTx in AcquireTxEnvInRequest.
+	txHolderRelease func()
 }
 
 // appState holds all process-lifetime state. It is embedded in app by
@@ -167,6 +170,10 @@ type appState struct {
 	conn      *sql.DB
 	writeConn *sql.DB
 	queueConn *sql.DB // separate connection for goqite so queue polling never blocks app writes
+
+	// writeHolder tracks who occupies the single write connection (dev-only
+	// diagnostic behind /debug/write-holder); no-op in production.
+	writeHolder *db.WriteHolder
 
 	noteBus *notebus.Bus
 
@@ -295,9 +302,11 @@ func main() {
 	// it, so the write pool and WithTx paths must not use this).
 	readDBTX := db.WithLogger(conn, logger.WithPrefix(log, "read: no tx:"))
 	queries := db.New(db.NewStmtCache(conn, readDBTX))
+	writeHolder := db.NewWriteHolder(config.DevMode)
 	writeQueries := db.NewWriteQueries(
 		db.WithLogger(writeConn, logger.WithPrefix(log, "write: no tx:")).
-			WithPoolStats(writeConn.Stats),
+			WithPoolStats(writeConn.Stats).
+			WithWriteHolder(writeHolder),
 	)
 
 	nowpaymentsClient, err := nowpayments.NewClient(config.NowpaymentsAPIKey, log)
@@ -334,8 +343,9 @@ func main() {
 			conn:    conn,
 			// mail:    mailyak.New(mailAddr, mailAuth),
 
-			writeConn: writeConn,
-			queueConn: queueConn,
+			writeConn:   writeConn,
+			queueConn:   queueConn,
+			writeHolder: writeHolder,
 
 			UserBans: userbans.New(queries),
 

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -305,6 +305,12 @@ func (a *app) startInternalServer() {
 		debugMux.HandleFunc("/debug/embedding", a.handleDebugEmbedding)
 	}
 
+	// Write-holder diagnostic: names who occupies the single write connection.
+	// Dev-only — the tracker captures stacks per acquire, too costly for prod.
+	if a.config.DevMode {
+		debugMux.HandleFunc("/debug/write-holder", a.handleDebugWriteHolder)
+	}
+
 	debugHandler := fasthttpadaptor.NewFastHTTPHandler(debugMux)
 
 	// Start metrics updater

--- a/internal/db/logger.go
+++ b/internal/db/logger.go
@@ -4,43 +4,61 @@ import (
 	"context"
 	"database/sql"
 	"strings"
+	"time"
 	"trip2g/internal/logger"
 )
 
+// defaultSlowWriteThreshold is how long a write may take on a contended pool
+// before it is worth a warning. Sub-millisecond handoffs between concurrent
+// writers are the normal single-writer steady state (e.g. several cron jobs
+// writing on the same tick) and must stay silent.
+const defaultSlowWriteThreshold = time.Second
+
 type DBLogger struct {
-	db        DBTX
-	log       logger.Logger
-	statsFunc func() sql.DBStats // if set, checked before each operation to warn on pool exhaustion
+	db                 DBTX
+	log                logger.Logger
+	statsFunc          func() sql.DBStats // if set, writes are timed to warn on real pool contention
+	slowWriteThreshold time.Duration
+	writeHolder        *WriteHolder // if set, in-flight writes are reported for /debug/write-holder
 }
 
 func WithLogger(db DBTX, log logger.Logger) *DBLogger {
 	return &DBLogger{
-		db:  db,
-		log: log,
+		db:                 db,
+		log:                log,
+		slowWriteThreshold: defaultSlowWriteThreshold,
 	}
 }
 
-// WithPoolStats attaches a stats func so the logger can warn when all connections
-// are in use before a new operation attempts to acquire one. Use this only for the
-// non-tx write connection where a blocked pool acquisition causes hangs.
+// WithPoolStats attaches a stats func so the logger can warn when an operation
+// stalls on an exhausted pool. Use this only for the non-tx write connection
+// where a blocked pool acquisition causes hangs.
 func (d *DBLogger) WithPoolStats(stats func() sql.DBStats) *DBLogger {
 	d.statsFunc = stats
 	return d
 }
 
-func (d *DBLogger) checkPool(query string) {
+// WithSlowWriteThreshold overrides the contended-write warning threshold.
+func (d *DBLogger) WithSlowWriteThreshold(threshold time.Duration) *DBLogger {
+	d.slowWriteThreshold = threshold
+	return d
+}
+
+// WithWriteHolder attaches a WriteHolder so in-flight statements on this
+// connection show up in write-holder snapshots (dev diagnostic).
+func (d *DBLogger) WithWriteHolder(h *WriteHolder) *DBLogger {
+	d.writeHolder = h
+	return d
+}
+
+// poolContended reports whether every pool connection is in use right now,
+// meaning the next acquisition will have to wait.
+func (d *DBLogger) poolContended() bool {
 	if d.statsFunc == nil {
-		return
+		return false
 	}
 	s := d.statsFunc()
-	if s.MaxOpenConnections > 0 && s.InUse >= s.MaxOpenConnections {
-		d.log.Warn("write pool exhausted — next operation will block",
-			"in_use", s.InUse,
-			"max", s.MaxOpenConnections,
-			"wait_count", s.WaitCount,
-			"query", formatSQL(query),
-		)
-	}
+	return s.MaxOpenConnections > 0 && s.InUse >= s.MaxOpenConnections
 }
 
 func formatSQL(s string) string {
@@ -48,10 +66,30 @@ func formatSQL(s string) string {
 }
 
 func (d *DBLogger) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
-	d.checkPool(query)
 	d.log.Debug("ExecContext", "query", formatSQL(query), "args", args)
 
+	contended := d.poolContended()
+	start := time.Now()
+
+	releaseHolder := d.writeHolder.Acquire(formatSQL(query))
+
 	res, err := d.db.ExecContext(ctx, query, args...)
+
+	releaseHolder()
+
+	if contended {
+		if elapsed := time.Since(start); elapsed >= d.slowWriteThreshold {
+			s := d.statsFunc()
+			d.log.Warn("write stalled on exhausted write pool",
+				"waited", elapsed,
+				"in_use", s.InUse,
+				"max", s.MaxOpenConnections,
+				"wait_count", s.WaitCount,
+				"query", formatSQL(query),
+			)
+		}
+	}
+
 	if err != nil {
 		d.log.Error("ExecContext Error", "error", err, "query", query, "args", args)
 	}

--- a/internal/db/logger_test.go
+++ b/internal/db/logger_test.go
@@ -1,0 +1,142 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type captureLogger struct {
+	mu    sync.Mutex
+	warns []string
+}
+
+func (l *captureLogger) Info(string, ...interface{})  {}
+func (l *captureLogger) Error(string, ...interface{}) {}
+func (l *captureLogger) Debug(string, ...interface{}) {}
+
+func (l *captureLogger) Warn(msg string, _ ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warns = append(l.warns, msg)
+}
+
+func (l *captureLogger) warnCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.warns)
+}
+
+type fakeDBTX struct {
+	delay time.Duration
+}
+
+func (f *fakeDBTX) ExecContext(context.Context, string, ...interface{}) (sql.Result, error) {
+	time.Sleep(f.delay)
+	return nil, nil
+}
+
+func (f *fakeDBTX) PrepareContext(context.Context, string) (*sql.Stmt, error) { return nil, nil }
+
+func (f *fakeDBTX) QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error) {
+	return nil, nil
+}
+
+func (f *fakeDBTX) QueryRowContext(context.Context, string, ...interface{}) *sql.Row { return nil }
+
+func fullPoolStats() sql.DBStats {
+	return sql.DBStats{MaxOpenConnections: 1, InUse: 1, WaitCount: 42}
+}
+
+func freePoolStats() sql.DBStats {
+	return sql.DBStats{MaxOpenConnections: 1, InUse: 0}
+}
+
+// A momentarily busy pool with a fast write is the normal single-writer
+// steady state (e.g. two cron jobs writing on the same tick) — no warning.
+func TestDBLogger_FastWriteOnBusyPool_NoWarn(t *testing.T) {
+	log := &captureLogger{}
+	d := WithLogger(&fakeDBTX{}, log).
+		WithPoolStats(fullPoolStats).
+		WithSlowWriteThreshold(50 * time.Millisecond)
+
+	_, err := d.ExecContext(context.Background(), "update t set x = 1")
+	require.NoError(t, err)
+	require.Equal(t, 0, log.warnCount())
+}
+
+// A write that stalls while the pool is exhausted is the real signal: warn
+// with the measured duration.
+func TestDBLogger_SlowWriteOnBusyPool_Warns(t *testing.T) {
+	log := &captureLogger{}
+	d := WithLogger(&fakeDBTX{delay: 20 * time.Millisecond}, log).
+		WithPoolStats(fullPoolStats).
+		WithSlowWriteThreshold(5 * time.Millisecond)
+
+	_, err := d.ExecContext(context.Background(), "update t set x = 1")
+	require.NoError(t, err)
+	require.Equal(t, 1, log.warnCount())
+}
+
+// A slow write on a free pool is not contention — no warning.
+func TestDBLogger_SlowWriteOnFreePool_NoWarn(t *testing.T) {
+	log := &captureLogger{}
+	d := WithLogger(&fakeDBTX{delay: 20 * time.Millisecond}, log).
+		WithPoolStats(freePoolStats).
+		WithSlowWriteThreshold(5 * time.Millisecond)
+
+	_, err := d.ExecContext(context.Background(), "update t set x = 1")
+	require.NoError(t, err)
+	require.Equal(t, 0, log.warnCount())
+}
+
+// Without pool stats attached nothing changes.
+func TestDBLogger_NoPoolStats_NoWarn(t *testing.T) {
+	log := &captureLogger{}
+	d := WithLogger(&fakeDBTX{delay: 20 * time.Millisecond}, log)
+
+	_, err := d.ExecContext(context.Background(), "update t set x = 1")
+	require.NoError(t, err)
+	require.Equal(t, 0, log.warnCount())
+}
+
+// The write DBLogger reports in-flight statements to the WriteHolder so
+// /debug/write-holder can name a long-running statement (e.g. VACUUM).
+func TestDBLogger_WriteHolderTracksExec(t *testing.T) {
+	holder := NewWriteHolder(true)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	d := WithLogger(&blockingDBTX{started: started, release: release}, &captureLogger{}).
+		WithWriteHolder(holder)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = d.ExecContext(context.Background(), "VACUUM")
+	}()
+
+	<-started
+	infos := holder.Snapshot()
+	require.Len(t, infos, 1)
+	require.Equal(t, "VACUUM", infos[0].Label)
+
+	close(release)
+	<-done
+	require.Empty(t, holder.Snapshot())
+}
+
+type blockingDBTX struct {
+	fakeDBTX
+	started chan struct{}
+	release chan struct{}
+}
+
+func (b *blockingDBTX) ExecContext(context.Context, string, ...interface{}) (sql.Result, error) {
+	close(b.started)
+	<-b.release
+	return nil, nil
+}

--- a/internal/db/writeholder.go
+++ b/internal/db/writeholder.go
@@ -1,0 +1,106 @@
+package db
+
+import (
+	"runtime"
+	"sort"
+	"sync"
+	"time"
+)
+
+// WriteHolder is a dev-only diagnostic that records who currently occupies the
+// single write connection: open write transactions and in-flight non-tx write
+// statements. When the write pool is exhausted (in_use=1 max=1), its Snapshot
+// names the holder with a goroutine stack and hold duration instead of leaving
+// only "someone is blocking" warnings in the log.
+//
+// Capturing a stack per acquire has a cost, so the tracker is enabled only in
+// dev mode; disabled (or nil) it is a no-op.
+type WriteHolder struct {
+	enabled bool
+
+	mu      sync.Mutex
+	nextID  uint64
+	entries map[uint64]*writeHolderEntry
+}
+
+type writeHolderEntry struct {
+	label string
+	stack []byte
+	since time.Time
+}
+
+// WriteHolderInfo is one snapshot entry.
+type WriteHolderInfo struct {
+	Label   string        `json:"label"`
+	HeldFor time.Duration `json:"held_for"`
+	Stack   string        `json:"stack"`
+}
+
+// NewWriteHolder creates a tracker. When enabled is false every method is a
+// no-op (production path).
+func NewWriteHolder(enabled bool) *WriteHolder {
+	return &WriteHolder{
+		enabled: enabled,
+		entries: make(map[uint64]*writeHolderEntry),
+	}
+}
+
+// Acquire records the calling goroutine as occupying the write connection and
+// returns a release func. The release func is idempotent.
+func (h *WriteHolder) Acquire(label string) func() {
+	if h == nil || !h.enabled {
+		return func() {}
+	}
+
+	buf := make([]byte, 16*1024)
+	buf = buf[:runtime.Stack(buf, false)]
+
+	h.mu.Lock()
+	h.nextID++
+	id := h.nextID
+	h.entries[id] = &writeHolderEntry{
+		label: label,
+		stack: buf,
+		since: time.Now(),
+	}
+	h.mu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			h.mu.Lock()
+			delete(h.entries, id)
+			h.mu.Unlock()
+		})
+	}
+}
+
+// Snapshot returns the current entries, oldest first. With a single write
+// connection the oldest entry is the actual holder; younger ones are waiters
+// queued behind it.
+func (h *WriteHolder) Snapshot() []WriteHolderInfo {
+	if h == nil || !h.enabled {
+		return nil
+	}
+
+	h.mu.Lock()
+	entries := make([]*writeHolderEntry, 0, len(h.entries))
+	for _, e := range h.entries {
+		entries = append(entries, e)
+	}
+	h.mu.Unlock()
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].since.Before(entries[j].since) })
+
+	now := time.Now()
+	infos := make([]WriteHolderInfo, 0, len(entries))
+	for _, e := range entries {
+		infos = append(infos, WriteHolderInfo{
+			Label:   e.label,
+			HeldFor: now.Sub(e.since),
+			Stack:   string(e.stack),
+		})
+	}
+
+	return infos
+}

--- a/internal/db/writeholder_test.go
+++ b/internal/db/writeholder_test.go
@@ -1,0 +1,64 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteHolder_AcquireRelease(t *testing.T) {
+	h := NewWriteHolder(true)
+
+	require.Empty(t, h.Snapshot(), "fresh holder must be free")
+
+	release := h.Acquire("tx pushNotes")
+	infos := h.Snapshot()
+	require.Len(t, infos, 1)
+	require.Equal(t, "tx pushNotes", infos[0].Label)
+	require.Contains(t, infos[0].Stack, "TestWriteHolder_AcquireRelease",
+		"stack must point at the acquiring goroutine")
+	require.GreaterOrEqual(t, infos[0].HeldFor, time.Duration(0))
+
+	release()
+	require.Empty(t, h.Snapshot(), "release must clear the entry")
+
+	// double release is a no-op
+	release()
+	require.Empty(t, h.Snapshot())
+}
+
+func TestWriteHolder_OldestFirst(t *testing.T) {
+	h := NewWriteHolder(true)
+
+	rel1 := h.Acquire("first")
+	time.Sleep(time.Millisecond)
+	rel2 := h.Acquire("second")
+
+	infos := h.Snapshot()
+	require.Len(t, infos, 2)
+	require.Equal(t, "first", infos[0].Label, "oldest entry (the likely holder) comes first")
+	require.Equal(t, "second", infos[1].Label)
+
+	rel1()
+	infos = h.Snapshot()
+	require.Len(t, infos, 1)
+	require.Equal(t, "second", infos[0].Label)
+	rel2()
+}
+
+func TestWriteHolder_Disabled(t *testing.T) {
+	h := NewWriteHolder(false)
+
+	release := h.Acquire("tx x")
+	require.Empty(t, h.Snapshot(), "disabled holder must not capture anything")
+	release()
+}
+
+func TestWriteHolder_NilSafe(t *testing.T) {
+	var h *WriteHolder
+
+	release := h.Acquire("x")
+	release()
+	require.Empty(t, h.Snapshot())
+}


### PR DESCRIPTION
## Root cause

The flood is **warning noise, not a stuck writer**. Evidence from the live dev instance (`trip2g-memory-vaultout`, the one obsidian-sync pushes to):

- Warnings arrive in bursts of 2-5 **once per minute** (log timestamps 01:12:05, 01:13:09, 01:14:07, ...), `wait_count` growing ~5/min.
- Pool metrics on the same instance: `go_sql_wait_count_total{db_name="write"} 5137` with `go_sql_wait_duration_seconds_total 3.07` — **average actual wait 0.6 ms**.
- A full goroutine dump showed **zero** goroutines blocked on the write pool.

Mechanics:

1. `internal/db/logger.go:36` warned whenever `InUse >= MaxOpenConnections` at the moment a write was submitted. With `max=1` that is true during *any* momentary overlap of two writes — the normal single-writer steady state, not exhaustion.
2. Every minute several cron jobs fire together (`expirestalewebhookdeliveries` runs `"0 * * * * *"` — `internal/case/cronjob/expirestalewebhookdeliveries/job.go:11` — plus `executecronwebhooks` on its configured cadence). Each execution does 3-4 sequential writes (`internal/cronjobs/jobs.go:218-280`), so their writes overlap on the max=1 pool → guaranteed warnings every minute, forever.
3. `wait_count` is Go's **cumulative-since-process-start** counter, so it "climbing monotonically past 18,600" is expected bookkeeping (~5/min over days), not a growing queue.

Hypotheses 1/2/4 (long-held tx, leaked conn, deadlock) were checked and **refuted**: all `BeginTx` sites (`cmd/server/graphql.go:46`, `cmd/server/config.go:79`) release on all paths; webhook/telegram deliveries only *enqueue* inside tx; goqite uses a separate `queueConn`; the goroutine dump shows no pool waiter.

Recency: triggered by recent work — the per-minute `expire_stale_webhook_deliveries` cron (agent-runtime/webhooks) meets the warning added in 23290e8d (2026-04-30).

## Fix

**1. Measured warning instead of pre-emptive (`internal/db/logger.go`)** — warn only when a write on a contended pool actually takes ≥ 1s (`write stalled on exhausted write pool`, with the measured duration). Sub-ms handoffs stay silent; a genuinely stuck writer still warns loudly on every blocked write.

**2. Dev-only `/debug/write-holder` (new)** — names who occupies the single write connection when a real incident happens:
- `internal/db/writeholder.go`: tracker recording goroutine stack + label + timestamp per acquire; no-op unless dev mode.
- Wired at every write-connection occupancy point: request tx (`AcquireTxEnvInRequest`/`ReleaseTxEnvInRequest`), `WithTransaction`, and each in-flight non-tx write statement (catches e.g. a long `VACUUM`).
- Endpoint on the internal debug mux, registered only when `-dev`:

```
curl -s localhost:8082/debug/write-holder | jq
# {"held":true,"holders":[{"label":"tx pushNotes","held_for":"12.4s","stack":"goroutine 42 ..."}]}
```

Oldest entry = the actual holder; younger entries are waiters queued behind it.

## Verification

- `go build -tags=dev ./...` exit 0 (non-dev build only lacks built frontend assets in a fresh worktree)
- `go test -tags=dev ./cmd/server/ ./internal/db/ ./internal/cronjobs/` all ok (new tests: measured-warning matrix, holder acquire/release/disabled/nil-safety, endpoint JSON)
- `golangci-lint run` — no findings in changed files (9 pre-existing elsewhere)

Separate observation (not fixed here): the same instance has ~820 leaked `NoteChanges` subscription goroutines idle up to 748 min (`internal/graph/schema.resolvers.go:3320`) — read-path leak, worth its own issue.