### PR TITLE
fix: prevent stored XSS in embed renderers

### DIFF
--- a/internal/enclavefix/enclavefix_test.go
+++ b/internal/enclavefix/enclavefix_test.go
@@ -49,3 +49,104 @@ func TestYouTubeShortLinkStandalone(t *testing.T) {
 
 	require.Contains(t, html, "youtube", "Should contain youtube-related content")
 }
+
+func TestYouTubeObjectIDCannotBreakOutOfAttribute(t *testing.T) {
+	md := goldmark.New(goldmark.WithExtensions(enclavefix.New(&enclavecore.Config{})))
+
+	var buf bytes.Buffer
+	err := md.Convert([]byte(`![](https://www.youtube.com/watch?v=%22%20onload%3D%22alert(1))`), &buf)
+	require.NoError(t, err)
+	html := buf.String()
+	require.NotContains(t, html, `onload="alert`)
+	require.NotContains(t, html, `src="https://www.youtube.com/embed/%22`)
+	require.Contains(t, html, "Failed to load youtube")
+}
+
+func TestTradingViewSymbolCannotBreakOutOfScript(t *testing.T) {
+	md := goldmark.New(goldmark.WithExtensions(enclavefix.New(&enclavecore.Config{})))
+
+	var buf bytes.Buffer
+	err := md.Convert([]byte(`![](https://www.tradingview.com/chart/abc/?symbol=%22%3Balert(1)%3B%2F%2F)`), &buf)
+	require.NoError(t, err)
+	html := buf.String()
+	require.NotContains(t, html, `<script`)
+	require.NotContains(t, html, `";alert`)
+	require.Contains(t, html, `&#34;;alert(1);//`)
+	require.Contains(t, html, "Failed to load tradingview")
+}
+
+func TestBilibiliObjectIDCannotBreakOutOfAttribute(t *testing.T) {
+	md := goldmark.New(goldmark.WithExtensions(enclavefix.New(&enclavecore.Config{})))
+
+	var buf bytes.Buffer
+	err := md.Convert([]byte(`![](https://www.bilibili.com/video/%22%20onload%3D%22alert(1))`), &buf)
+	require.NoError(t, err)
+	html := buf.String()
+	require.NotContains(t, html, `<iframe`)
+	require.NotContains(t, html, `onload="alert(1)"`)
+	require.Contains(t, html, "Failed to load bilibili")
+}
+
+func TestQuailLayoutCannotBreakOutOfAttribute(t *testing.T) {
+	md := goldmark.New(goldmark.WithExtensions(enclavefix.New(&enclavecore.Config{})))
+
+	var buf bytes.Buffer
+	err := md.Convert([]byte(`![](https://quaily.com/list?layout=%22%20onload%3D%22alert(1))`), &buf)
+	require.NoError(t, err)
+	html := buf.String()
+	require.NotContains(t, html, `<iframe`)
+	require.NotContains(t, html, `onload="alert(1)"`)
+	require.Contains(t, html, "Failed to load quail")
+}
+
+func TestDifyURLCannotBreakOutOfAttribute(t *testing.T) {
+	md := goldmark.New(goldmark.WithExtensions(enclavefix.New(&enclavecore.Config{})))
+
+	var buf bytes.Buffer
+	err := md.Convert([]byte(`![](dify://udify.app/chatbot/%22%20onload%3D%22alert(1))`), &buf)
+	require.NoError(t, err)
+	html := buf.String()
+	require.NotContains(t, html, `<iframe`)
+	require.NotContains(t, html, `onload="alert(1)"`)
+	require.Contains(t, html, "Failed to load dify")
+}
+
+func TestQuailImageAttributesAreEscaped(t *testing.T) {
+	md := goldmark.New(goldmark.WithExtensions(enclavefix.New(&enclavecore.Config{})))
+
+	var buf bytes.Buffer
+	err := md.Convert([]byte(`![" onload="alert(1)](https://example.com/image.jpg?w=%22%20onload%3D%22alert(1))`), &buf)
+	require.NoError(t, err)
+	html := buf.String()
+	require.NotContains(t, html, `onload="alert(1)"`)
+	require.NotContains(t, html, `width=""`)
+	require.Contains(t, html, `&#34;`)
+}
+
+func TestAudioURLCannotBreakOutOfAttribute(t *testing.T) {
+	md := goldmark.New(goldmark.WithExtensions(enclavefix.New(&enclavecore.Config{})))
+
+	var buf bytes.Buffer
+	err := md.Convert([]byte(`![](<https://example.com/a.mp3?x=" onload="alert(1)>)`), &buf)
+	require.NoError(t, err)
+	html := buf.String()
+	require.NotContains(t, html, `onload="alert(1)"`)
+	require.Contains(t, html, `&#34;`)
+}
+
+func TestQuailImageUnitlessSizeUsesPixels(t *testing.T) {
+	md := goldmark.New(goldmark.WithExtensions(enclavefix.New(&enclavecore.Config{})))
+
+	var buf bytes.Buffer
+	err := md.Convert([]byte(`![image](https://example.com/image.jpg?w=200)`), &buf)
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), `style="width: 200px;`)
+}
+
+func TestValidEmbedIDPreservesSupportedIdentifiers(t *testing.T) {
+	require.True(t, enclavefix.ValidEmbedID(enclavecore.EnclaveProviderYouTube, "dQw4w9WgXcQ"))
+	require.True(t, enclavefix.ValidEmbedID(enclavecore.EnclaveProviderBilibili, "BV1xx411c7mD"))
+	require.True(t, enclavefix.ValidEmbedID(enclavecore.EnclaveProviderTradingView, "CME_MINI:ES1!"))
+	require.True(t, enclavefix.ValidEmbedID(enclavecore.EnclaveProviderTradingView, "(NASDAQ:AAPL+NASDAQ:MSFT)/2"))
+	require.True(t, enclavefix.ValidDifyURL("https://udify.app/chatbot/1NaVTsaJ1t54UrNE"))
+}

