### PR TITLE
fix: contain Jet layout panics in preview render and pushNotes load

### DIFF
--- a/internal/case/admin/renderpreview/resolve.go
+++ b/internal/case/admin/renderpreview/resolve.go
@@ -102,12 +102,25 @@ func Resolve(ctx context.Context, env Env, input graphmodel.RenderLayoutInput) (
 			vars["note"] = reflect.ValueOf(noteView)
 		}
 		vars["nvs"] = reflect.ValueOf(templateviews.NewNVS(nvs, "latest"))
+		vars["title"] = reflect.ValueOf(previewTitle(noteView))
 		vars["publicURL"] = reflect.ValueOf("")
 		// Set empty injection slices to prevent "identifier not available" errors
 		// in layouts that call {{ range injection := htmlInjectionsHead }}.
 		vars["htmlInjectionsHead"] = reflect.ValueOf([]struct{}{})
 		vars["htmlInjectionsBodyEnd"] = reflect.ValueOf([]struct{}{})
-		if err := layout.View.Execute(&buf, vars, nil); err != nil {
+		// Stub namespaces the real page render injects (rendernotepage). They need
+		// a live HTTP request context to populate; no-op values keep layouts that
+		// call defaultTemplate.Styles() / currentUser.IsAdmin() previewable.
+		vars["defaultTemplate"] = reflect.ValueOf(map[string]interface{}{
+			"UserSpaceScripts": func() string { return "" },
+			"Header":           func() string { return "" },
+			"Footer":           func() string { return "" },
+			"Styles":           func() string { return "" },
+		})
+		vars["currentUser"] = reflect.ValueOf(map[string]interface{}{
+			"IsAdmin": func() bool { return false },
+		})
+		if err := executePreview(env, layout.View, &buf, vars); err != nil {
 			warnings.Layout = append(warnings.Layout, "runtime: "+err.Error())
 		}
 	}
@@ -121,6 +134,26 @@ func Resolve(ctx context.Context, env Env, input graphmodel.RenderLayoutInput) (
 		PreviewURL: "/_system/renderlayout?preview_id=" + entry.ID,
 		Warnings:   warnings,
 	}, nil
