### PR TITLE
fix(auth): reject session JWTs as short-API tokens (token-type confusion)

### DIFF
--- a/internal/graph/shortapitoken_stamp_test.go
+++ b/internal/graph/shortapitoken_stamp_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
 
@@ -77,6 +78,24 @@ func TestStampShortAPIToken(t *testing.T) {
 			setup: func(t *testing.T) *appreq.Request {
 				return newBearerRequest(t, "not.a.valid.jwt")
 			},
+		},
+		{
+			// Token-type confusion guard: a validly-signed SESSION JWT (same
+			// signing secret, HS256) must NOT be stamped as a scoped short-API
+			// token. It lacks the short-API discriminator, so the stamp is a
+			// no-op and the request falls through to normal session auth.
+			name: "validly-signed session JWT — not stamped (falls through)",
+			setup: func(t *testing.T) *appreq.Request {
+				sessionJWT := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+					"i":   1,
+					"r":   "admin",
+					"exp": time.Now().Add(time.Hour).Unix(),
+				})
+				signed, err := sessionJWT.SignedString([]byte(testSecret))
+				require.NoError(t, err)
+				return newBearerRequest(t, signed)
+			},
+			// All expectations remain zero-value: not stamped, not scoped.
 		},
 		{
 			name: "expired token — no-op (anonymous)",

--- a/internal/shortapitoken/token.go
+++ b/internal/shortapitoken/token.go
@@ -8,6 +8,12 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
+// tokenType is the positive discriminator that distinguishes a short API token
+// from other HS256 JWTs signed with the same secret (notably session-login
+// tokens). Parse requires it, so a JWT lacking it is rejected as not-a-short-
+// API-token rather than silently accepted with empty scope.
+const tokenType = "sat" // short API token
+
 // Data holds the claims embedded in a short API token.
 type Data struct {
 	Depth         int      `json:"d"`
@@ -19,6 +25,9 @@ type Data struct {
 
 type claims struct {
 	jwt.RegisteredClaims
+	// Typ is the token-type discriminator; always tokenType for short API
+	// tokens. Session JWTs never carry it.
+	Typ string `json:"typ"`
 	Data
 }
 
@@ -31,6 +40,7 @@ func Sign(d Data, secret string, ttl time.Duration) (string, error) {
 			IssuedAt:  jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(now.Add(ttl)),
 		},
+		Typ:  tokenType,
 		Data: d,
 	}
 
@@ -59,6 +69,13 @@ func Parse(tokenStr string, secret string) (Data, error) {
 	c, ok := token.Claims.(*claims)
 	if !ok || !token.Valid {
 		return Data{}, errors.New("invalid short API token claims")
+	}
+
+	// Require the positive discriminator: a validly-signed JWT that lacks it
+	// (e.g. a session-login token sharing the signing secret) is NOT a short
+	// API token and must be rejected to avoid token-type confusion.
+	if c.Typ != tokenType {
+		return Data{}, errors.New("not a short API token")
 	}
 
 	return c.Data, nil

--- a/internal/shortapitoken/token_test.go
+++ b/internal/shortapitoken/token_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,6 +40,25 @@ func TestParse_ExpiredToken(t *testing.T) {
 	_, err = Parse(token, secret)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "token is expired")
+}
+
+// TestParse_ForeignJWTRejected guards against token-type confusion: a validly
+// signed HS256 JWT that lacks the short-API-token discriminator claim (e.g. a
+// session-login JWT sharing the same signing secret) must NOT be accepted as a
+// short API token.
+func TestParse_ForeignJWTRejected(t *testing.T) {
+	secret := "shared-secret"
+
+	// Mimic a session JWT: same secret, HS256, but no short-API discriminator.
+	foreign := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"id":  int64(42),
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	signed, err := foreign.SignedString([]byte(secret))
+	require.NoError(t, err)
+
+	_, err = Parse(signed, secret)
+	require.Error(t, err, "a JWT without the short-API discriminator must be rejected")
 }
 
 func TestParse_WrongSecret(t *testing.T) {


### PR DESCRIPTION
## Problem

A normal session-login JWT sent as \`Authorization: Bearer <jwt>\` was misclassified as an empty-scope short-API token, causing a silent deny-all on GraphQL reads/search (Medium severity, fail-closed).

Root cause: session JWTs and scoped short-API tokens **share one HS256 signing secret** (\`ShortAPITokenSecret()\` returns \`config.UserToken.Secret\`). \`shortapitoken.Parse\` accepted ANY validly-signed HS256 JWT; a session JWT just lacked scope claims → returned zero-value \`Data\`, no error. \`stampShortAPIToken\` then set \`WebhookScoped=true\` with empty read patterns → deny-all in \`sitesearch\` / \`canreadnote\` (both check \`Scoped(ctx)\` before admin/user).

Real caller hit: simplepanel harvests a HAT-issued **session** token and re-sends it as Bearer over private http (documented in \`internal/appreq/request.go\`), so a documented internal channel silently deny-alled.

## Fix (discriminator, minimal)

Chose a **positive claim discriminator** (\`typ: "sat"\`) over a separate secret — it's the smallest diff, keeps the existing single-secret setup, and localizes the change to the \`shortapitoken\` package (no config/wiring changes, no key rotation).

- \`Sign\` stamps \`typ: "sat"\` at mint time (\`internal/shortapitoken/token.go\`).
- \`Parse\` now **requires** \`typ == "sat"\`; a JWT lacking it is rejected with \`"not a short API token"\`.
- Session JWTs (\`usertoken.fullData\`) never carry \`typ\`, so \`stampShortAPIToken\` and \`checkapikey.resolveShortAPIToken\` treat them as not-a-short-API-token → the stamp is a no-op → the request falls through to the normal Bearer→session path in \`appreq.UserToken()\`.

## Tests (red → green)

- \`TestParse_ForeignJWTRejected\` (\`internal/shortapitoken\`) — a validly-signed HS256 JWT without the discriminator is rejected.
- \`TestStampShortAPIToken/validly-signed session JWT — not stamped (falls through)\` (\`internal/graph\`) — a real session-shaped JWT is not stamped as scoped.
- Regression guards kept green: \`TestSignParse_Roundtrip\`, \`TestStampShortAPIToken/scoped token stamps read and write patterns\`, \`TestStampShortAPIToken_ScopedTokenPath\`, delivery-identity + webhook delivery tests. Scoped least-privilege is unchanged.

## Migration note

Short-API tokens minted before this change lack \`typ\` and would now fall through to session auth (and fail, since they aren't valid session tokens). Their TTL is the webhook timeout + margin — short-lived and tied to a single in-flight delivery — so any pre-change token expires within its delivery window. No grace path needed.

## Verify

\`go build ./...\` (only pre-existing missing-generated-asset errors), \`go vet\` clean on touched packages, token/auth/search tests green, \`golangci-lint\` 0 issues on touched packages.