### PR TITLE
fix(fleet): scope leading-slash matching + empty-write_patterns warning

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -198,6 +198,11 @@ func runOnce(ctx context.Context, cli cliFlags) error {
 		return fmt.Errorf("once: validate role: %w", err)
 	}
 
+	// Surface the deny-all trap loudly: write tools declared but no write_patterns.
+	// Without this the model paraphrases the per-tool "access denied" as its own
+	// refusal, hiding the config gap from the operator.
+	role.WarnIfWriteScopeMisconfigured(zerologger.New(cli.cfg.LogLevel, false))
+
 	// Load target note content if --target was given.
 	var targetContent string
 	if cli.targetPath != "" {
@@ -373,6 +378,9 @@ func syncOnce(ctx context.Context, lg logger.Logger, f *fleet.Fleet, d *fleet.Di
 	roles, errs := d.DiscoverRoles(ctx)
 	for _, e := range errs {
 		lg.Warn("discover: skipped role", "err", e)
+	}
+	for _, role := range roles {
+		role.WarnIfWriteScopeMisconfigured(lg)
 	}
 	f.SetRoles(roles)
 	if err := r.Reconcile(ctx, roles); err != nil {

--- a/internal/agentruntime/scope.go
+++ b/internal/agentruntime/scope.go
@@ -3,6 +3,8 @@ package agentruntime
 import (
 	"context"
 	"errors"
+	pathpkg "path"
+	"strings"
 
 	"trip2g/internal/webhookutil"
 )
@@ -33,14 +35,56 @@ func NewScopedKB(kb KB, readPatterns, writePatterns []string) *ScopedKB {
 	}
 }
 
+// normalizeScopePath cleans a candidate path to a scope-relative form before
+// glob-matching. Small LLM models sometimes prepend "/" or "./" to a path, so
+// "/concepts/x.md" must match "concepts/**". It strips leading "./" and "/",
+// then path.Clean-resolves any "." / ".." segments. If the cleaned path still
+// escapes the scope root (leading "..", ".", or empty), it returns "" — a
+// sentinel that never matches any pattern, so traversal ("../x",
+// "concepts/../../etc/passwd") and absolute-escape stay denied.
+func normalizeScopePath(p string) string {
+	p = strings.TrimSpace(p)
+	// Strip a leading "./" and any leading "/" so absolute-looking inputs become
+	// scope-relative. Repeat because "/./" style prefixes can stack.
+	for {
+		switch {
+		case strings.HasPrefix(p, "./"):
+			p = p[2:]
+		case strings.HasPrefix(p, "/"):
+			p = p[1:]
+		default:
+			goto cleaned
+		}
+	}
+cleaned:
+	if p == "" {
+		return ""
+	}
+	c := pathpkg.Clean(p)
+	// After cleaning, a leading ".." (or bare "." / "..") means the path resolved
+	// outside the scope root: deny by returning the never-match sentinel.
+	if c == "." || c == ".." || strings.HasPrefix(c, "../") {
+		return ""
+	}
+	return c
+}
+
 // CanRead reports whether path is within the read scope.
 func (s *ScopedKB) CanRead(path string) bool {
-	return webhookutil.MatchesAny(path, s.readPatterns)
+	norm := normalizeScopePath(path)
+	if norm == "" {
+		return false
+	}
+	return webhookutil.MatchesAny(norm, s.readPatterns)
 }
 
 // CanWrite reports whether path is within the write scope.
 func (s *ScopedKB) CanWrite(path string) bool {
-	return webhookutil.MatchesAny(path, s.writePatterns)
+	norm := normalizeScopePath(path)
+	if norm == "" {
+		return false
+	}
+	return webhookutil.MatchesAny(norm, s.writePatterns)
 }
 
 // Read returns the document at path, or ErrReadDenied if it is out of scope.

--- a/internal/agentruntime/scope_test.go
+++ b/internal/agentruntime/scope_test.go
@@ -73,6 +73,47 @@ func TestScopedKB_EmptyWritePatternsIsReadOnly(t *testing.T) {
 	}
 }
 
+// TestScopedKB_LeadingSlashNormalization is the regression test for the
+// leading-slash matching bug: small models sometimes prepend "/" or "./" to the
+// path they write, so a candidate like "/concepts/x.md" was wrongly denied
+// against pattern "concepts/**". Normalization must ALLOW those while keeping
+// traversal/absolute-escape paths DENIED.
+func TestScopedKB_LeadingSlashNormalization(t *testing.T) {
+	patterns := []string{"concepts/**"}
+	scoped := NewScopedKB(newMemKB(nil), patterns, patterns)
+
+	allowed := []string{
+		"concepts/x.md",
+		"/concepts/x.md",
+		"./concepts/x.md",
+		"concepts/sub/y.md",
+		"/concepts/sub/y.md",
+	}
+	for _, p := range allowed {
+		if !scoped.CanWrite(p) {
+			t.Errorf("expected ALLOW for %q under %v, got DENY", p, patterns)
+		}
+		if !scoped.CanRead(p) {
+			t.Errorf("expected read ALLOW for %q under %v, got DENY", p, patterns)
+		}
+	}
+
+	denied := []string{
+		"../x.md",
+		"concepts/../x.md",
+		"/concepts/../secrets.md",
+		"/etc/passwd",
+		"../../etc/passwd",
+		"concepts/../../etc/passwd",
+		"secrets/x.md",
+	}
+	for _, p := range denied {
+		if scoped.CanWrite(p) {
+			t.Errorf("expected DENY for %q under %v, got ALLOW", p, patterns)
+		}
+	}
+}
+
 // TestScopedKB_PatchUniqueness is the regression test for G5: Patch must error
 // when find is absent (0 occurrences) or ambiguous (>1 occurrences), and must
 // patch correctly when find is unique (exactly 1 occurrence). The duplicate-match

--- a/internal/fleet/role.go
+++ b/internal/fleet/role.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"trip2g/internal/agentruntime"
+	"trip2g/internal/logger"
 	"trip2g/internal/webhookutil"
 )
 
