### PR TITLE
fix: enforce anonymous access rules in RSS feeds

### DIFF
--- a/cmd/server/routing.go
+++ b/cmd/server/routing.go
@@ -143,7 +143,9 @@ func (a *app) handleRSSFeed(req *appreq.Request) bool {
 
 	notes := a.LiveNoteViews()
 	note := notes.GetByPath(notePath)
-	if note == nil {
+	// RSS is an unauthenticated endpoint and must honor every static anonymous
+	// access gate, including sign-in-only subgraphs and internal/template notes.
+	if !rssfeed.IsPubliclyReadable(note) {
 		return false
 	}
 

--- a/internal/rssfeed/rssfeed.go
+++ b/internal/rssfeed/rssfeed.go
@@ -189,11 +189,31 @@ func buildItem(l link, publicURL string, notes *model.NoteViews) RSSItem {
 	return item
 }
 
+// IsPubliclyReadable reports whether a note may be exposed through an
+// unauthenticated endpoint. RSS has no user context, so it must honor the same
+// static gates as anonymous page rendering rather than relying on Free alone.
+func IsPubliclyReadable(note *model.NoteView) bool {
+	if note == nil || !note.Free {
+		return false
+	}
+	if strings.HasSuffix(note.Path, ".html") || note.IsSystem() {
+		return false
+	}
+	for _, subgraph := range note.Subgraphs {
+		if subgraph != nil && subgraph.RequireSignin {
+			return false
+		}
+	}
+	return true
+}
+
 // textContent extracts plain text from an AST node's children.
 // enrichItem adds metadata from the target note to an RSS item.
 func enrichItem(item *RSSItem, notes *model.NoteViews, path string) {
 	target := notes.GetByPath(path)
-	if target == nil {
+	// Keep link/title metadata for inaccessible targets so readers can discover
+	// the item, but never include private description, dates, or rendered HTML.
+	if !IsPubliclyReadable(target) {
 		return
 	}
 

--- a/internal/rssfeed/rssfeed_test.go
+++ b/internal/rssfeed/rssfeed_test.go
@@ -66,6 +66,7 @@ func TestGenerate(t *testing.T) {
 					"/about": {
 						Title:       "About",
 						Permalink:   "/about",
+						Free:        true,
 						Description: strPtr("About page description"),
 						CreatedAt:   time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC),
 					},
@@ -94,6 +95,7 @@ func TestGenerate(t *testing.T) {
 					"/my-page": {
 						Title:       "My Page",
 						Permalink:   "/my-page",
+						Free:        true,
 						Description: strPtr("A cool page"),
 						CreatedAt:   time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC),
 					},
@@ -140,6 +142,87 @@ func TestGenerate(t *testing.T) {
 			for _, s := range tt.notContains {
 				require.NotContains(t, xml, s, "expected XML to NOT contain: %s", s)
 			}
+		})
+	}
+}
+
+func TestGenerateOmitsPaywalledTargetContent(t *testing.T) {
+	note := &model.NoteView{
+		Title:         "Feed",
+		Permalink:     "/feed",
+		Free:          true,
+		ResolvedLinks: map[string]string{"secret": "/secret"},
+	}
+	parseNote(t, "[[secret]]", note)
+
+	result, err := Generate(note, "https://example.com", &model.NoteViews{Map: map[string]*model.NoteView{
+		"/secret": {
+			Title:       "Secret",
+			Permalink:   "/secret",
+			Free:        false,
+			Description: strPtr("private description"),
+			HTML:        "<p>private body</p>",
+		},
+	}})
+	require.NoError(t, err)
+	xml := string(result)
+	require.Contains(t, xml, `<link>https://example.com/secret</link>`)
+	require.NotContains(t, xml, "private body")
+	require.NotContains(t, xml, "private description")
+	require.NotContains(t, xml, "content:encoded")
+}
+
+func TestGenerateOmitsSignInOnlyTargetContent(t *testing.T) {
+	note := &model.NoteView{
+		Title:         "Feed",
+		Permalink:     "/feed",
+		Free:          true,
+		ResolvedLinks: map[string]string{"members": "/members"},
+	}
+	parseNote(t, "[[members]]", note)
+
+	result, err := Generate(note, "https://example.com", &model.NoteViews{Map: map[string]*model.NoteView{
+		"/members": {
+			Title:       "Members",
+			Permalink:   "/members",
+			Free:        true,
+			Description: strPtr("members-only description"),
+			HTML:        "<p>members-only body</p>",
+			Subgraphs: map[string]*model.NoteSubgraph{
+				"members": {RequireSignin: true},
+			},
+		},
+	}})
+	require.NoError(t, err)
+	xml := string(result)
+	require.Contains(t, xml, `<link>https://example.com/members</link>`)
+	require.NotContains(t, xml, "members-only body")
+	require.NotContains(t, xml, "members-only description")
+}
+
+func TestIsPubliclyReadable(t *testing.T) {
+	tests := []struct {
+		name string
+		note *model.NoteView
+		want bool
+	}{
+		{name: "public free note", note: &model.NoteView{Path: "post.md", Permalink: "/post", Free: true}, want: true},
+		{name: "paywalled", note: &model.NoteView{Path: "post.md", Permalink: "/post"}},
+		{name: "sign-in-only", note: &model.NoteView{
+			Path:      "post.md",
+			Permalink: "/post",
+			Free:      true,
+			Subgraphs: map[string]*model.NoteSubgraph{"members": {RequireSignin: true}},
+		}},
+		{name: "internal route", note: &model.NoteView{Path: "_system/config.md", Permalink: "/_system/config", Free: true}},
+		{name: "nested internal route", note: &model.NoteView{Path: "docs/_internal/note.md", Permalink: "/docs/_internal/note", Free: true}},
+		{name: "HTML template", note: &model.NoteView{Path: "_layouts/page.html", Permalink: "/page.html", Free: true}},
+		{name: "missing note"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, IsPubliclyReadable(tt.note))
 		})
 	}
 }


### PR DESCRIPTION
## Problem

RSS is an unauthenticated endpoint, but feed generation did not enforce the complete anonymous-read contract. A feed source or linked target could be paywalled, sign-in-only through a subgraph, an internal note, or an HTML template. Inaccessible target HTML, descriptions, and publication dates could therefore be exposed to feed readers.

## Solution

- Add one shared `IsPubliclyReadable` predicate for RSS source admission and target enrichment.
- Require the note to be free, outside sign-in-only subgraphs, non-system, and non-template.
- Return no RSS response for inaccessible source notes.
- Keep inaccessible targets discoverable as title/link/GUID, but omit description, publication date, and rendered HTML.
- Add regressions for paid, sign-in-only, root/nested internal, template, missing, and public notes.

## RSS UX

Public RSS remains useful for public editorial content. Paid and sign-in-only items may appear only as links when referenced by a public feed, which preserves discovery without bypassing access control.

Authenticated paid RSS is intentionally not introduced here. It should be a separate product mode with revocable per-user feed tokens and purchase/subscription-aware authorization; otherwise feed URLs become durable bearer secrets.

## Validation

- `go test -race ./internal/rssfeed`
- `go vet ./internal/rssfeed`
- Independent code review: APPROVE

The full `cmd/server` package could not run in the isolated worktree because generated embedded UI/vault assets are not present there; the changed routing code is covered through the shared predicate tests.