### PR TITLE
fix(reranker): use TEI wire format (texts field, bare array response)

### DIFF
--- a/internal/case/sitesearch/rerank_test.go
+++ b/internal/case/sitesearch/rerank_test.go
@@ -54,12 +54,13 @@ func rerankerFeatures(w float64, url string) features.Features {
 }
 
 // ceServer returns a rerank server that scores each doc via scoreFor, letting
-// tests drive the cross-encoder ranking.
+// tests drive the cross-encoder ranking. Request/response shapes match TEI:
+// request has "texts" (not "documents"), response is a bare array [{index, score}].
 func ceServer(t *testing.T, scoreFor func(doc string) float64) *httptest.Server {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req struct {
-			Documents []string `json:"documents"`
+			Texts []string `json:"texts"`
 		}
 		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&req)) {
 			return
@@ -67,13 +68,11 @@ func ceServer(t *testing.T, scoreFor func(doc string) float64) *httptest.Server 
 
 		type result struct {
 			Index int     `json:"index"`
-			Score float64 `json:"relevance_score"`
+			Score float64 `json:"score"`
 		}
-		out := struct {
-			Results []result `json:"results"`
-		}{}
-		for i, d := range req.Documents {
-			out.Results = append(out.Results, result{Index: i, Score: scoreFor(d)})
+		var out []result
+		for i, d := range req.Texts {
+			out = append(out, result{Index: i, Score: scoreFor(d)})
 		}
 		w.Header().Set("Content-Type", "application/json")
 		assert.NoError(t, json.NewEncoder(w).Encode(out))

--- a/internal/reranker/client.go
+++ b/internal/reranker/client.go
@@ -60,7 +60,7 @@ func (c *Client) Rerank(ctx context.Context, query string, docs []string) ([]Res
 	if len(docs) == 0 {
 		return nil, nil
 	}
-	body, _ := json.Marshal(map[string]any{"model": c.model, "query": query, "documents": docs})
+	body, _ := json.Marshal(map[string]any{"query": query, "texts": docs})
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
@@ -77,18 +77,16 @@ func (c *Client) Rerank(ctx context.Context, query string, docs []string) ([]Res
 		return nil, fmt.Errorf("rerank status %d", resp.StatusCode)
 	}
 
-	var out struct {
-		Results []struct {
-			Index int     `json:"index"`
-			Score float64 `json:"relevance_score"`
-		} `json:"results"`
+	var out []struct {
+		Index int     `json:"index"`
+		Score float64 `json:"score"`
 	}
 	if decErr := json.NewDecoder(resp.Body).Decode(&out); decErr != nil {
 		return nil, fmt.Errorf("decode rerank response: %w", decErr)
 	}
 
-	results := make([]Result, 0, len(out.Results))
-	for _, r := range out.Results {
+	results := make([]Result, 0, len(out))
+	for _, r := range out {
 		if r.Index >= 0 && r.Index < len(docs) {
 			results = append(results, Result{Index: r.Index, Score: r.Score})
 		}

--- a/internal/reranker/client_test.go
+++ b/internal/reranker/client_test.go
@@ -13,7 +13,8 @@ import (
 func TestRerankReturnsScores(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/rerank", r.URL.Path)
-		_, _ = w.Write([]byte(`{"results":[{"index":2,"relevance_score":0.9},{"index":0,"relevance_score":0.5},{"index":1,"relevance_score":0.1}]}`))
+		// TEI returns a bare array with "score" (not a wrapped {"results":[...]} with "relevance_score").
+		_, _ = w.Write([]byte(`[{"index":2,"score":0.9},{"index":0,"score":0.5},{"index":1,"score":0.1}]`))
 	}))
 	defer srv.Close()
 
@@ -32,7 +33,7 @@ func TestRerankEmptyDocs(t *testing.T) {
 
 func TestRerankDropsOutOfRangeIndices(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"results":[{"index":5,"relevance_score":0.9},{"index":0,"relevance_score":0.5}]}`))
+		_, _ = w.Write([]byte(`[{"index":5,"score":0.9},{"index":0,"score":0.5}]`))
 	}))
 	defer srv.Close()
 


### PR DESCRIPTION
## Проблема
Клиент reranker слал в TEI `/rerank` тело `{"model","query","documents"}` и ждал ответ `{"results":[{"relevance_score"}]}`. TEI (text-embeddings-inference) ждёт `{"query","texts":[...]}` и отдаёт голый массив `[{"index","score"}]` — из-за несовпадения формата rerank молча не работал против внешнего TEI-сервера (bge-reranker-v2-m3 на 157.180.98.120:11436).

## Изменения
- `internal/reranker/client.go` — тело запроса: убран `model`, `documents` → `texts`; разбор ответа: голый массив `[{"index","score"}]` вместо `{"results":[{"relevance_score"}]}`.
- `internal/reranker/client_test.go` + `internal/case/sitesearch/rerank_test.go` — моки приведены к реальному wire-формату TEI.

## Проверка
- `gofmt -w` — чисто
- `go build ./...` — ок
- `go test ./internal/reranker/... ./internal/case/sitesearch/...` — зелёно

После мержа пересобрать образ trip2g с этой ветки (текущий 0e50f2e6 предшествует фиксу).