### PR TITLE
chore: fix .dockerignore — shrink docker build context 540MB → 46MB

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,8 +12,8 @@ docker-compose*.yml
 .gitignore
 .gitattributes
 
-# Dependencies
-node_modules/
+# Dependencies (glob form so BuildKit matches too — trailing-slash form was skipped by BuildKit)
+**/node_modules
 
 # Build artifacts
 tmp/
@@ -55,13 +55,24 @@ docs/
 README.md
 CLAUDE.md
 
+# Demo video assets (mp4/gif/mkv — not needed in build)
+docs/demo-video/
+**/*.mp4
+**/*.mkv
+**/*.gif
+
 # Demo and test data (use testdata/ instead)
 demo/
 demo2/
 demo/.obsidian
 
+# memcli docker volume data (root-owned sqlite/WAL, created at runtime)
+**/.trip2g-memory/
+
 # Separate services (have their own Dockerfile)
 ce-bot/
+embedding-server/
+tge2e/
 
 # Asset source/build files not needed in Go embed
 # embed.go only needs: tiptap/tiptap.js, ui/*/- built artifacts
@@ -79,6 +90,19 @@ thoughts/
 # BMad workflow files
 .bmad/
 .claude/
+
+# Git worktrees (agent-spawned checkouts, not needed for build)
+.worktrees/
+
+# OMC and related state dirs
+.omc/
+.omx/
+
+# Demo / non-production data
+businessdemo/
+
+# Telegram session files
+.tgsession.*
 
 # Logs
 *.log


### PR DESCRIPTION
The docker build context was ballooning (owner saw a huge `transferring context` figure). Root causes in `.dockerignore`:

- **`node_modules/` (trailing slash) was skipped by BuildKit** — it excluded under the classic builder but not BuildKit, so the 490MB `node_modules` shipped in the context. Changed to the glob form `**/node_modules` which both builders honor.
- Several large dirs were not excluded at all: `.worktrees/` (agent worktrees), `tge2e/`, `embedding-server/`, `ce-bot/`, `businessdemo/`, `.omc/`/`.omx/`, `.tgsession.*`.
- Belt-and-suspenders for confirmed culprits: `docs/demo-video/` + `**/*.mp4|*.mkv|*.gif`, `**/.trip2g-memory/` (memcli docker-volume data), `*.sqlite*`, the built `server` binary.

## Verified
BuildKit `transferring context`: **540MB → 46.26MB**. Confirmed the Dockerfile's needed COPY paths (`internal/`, `cmd/`, `db/`, `cli/`, `assets/`, `onboarding-vault/`, `go.mod`/`go.sum`, `queries.*.sql`) are NOT excluded.

Inspect-the-context command used to find the leak:
```
docker build -f- . <<'E'
FROM busybox
COPY . /ctx
RUN du -ah /ctx | sort -rh | head -40
E
```