--- a/internal/enclavefix/render.go
+++ b/internal/enclavefix/render.go
@@ -2,6 +2,11 @@ package enclavefix
 
 import (
 	"fmt"
+	"html"
+	"net/url"
+	"regexp"
+	"strings"
+	"unicode"
 
 	"github.com/quailyquaily/goldmark-enclave/core"
 	"github.com/quailyquaily/goldmark-enclave/object"
@@ -10,6 +15,62 @@ import (
 	"github.com/yuin/goldmark/renderer"
 	"github.com/yuin/goldmark/util"
 )
+
+var (
+	youtubeIDPattern         = regexp.MustCompile(`^[A-Za-z0-9_-]{11}$`)
+	bilibiliIDPattern        = regexp.MustCompile(`^(?:BV[A-Za-z0-9]{10}|av[0-9]+)$`)
+	imageSizePattern         = regexp.MustCompile(`^[0-9]+(?:%|px|rem)?$`)
+	unitlessImageSizePattern = regexp.MustCompile(`^[0-9]+$`)
+	difyPathPattern          = regexp.MustCompile(`^/chatbot/[A-Za-z0-9_-]+/?$`)
+)
+
+// ValidEmbedID reports whether an embed identifier is safe for the provider's
+// downstream HTML/JavaScript template. It is shared with mdloader, which has a
+// second renderer for the same AST nodes.
+func ValidEmbedID(provider, id string) bool {
+	switch provider {
+	case "youtube":
+		return youtubeIDPattern.MatchString(id)
+	case "bilibili":
+		return bilibiliIDPattern.MatchString(id)
+	case "tradingview":
+		if id == "" || strings.ContainsAny(id, `"\<>`) {
+			return false
+		}
+		for _, r := range id {
+			if unicode.IsControl(r) || r == '\u2028' || r == '\u2029' {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+// ValidDifyURL accepts only the HTTPS chatbot URLs emitted by the transformer.
+// In particular, it rejects decoded quotes from dify: URLs before they reach
+// the upstream text/template iframe renderer.
+func ValidDifyURL(raw string) bool {
+	u, err := url.Parse(raw)
+	return err == nil && u.Scheme == "https" && u.Host == "udify.app" &&
+		u.User == nil && u.RawQuery == "" && u.Fragment == "" && difyPathPattern.MatchString(u.Path)
+}
+
+// SafeImageDimension returns a dimension only when it is safe to place in an
+// HTML attribute or inline style. Invalid values are dropped.
+func SafeImageDimension(value string) string {
+	if imageSizePattern.MatchString(value) {
+		return value
+	}
+	return ""
+}
+
+// ValidQuailLayout constrains the only query parameter that the upstream
+// renderer interpolates into an iframe URL using text/template.
+func ValidQuailLayout(layout string) bool {
+	return layout == "" || layout == "subscribe_form" || layout == "subscribe_form_mini"
+}
 
 type HTMLRenderer struct {
 	cfg *core.Config
@@ -45,6 +106,10 @@ func (r *HTMLRenderer) renderEnclave(w util.BufWriter, source []byte, node ast.N
 	switch enc.Provider {
 	case core.EnclaveProviderYouTube:
 		{
+			if !ValidEmbedID("youtube", enc.ObjectID) {
+				w.Write([]byte(r.wrapEnclaveErrorHtml("youtube", enc.ObjectID)))
+				break
+			}
 			html, err := object.GetYoutubeEmbedHtml(enc)
 			if err != nil || html == "" {
 				html = r.wrapEnclaveErrorHtml("youtube", enc.ObjectID)
@@ -56,6 +121,10 @@ func (r *HTMLRenderer) renderEnclave(w util.BufWriter, source []byte, node ast.N
 
 	case core.EnclaveProviderBilibili:
 		{
+			if !ValidEmbedID("bilibili", enc.ObjectID) {
+				w.Write([]byte(r.wrapEnclaveErrorHtml("bilibili", enc.ObjectID)))
+				break
+			}
 			html, err := object.GetBilibiliEmbedHtml(enc)
 			if err != nil || html == "" {
 				html = r.wrapEnclaveErrorHtml("bilibili", enc.ObjectID)
@@ -77,7 +146,13 @@ func (r *HTMLRenderer) renderEnclave(w util.BufWriter, source []byte, node ast.N
 		w.Write([]byte(html))
 
 	case core.EnclaveProviderTradingView:
-		html, err := object.GetTradingViewWidgetHtml(enc)
+		var html string
+		var err error
+		if ValidEmbedID("tradingview", enc.ObjectID) {
+			html, err = object.GetTradingViewWidgetHtml(enc)
+		} else {
+			err = fmt.Errorf("invalid TradingView symbol")
+		}
 		if err != nil || html == "" {
 			// html = fmt.Sprintf(`<div class="enclave-object-wrapper normal-wrapper"><div class="enclave-object tradingview-enclave-object error">Failed to load tradingview chart from %s</div></div>`, enc.ObjectID)
 			html = r.wrapEnclaveErrorHtml("tradingview", enc.ObjectID)
@@ -88,7 +163,13 @@ func (r *HTMLRenderer) renderEnclave(w util.BufWriter, source []byte, node ast.N
 		w.Write([]byte(html))
 
 	case core.EnclaveProviderDifyWidget:
-		html, err := object.GetDifyWidgetHtml(enc)
+		var html string
+		var err error
+		if ValidDifyURL(enc.ObjectID) {
+			html, err = object.GetDifyWidgetHtml(enc)
+		} else {
+			err = fmt.Errorf("invalid Dify chatbot URL")
+		}
 		if err != nil || html == "" {
 			// html = fmt.Sprintf(`<div class="enclave-object-wrapper normal-wrapper"><div class="enclave-object dify-enclave-object error">Failed to load dify widget from %s</div></div>`, enc.ObjectID)
 			html = r.wrapEnclaveErrorHtml("dify", enc.ObjectID)
@@ -99,7 +180,13 @@ func (r *HTMLRenderer) renderEnclave(w util.BufWriter, source []byte, node ast.N
 		w.Write([]byte(html))
 
 	case core.EnclaveProviderQuailWidget:
-		html, err := object.GetQuailWidgetHtml(enc)
+		var html string
+		var err error
+		if ValidQuailLayout(enc.Params["layout"]) {
+			html, err = object.GetQuailWidgetHtml(enc)
+		} else {
+			err = fmt.Errorf("invalid Quail layout")
+		}
 		if err != nil || html == "" {
 			// html = fmt.Sprintf(`<div class="enclave-object-wrapper normal-wrapper"><div class="enclave-object quail-enclave-object error">Failed to load quail widget from %s</div></div>`, enc.ObjectID)
 			html = r.wrapEnclaveErrorHtml("quail", enc.ObjectID)
@@ -137,37 +224,28 @@ func (r *HTMLRenderer) renderEnclave(w util.BufWriter, source []byte, node ast.N
 		w.Write([]byte(html))
 
 	case core.EnclaveHtml5Audio:
-		html, err := object.GetAudioHtml(enc)
-		if err != nil || html == "" {
-			html = r.wrapEnclaveErrorHtml("audio", enc.ObjectID)
-		} else {
-			html = r.wrapEnclaveHtml("audio", html, true, false)
-		}
-		w.Write([]byte(html))
+		audioHTML := fmt.Sprintf(`<audio controls src="%s"></audio>`, html.EscapeString(enc.ObjectID))
+		w.Write([]byte(r.wrapEnclaveHtml("audio", audioHTML, true, false)))
 
 	case core.EnclaveProviderQuailImage:
-		var alt string
+		alt := enc.Alt
 		if enc.Alt == "" && len(enc.Title) != 0 {
 			alt = fmt.Sprintf("An image to describe %s", enc.Title)
 		}
 		if alt == "" {
 			alt = "An image to describe post"
 		}
-		html, err := object.GetQuailImageHtml(enc)
-		if err != nil || html == "" {
-			html = r.wrapEnclaveErrorHtml("quail-image", enc.ObjectID)
-		}
-		w.Write([]byte(html))
+		w.Write([]byte(renderQuailImageHTML(enc, alt)))
 
 	case core.EnclaveRegularImage:
-		var alt string
+		alt := enc.Alt
 		if enc.Alt == "" && len(enc.Title) != 0 {
 			alt = fmt.Sprintf("An image to describe %s", enc.Title)
 		}
 		if alt == "" {
 			alt = "An image to describe post"
 		}
-		html := fmt.Sprintf(`<img src="%s" alt="%s" />`, enc.URL.String(), alt)
+		html := fmt.Sprintf(`<img src="%s" alt="%s" />`, html.EscapeString(enc.URL.String()), html.EscapeString(alt))
 		w.Write([]byte(html))
 
 	}
@@ -175,10 +253,44 @@ func (r *HTMLRenderer) renderEnclave(w util.BufWriter, source []byte, node ast.N
 	return ast.WalkContinue, nil
 }
 
+func renderQuailImageHTML(enc *core.Enclave, alt string) string {
+	width := styleImageDimension(enc.Params["width"])
+	if width == "" {
+		width = "auto"
+	}
+	height := styleImageDimension(enc.Params["height"])
+	if height == "" {
+		height = "auto"
+	}
+	margin := "0 auto"
+	if enc.Params["align"] == "left" {
+		margin = "0 auto 0 0"
+	} else if enc.Params["align"] == "right" {
+		margin = "0 0 0 auto"
+	}
+	return fmt.Sprintf(
+		`<figure class="quail-image-wrapper" style="width: %s; height: %s; margin: %s; display: block"><img src="%s" alt="%s" style="width: 100%%; height: auto" class="quail-image" /><figcaption class="quail-image-caption" style="display: block">%s</figcaption></figure>`,
+		width,
+		height,
+		margin,
+		html.EscapeString(enc.URL.String()),
+		html.EscapeString(alt),
+		html.EscapeString(enc.Title),
+	)
+}
+
+func styleImageDimension(value string) string {
+	value = SafeImageDimension(value)
+	if unitlessImageSizePattern.MatchString(value) {
+		return value + "px"
+	}
+	return value
+}
+
 func (r *HTMLRenderer) wrapEnclaveErrorHtml(enclaveName, objectID string) string {
 	html := fmt.Sprintf(
 		`<div class="enclave-object-wrapper normal-wrapper"><div class="enclave-object %s-enclave-object error">Failed to load %s from %s</div></div>`,
-		enclaveName, enclaveName, objectID,
+		html.EscapeString(enclaveName), html.EscapeString(enclaveName), html.EscapeString(objectID),
 	)
 	return html
 }

--- a/internal/mdloader/image_renderer.go
+++ b/internal/mdloader/image_renderer.go
@@ -1,6 +1,7 @@
 package mdloader
 
 import (
+	"errors"
 	"fmt"
 	"html"
 	"regexp"
@@ -123,7 +124,7 @@ func (r *imageRenderer) renderEnclave(w util.BufWriter, source []byte, node ast.
 		if enclavefix.ValidEmbedID(enclavecore.EnclaveProviderYouTube, enc.ObjectID) {
 			html, err = object.GetYoutubeEmbedHtml(enc)
 		} else {
-			err = fmt.Errorf("invalid YouTube video ID")
+			err = errors.New("invalid YouTube video ID")
 		}
 		if err != nil || html == "" {
 			html = wrapEnclaveErrorHTML("youtube", enc.ObjectID)
@@ -138,7 +139,7 @@ func (r *imageRenderer) renderEnclave(w util.BufWriter, source []byte, node ast.
 		if enclavefix.ValidEmbedID(enclavecore.EnclaveProviderBilibili, enc.ObjectID) {
 			html, err = object.GetBilibiliEmbedHtml(enc)
 		} else {
-			err = fmt.Errorf("invalid Bilibili video ID")
+			err = errors.New("invalid Bilibili video ID")
 		}
 		if err != nil || html == "" {
 			html = wrapEnclaveErrorHTML("bilibili", enc.ObjectID)
@@ -162,7 +163,7 @@ func (r *imageRenderer) renderEnclave(w util.BufWriter, source []byte, node ast.
 		if enclavefix.ValidEmbedID(enclavecore.EnclaveProviderTradingView, enc.ObjectID) {
 			html, err = object.GetTradingViewWidgetHtml(enc)
 		} else {
-			err = fmt.Errorf("invalid TradingView symbol")
+			err = errors.New("invalid TradingView symbol")
 		}
 		if err != nil || html == "" {
 			html = wrapEnclaveErrorHTML("tradingview", enc.ObjectID)
@@ -177,7 +178,7 @@ func (r *imageRenderer) renderEnclave(w util.BufWriter, source []byte, node ast.
 		if enclavefix.ValidDifyURL(enc.ObjectID) {
 			html, err = object.GetDifyWidgetHtml(enc)
 		} else {
-			err = fmt.Errorf("invalid Dify chatbot URL")
+			err = errors.New("invalid Dify chatbot URL")
 		}
 		if err != nil || html == "" {
 			html = wrapEnclaveErrorHTML("dify", enc.ObjectID)
@@ -192,7 +193,7 @@ func (r *imageRenderer) renderEnclave(w util.BufWriter, source []byte, node ast.
 		if enclavefix.ValidQuailLayout(enc.Params["layout"]) {
 			html, err = object.GetQuailWidgetHtml(enc)
 		} else {
-			err = fmt.Errorf("invalid Quail layout")
+			err = errors.New("invalid Quail layout")
 		}
 		if err != nil || html == "" {
 			html = wrapEnclaveErrorHTML("quail", enc.ObjectID)
@@ -314,7 +315,14 @@ func (r *imageRenderer) renderImage(w util.BufWriter, enc *enclavecore.Enclave) 
 	var out string
 	if size != nil {
 		if size.Height != "" {
-			out = fmt.Sprintf(`<img src="%s" alt="%s"%s width="%s" height="%s" />`, safeSrc, safeAlt, classAttr, html.EscapeString(size.Width), html.EscapeString(size.Height))
+			out = fmt.Sprintf(
+				`<img src="%s" alt="%s"%s width="%s" height="%s" />`,
+				safeSrc,
+				safeAlt,
+				classAttr,
+				html.EscapeString(size.Width),
+				html.EscapeString(size.Height),
+			)
 		} else {
 			out = fmt.Sprintf(`<img src="%s" alt="%s"%s width="%s" />`, safeSrc, safeAlt, classAttr, html.EscapeString(size.Width))
 		}

--- a/internal/mdloader/image_renderer.go
+++ b/internal/mdloader/image_renderer.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"strings"
 
+	"trip2g/internal/enclavefix"
+
 	enclavecore "github.com/quailyquaily/goldmark-enclave/core"
 	"github.com/quailyquaily/goldmark-enclave/object"
 	"github.com/yuin/goldmark/ast"
@@ -116,7 +118,13 @@ func (r *imageRenderer) renderEnclave(w util.BufWriter, source []byte, node ast.
 		r.renderImage(w, enc)
 
 	case enclavecore.EnclaveProviderYouTube:
-		html, err := object.GetYoutubeEmbedHtml(enc)
+		var html string
+		var err error
+		if enclavefix.ValidEmbedID(enclavecore.EnclaveProviderYouTube, enc.ObjectID) {
+			html, err = object.GetYoutubeEmbedHtml(enc)
+		} else {
+			err = fmt.Errorf("invalid YouTube video ID")
+		}
 		if err != nil || html == "" {
 			html = wrapEnclaveErrorHTML("youtube", enc.ObjectID)
 		} else {
@@ -125,7 +133,13 @@ func (r *imageRenderer) renderEnclave(w util.BufWriter, source []byte, node ast.
 		_, _ = w.Write([]byte(html))
 
 	case enclavecore.EnclaveProviderBilibili:
-		html, err := object.GetBilibiliEmbedHtml(enc)
+		var html string
+		var err error
+		if enclavefix.ValidEmbedID(enclavecore.EnclaveProviderBilibili, enc.ObjectID) {
+			html, err = object.GetBilibiliEmbedHtml(enc)
+		} else {
+			err = fmt.Errorf("invalid Bilibili video ID")
+		}
 		if err != nil || html == "" {
 			html = wrapEnclaveErrorHTML("bilibili", enc.ObjectID)
 		} else {
@@ -143,7 +157,13 @@ func (r *imageRenderer) renderEnclave(w util.BufWriter, source []byte, node ast.
 		_, _ = w.Write([]byte(html))
 
 	case enclavecore.EnclaveProviderTradingView:
-		html, err := object.GetTradingViewWidgetHtml(enc)
+		var html string
+		var err error
+		if enclavefix.ValidEmbedID(enclavecore.EnclaveProviderTradingView, enc.ObjectID) {
+			html, err = object.GetTradingViewWidgetHtml(enc)
+		} else {
+			err = fmt.Errorf("invalid TradingView symbol")
+		}
 		if err != nil || html == "" {
 			html = wrapEnclaveErrorHTML("tradingview", enc.ObjectID)
 		} else {
@@ -152,7 +172,13 @@ func (r *imageRenderer) renderEnclave(w util.BufWriter, source []byte, node ast.
 		_, _ = w.Write([]byte(html))
 
 	case enclavecore.EnclaveProviderDifyWidget:
-		html, err := object.GetDifyWidgetHtml(enc)
+		var html string
+		var err error
+		if enclavefix.ValidDifyURL(enc.ObjectID) {
+			html, err = object.GetDifyWidgetHtml(enc)
+		} else {
+			err = fmt.Errorf("invalid Dify chatbot URL")
+		}
 		if err != nil || html == "" {
 			html = wrapEnclaveErrorHTML("dify", enc.ObjectID)
 		} else {
@@ -161,7 +187,13 @@ func (r *imageRenderer) renderEnclave(w util.BufWriter, source []byte, node ast.
 		_, _ = w.Write([]byte(html))
 
 	case enclavecore.EnclaveProviderQuailWidget:
-		html, err := object.GetQuailWidgetHtml(enc)
+		var html string
+		var err error
+		if enclavefix.ValidQuailLayout(enc.Params["layout"]) {
+			html, err = object.GetQuailWidgetHtml(enc)
+		} else {
+			err = fmt.Errorf("invalid Quail layout")
+		}
 		if err != nil || html == "" {
 			html = wrapEnclaveErrorHTML("quail", enc.ObjectID)
 		} else {
@@ -241,8 +273,8 @@ func (r *imageRenderer) renderImage(w util.BufWriter, enc *enclavecore.Enclave) 
 	var size *imageSize
 	if enc.Provider == enclavecore.EnclaveProviderQuailImage {
 		// Size is in Params for QuailImage
-		width := enc.Params["width"]
-		height := enc.Params["height"]
+		width := enclavefix.SafeImageDimension(enc.Params["width"])
+		height := enclavefix.SafeImageDimension(enc.Params["height"])
 		if width != "" {
 			size = &imageSize{Width: width, Height: height}
 		}
@@ -282,9 +314,9 @@ func (r *imageRenderer) renderImage(w util.BufWriter, enc *enclavecore.Enclave) 
 	var out string
 	if size != nil {
 		if size.Height != "" {
-			out = fmt.Sprintf(`<img src="%s" alt="%s"%s width="%s" height="%s" />`, safeSrc, safeAlt, classAttr, size.Width, size.Height)
+			out = fmt.Sprintf(`<img src="%s" alt="%s"%s width="%s" height="%s" />`, safeSrc, safeAlt, classAttr, html.EscapeString(size.Width), html.EscapeString(size.Height))
 		} else {
-			out = fmt.Sprintf(`<img src="%s" alt="%s"%s width="%s" />`, safeSrc, safeAlt, classAttr, size.Width)
+			out = fmt.Sprintf(`<img src="%s" alt="%s"%s width="%s" />`, safeSrc, safeAlt, classAttr, html.EscapeString(size.Width))
 		}
 	} else {
 		out = fmt.Sprintf(`<img src="%s" alt="%s"%s />`, safeSrc, safeAlt, classAttr)
@@ -296,7 +328,7 @@ func (r *imageRenderer) renderImage(w util.BufWriter, enc *enclavecore.Enclave) 
 func wrapEnclaveErrorHTML(enclaveName, objectID string) string {
 	return fmt.Sprintf(
 		`<div class="enclave-object-wrapper normal-wrapper"><div class="enclave-object %s-enclave-object error">Failed to load %s from %s</div></div>`,
-		enclaveName, enclaveName, objectID,
+		html.EscapeString(enclaveName), html.EscapeString(enclaveName), html.EscapeString(objectID),
 	)
 }
 

--- a/internal/mdloader/image_renderer_xss_test.go
+++ b/internal/mdloader/image_renderer_xss_test.go
@@ -86,3 +86,93 @@ func TestImageAltSpecialCharsEscaped(t *testing.T) {
 	html := string(pages.Map["/note"].HTML)
 	require.NotContains(t, html, `<script>`, "script tags in alt must be escaped")
 }
+
+func TestYouTubeEmbedIDCannotInjectHTMLAttribute(t *testing.T) {
+	log := logger.TestLogger{}
+	pages, err := mdloader.Load(mdloader.Options{
+		Sources: []mdloader.SourceFile{{
+			Path:    "note.md",
+			Content: []byte(`![](https://www.youtube.com/watch?v=video-id%22%20onload%3D%22trip2g-marker%22)`),
+		}},
+		Log: &log,
+	})
+	require.NoError(t, err)
+	html := string(pages.Map["/note"].HTML)
+	require.NotContains(t, html, `<iframe`, "invalid YouTube IDs must not reach the embed template")
+	require.NotContains(t, html, `onload="trip2g-marker"`, "YouTube IDs must not break out of iframe attributes")
+	require.Contains(t, html, `&#34;`, "the rejected identifier must be escaped in the error message")
+}
+
+func TestTradingViewSymbolCannotInjectScript(t *testing.T) {
+	log := logger.TestLogger{}
+	pages, err := mdloader.Load(mdloader.Options{
+		Sources: []mdloader.SourceFile{{
+			Path:    "note.md",
+			Content: []byte(`![](https://www.tradingview.com/chart/abc/?symbol=%22%3Balert(1)%3B%2F%2F)`),
+		}},
+		Log: &log,
+	})
+	require.NoError(t, err)
+	html := string(pages.Map["/note"].HTML)
+	require.NotContains(t, html, `";alert(1)`, "TradingView symbols must not break out of widget JavaScript")
+}
+
+func TestBilibiliEmbedIDCannotInjectHTMLAttribute(t *testing.T) {
+	log := logger.TestLogger{}
+	pages, err := mdloader.Load(mdloader.Options{
+		Sources: []mdloader.SourceFile{{
+			Path:    "note.md",
+			Content: []byte(`![](https://www.bilibili.com/video/%22%20onload%3D%22trip2g-marker%22)`),
+		}},
+		Log: &log,
+	})
+	require.NoError(t, err)
+	html := string(pages.Map["/note"].HTML)
+	require.NotContains(t, html, `<iframe`, "invalid Bilibili IDs must not reach the embed template")
+	require.NotContains(t, html, `onload="trip2g-marker"`)
+}
+
+func TestQuailLayoutCannotInjectHTMLAttribute(t *testing.T) {
+	log := logger.TestLogger{}
+	pages, err := mdloader.Load(mdloader.Options{
+		Sources: []mdloader.SourceFile{{
+			Path:    "note.md",
+			Content: []byte(`![](https://quaily.com/list?layout=%22%20onload%3D%22trip2g-marker%22)`),
+		}},
+		Log: &log,
+	})
+	require.NoError(t, err)
+	html := string(pages.Map["/note"].HTML)
+	require.NotContains(t, html, `<iframe`, "invalid Quail layouts must not reach the embed template")
+	require.NotContains(t, html, `onload="trip2g-marker"`)
+}
+
+func TestDifyURLCannotInjectHTMLAttribute(t *testing.T) {
+	log := logger.TestLogger{}
+	pages, err := mdloader.Load(mdloader.Options{
+		Sources: []mdloader.SourceFile{{
+			Path:    "note.md",
+			Content: []byte(`![](dify://udify.app/chatbot/%22%20onload%3D%22trip2g-marker%22)`),
+		}},
+		Log: &log,
+	})
+	require.NoError(t, err)
+	html := string(pages.Map["/note"].HTML)
+	require.NotContains(t, html, `<iframe`, "invalid Dify URLs must not reach the embed template")
+	require.NotContains(t, html, `onload="trip2g-marker"`)
+}
+
+func TestImageDimensionCannotInjectHTMLAttribute(t *testing.T) {
+	log := logger.TestLogger{}
+	pages, err := mdloader.Load(mdloader.Options{
+		Sources: []mdloader.SourceFile{{
+			Path:    "note.md",
+			Content: []byte(`![image](https://example.com/image.jpg?w=%22%20onload%3D%22trip2g-marker%22)`),
+		}},
+		Log: &log,
+	})
+	require.NoError(t, err)
+	html := string(pages.Map["/note"].HTML)
+	require.NotContains(t, html, `onload="trip2g-marker"`)
+	require.NotContains(t, html, `width=""`)
+}


### PR DESCRIPTION
## Problem

The pinned goldmark-enclave helpers build raw HTML and inline JavaScript with `text/template`. Percent-decoded provider identifiers and query parameters could break out of iframe attributes or JavaScript strings, creating stored XSS in rendered notes. The same AST also has two renderer paths, so protecting only one path leaves a bypass.

## Solution

- Validate YouTube and Bilibili IDs before raw iframe rendering.
- Validate Dify scheme, host, and chatbot path.
- Constrain Quail layout values.
- Reject TradingView values that can escape a JavaScript string or terminate a script while preserving futures and composite symbols.
- Apply the same checks in both enclavefix and mdloader renderers.
- Escape rejected identifiers and standalone image/audio attributes.
- Sanitize image dimensions before writing attributes or inline styles.
- Add regressions for encoded quote/script payloads across both renderer paths.

## Validation

- `go test -race ./internal/enclavefix ./internal/mdloader`
- `go vet ./internal/enclavefix ./internal/mdloader`
- `git diff --check`
- Independent security review: APPROVE

Browser-level behavior under site-specific CSP configurations was not tested.