### PR TITLE
fix(graph): SSE keepalive ping so disconnected noteChanges subscribers are reaped

### DIFF
--- a/internal/fastgql/sse_handler_test.go
+++ b/internal/fastgql/sse_handler_test.go
@@ -13,6 +13,9 @@ import (
 
 	"trip2g/internal/fastgql"
 
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/99designs/gqlgen/graphql/handler/testserver"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
 	"github.com/valyala/fasthttp/fasthttpadaptor"
@@ -175,6 +178,55 @@ func TestSSEHandler_CancelsContextOnDisconnect(t *testing.T) {
 		// Handler context was cancelled — success.
 	case <-time.After(5 * time.Second):
 		t.Fatal("handler context was not cancelled after client disconnect")
+	}
+}
+
+// TestSSEHandler_IdleSubscriptionKeepAliveDetectsDisconnect reproduces the
+// NoteChanges goroutine leak scenario end-to-end with gqlgen's real SSE
+// transport: a subscription that never produces events writes nothing, so a
+// silent client disconnect is only detected when keepalive pings are enabled
+// (fasthttp observes a dead connection only through a failed write/flush).
+// With KeepAlivePingInterval > 0 the operation context must be cancelled
+// shortly after the client goes away; with 0 (the pre-fix production wiring)
+// it never is and the subscription goroutine leaks forever.
+func TestSSEHandler_IdleSubscriptionKeepAliveDetectsDisconnect(t *testing.T) {
+	srv := testserver.New()
+	srv.AddTransport(transport.SSE{KeepAlivePingInterval: 20 * time.Millisecond})
+
+	ctxCancelled := make(chan struct{})
+	srv.AroundOperations(func(ctx context.Context, next graphql.OperationHandler) graphql.ResponseHandler {
+		go func() {
+			<-ctx.Done()
+			close(ctxCancelled)
+		}()
+		return next(ctx)
+	})
+
+	handler := fastgql.NewSSEHandler(srv)
+	ln := startTestServer(t, handler)
+
+	// Client subscribes, then goes away without ever receiving an event.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+ln.Addr().String()+"/graphql",
+		strings.NewReader(`{"query":"subscription { name }"}`))
+	require.NoError(t, err)
+
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err == nil {
+		_, _ = io.ReadAll(resp.Body) // fails when the client ctx expires
+		resp.Body.Close()
+	}
+
+	select {
+	case <-ctxCancelled:
+		// Idle stream disconnect detected via keepalive ping — no leak.
+	case <-time.After(5 * time.Second):
+		t.Fatal("subscription context was not cancelled after client disconnect on an idle stream")
 	}
 }
 

