### PR TITLE
feat(routing): canonical /_system/admin + note-controlled legacy /admin and /graphql

### DIFF
--- a/cmd/server/assets.go
+++ b/cmd/server/assets.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -16,7 +15,6 @@ import (
 	"time"
 	"trip2g/assets"
 	"trip2g/internal/appconfig"
-	"trip2g/internal/appreq"
 	"trip2g/internal/case/uploadnoteasset"
 	"trip2g/internal/db"
 	graphmodel "trip2g/internal/graph/model"
@@ -219,18 +217,4 @@ func (a *app) UserInlineCSS() string {
 
 func (a *app) AssetVersion() string {
 	return strconv.FormatInt(time.Now().UnixMilli(), 10)
-}
-
-func (a *app) handleAdminAssets(req *appreq.Request, path string) bool {
-	if len(a.config.AdminJSURL) > 0 && a.config.AdminJSURL[0] == '/' &&
-		strings.HasPrefix(path, a.config.AdminJSURL) {
-		userToken, err := req.UserToken()
-		if err != nil || userToken == nil {
-			req.Req.SetStatusCode(http.StatusUnauthorized)
-			req.Req.SetBodyString("401 Unauthorized")
-			return true
-		}
-	}
-
-	return false
 }

--- a/cmd/server/routing.go
+++ b/cmd/server/routing.go
@@ -227,9 +227,6 @@ func (a *app) prepareMiddlewares() []Middleware {
 			return a.gitAPI != nil && a.gitAPI.HandleRequest(req.Req)
 		},
 		func(req *appreq.Request) bool {
-			return a.handleAdminAssets(req, req.Path)
-		},
-		func(req *appreq.Request) bool {
 			if strings.HasPrefix(req.Path, "/assets/") {
 				fsHandler(req.Req)
 				return true

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -37,7 +37,22 @@ func (a *app) serveHTTP(s *fasthttp.Server) error {
 func (a *app) startServer() { //nolint:gocognit // server startup wiring
 	makeGraphQLHandler := a.prepareGraphQLHandler()
 	handleGraphQL := makeGraphQLHandler("/_system/graphql")
-	handleGraphQLCompat := makeGraphQLHandler("/graphql")
+	handleGraphQLCompatRaw := makeGraphQLHandler("/graphql")
+
+	// The deprecated /graphql alias keeps working until a live note at /graphql
+	// replaces it — then the note takes over the path (served by the router's
+	// note renderer) and GraphQL stays at its canonical /_system/graphql.
+	handleGraphQLCompat := func(ctx *fasthttp.RequestCtx, path string) bool {
+		if !strings.HasPrefix(path, "/graphql") {
+			return false
+		}
+
+		if nvs := a.LiveNoteViews(); nvs != nil && nvs.GetByPath("/graphql") != nil {
+			return false
+		}
+
+		return handleGraphQLCompatRaw(ctx, path)
+	}
 
 	rtr := router.New(a)
 

--- a/internal/case/renderadminpage/endpoint.go
+++ b/internal/case/renderadminpage/endpoint.go
@@ -3,32 +3,22 @@ package renderadminpage
 import (
 	"net/http"
 	"trip2g/internal/appreq"
-	"trip2g/internal/case/render404"
+	"trip2g/internal/case/rendernotepage"
 )
 
 //go:generate go run github.com/valyala/quicktemplate/qtc -dir=.
 
-type Endpoint struct{}
-
-func (e Endpoint) Handle(req *appreq.Request) (interface{}, error) {
-	token, err := req.UserToken()
-	if err != nil {
-		return nil, err
-	}
-
-	request := Request{
-		UserToken: token,
-	}
-
+// renderPage serves the admin app shell (HTML + admin JS bundle). The shell is
+// not a secret: for guests the bundle renders the auth form ($trip2g_admin
+// extends $trip2g_auth) and every admin query is authorized server-side in the
+// GraphQL layer, the same way /graphql serves the playground to everyone while
+// the queries themselves stay gated.
+func renderPage(req *appreq.Request) (interface{}, error) {
 	ctx := req.Req
 
-	resp, err := Resolve(ctx, req.Env.(Env), request)
+	resp, err := Resolve(ctx, req.Env.(Env), Request{})
 	if err != nil {
 		return nil, err
-	}
-
-	if resp == nil {
-		return render404.Handle(req)
 	}
 
 	ctx.SetContentType("text/html; charset=utf-8")
@@ -39,10 +29,40 @@ func (e Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 	return nil, nil
 }
 
+// Endpoint serves the legacy /admin path. It keeps working for backward
+// compatibility until a live note at /admin replaces it — then the note takes
+// over the path and the admin app remains at its canonical /_system/admin.
+type Endpoint struct{}
+
+func (e Endpoint) Handle(req *appreq.Request) (interface{}, error) {
+	if nvs := req.Env.(Env).LiveNoteViews(); nvs != nil && nvs.GetByPath("/admin") != nil {
+		return rendernotepage.Endpoint{}.Handle(req)
+	}
+
+	return renderPage(req)
+}
+
 func (Endpoint) Path() string {
 	return "/admin"
 }
 
 func (Endpoint) Method() string {
+	return http.MethodGet
+}
+
+// GetEndpoint serves the canonical /_system/admin path, mirroring
+// /_system/graphql: always mounted, part of the /_system namespace that is the
+// single home for system endpoints.
+type GetEndpoint struct{}
+
+func (e GetEndpoint) Handle(req *appreq.Request) (interface{}, error) {
+	return renderPage(req)
+}
+
+func (GetEndpoint) Path() string {
+	return "/_system/admin"
+}
+
+func (GetEndpoint) Method() string {
 	return http.MethodGet
 }

--- a/internal/case/renderadminpage/endpoint_test.go
+++ b/internal/case/renderadminpage/endpoint_test.go
@@ -1,0 +1,69 @@
+package renderadminpage_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"trip2g/internal/appreq"
+	"trip2g/internal/case/renderadminpage"
+	"trip2g/internal/model"
+
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+type stubEnv struct {
+	views *model.NoteViews
+}
+
+func (stubEnv) AdminJSURL() string { return "/assets/ui/admin/-/web.js?h=deadbeef" }
+
+func (e stubEnv) LiveNoteViews() *model.NoteViews { return e.views }
+
+func newRequest(env renderadminpage.Env) *appreq.Request {
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Init(&fasthttp.Request{}, nil, nil)
+
+	return &appreq.Request{
+		Env: env,
+		Req: fctx,
+	}
+}
+
+func TestCanonicalSystemAdminServesShell(t *testing.T) {
+	ep := renderadminpage.GetEndpoint{}
+	require.Equal(t, "/_system/admin", ep.Path())
+	require.Equal(t, http.MethodGet, ep.Method())
+
+	req := newRequest(stubEnv{})
+
+	resp, err := ep.Handle(req)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	require.Equal(t, http.StatusOK, req.Req.Response.StatusCode())
+
+	body := string(req.Req.Response.Body())
+	require.Contains(t, body, `mol_view_root="$trip2g_admin"`)
+	require.Contains(t, body, "/assets/ui/admin/-/web.js?h=deadbeef")
+	require.True(t, strings.HasPrefix(string(req.Req.Response.Header.ContentType()), "text/html"))
+}
+
+func TestLegacyAdminServesShellWithoutNote(t *testing.T) {
+	ep := renderadminpage.Endpoint{}
+	require.Equal(t, "/admin", ep.Path())
+	require.Equal(t, http.MethodGet, ep.Method())
+
+	// No live note at /admin: the legacy path keeps serving the admin shell,
+	// with no server-side token gate — auth is handled by the shell itself and
+	// per-query GraphQL authorization.
+	req := newRequest(stubEnv{views: &model.NoteViews{Map: map[string]*model.NoteView{}}})
+
+	resp, err := ep.Handle(req)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	require.Equal(t, http.StatusOK, req.Req.Response.StatusCode())
+	require.Contains(t, string(req.Req.Response.Body()), `mol_view_root="$trip2g_admin"`)
+}

--- a/internal/case/renderadminpage/resolve.go
+++ b/internal/case/renderadminpage/resolve.go
@@ -2,27 +2,20 @@ package renderadminpage
 
 import (
 	"context"
-	"trip2g/internal/usertoken"
+	"trip2g/internal/model"
 )
 
 type Env interface {
 	AdminJSURL() string
+	LiveNoteViews() *model.NoteViews
 }
 
-type Request struct {
-	UserToken *usertoken.Data
-}
+type Request struct{}
 
 type Response struct {
 	JSURL string
 }
 
 func Resolve(ctx context.Context, env Env, request Request) (*Response, error) {
-	if !request.UserToken.IsAdmin() {
-		return nil, nil
-	}
-
-	jsURL := env.AdminJSURL()
-
-	return &Response{JSURL: jsURL}, nil
+	return &Response{JSURL: env.AdminJSURL()}, nil
 }

--- a/internal/router/endpoints_gen.go
+++ b/internal/router/endpoints_gen.go
@@ -42,6 +42,7 @@ var endpoints = []Endpoint{
 	&processpatreonwebhookprocesspatreonwebhook.Endpoint{},
 	&render404render404.Endpoint{},
 	&renderadminpagerenderadminpage.Endpoint{},
+	&renderadminpagerenderadminpage.GetEndpoint{},
 	&rendernotepagerendernotepage.Endpoint{},
 	&rendersearchpagerendersearchpage.Endpoint{},
 	&signinbyhatsigninbyhat.Endpoint{},


### PR DESCRIPTION
## Design

The `/_system/*` namespace becomes the single canonical home for system endpoints, and **notes control the legacy paths**:

| Path | Default | With a live note at that path |
|---|---|---|
| `/_system/admin` | admin app shell (new, canonical) | unchanged |
| `/_system/graphql` | GraphQL (unchanged, canonical) | unchanged |
| `/admin` | admin app shell (backward-compat) | the note takes over the path |
| `/graphql` | GraphQL compat alias (backward-compat, already deprecated in docs) | the note takes over the path |

Publishing an `admin.md` / `graphql.md` note (permalink `/admin` / `/graphql`) relocates the API to its `/_system/*` canonical path only; unpublishing restores the legacy alias. No config, no new mechanism — it reuses the live-note map (`LiveNoteViews().GetByPath`) that already drives page routing.

## Obscurity removed (and why it is safe)

`handleAdminAssets` served the admin JS bundle only to requests carrying *any* user token — token-presence, not `IsAdmin()`. On a public project the bundle is not a secret: hiding it is security-by-obscurity, not access control. It is removed outright.

Similarly, `/admin` used to 404 for non-admins. Now the shell is served to everyone: an anonymous visitor gets the auth/login form the shell itself renders (`$trip2g_admin` extends `$trip2g_auth`) — the same model as `/graphql`, which serves the playground to everyone.

**No real access control is loosened**: every admin operation is authorized server-side per GraphQL query (`checkAdmin` in `internal/graph/helpers.go`), which was always the actual protection.

## Files changed

- `internal/case/renderadminpage/endpoint.go` — legacy `/admin` endpoint (note-replacement check, no token gate) + new `GetEndpoint` for `/_system/admin`
- `internal/case/renderadminpage/resolve.go` — drop the `IsAdmin`→404 gate; `Env` gains `LiveNoteViews()`
- `internal/case/renderadminpage/endpoint_test.go` — new: `/_system/admin` + default `/admin` serve the shell anonymously
- `cmd/server/server.go` — `/graphql` compat alias yields to a live note at `/graphql`
- `cmd/server/assets.go`, `cmd/server/routing.go` — remove `handleAdminAssets` middleware (the L1 obscurity)
- `internal/router/endpoints_gen.go` — regenerated (`go run ./internal/router/gencmd`)

## Spec deviation note

The task described an existing "note gates `/_system/*`" convention; in the codebase `/_system/*` endpoints are always mounted (hat, mcp, auth, graphql) and no note-gating existed. This PR keeps `/_system/*` always-on (matching the real convention) and applies notes to the *legacy* paths — presence of a note relocates the endpoint to `/_system/*` only.

## Verification

- `gofmt -w` clean on touched packages
- `go build ./...` — pass
- `go test ./...` — all packages ok (also enforced by the pre-push hook)