### PR TITLE
feat(cronjobs): run ExecuteAfterStart jobs once at boot (async, non-blocking)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,10 @@ MINIO_URL_EXPIRES_IN=10m
 # MINIO_PREFIX=prod
 SIMPLE_BACKUP=true
 
+# Optional: run ExecuteAfterStart cron jobs once at boot (async, after ready).
+# Off by default — frequent restarts would re-run these jobs on every boot.
+# CRONJOBS_RUN_ON_START=true
+
 # Optional payments
 # NOWPAYMENTS_API_KEY=your_nowpayments_api_key_here
 # NOWPAYMENTS_IPN_KEY=your_nowpayments_ipn_key_here

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -520,6 +520,11 @@ func main() {
 	a.ready.Store(true)
 	log.Info("instance ready — serving reads+writes")
 
+	// Boot-refresh: run ExecuteAfterStart cron jobs once, in the background,
+	// never blocking readiness. Opt-in via CRONJOBS_RUN_ON_START (off by
+	// default: frequent restarts would re-run these jobs on every boot).
+	go a.RunStartupJobs(a.shutdownCtx, config.CronJobs.RunOnStart)
+
 	a.startServer()
 }
 

--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -188,6 +188,10 @@ type SimpleBackupConfig struct {
 // CronJobsConfig holds cron jobs admin configuration.
 type CronJobsConfig struct {
 	AllowEdit bool
+	// RunOnStart runs every ExecuteAfterStart cron job once at boot,
+	// asynchronously after the instance is ready. Off by default: instances
+	// restart often and re-running these jobs on every boot is needless load.
+	RunOnStart bool
 }
 
 // Default values for configuration.
@@ -529,6 +533,12 @@ func (c *Config) defineServerFlags() {
 		"Enable the periodic VACUUM/ANALYZE database maintenance cron. Off by default (heavy full-DB rewrite; incompatible with Litestream WAL replication).",
 	)
 	flag.BoolVar(&c.CronJobs.AllowEdit, "cronjobs-allow-edit", false, "Allow admin to edit cron job schedule and enabled state")
+	flag.BoolVar(
+		&c.CronJobs.RunOnStart,
+		"cronjobs-run-on-start",
+		false,
+		"Run ExecuteAfterStart cron jobs once at boot, async after ready (env CRONJOBS_RUN_ON_START). Off by default.",
+	)
 
 	// Storage limits.
 	datasize.FlagVar(

--- a/internal/cronjobs/jobs.go
+++ b/internal/cronjobs/jobs.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"sync"
+	"time"
 	"trip2g/internal/db"
 	"trip2g/internal/logger"
 	"trip2g/internal/model"
@@ -281,6 +283,62 @@ func (cj *CronJobs) executeJob(jobID int64) (*db.CronJobExecution, error) {
 	}
 
 	return &execution, nil
+}
+
+// RunStartupJobs executes once, sequentially, every enabled job whose
+// ExecuteAfterStart() returns true, through the same executeJob path as a
+// scheduled run (identical cron_job_executions bookkeeping). Sequential on
+// purpose: the jobs contend for the single write connection. Meant to run in
+// a background goroutine after the instance is ready; ctx cancellation stops
+// the loop between jobs. enabled comes from the cronjobs-run-on-start flag
+// (CRONJOBS_RUN_ON_START), off by default — when false this is a no-op.
+func (cj *CronJobs) RunStartupJobs(ctx context.Context, enabled bool) {
+	if !enabled {
+		cj.log.Debug("boot jobs: disabled (cronjobs-run-on-start=false), skipping")
+		return
+	}
+
+	cj.jobsMU.Lock()
+	type startupJob struct {
+		id   int64
+		name string
+	}
+	var jobs []startupJob
+	for id, item := range cj.jobs {
+		if item.config.Enabled && item.job.ExecuteAfterStart() {
+			jobs = append(jobs, startupJob{id: id, name: item.job.Name()})
+		}
+	}
+	cj.jobsMU.Unlock()
+
+	sort.Slice(jobs, func(i, j int) bool { return jobs[i].name < jobs[j].name })
+
+	cj.log.Info("boot jobs: running startup-execute jobs", "count", len(jobs))
+	start := time.Now()
+	ran := 0
+
+	for _, job := range jobs {
+		if ctx.Err() != nil {
+			cj.log.Info("boot jobs: shutdown requested, stopping", "ran", ran)
+			return
+		}
+
+		jobStart := time.Now()
+		exec, err := cj.executeJob(job.id)
+		took := time.Since(jobStart)
+
+		switch {
+		case err != nil:
+			cj.log.Info("boot job done", "job", job.name, "took", took, "error", err)
+		case exec != nil && exec.Status == JobStatusFailed && exec.ErrorMessage != nil:
+			cj.log.Info("boot job done", "job", job.name, "took", took, "error", *exec.ErrorMessage)
+		default:
+			cj.log.Info("boot job done", "job", job.name, "took", took)
+		}
+		ran++
+	}
+
+	cj.log.Info("boot jobs complete", "total", time.Since(start), "ran", ran)
 }
 
 func (cj *CronJobs) RefreshCronJob(job db.CronJob) error {

--- a/internal/cronjobs/jobs_test.go
+++ b/internal/cronjobs/jobs_test.go
@@ -112,3 +112,78 @@ func TestExecuteJob_DoesNotHoldMutexDuringDBOps(t *testing.T) {
 
 	close(job1Block) // unblock job1 to let goroutines exit cleanly
 }
+
+// countingJob records how many times Execute was called.
+type countingJob struct {
+	name       string
+	afterStart bool
+	execCount  int
+}
+
+func (j *countingJob) Name() string            { return j.name }
+func (j *countingJob) Schedule() string        { return "0 0 * * * *" }
+func (j *countingJob) ExecuteAfterStart() bool { return j.afterStart }
+func (j *countingJob) Execute(_ context.Context, _ interface{}) (interface{}, error) {
+	j.execCount++
+	return nil, nil
+}
+
+func TestRunStartupJobs_RunsOnlyExecuteAfterStartJobsOnce(t *testing.T) {
+	jobA := &countingJob{name: "a", afterStart: true}
+	jobB := &countingJob{name: "b", afterStart: false}
+	jobC := &countingJob{name: "c", afterStart: true}
+	jobD := &countingJob{name: "d", afterStart: true} // disabled in DB config
+
+	env := &mockEnv{}
+	cj := newTestCronJobs(env, nil)
+	cj.jobs[1] = &jobItem{job: jobA, config: db.CronJob{ID: 1, Name: "a", Enabled: true}}
+	cj.jobs[2] = &jobItem{job: jobB, config: db.CronJob{ID: 2, Name: "b", Enabled: true}}
+	cj.jobs[3] = &jobItem{job: jobC, config: db.CronJob{ID: 3, Name: "c", Enabled: true}}
+	cj.jobs[4] = &jobItem{job: jobD, config: db.CronJob{ID: 4, Name: "d", Enabled: false}}
+
+	cj.RunStartupJobs(context.Background(), true)
+
+	if jobA.execCount != 1 {
+		t.Errorf("job a (afterStart=true): expected 1 execution, got %d", jobA.execCount)
+	}
+	if jobB.execCount != 0 {
+		t.Errorf("job b (afterStart=false): expected 0 executions, got %d", jobB.execCount)
+	}
+	if jobC.execCount != 1 {
+		t.Errorf("job c (afterStart=true): expected 1 execution, got %d", jobC.execCount)
+	}
+	if jobD.execCount != 0 {
+		t.Errorf("job d (disabled): expected 0 executions, got %d", jobD.execCount)
+	}
+}
+
+func TestRunStartupJobs_StopsOnCancelledContext(t *testing.T) {
+	jobA := &countingJob{name: "a", afterStart: true}
+
+	env := &mockEnv{}
+	cj := newTestCronJobs(env, nil)
+	cj.jobs[1] = &jobItem{job: jobA, config: db.CronJob{ID: 1, Name: "a", Enabled: true}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cj.RunStartupJobs(ctx, true)
+
+	if jobA.execCount != 0 {
+		t.Errorf("expected 0 executions with cancelled context, got %d", jobA.execCount)
+	}
+}
+
+func TestRunStartupJobs_DisabledRunsNothing(t *testing.T) {
+	jobA := &countingJob{name: "a", afterStart: true}
+
+	env := &mockEnv{}
+	cj := newTestCronJobs(env, nil)
+	cj.jobs[1] = &jobItem{job: jobA, config: db.CronJob{ID: 1, Name: "a", Enabled: true}}
+
+	cj.RunStartupJobs(context.Background(), false)
+
+	if jobA.execCount != 0 {
+		t.Errorf("expected 0 executions with flag disabled, got %d", jobA.execCount)
+	}
+}


### PR DESCRIPTION
Wires up the previously dead `ExecuteAfterStart()` cron feature: jobs whose `ExecuteAfterStart()` returns true now run once at boot — asynchronously, after `/readyz` flips to 200, sequentially (single write conn), through the same `executeJob` path as scheduled runs (identical `cron_job_executions` bookkeeping).

**Gated behind `CRONJOBS_RUN_ON_START` (flag `cronjobs-run-on-start`), default OFF** — most spaces restart often, and re-running these jobs on every boot is needless load.

## Changes
- `internal/cronjobs/jobs.go` — new `RunStartupJobs(ctx, enabled)`: selects enabled jobs with `ExecuteAfterStart()==true`, runs each once via `executeJob`, per-job + total timing logs, stops between jobs on ctx cancellation; no-op when disabled.
- `cmd/server/main.go` — `go a.RunStartupJobs(a.shutdownCtx, config.CronJobs.RunOnStart)` right after `a.ready.Store(true)` — never blocks readiness.
- `internal/appconfig/config.go` — `CronJobs.RunOnStart` + `cronjobs-run-on-start` flag (env `CRONJOBS_RUN_ON_START`), default false.
- `.env.example` — documented (commented out).

## Verification
- `go build ./...` + `go test ./internal/cronjobs/... ./cmd/server/...` green; golangci-lint 0 issues.
- Tests: flag on → only `ExecuteAfterStart()==true` + enabled jobs run, once each; disabled-in-DB and `false` jobs skipped; flag off → nothing runs; cancelled ctx → loop stops.
- Fresh dev instance:
  - flag off (default): `/readyz` 200 in **0.33s**, zero boot-job lines — no behavior change.
  - flag on: `/readyz` 200 in **0.12s** (unchanged, jobs run after ready), then:
    ```
    boot jobs: running startup-execute jobs count=3
    boot job done job=regenerate_note_embeddings took=5.8ms
    boot job done job=remove_expired_tg_chat_members took=0.43ms
    boot job done job=send_scheduled_telegram_publishposts took=0.61ms
    boot jobs complete ran=3 total=6.9ms
    ```

Note: only 3 of 16 jobs currently return `true` (regenerate_note_embeddings, remove_expired_tg_chat_members, send_scheduled_telegram_publishposts). `sendscheduledtelegrampublishposts` returns true with a comment saying "Don't run immediately on startup" — left as-is, flagging for review.