+}
+
+// executePreview runs a user-authored layout. Jet's Execute re-panics
+// runtime errors and non-error panics, so without a recover a bad layout
+// would kill the server process (same guard as rendernotepage.renderLayout).
+func executePreview(env Env, view *jet.Template, buf *bytes.Buffer, vars jet.VarMap) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			env.Logger().Error("template panic", "layout", "preview", "error", r)
+			err = fmt.Errorf("template panic: %v", r)
+		}
+	}()
+	return view.Execute(buf, vars, nil)
+}
+
+func previewTitle(noteView *templateviews.Note) string {
+	if noteView == nil {
+		return ""
+	}
+	return noteView.Title()
 }
 
 func renderMarkdownNote(content string) *model.NoteView {

--- a/internal/case/admin/renderpreview/resolve_test.go
+++ b/internal/case/admin/renderpreview/resolve_test.go
@@ -1,0 +1,100 @@
+package renderpreview
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/CloudyKit/jet/v6"
+	"github.com/stretchr/testify/require"
+
+	graphmodel "trip2g/internal/graph/model"
+	"trip2g/internal/layoutloader"
+	"trip2g/internal/logger"
+	"trip2g/internal/model"
+)
+
+type testEnv struct {
+	log     logger.Logger
+	nvs     *model.NoteViews
+	preview func(main model.LayoutSourceFile, extra map[string]string) (model.Layout, []string)
+	buffer  *PreviewBuffer
+}
+
+func (e *testEnv) Logger() logger.Logger             { return e.log }
+func (e *testEnv) LatestNoteViews() *model.NoteViews { return e.nvs }
+func (e *testEnv) PreviewBuffer() *PreviewBuffer     { return e.buffer }
+func (e *testEnv) LoadPreviewLayout(main model.LayoutSourceFile, extra map[string]string) (model.Layout, []string) {
+	return e.preview(main, extra)
+}
+
+type loaderEnv struct{ log logger.Logger }
+
+func (e *loaderEnv) Logger() logger.Logger { return e.log }
+func (e *loaderEnv) IsDevMode() bool       { return false }
+
+func newTestEnv(t *testing.T) *testEnv {
+	t.Helper()
+	layouts, err := layoutloader.Load(&loaderEnv{log: &logger.TestLogger{}}, nil, layoutloader.Options{})
+	require.NoError(t, err)
+	return &testEnv{
+		log:     &logger.TestLogger{},
+		nvs:     &model.NoteViews{},
+		preview: layouts.LoadPreview,
+		buffer:  NewPreviewBuffer(DefaultConfig()),
+	}
+}
+
+func src(s string) *string { return &s }
+
+// A layout that panics at render time (Jet re-panics runtime.Error and
+// non-error panics from Execute) must return a clean warning payload, not
+// crash the process. Regression for: preview panic killing the server.
+func TestResolveRenderPanicRecovered(t *testing.T) {
+	env := newTestEnv(t)
+	// Build a view whose execution panics with a non-error value, which Jet's
+	// own Execute recover re-panics instead of returning as error (same for
+	// runtime.Error panics like out-of-range indexing).
+	loader := jet.NewInMemLoader()
+	loader.Set("/boom", `{{ boom() }}`)
+	set := jet.NewSet(loader)
+	set.AddGlobalFunc("boom", func(a jet.Arguments) reflect.Value {
+		panic("boom: exec-time panic") // non-error panic -> Jet Execute re-panics it
+	})
+	view, err := set.GetTemplate("/boom")
+	require.NoError(t, err)
+
+	env.preview = func(model.LayoutSourceFile, map[string]string) (model.Layout, []string) {
+		return model.Layout{View: view}, nil
+	}
+
+	payload, err := Resolve(context.Background(), env, graphmodel.RenderLayoutInput{
+		Layout: &graphmodel.RenderLayoutFileInput{Path: "boom.html", Src: src(`{{ boom() }}`)},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, payload)
+	require.NotEmpty(t, payload.Warnings.Layout)
+	require.Contains(t, payload.Warnings.Layout[0], "panic")
+}
+
+// Preview must expose the same defaultTemplate / currentUser / title vars the
+// real page render injects, so layouts using them can be previewed.
+func TestResolveInjectsUserSpaceVars(t *testing.T) {
+	env := newTestEnv(t)
+
+	payload, err := Resolve(context.Background(), env, graphmodel.RenderLayoutInput{
+		Layout: &graphmodel.RenderLayoutFileInput{
+			Path: "parity/index.html",
+			Src: src(`<head>{{ defaultTemplate.Styles() }}{{ title }}</head>` +
+				`<body>{{ defaultTemplate.Header() }}admin:{{ currentUser.IsAdmin() }}` +
+				`{{ defaultTemplate.Footer() }}{{ defaultTemplate.UserSpaceScripts() }}</body>`),
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, payload)
+	require.Empty(t, payload.Warnings.Layout)
+
+	entry, ok := env.buffer.GetByID(payload.PreviewID)
+	require.True(t, ok)
+	require.Contains(t, entry.HTML, "admin:false")
+}

--- a/internal/layoutloader/loader.go
+++ b/internal/layoutloader/loader.go
@@ -245,26 +245,14 @@ func (jl *jetLoader) processTemplates(sourceFiles []model.LayoutSourceFile) {
 		assetWalker := assetFinder{}
 		safeWalk(view, &assetWalker)
 		// utils.Walk does not recurse into {{ import }} templates — walk them explicitly.
-		if views, ok := jl.sets[source.ID]; ok {
-			for _, importPath := range extractImportPaths(source.Content) {
-				if imported, err := views.GetTemplate(importPath); err == nil {
-					safeWalk(imported, &assetWalker)
-				}
-			}
-		}
+		jl.walkImported(source, &assetWalker)
 
 		jl.log.Debug("detect assets", "assets", assetWalker.List)
 
 		// Find block definitions
 		blockWalker := blockFinder{sourceID: source.ID}
 		safeWalk(view, &blockWalker)
-		if views, ok := jl.sets[source.ID]; ok {
-			for _, importPath := range extractImportPaths(source.Content) {
-				if imported, err := views.GetTemplate(importPath); err == nil {
-					safeWalk(imported, &blockWalker)
-				}
-			}
-		}
+		jl.walkImported(source, &blockWalker)
 
 		for _, block := range blockWalker.blocks {
 			// Add to ByName (last one wins if duplicate names)
@@ -310,6 +298,25 @@ func (jl *jetLoader) processTemplates(sourceFiles []model.LayoutSourceFile) {
 
 			Warnings:     warnings,
 			Personalized: personalized,
+		}
+	}
+}
+
+// walkImported walks the templates a source explicitly imports. Panics from a
+// broken imported template are contained (the import's own load reports the
+// error), so it can't crash processing of the importing page.
+func (jl *jetLoader) walkImported(source model.LayoutSourceFile, v utils.Visitor) {
+	views, ok := jl.sets[source.ID]
+	if !ok {
+		return
+	}
+	for _, importPath := range extractImportPaths(source.Content) {
+		imported, err := views.GetTemplate(importPath)
+		if err != nil {
+			continue
+		}
+		if msg := walkContained(imported, v); msg != "" {
+			jl.log.Warn("imported template walk panic", "source", source.ID, "import", importPath, "error", msg)
 		}
 	}
 }
@@ -395,9 +402,24 @@ func (w *yieldBlocksUsageFinder) Visit(vc utils.VisitorContext, node jet.Node) {
 
 // load parses a template and returns (template, parseError).
 // If parsing fails, returns (nil, errorMessage).
-func (jl *jetLoader) load(source model.LayoutSourceFile) (*jet.Template, string) {
+//
+// Panics are recovered and reported as a parse error so one broken layout
+// (e.g. `{{ range _, x := ... }}`, which Jet parses but whose AST walker
+// panics on with "unexpected node _") can't crash the whole Load cycle —
+// and with it the entire pushNotes batch.
+//
+//nolint:nonamedreturns // named returns required for defer/recover to set them
+func (jl *jetLoader) load(source model.LayoutSourceFile) (view *jet.Template, parseErr string) {
 	jl.mu.Lock()
 	defer jl.mu.Unlock()
+
+	defer func() {
+		if r := recover(); r != nil {
+			jl.log.Error("layout load panic", "id", source.ID, "error", r)
+			view = nil
+			parseErr = fmt.Sprintf("layout panic: %v", r)
+		}
+	}()
 
 	// Add content to templates map (auto-convert JSON if needed)
 	content := source.Content

--- a/internal/layoutloader/panic_recover_test.go
+++ b/internal/layoutloader/panic_recover_test.go
@@ -1,0 +1,106 @@
+package layoutloader
+
+import (
+	"testing"
+	"trip2g/internal/logger"
+	"trip2g/internal/model"
+
+	"github.com/stretchr/testify/require"
+)
+
+// `{{ range _, x := ... }}` parses in Jet but its AST walker panics with
+// "unexpected node _". The panic must be contained per-layout: the bad layout
+// gets a critical warning, other layouts load, Load does not panic.
+// Regression for: one bad layout crashing the whole pushNotes batch.
+func TestLoadUnderscoreRangePanicContained(t *testing.T) {
+	sources := []model.LayoutSourceFile{
+		{
+			ID:      "/bad/index",
+			Path:    "_layouts/bad/index.html",
+			Content: `<html>{{ range _, x := note.List() }}{{ x }}{{ end }}</html>`,
+		},
+		{
+			ID:      "/good/index",
+			Path:    "_layouts/good/index.html",
+			Content: `<html>ok</html>`,
+		},
+	}
+
+	layouts, err := Load(&testEnv{logger: &logger.TestLogger{}}, sources, Options{})
+	require.NoError(t, err)
+
+	bad := layouts.Map["/bad/index"]
+	require.Nil(t, bad.View)
+	require.NotEmpty(t, bad.Warnings)
+	require.Equal(t, model.NoteWarningCritical, bad.Warnings[0].Level)
+	require.Contains(t, bad.Warnings[0].Message, "unexpected node _")
+
+	good := layouts.Map["/good/index"]
+	require.NotNil(t, good.View)
+	require.Empty(t, good.Warnings)
+}
+
+// A broken layout must not poison OTHER layouts: buildBlockRegistry walks
+// every other template's AST during each page's load, so with the good page
+// first the bad component's walker panic would surface inside the good page.
+func TestLoadUnderscoreRangeDoesNotPoisonOtherLayouts(t *testing.T) {
+	sources := []model.LayoutSourceFile{
+		{
+			ID:      "/good/index",
+			Path:    "_layouts/good/index.html",
+			Content: `<html>ok</html>`,
+		},
+		{
+			ID:      "/bad/index",
+			Path:    "_layouts/bad/index.html",
+			Content: `<html>{{ range _, x := note.List() }}{{ x }}{{ end }}</html>`,
+		},
+	}
+
+	layouts, err := Load(&testEnv{logger: &logger.TestLogger{}}, sources, Options{})
+	require.NoError(t, err)
+
+	good := layouts.Map["/good/index"]
+	require.NotNil(t, good.View)
+	require.Empty(t, good.Warnings)
+
+	require.Nil(t, layouts.Map["/bad/index"].View)
+}
+
+// A page explicitly importing a broken layout must not crash Load: the
+// imported-template walks in processTemplates hit the same walker panic.
+func TestLoadUnderscoreRangeImportedPanicContained(t *testing.T) {
+	sources := []model.LayoutSourceFile{
+		{
+			ID:      "/page/index",
+			Path:    "_layouts/page/index.html",
+			Content: `{{ import "/bad/index" }}<html>ok</html>`,
+		},
+		{
+			ID:      "/bad/index",
+			Path:    "_layouts/bad/index.html",
+			Content: `{{ range _, x := note.List() }}{{ x }}{{ end }}`,
+		},
+	}
+
+	layouts, err := Load(&testEnv{logger: &logger.TestLogger{}}, sources, Options{})
+	require.NoError(t, err)
+	require.NotNil(t, layouts.Map["/page/index"].View)
+	require.Nil(t, layouts.Map["/bad/index"].View)
+}
+
+// The same panic must be contained in the preview compile path.
+func TestLoadPreviewUnderscoreRangePanicContained(t *testing.T) {
+	layouts, err := Load(&testEnv{logger: &logger.TestLogger{}}, nil, Options{})
+	require.NoError(t, err)
+
+	layout, warnings := layouts.LoadPreview(model.LayoutSourceFile{
+		ID:      "/bad/index",
+		Path:    "/_layouts/bad/index.html",
+		Content: `<html>{{ range _, x := note.List() }}{{ x }}{{ end }}</html>`,
+	}, nil)
+
+	require.Nil(t, layout.View)
+	require.NotEmpty(t, warnings)
+	require.Contains(t, warnings[0], "unexpected node _")
+}

--- a/internal/layoutloader/personalization.go
+++ b/internal/layoutloader/personalization.go
@@ -70,7 +70,11 @@ func (jl *jetLoader) detectPersonalized(sourceID, content string, view *jet.Temp
 			if err != nil {
 				continue
 			}
-			safeWalk(imported, finder)
+			// Contained: a broken imported template (reported by its own load)
+			// must not crash personalization detection for the importing page.
+			if msg := walkContained(imported, finder); msg != "" {
+				continue
+			}
 			if finder.found {
 				return true
 			}

--- a/internal/layoutloader/registry.go
+++ b/internal/layoutloader/registry.go
@@ -37,7 +37,11 @@ func buildBlockRegistry(
 			continue
 		}
 		finder := &blockNameFinder{}
-		safeWalk(t, finder)
+		if msg := walkContained(t, finder); msg != "" {
+			// Broken template (its own load reports the error) — skip its blocks
+			// so it can't take down registry building for other pages.
+			continue
+		}
 		for _, name := range finder.names {
 			if existing, ok := registry[name]; ok {
 				warnings = append(warnings, model.NoteWarning{

--- a/internal/layoutloader/safe_walk.go
+++ b/internal/layoutloader/safe_walk.go
@@ -1,6 +1,8 @@
 package layoutloader
 
 import (
+	"fmt"
+
 	"github.com/CloudyKit/jet/v6"
 	"github.com/CloudyKit/jet/v6/utils"
 )
@@ -12,6 +14,22 @@ import (
 //   - YieldNode.Parameters may be nil for {{ yield content }} nodes — initialised.
 func safeWalk(tmpl *jet.Template, v utils.Visitor) {
 	utils.Walk(tmpl, &guardedWalker{inner: v})
+}
+
+// walkContained runs safeWalk and recovers panics from Jet's AST walker
+// (e.g. "unexpected node _" for underscore range vars). Used where one
+// template's walk must not take down analysis of others (block registry,
+// imported-template walks). Returns the panic message, or "" on success.
+//
+//nolint:nonamedreturns // named return required for defer/recover to set it
+func walkContained(tmpl *jet.Template, v utils.Visitor) (panicMsg string) {
+	defer func() {
+		if r := recover(); r != nil {
+			panicMsg = fmt.Sprint(r)
+		}
+	}()
+	safeWalk(tmpl, v)
+	return ""
 }
 
 type guardedWalker struct{ inner utils.Visitor }


### PR DESCRIPTION
Two robustness bugs in custom Jet layout rendering, found by live testing. Both are containment fixes: a bad layout now produces a clean, per-layout error instead of a process crash or a batch-wide opaque failure. Layout semantics are unchanged (`_` as a range variable is still an error).

## Bug 1: layout preview panic kills the server

`POST /_system/renderlayout` -> `renderpreview.Resolve` executed a user-authored Jet layout with no recover. Jet's `Runtime.recover` re-panics `runtime.Error` and non-error panics from `Execute`, so a layout that panics at render time took down the whole server process.

**Root cause:** `internal/case/admin/renderpreview/resolve.go:110` (unguarded `layout.View.Execute`).

**Fix:** execution extracted into `executePreview` with the same defer/recover guard as `rendernotepage.renderLayout` (`internal/case/rendernotepage/endpoint.go:369`). A panicking preview now returns a `runtime: template panic: ...` warning in the payload.

Also: the preview render was missing the `defaultTemplate`, `currentUser`, and `title` vars the real page render injects, so layouts calling `defaultTemplate.Styles()` / `currentUser.IsAdmin()` could not be previewed. Preview now injects the same no-op stubs the pushNotes smoke render uses (`internal/noteloader/smoke_render.go`) — full `userSpaceHelper` parity needs a live fasthttp request context, which the GraphQL preview path does not have.

## Bug 2: one bad layout panics the whole pushNotes batch

A layout with `{{ range _, x := items }}` parses fine in Jet, but Jet's AST walker (`utils.VisitorContext.Visit`) panics with `unexpected node _`. The panic escaped `jetLoader.load` -> `buildAutoImportPreamble` -> `resolveNeededFiles` -> `safeWalk`, crashing `layoutloader.Load` -> `PrepareLatestNotes` -> the entire `pushNotes` batch as an opaque gqlgen internal error, with no notes committed.

**Root cause:** `internal/layoutloader/loader.go` `load()` (compile + AST analysis step, no recover).

**Fix:**
- `jetLoader.load` recovers panics into a critical `layout panic: unexpected node _` warning on that layout only; other layouts load, the batch commits.
- New `walkContained` helper (`safe_walk.go`) contains walker panics where one template's AST walk feeds analysis of *others*: block registry (`registry.go`), explicit-import walks (`loader.go` `walkImported`), and personalization detection (`personalization.go`). Without this, a broken component poisoned good pages depending on load order.

## Tests (TDD: each reproduced the panic red first)

- `layoutloader`: `TestLoadUnderscoreRangePanicContained`, `TestLoadUnderscoreRangeDoesNotPoisonOtherLayouts`, `TestLoadUnderscoreRangeImportedPanicContained`, `TestLoadPreviewUnderscoreRangePanicContained`
- `renderpreview`: `TestResolveRenderPanicRecovered`, `TestResolveInjectsUserSpaceVars`

## Verification

- `go test ./internal/...` — all green
- `golangci-lint run internal/layoutloader/... internal/case/admin/renderpreview/...` — 0 issues