--- a/internal/graph/handler.go
+++ b/internal/graph/handler.go
@@ -2,6 +2,8 @@ package graph
 
 import (
 	"context"
+	"time"
+
 	"trip2g/internal/appreq"
 	"trip2g/internal/logger"
 
@@ -47,6 +49,15 @@ func buildSkipTxMap(schema graphql.ExecutableSchema) map[string]struct{} {
 	return skipTxMutations
 }
 
+// sseTransport returns the SSE transport for subscriptions. The keepalive ping
+// is required: over fasthttp (internal/fastgql) a client disconnect is only
+// observable through a failed write/flush, so without periodic pings an idle
+// subscription stream never learns the client is gone — its context is never
+// cancelled and the resolver goroutine (plus its notebus subscriber) leaks.
+func sseTransport() transport.SSE {
+	return transport.SSE{KeepAlivePingInterval: 30 * time.Second}
+}
+
 func NewHandler(env Env) *handler.Server {
 	log := env.Logger()
 
@@ -66,7 +77,7 @@ func NewHandler(env Env) *handler.Server {
 
 	maxBodySize := int64(env.MaxRequestBodySize() * 1024 * 1024)
 
-	srv.AddTransport(transport.SSE{})
+	srv.AddTransport(sseTransport())
 	srv.AddTransport(transport.Options{})
 	srv.AddTransport(transport.POST{})
 	srv.AddTransport(transport.MultipartForm{

--- a/internal/graph/note_changes_leak_test.go
+++ b/internal/graph/note_changes_leak_test.go
@@ -1,0 +1,163 @@
+package graph
+
+// Regression tests for the NoteChanges subscription goroutine leak.
+//
+// Production incident: ~820 NoteChanges subscription goroutines leaked (idle up
+// to 748 min) because a disconnected SSE client never cancelled the subscription
+// context. The resolver goroutine itself is correct — it exits and unsubscribes
+// from notebus on ctx.Done — but over fasthttp a client disconnect is only
+// observable through a failed write, and transport.SSE was registered without
+// KeepAlivePingInterval, so an idle stream never wrote anything and never
+// learned the client was gone.
+//
+// These tests pin down both halves of the contract:
+//   - sseTransport() must have keepalive enabled (the actual fix);
+//   - the resolver goroutine must exit and unsubscribe from notebus once its
+//     ctx is cancelled, including while parked on a payload send.
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trip2g/internal/db"
+	"trip2g/internal/graph/model"
+	"trip2g/internal/logger"
+	appmodel "trip2g/internal/model"
+	"trip2g/internal/notebus"
+	"trip2g/internal/usertoken"
+)
+
+// TestSSETransport_KeepAliveEnabled guards the root-cause fix: without a
+// keepalive ping the fasthttp SSE bridge (internal/fastgql) has no write on an
+// idle stream, so a dead client is never detected and the subscription ctx is
+// never cancelled — leaking the resolver goroutine and its notebus subscriber.
+func TestSSETransport_KeepAliveEnabled(t *testing.T) {
+	require.Positive(t, sseTransport().KeepAlivePingInterval,
+		"SSE transport must send keepalive pings: over fasthttp a client disconnect "+
+			"is only observable through a failed write, so an idle noteChanges stream "+
+			"would otherwise leak its goroutine and notebus subscriber forever")
+}
+
+// noteChangesLeakEnv implements just the Env surface NoteChanges touches, over
+// a real notebus.Bus. The embedded nil Env panics on any unexpected call.
+type noteChangesLeakEnv struct {
+	Env
+	bus *notebus.Bus
+	nvs *appmodel.NoteViews
+}
+
+func (e *noteChangesLeakEnv) SubscribeNoteChanges(include, exclude []string) *notebus.Subscriber {
+	return e.bus.Subscribe(include, exclude, 1)
+}
+
+func (e *noteChangesLeakEnv) UnsubscribeNoteChanges(sub *notebus.Subscriber) {
+	e.bus.Unsubscribe(sub)
+}
+
+func (e *noteChangesLeakEnv) CurrentUserToken(_ context.Context) (*usertoken.Data, error) {
+	return &usertoken.Data{ID: 1, Role: "admin"}, nil
+}
+
+//nolint:staticcheck // name fixed by the checkapikey.Env interface
+func (e *noteChangesLeakEnv) ApiKeyByValue(_ context.Context, _ string) (db.ApiKey, error) {
+	return db.ApiKey{}, sql.ErrNoRows
+}
+
+func (e *noteChangesLeakEnv) InsertAPIKeyLog(_ context.Context, _ db.InsertAPIKeyLogParams) error {
+	return nil
+}
+
+func (e *noteChangesLeakEnv) UpsertAPIKeyLogAction(_ context.Context, _ string) error { return nil }
+
+func (e *noteChangesLeakEnv) UpsertAPIKeyLogIP(_ context.Context, _ string) error { return nil }
+
+func (e *noteChangesLeakEnv) ShortAPITokenSecret() string { return testShortAPISecret }
+
+func (e *noteChangesLeakEnv) LatestNoteViews() *appmodel.NoteViews { return e.nvs }
+
+func (e *noteChangesLeakEnv) CanReadNote(_ context.Context, _ *appmodel.NoteView) (bool, error) {
+	return true, nil
+}
+
+func (e *noteChangesLeakEnv) Logger() logger.Logger { return &logger.DummyLogger{} }
+
+// cancelableAuthCtx combines a cancellable base context with an authCtx-built
+// fasthttp context for Value lookups (a bare fasthttp.RequestCtx cannot be a
+// context.WithCancel parent — its Done() needs a running server).
+type cancelableAuthCtx struct {
+	context.Context
+	values context.Context
+}
+
+func (c *cancelableAuthCtx) Value(key any) any { return c.values.Value(key) }
+
+func startLeakSubscription(t *testing.T) (*notebus.Bus, <-chan *model.NoteChangesSubscriptionPayload, context.CancelFunc) {
+	t.Helper()
+
+	bus := notebus.New(&logger.DummyLogger{})
+	env := &noteChangesLeakEnv{
+		bus: bus,
+		nvs: aclNvs(aclNote(1, "a/one.md", "/a-one", "a")),
+	}
+	r := &subscriptionResolver{&Resolver{DefaultEnv: env}}
+
+	base, cancel := context.WithCancel(context.Background())
+	ctx := &cancelableAuthCtx{Context: base, values: authCtx(&usertoken.Data{ID: 1, Role: "admin"}, nil)}
+
+	ch, err := r.NoteChanges(ctx, model.NoteChangesFilter{IncludePatterns: []string{"**"}})
+	require.NoError(t, err)
+	require.Equal(t, 1, bus.Stats().Subscribers, "subscription must register on notebus")
+
+	return bus, ch, cancel
+}
+
+// requireSubscriptionGone asserts the resolver goroutine exited (payload
+// channel closed) and the notebus subscriber count returned to baseline.
+func requireSubscriptionGone(t *testing.T, bus *notebus.Bus, ch <-chan *model.NoteChangesSubscriptionPayload) {
+	t.Helper()
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				require.Eventually(t, func() bool { return bus.Stats().Subscribers == 0 },
+					5*time.Second, 10*time.Millisecond,
+					"notebus subscriber must be removed after the goroutine exits")
+				return
+			}
+			// drain payloads buffered before cancellation
+		case <-deadline:
+			t.Fatal("subscription goroutine did not exit after ctx cancel")
+		}
+	}
+}
+
+func TestNoteChanges_CtxCancelWhileIdle_ExitsAndUnsubscribes(t *testing.T) {
+	bus, ch, cancel := startLeakSubscription(t)
+
+	cancel()
+
+	requireSubscriptionGone(t, bus, ch)
+}
+
+func TestNoteChanges_CtxCancelWhileSendBlocked_ExitsAndUnsubscribes(t *testing.T) {
+	bus, ch, cancel := startLeakSubscription(t)
+
+	// Nobody reads ch (cap 1): the first publish fills the payload buffer, the
+	// second parks the goroutine on the payload send. Cancel must unblock it.
+	batch := notebus.Batch{Changes: []notebus.Change{{PathID: 1, Path: "a/one.md", Event: "remove"}}}
+	bus.Publish(batch)
+	require.Eventually(t, func() bool { return len(ch) == 1 }, 5*time.Second, 10*time.Millisecond,
+		"first payload must be buffered")
+	bus.Publish(batch)
+	time.Sleep(50 * time.Millisecond) // let the goroutine park on the blocked send
+
+	cancel()
+
+	requireSubscriptionGone(t, bus, ch)
+}


### PR DESCRIPTION
## Root cause

A live production instance accumulated ~820 leaked `NoteChanges` subscription goroutines, idle up to 748 minutes, never reclaimed after SSE client disconnect.

The resolver goroutine itself is correct — `internal/graph/schema.resolvers.go:3407-3434` has `defer UnsubscribeNoteChanges(sub)` and every receive/send selects on `<-ctx.Done()`. The problem is that **ctx was never cancelled on client disconnect**:

- The fasthttp SSE bridge (`internal/fastgql/sse_handler.go`) can only detect a dead client through a **failed write/flush** — `sseResponseWriter.Write`/`Flush` call `cancel()` on error. fasthttp has no passive connection-close notification (unlike net/http, which cancels `r.Context()` on disconnect).
- gqlgen's SSE transport was registered as `transport.SSE{}` (`internal/graph/handler.go:69`) — `KeepAlivePingInterval: 0`, so **no keepalive pings were ever sent**.
- An idle subscription (no matching note changes) therefore never writes anything after the initial `:` comment. When the client goes away, nothing ever touches the socket, the write error never happens, `cancel()` never fires, `<-ctx.Done()` never returns — the goroutine parks on `<-sub.Ch` forever and its notebus subscriber is never removed.

The existing test `TestSSEHandler_CancelsContextOnDisconnect` even documented the assumption: disconnect detection "matches real gqlgen SSE behavior where events or keepalive pings are sent continuously" — but keepalive was never enabled.

## Fix

Enable gqlgen's built-in SSE keepalive (`internal/graph/handler.go`):

```go
srv.AddTransport(sseTransport()) // transport.SSE{KeepAlivePingInterval: 30 * time.Second}
```

Every 30s gqlgen writes an SSE comment (`: ping`) and flushes. On a dead connection the flush fails, the bridge cancels the stream ctx, the resolver goroutine exits and unsubscribes from notebus. Pings are SSE comments — ignored by all clients, negligible traffic.

## How the tests prove no leak

Written test-first:

- `internal/fastgql/sse_handler_test.go` — `TestSSEHandler_IdleSubscriptionKeepAliveDetectsDisconnect`: end-to-end over a real fasthttp server + gqlgen `testserver` + real `transport.SSE` with keepalive. Client subscribes, receives nothing, disconnects silently; asserts the subscription operation ctx is cancelled within a bounded wait. **Red proof:** run with `transport.SSE{}` (pre-fix wiring) the ctx is never cancelled and the leaked stream even hangs `fasthttp.Server.Shutdown` until the `go test` timeout — exactly the production leak.
- `internal/graph/note_changes_leak_test.go`:
  - `TestSSETransport_KeepAliveEnabled` — guards the wiring: the SSE transport used by `NewHandler` must have `KeepAlivePingInterval > 0` (red before the fix).
  - `TestNoteChanges_CtxCancelWhileIdle_ExitsAndUnsubscribes` — real `notebus.Bus`; cancels ctx, asserts the payload channel closes (goroutine exited) and `bus.Stats().Subscribers` returns to baseline (bounded poll, no fixed sleeps).
  - `TestNoteChanges_CtxCancelWhileSendBlocked_ExitsAndUnsubscribes` — same, with the goroutine parked on a blocked payload send (hypothesis-3 guard).

## Verification

- `go build ./...` — exit 0
- `go test ./internal/graph/... ./internal/notebus/... ./internal/fastgql/... -count=1 -race` — pass
- `go tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint run --build-tags dev internal/graph/ internal/notebus/ internal/fastgql/` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)