### PR TITLE
feat(server): log instance-ready line

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -480,6 +480,7 @@ func main() {
 		a.replicaReload = replicareload.New(a, a.log, replicaNoteReloadInterval)
 		go a.replicaReload.Run(a.shutdownCtx)
 		a.ready.Store(true)
+		log.Info("instance ready — serving reads+writes")
 		a.startServer()
 		return
 	}
@@ -517,6 +518,7 @@ func main() {
 
 	// Fully ready: can serve reads AND writes. /readyz flips to 200.
 	a.ready.Store(true)
+	log.Info("instance ready — serving reads+writes")
 
 	a.startServer()
 }

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -161,6 +161,7 @@ func (a *app) startServer() { //nolint:gocognit // server startup wiring
 
 	runServer := func() {
 		if len(a.config.AcmeDomains) == 0 {
+			a.log.Info("http server listening", "addr", a.config.ListenAddr)
 			if err := a.serveHTTP(s); err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
## Summary
- Adds `log.Info("instance ready — serving reads+writes")` immediately after both `a.ready.Store(true)` calls: the normal writer path and the read-only-replica path.
- Adds `a.log.Info("http server listening", "addr", ...)` in `startServer` before `serveHTTP`.

## Test plan
- [ ] `go build ./cmd/server/...` passes
- [ ] `go vet ./cmd/server/...` passes
- [ ] `go test ./cmd/server/...` passes