### PR TITLE
fix(graph): currentTime subscription send selects on ctx.Done

### DIFF
--- a/internal/graph/schema.resolvers.go
+++ b/internal/graph/schema.resolvers.go
@@ -3377,7 +3377,11 @@ func (r *subscriptionResolver) CurrentTime(ctx context.Context, format *string) 
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				ch <- r.DefaultEnv.Now().Format(timeFormat)
+				select {
+				case ch <- r.DefaultEnv.Now().Format(timeFormat):
+				case <-ctx.Done():
+					return
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
Follow-up to #114 (NoteChanges goroutine leak): same-pattern sweep found one more subscription goroutine that can outlive its client.

`CurrentTime` (`internal/graph/schema.resolvers.go:3380`) sent on the payload channel with a plain blocking send. After the client goes away and ctx is cancelled, gqlgen stops draining the channel; the goroutine fills the 1-slot buffer on the next tick, then parks forever on the following send — never reaching the `<-ctx.Done()` case of the outer select.

Fix: wrap the send in `select { case ch <- ...: case <-ctx.Done(): return }`, same as NoteChanges does.

Verification: `go build ./...` exit 0, `go test ./internal/graph/...` pass, golangci-lint 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)