### PR TITLE
build(make): airfleet — dev hot-reload for the fleet sidecar + debug UIs

### DIFF
--- a/.air.fleet.toml
+++ b/.air.fleet.toml
@@ -1,0 +1,36 @@
+root = "."
+tmp_dir = "tmp"
+
+# Dev hot-reload config for the fleet sidecar (see `make airfleet`).
+# Runs cmd/fleet against a local `make air` hub with the dev defaults:
+#   - hub user-token secret = the dev default ("please-change-me-...")
+#   - graph UI  → http://127.0.0.1:9099/   (JSON at /graph.json)
+#   - code-block debug UI → http://127.0.0.1:9098/
+# LLM roles: export TRIP2G_FLEET_LLM_BASE_URL / TRIP2G_FLEET_LLM_API_KEY before running.
+[build]
+  cmd = "go build -tags=dev -o ./tmp/fleet ./cmd/fleet"
+  bin = "./tmp/fleet"
+  args_bin = [
+    "--trip2g-url", "http://localhost:8081",
+    "--callback-url", "http://localhost:9090",
+    "--jwt-secret", "please-change-me-to-something-secret",
+    "--fleet-secret", "dev-fleet-secret",
+    "--agents-folder", "roles/",
+    "--allowed-programs", "python,bash,node",
+    "--graph-addr", "127.0.0.1:9099",
+    "--debug-listen", "127.0.0.1:9098",
+  ]
+  delay = 500
+  exclude_dir = ["assets", "tmp", "vendor", "testdata", "node_modules", "out", "obsidian-sync", "infra", "test-results", "playwright-report", "docs", "demo"]
+  exclude_regex = ["_test.go", "easyjson"]
+  include_ext = ["go", "html"]
+  kill_delay = "2s"
+  log = "build-errors.log"
+  send_interrupt = true
+
+[log]
+  main_only = false
+  time = true
+
+[misc]
+  clean_on_exit = false

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,12 @@ docker-deps:
 air: docker-deps
 	go tool github.com/air-verse/air
 
+# airfleet: run the fleet sidecar in dev with hot reload, against the local `make air` hub.
+#   Graph UI → http://127.0.0.1:9099/ (JSON at /graph.json); code-block debug UI → http://127.0.0.1:9098/
+#   LLM roles: export TRIP2G_FLEET_LLM_BASE_URL / TRIP2G_FLEET_LLM_API_KEY first.
+airfleet:
+	go tool github.com/air-verse/air -c .air.fleet.toml
+
 # bench: 60s load test against http://localhost:8081/ + cpu profile saved to /tmp/trip2g-bench-*
 # Usage: make bench              — test homepage
 #        make bench URL=/ru      — test specific path


### PR DESCRIPTION
Adds `make airfleet`: runs cmd/fleet under air (hot reload) against a local `make air` hub with dev defaults, exposing the two loopback dev UIs.

- Graph UI → http://127.0.0.1:9099/ (JSON at /graph.json) — from #111 (`--graph-addr`, already on main)
- Code-block debug UI → http://127.0.0.1:9098/ — from #110 (`--debug-listen`)
- Dev default hub user-token secret; LLM roles via `TRIP2G_FLEET_LLM_BASE_URL`/`_API_KEY` env.

**Depends on #110** for `--debug-listen` — merge AFTER #110, else `make airfleet` errors on the unknown flag. `--graph-addr` already on main via #111.

Files: Makefile (airfleet target), .air.fleet.toml.