### PR TITLE
fix(cronjobs): serialize job execution to bound memory (prevent OOM from concurrent jobs)

### DIFF
--- a/internal/cronjobs/jobs.go
+++ b/internal/cronjobs/jobs.go
@@ -62,6 +62,10 @@ type CronJobs struct {
 
 	runningMU   sync.Mutex
 	runningJobs map[int64]db.CronJobExecution
+
+	// execMu ensures at most one job's Execute runs at a time, bounding
+	// peak memory on small boxes where multiple jobs fire at the same minute.
+	execMu sync.Mutex
 }
 
 func jobQueueID(id string) string {
@@ -239,8 +243,11 @@ func (cj *CronJobs) executeJob(jobID int64) (*db.CronJobExecution, error) {
 	cj.runningJobs[jobID] = exec
 	cj.runningMU.Unlock()
 
-	// Execute the job
+	// Execute the job — serialised globally to bound peak memory.
+	// DB bookkeeping above is intentionally outside this lock.
+	cj.execMu.Lock()
 	report, jobErr := job.job.Execute(cj.ctx, cj.env)
+	cj.execMu.Unlock()
 
 	// Update execution status
 	status := JobStatusCompleted

--- a/internal/cronjobs/serial_test.go
+++ b/internal/cronjobs/serial_test.go
@@ -1,0 +1,80 @@
+package cronjobs
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"trip2g/internal/db"
+)
+
+// timingJob records entry/exit timestamps for each Execute call.
+type timingJob struct {
+	name string
+	mu   sync.Mutex
+	// windows holds (entry, exit) pairs in execution order
+	windows [][2]time.Time
+}
+
+func (j *timingJob) Name() string                    { return j.name }
+func (j *timingJob) Schedule() string                { return "0 0 * * * *" }
+func (j *timingJob) ExecuteAfterStart() bool         { return false }
+func (j *timingJob) Execute(_ context.Context, _ interface{}) (interface{}, error) {
+	entry := time.Now()
+	time.Sleep(50 * time.Millisecond)
+	exit := time.Now()
+	j.mu.Lock()
+	j.windows = append(j.windows, [2]time.Time{entry, exit})
+	j.mu.Unlock()
+	return nil, nil
+}
+
+// TestSerialExecution verifies that only one cron job runs at a time.
+// The two Execute windows must NOT overlap.
+//
+// RED: fails without execMu because both goroutines run Execute concurrently.
+// GREEN: passes after execMu serialises them.
+func TestSerialExecution(t *testing.T) {
+	j1 := &timingJob{name: "job-a"}
+	j2 := &timingJob{name: "job-b"}
+
+	env := &mockEnv{}
+	cj := &CronJobs{
+		ctx:         context.Background(),
+		env:         env,
+		jobs:        make(map[int64]*jobItem),
+		runningJobs: make(map[int64]db.CronJobExecution),
+		log:         env.Logger(),
+	}
+	cj.jobs[1] = &jobItem{job: j1, config: db.CronJob{ID: 1}}
+	cj.jobs[2] = &jobItem{job: j2, config: db.CronJob{ID: 2}}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); cj.executeJob(1) }()
+	go func() { defer wg.Done(); cj.executeJob(2) }()
+	wg.Wait()
+
+	j1.mu.Lock()
+	w1 := j1.windows
+	j1.mu.Unlock()
+	j2.mu.Lock()
+	w2 := j2.windows
+	j2.mu.Unlock()
+
+	if len(w1) == 0 || len(w2) == 0 {
+		t.Fatal("at least one job did not execute")
+	}
+
+	a := w1[0]
+	b := w2[0]
+
+	// Windows must not overlap: one must finish before the other starts.
+	overlap := a[0].Before(b[1]) && b[0].Before(a[1])
+	if overlap {
+		t.Errorf("jobs ran concurrently: job-a [%v, %v] overlaps job-b [%v, %v]",
+			a[0].Format(time.RFC3339Nano), a[1].Format(time.RFC3339Nano),
+			b[0].Format(time.RFC3339Nano), b[1].Format(time.RFC3339Nano))
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `execMu sync.Mutex` to `CronJobs` struct
- Acquires the mutex immediately before `job.job.Execute(...)` and releases immediately after — serialising all job execution globally
- All DB bookkeeping remains outside the lock (pre-existing fix from `0491a327` is preserved)

## Motivation

On small boxes, multiple cron jobs firing at the same minute boundary run concurrently, causing memory spikes that can cascade into OOM. Serialising execution bounds peak memory to one job at a time.

## Test

New `serial_test.go::TestSerialExecution` — two 50ms jobs triggered concurrently; asserts their Execute windows do not overlap. Confirmed RED before fix, GREEN after.

`go test ./internal/cronjobs/... -race` passes with no data races.