### PR TITLE
test(e2e): mock IdP issues real RS256 id_token with nonce echo

### DIFF
--- a/e2e/helpers/mock-idp.js
+++ b/e2e/helpers/mock-idp.js
@@ -8,7 +8,18 @@
 //   - authorize -> reached by the BROWSER on the host, so it uses `localhost`.
 //
 // The server binds 0.0.0.0 so the container can reach it via the host gateway.
+//
+// id_token is a real RS256 JWT, signed with a key generated at startup and
+// published via /jwks, so the backend's signature/iss/aud/exp/nonce/sub
+// verification (see internal/oidcauth) passes against this mock.
 import http from 'node:http';
+import crypto from 'node:crypto';
+
+// base64url without padding, as used for both JWK members and JWT segments.
+function base64url(input) {
+  const buf = Buffer.isBuffer(input) ? input : Buffer.from(input);
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
 
 export async function startMockIdp({
   port = 19200,
@@ -16,6 +27,15 @@ export async function startMockIdp({
   hostForBrowser = 'localhost',
 } = {}) {
   const issuer = `http://${hostForContainer}:${port}`;
+  const clientId = 'trip2g-test';
+  const kid = 'mock-key-1';
+
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const jwk = publicKey.export({ format: 'jwk' });
+
+  // nonce from the authorize request, keyed by the code we hand back so the
+  // token endpoint can echo it into the id_token.
+  const noncesByCode = new Map();
 
   // Mutable identity returned by /userinfo; set per-test via setUser().
   let currentUser = {
@@ -25,6 +45,22 @@ export async function startMockIdp({
     name: 'OIDC User',
     groups: [],
   };
+
+  function signIdToken(nonce) {
+    const header = { alg: 'RS256', typ: 'JWT', kid };
+    const now = Math.floor(Date.now() / 1000);
+    const payload = {
+      iss: issuer,
+      aud: clientId,
+      sub: currentUser.sub,
+      exp: now + 3600,
+      iat: now,
+      ...(nonce ? { nonce } : {}),
+    };
+    const signingInput = `${base64url(JSON.stringify(header))}.${base64url(JSON.stringify(payload))}`;
+    const signature = crypto.createSign('RSA-SHA256').update(signingInput).sign(privateKey);
+    return `${signingInput}.${base64url(signature)}`;
+  }
 
   const json = (res, code, body) => {
     res.writeHead(code, { 'content-type': 'application/json' });
@@ -52,17 +88,24 @@ export async function startMockIdp({
     if (url.pathname === '/authorize') {
       const redirectUri = url.searchParams.get('redirect_uri');
       const state = url.searchParams.get('state') || '';
-      const location = `${redirectUri}?code=mock-code&state=${encodeURIComponent(state)}`;
+      const nonce = url.searchParams.get('nonce') || '';
+      const code = 'mock-code';
+      noncesByCode.set(code, nonce);
+      const location = `${redirectUri}?code=${code}&state=${encodeURIComponent(state)}`;
       res.writeHead(302, { location });
       return res.end();
     }
 
     if (url.pathname === '/token' && req.method === 'POST') {
+      // Body parsing isn't needed: the mock only ever hands out one code at a
+      // time (tests run serially), so just use the last stored nonce.
+      const code = 'mock-code';
+      const nonce = noncesByCode.get(code) || '';
       return json(res, 200, {
         access_token: 'mock-access-token',
         token_type: 'Bearer',
         expires_in: 3600,
-        id_token: 'mock.unsigned.idtoken',
+        id_token: signIdToken(nonce),
       });
     }
 
@@ -71,7 +114,7 @@ export async function startMockIdp({
     }
 
     if (url.pathname === '/jwks') {
-      return json(res, 200, { keys: [] });
+      return json(res, 200, { keys: [{ ...jwk, kid, use: 'sig', alg: 'RS256' }] });
     }
 
     res.writeHead(404);


### PR DESCRIPTION
## Summary
- `e2e/helpers/mock-idp.js` now mints a real RS256-signed JWT id_token (RSA keypair generated at startup, published via `/jwks`) instead of the literal string `mock.unsigned.idtoken`, so it passes the strict verification added in #149/#150 (signature vs `jwks_uri`, `iss`/`aud`/`exp`/`iat`, nonce echo, `sub` == userinfo `sub`).
- `/authorize` now captures the `nonce` request param and the `/token` endpoint echoes it into the signed id_token.
- No backend/production code changed — this is a test-helper-only fix.

## Test plan
- [x] `./scripts/test-e2e.sh oidc.spec.js` (full harness, fresh docker rebuild): 258 passed, 1 failed, 44 skipped. All 7 `oidc.spec.js` tests pass (including the previously-broken "existing user, auto_provision off -> logged in").
- [x] The 1 failure is `e2e/mcp-toc.spec.js:127` — pre-existing, unrelated to this change or to the OIDC work (see investigation note below).
- [x] Cross-checked the mock's JWT shape against `internal/oidcauth/verify.go` and `jwks.go` (RS256-only, `base64.RawURLEncoding` JWK decoding, `WithAudience`/`WithIssuer`/`WithExpirationRequired`/`WithIssuedAt`) and independently verified with a standalone Node script that the generated JWK round-trips and the signature verifies.
- [x] `e2e/oidc-dex.spec.js` (real Dex IdP) also passed in the same run, confirming no regression there.

### mcp-toc.spec.js investigation (requested, not fixed)
`e2e/mcp-toc.spec.js:127` ("unknown toc_path falls back to full note HTML") fails deterministically, reproduced standalone (13/14 in that file pass). Root cause: **pre-existing product/spec mismatch, unrelated to today's commits or to this PR.** `internal/case/mcp/resolve.go:926-932` intentionally returns an MCP `invalid_params` error with a nudge listing top-level sections when `toc_path` doesn't resolve (comment at :913: "A pointer miss must never silently dump the full note... Fail loud and cheap"), but the spec still asserts the old silent-fallback-to-full-HTML behavior. Not a flake, not caused by the demo-notes/golden-snapshot commit (`c3d6727b`) — left as-is per instructions; recommend a follow-up to either update the spec's expectation or reconsider the fail-loud behavior for this specific case.