@@ -94,6 +95,45 @@ func (r Role) EffectiveTimeoutSeconds() int {
 		return defaultTimeoutSeconds
 	}
 	return r.TimeoutSeconds
+}
+
+// Tool names that mutate the KB. A role listing either but with an empty
+// write_patterns will have every write denied (deny-all).
+const (
+	toolWriteNote = "write_note"
+	toolPatchNote = "patch_note"
+)
+
+// DeclaresWriteToolsButNoWritePatterns reports the deny-all trap: the role lists
+// a write tool yet write_patterns is empty, so every write is silently denied.
+func (r Role) DeclaresWriteToolsButNoWritePatterns() bool {
+	if len(r.WritePatterns) > 0 {
+		return false
+	}
+	for _, t := range r.Tools {
+		if t == toolWriteNote || t == toolPatchNote {
+			return true
+		}
+	}
+	return false
+}
+
+// WarnIfWriteScopeMisconfigured emits a loud WARNING when the role declares
+// write tools but has an empty write_patterns. In that state every write is
+// denied deny-all, and the denial surfaces to the model as a per-tool "access
+// denied" that it paraphrases as its own refusal — hiding the real cause (a
+// config gap) from the operator. Empty write_patterns can be intentional for a
+// read-only role, so this is a warning, not a hard failure; the security
+// behavior (empty = deny-all) is unchanged.
+func (r Role) WarnIfWriteScopeMisconfigured(lg logger.Logger) {
+	if lg == nil || !r.DeclaresWriteToolsButNoWritePatterns() {
+		return
+	}
+	lg.Warn(
+		fmt.Sprintf("role %q declares write tools but write_patterns is empty; all writes will be denied", r.NotePath),
+		"role", r.NotePath,
+		"tools", strings.Join(r.Tools, ","),
+	)
 }
 
 // for_each modes. These strings double as the Jet template variable names the

