### PR TITLE
fix(cronjobs): mark orphaned running executions dead (status was compared as string, a no-op)

### DIFF
--- a/internal/cronjobs/jobs.go
+++ b/internal/cronjobs/jobs.go
@@ -217,7 +217,7 @@ func (cj *CronJobs) executeJob(jobID int64) (*db.CronJobExecution, error) {
 	// for a SQLite write lock (e.g. when another cron job holds a write transaction).
 	updateErr := cj.env.UpdateRunningCronJobExecutions(cj.ctx, db.UpdateRunningCronJobExecutionsParams{
 		JobID:        jobID,
-		Status:       JobStatusRunning,
+		Status:       JobStatusFailed,
 		ErrorMessage: ptr.To("died"),
 	})
 	if updateErr != nil {

--- a/internal/db/cron_executions_test.go
+++ b/internal/db/cron_executions_test.go
@@ -1,0 +1,72 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trip2g/internal/db"
+)
+
+// TestUpdateRunningCronJobExecutions_MarksRowDead is a regression test for the
+// "mark stale running executions as dead on startup" feature.
+//
+// Root cause: the SQL WHERE clause used status = 'running' (a string literal)
+// but the status column is INTEGER (running=1). SQLite coerces 'running' to 0,
+// so the predicate never matched and the update was a permanent no-op.
+//
+// RED: on unfixed code the row stays status=1 (running) after the call.
+// GREEN: after the fix the row is status=3 (failed) with the "died" message.
+func TestUpdateRunningCronJobExecutions_MarksRowDead(t *testing.T) {
+	conn, _, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	wq := db.NewWriteQueries(conn)
+
+	// Insert a cron_jobs row (required by the FK on cron_job_executions).
+	var jobID int64
+	err := conn.QueryRow(`
+		insert into cron_jobs (name, expression)
+		values ('test-job', '0 * * * *')
+		returning id
+	`).Scan(&jobID)
+	require.NoError(t, err)
+
+	// Insert a cron_job_executions row with status = 1 (running).
+	// This simulates a row left behind by a killed/crashed instance.
+	const statusRunning int64 = 1
+	var execID int64
+	err = conn.QueryRow(`
+		insert into cron_job_executions (job_id, status)
+		values (?, ?)
+		returning id
+	`, jobID, statusRunning).Scan(&execID)
+	require.NoError(t, err)
+
+	// Call the mark-dead path: WHERE status = running → SET status = failed.
+	const statusFailed int64 = 3
+	died := "died"
+	updateErr := wq.UpdateRunningCronJobExecutions(ctx, db.UpdateRunningCronJobExecutionsParams{
+		JobID:        jobID,
+		Status:       statusFailed,
+		ErrorMessage: &died,
+	})
+	require.NoError(t, updateErr)
+
+	// Assert: the row must now be status=3 (failed) with the error message.
+	var gotStatus int64
+	var gotMsg *string
+	err = conn.QueryRow(
+		`select status, error_message from cron_job_executions where id = ?`,
+		execID,
+	).Scan(&gotStatus, &gotMsg)
+	require.NoError(t, err)
+
+	require.Equal(t, statusFailed, gotStatus,
+		"stale running execution must be marked failed (dead); got status=%d — "+
+			"likely the WHERE status='running' string comparison bug is still present", gotStatus)
+	require.NotNil(t, gotMsg)
+	require.Equal(t, "died", *gotMsg)
+}

--- a/internal/db/queries.write.sql.go
+++ b/internal/db/queries.write.sql.go
@@ -4000,7 +4000,7 @@ const updateRunningCronJobExecutions = `-- name: UpdateRunningCronJobExecutions 
 update cron_job_executions
   set status = ?, error_message = ?
 where job_id = ?
-  and status = 'running'
+  and status = 1
 `
 
 type UpdateRunningCronJobExecutionsParams struct {

--- a/queries.write.sql
+++ b/queries.write.sql
@@ -660,7 +660,7 @@ where id = ?;
 update cron_job_executions
   set status = ?, error_message = ?
 where job_id = ?
-  and status = 'running';
+  and status = 1;
 
 -- name: UpdateCronJob :one
 update cron_jobs


### PR DESCRIPTION
## Summary

- `queries.write.sql`: `WHERE status = 'running'` compared an INTEGER column to a string literal — SQLite coerced the string to 0, so the predicate never matched and the update was a permanent no-op since the feature was introduced
- `internal/cronjobs/jobs.go`: caller passed `Status: JobStatusRunning` (1) as the SET value when it should have been `JobStatusFailed` (3); stale executions would have been re-marked running instead of dead
- `internal/db/cron_executions_test.go`: regression test (TDD, red-first) that inserts a `status=1` (running) execution, calls `UpdateRunningCronJobExecutions`, and asserts the row becomes `status=3` (failed) with `error_message="died"`

## Before / After

**SQL query** (`queries.write.sql` + regenerated `internal/db/queries.write.sql.go`):
```sql
-- before
  and status = 'running';

-- after
  and status = 1;
```

**Caller** (`internal/cronjobs/jobs.go`):
```go
// before
Status: JobStatusRunning,   // sets the row to running=1, wrong

// after
Status: JobStatusFailed,    // sets the row to failed=3, correct
```

## Enum values confirmed

```go
JobStatusPending   int64 = 0
JobStatusRunning   int64 = 1
JobStatusCompleted int64 = 2
JobStatusFailed    int64 = 3
```

## Test evidence

RED (before fix):
```
cron_executions_test.go:67: Not equal: expected: 3 actual: 1
stale running execution must be marked failed (dead); got status=1 — likely the WHERE status='running' string comparison bug is still present
--- FAIL: TestUpdateRunningCronJobExecutions_MarksRowDead
```

GREEN (after fix):
```
--- PASS: TestUpdateRunningCronJobExecutions_MarksRowDead (0.20s)
ok  trip2g/internal/db
ok  trip2g/internal/cronjobs
```