### PR TITLE
fix(jsonneteval): deny filesystem imports in jsonnet VM (arbitrary server file read)

### DIFF
--- a/internal/jsonneteval/import_exfil_test.go
+++ b/internal/jsonneteval/import_exfil_test.go
@@ -1,0 +1,41 @@
+package jsonneteval_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trip2g/internal/jsonneteval"
+)
+
+// TestEvalJSON_ImportstrCannotReadFiles is a regression guard for the arbitrary
+// server file-read vulnerability: a jsonnet snippet (reachable from note
+// frontmatter patches and webhook transforms) must not be able to read files
+// from disk via importstr/import. The deny-all importer makes such snippets
+// error out instead of leaking file contents into the rendered output.
+func TestEvalJSON_ImportstrCannotReadFiles(t *testing.T) {
+	secret := "TOP-SECRET-" + t.Name()
+	dir := t.TempDir()
+	secretPath := filepath.Join(dir, "secret.txt")
+	require.NoError(t, os.WriteFile(secretPath, []byte(secret), 0o600))
+
+	src := `{ leaked: importstr "` + secretPath + `" }`
+
+	out, err := jsonneteval.EvalJSON(src, nil)
+
+	// With the deny-all importer the snippet must fail, and the secret must
+	// never appear in the output.
+	require.Error(t, err, "importstr must be rejected, not read the file")
+	require.NotContains(t, string(out), secret, "secret file content leaked into output")
+}
+
+// TestEvalJSON_PureJsonnetStillWorks ensures the deny-all importer does not
+// break legitimate pure jsonnet transforms.
+func TestEvalJSON_PureJsonnetStillWorks(t *testing.T) {
+	src := `local p = std.parseJson(std.extVar("payload")); { doubled: p.n * 2 }`
+	out, err := jsonneteval.EvalJSON(src, map[string]string{"payload": `{"n":21}`})
+	require.NoError(t, err)
+	require.Contains(t, string(out), "42", "pure jsonnet must still evaluate")
+}

--- a/internal/jsonneteval/jsonneteval.go
+++ b/internal/jsonneteval/jsonneteval.go
@@ -11,10 +11,15 @@ import (
 	jsonnet "github.com/google/go-jsonnet"
 )
 
-// NewVM returns a jsonnet VM with a safe stack limit (no IO; go-jsonnet is pure).
+// NewVM returns a jsonnet VM with a safe stack limit and a deny-all importer.
+// Snippets come from untrusted sources (note frontmatter patches, webhook
+// transforms), so import/importstr must not reach the server filesystem: an
+// empty MemoryImporter makes every import resolve to "file not found" instead
+// of leaking file contents into the rendered output.
 func NewVM() *jsonnet.VM {
 	vm := jsonnet.MakeVM()
 	vm.MaxStack = 500 // Prevent stack overflow from recursive jsonnet.
+	vm.Importer(&jsonnet.MemoryImporter{})
 	return vm
 }
 


### PR DESCRIPTION
Jsonnet snippets from untrusted sources (note frontmatter patches and outbound webhook transforms) were evaluated in a VM built with `jsonnet.MakeVM()`, which enables the default `FileImporter`. That let `importstr`/`import` read arbitrary files off the server and leak their contents into the rendered output.

## Impact
A note whose frontmatter patch contains `{ x: importstr "/etc/passwd" }` (or any readable path) exfiltrates that file into the rendered note. Same path applies to webhook `TransformJsonnet`.

## Proof (before fix)
Rendering `{ leaked: importstr "<tempfile>" }` returned, with no error:
```
{ "leaked": "TOP-SECRET-LEAK-1234" }
```

## Fix
`jsonneteval.NewVM()` now installs an empty `jsonnet.MemoryImporter{}`, so every `import`/`importstr` resolves to "file not found" instead of touching the filesystem. This is the single chokepoint for all callers (frontmatter patches, change/cron webhook transforms, CRUD-time validation), so one change covers every path. Pure jsonnet transforms are unaffected.

## Test
Adds `import_exfil_test.go` as a regression guard:
- `TestEvalJSON_ImportstrCannotReadFiles` — `importstr` of a temp secret file now errors and the secret never appears in output.
- `TestEvalJSON_PureJsonnetStillWorks` — legitimate pure jsonnet still evaluates.

`go build ./...`, the affected packages, and the full `go test ./...` suite pass; `make lint` is clean.