--- a/internal/fleet/role_test.go
+++ b/internal/fleet/role_test.go
@@ -334,6 +334,43 @@ func TestRoleValidate_CodeExecutorSupportedFenceLangs(t *testing.T) {
 	}
 }
 
+// captureLogger records Warn calls for assertions.
+type captureLogger struct{ warns []string }
+
+func (c *captureLogger) Info(msg string, _ ...interface{})  {}
+func (c *captureLogger) Error(msg string, _ ...interface{}) {}
+func (c *captureLogger) Debug(msg string, _ ...interface{}) {}
+func (c *captureLogger) Warn(msg string, _ ...interface{})  { c.warns = append(c.warns, msg) }
+
+func TestRole_WarnIfWriteScopeMisconfigured(t *testing.T) {
+	tests := []struct {
+		name     string
+		tools    []string
+		patterns []string
+		wantWarn bool
+	}{
+		{"write tool + empty patterns warns", []string{"search", "write_note"}, nil, true},
+		{"patch tool + empty patterns warns", []string{"patch_note"}, nil, true},
+		{"write tool + non-empty patterns silent", []string{"write_note"}, []string{"concepts/**"}, false},
+		{"read-only role silent", []string{"search", "read_note"}, nil, false},
+		{"no tools silent", nil, nil, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := Role{NotePath: "roles/x.md", Tools: tc.tools, WritePatterns: tc.patterns}
+			lg := &captureLogger{}
+			r.WarnIfWriteScopeMisconfigured(lg)
+			if tc.wantWarn {
+				require.Len(t, lg.warns, 1)
+				require.Contains(t, lg.warns[0], "write_patterns is empty")
+				require.Contains(t, lg.warns[0], "roles/x.md")
+			} else {
+				require.Empty(t, lg.warns)
+			}
+		})
+	}
+}
+
 func TestParseRole_EnvPassthrough(t *testing.T) {
 	r, err := ParseRole("roles/a.md", "```bash\necho hi\n```", meta(
 		"mode", "change",


### PR DESCRIPTION
Two real fleet/agentruntime bugs found during the Phase-2 Aurelius KB build.

## Bug #2 — scope glob was leading-slash-sensitive
`write_patterns: ["concepts/**"]` did NOT match a candidate with a leading `/` or `./` (e.g. `/concepts/x.md`). Small LLM models sometimes prepend `/`, so the write was wrongly denied.

**Fix** (`internal/agentruntime/scope.go`): new `normalizeScopePath` strips a leading `./`/`/`, then `path.Clean`-resolves `.`/`..` segments before glob-matching. `CanRead`/`CanWrite` route through it.

**Security — traversal stays denied:** if the cleaned path still escapes the scope root (leading `..`, bare `.`/`..`, or empty) it returns a never-match sentinel. `../x`, `/etc/passwd`, `concepts/../secrets`, `concepts/../../etc/passwd` all resolve out of scope and are denied. Covered by `TestScopedKB_LeadingSlashNormalization` (allow + traversal cases).

## Bug #1 — empty write_patterns → silent deny-all that looks like a model refusal
When a role declares write tools (`write_note`/`patch_note`) but `write_patterns` is empty, every write is denied (correct: empty = deny-all). The denial surfaced as a per-tool "access denied" that the model paraphrased as its OWN refusal, hiding the config gap.

**Fix** (`internal/fleet/role.go`): `Role.DeclaresWriteToolsButNoWritePatterns()` + `Role.WarnIfWriteScopeMisconfigured(lg)` emit a loud WARNING via `internal/logger`. Wired into the `--once` path (`cmd/fleet/main.go` `runOnce`) and the daemon (`syncOnce`). Security behavior unchanged (empty stays deny-all) — warning only, since empty patterns may be intentional for a read-only role. Covered by `TestRole_WarnIfWriteScopeMisconfigured`.

## Verify
- `go build ./...` — only pre-existing missing-generated-asset embed errors
- `go vet` + `go tool golangci-lint run` on touched packages → 0 issues
- `go test ./internal/agentruntime/ ./internal/fleet/ ./cmd/fleet/` → green

Do NOT merge / deploy per request.