### PR TITLE
feat(mcp): Prometheus metrics for the MCP endpoint

### DIFF
--- a/cmd/server/federation.go
+++ b/cmd/server/federation.go
@@ -8,6 +8,7 @@ import (
 	"trip2g/internal/case/mcp"
 	"trip2g/internal/db"
 	"trip2g/internal/federation"
+	"trip2g/internal/metrics"
 	"trip2g/internal/model"
 )
 
@@ -103,4 +104,8 @@ func (a *app) FederationClient(reqCtx context.Context, kbID string) (model.Feder
 
 func (a *app) FederationMaxDepth() int {
 	return a.config.MCPFederationMaxDepth
+}
+
+func (a *app) MCPMetrics() *metrics.MCPMetrics {
+	return a.mcpMetrics
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -439,6 +439,7 @@ func main() {
 
 	a.liveNoteLoader = noteloader.New("live", makeLiveNoteLoaderWrapper(a), a.config.MDLoaderConfig)
 	a.latestNoteLoader = noteloader.New("latest", makeLatestNoteLoaderWrapper(a), a.config.MDLoaderConfig)
+	a.wireMCPDynamicToolsGauge()
 	a.ChartData = chartdata.New(a)
 	a.liveNoteLoader.SetChartDataProvider(a)
 	a.latestNoteLoader.SetChartDataProvider(a)
@@ -550,10 +551,16 @@ func (a *app) PrepareLatestNotes(ctx context.Context, partial bool) (*model.Note
 	// whole anonymous page cache rather than reasoning about which keys moved.
 	a.ClearPageCache()
 
-	// Keep the dynamic-tools gauge fresh even when no client calls tools/list.
-	a.mcpMetrics.SetDynamicToolsRegistered(mcp.DynamicToolCount(a.latestNoteLoader.NoteViews()))
-
 	return a.latestNoteLoader.NoteViews(), nil
+}
+
+// wireMCPDynamicToolsGauge makes the dynamic-tools gauge read the currently
+// published note snapshot at scrape time, so it stays fresh across reloads
+// without any tools/list call.
+func (a *app) wireMCPDynamicToolsGauge() {
+	a.mcpMetrics.SetDynamicToolsSource(func() int {
+		return mcp.DynamicToolCount(a.latestNoteLoader.NoteViews())
+	})
 }
 
 func (a *app) PrepareLiveNotes(ctx context.Context) (*model.NoteViews, error) {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -47,6 +47,7 @@ import (
 	"trip2g/internal/gitapi"
 	"trip2g/internal/hotauthtoken"
 	"trip2g/internal/logger"
+	"trip2g/internal/metrics"
 	"trip2g/internal/model"
 	"trip2g/internal/notebus"
 	"trip2g/internal/noteloader"
@@ -73,6 +74,8 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler"
+
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/valyala/fasthttp"
 
@@ -191,6 +194,8 @@ type appState struct {
 	personalTokenResolver *personaltoken.Resolver
 
 	notFoundTracker *notfoundtracker.Tracker
+
+	mcpMetrics *metrics.MCPMetrics
 
 	redirectManager *redirectmanager.Manager
 
@@ -336,6 +341,8 @@ func main() {
 			tgAuthTokenManager:  tgauthtoken.NewManager(config.TgAuthToken),
 
 			oidcKeys: oidcauth.NewKeyCache(),
+
+			mcpMetrics: metrics.NewMCPMetrics(prometheus.DefaultRegisterer),
 
 			purchaseTokenManager: purchasetoken.NewManager(config.PurchaseToken),
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -550,6 +550,9 @@ func (a *app) PrepareLatestNotes(ctx context.Context, partial bool) (*model.Note
 	// whole anonymous page cache rather than reasoning about which keys moved.
 	a.ClearPageCache()
 
+	// Keep the dynamic-tools gauge fresh even when no client calls tools/list.
+	a.mcpMetrics.SetDynamicToolsRegistered(mcp.DynamicToolCount(a.latestNoteLoader.NoteViews()))
+
 	return a.latestNoteLoader.NoteViews(), nil
 }
 

--- a/cmd/server/mcp_metrics_wiring_test.go
+++ b/cmd/server/mcp_metrics_wiring_test.go
@@ -43,20 +43,24 @@ func gaugeValue(t *testing.T, reg *prometheus.Registry, name string) float64 {
 	return 0
 }
 
-// TestPrepareLatestNotes_RefreshesMCPDynamicToolsGauge pins the reload->gauge
-// wiring: a notes reload must refresh trip2g_mcp_dynamic_tools_registered from
-// the loaded note index, without requiring any tools/list MCP call.
-func TestPrepareLatestNotes_RefreshesMCPDynamicToolsGauge(t *testing.T) {
+// TestMCPDynamicToolsGauge_FreshAfterReload pins the wiring: the gauge reads
+// the currently published note snapshot at scrape time, so a notes reload is
+// reflected immediately, without requiring any tools/list MCP call.
+func TestMCPDynamicToolsGauge_FreshAfterReload(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	a := &app{appState: &appState{
 		pageCache:  pagecache.New(),
 		mcpMetrics: metrics.NewMCPMetrics(reg),
 	}}
 	a.latestNoteLoader = noteloader.New("latest", mcpToolNoteLoaderEnv{}, mdloader.Config{})
+	a.wireMCPDynamicToolsGauge()
+
+	require.InDelta(t, 0, gaugeValue(t, reg, "trip2g_mcp_dynamic_tools_registered"), 1e-9,
+		"no notes loaded yet")
 
 	_, err := a.PrepareLatestNotes(context.Background(), true)
 	require.NoError(t, err)
 
 	require.InDelta(t, 1, gaugeValue(t, reg, "trip2g_mcp_dynamic_tools_registered"), 1e-9,
-		"PrepareLatestNotes must refresh the dynamic tools gauge from the note index")
+		"scrape after reload must reflect the current note index")
 }

--- a/cmd/server/mcp_metrics_wiring_test.go
+++ b/cmd/server/mcp_metrics_wiring_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"trip2g/internal/mdloader"
+	"trip2g/internal/metrics"
+	"trip2g/internal/noteloader"
+	"trip2g/internal/pagecache"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+// mcpToolNoteLoaderEnv loads one note exposing a dynamic MCP tool via mcp_method.
+type mcpToolNoteLoaderEnv struct{ emptyNoteLoaderEnv }
+
+func (mcpToolNoteLoaderEnv) RawNotes(context.Context) ([]noteloader.RawNote, error) {
+	return []noteloader.RawNote{{
+		Path:      "tools/my.md",
+		PathID:    1,
+		VersionID: 1,
+		Content:   "---\nmcp_method: my_tool\n---\nbody",
+		CreatedAt: time.Now(),
+	}}, nil
+}
+
+func gaugeValue(t *testing.T, reg *prometheus.Registry, name string) float64 {
+	t.Helper()
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, mf := range families {
+		if mf.GetName() == name {
+			require.Len(t, mf.GetMetric(), 1)
+			return mf.GetMetric()[0].GetGauge().GetValue()
+		}
+	}
+	var zero *dto.Metric
+	require.NotNil(t, zero, "gauge %s not found in registry", name)
+	return 0
+}
+
+// TestPrepareLatestNotes_RefreshesMCPDynamicToolsGauge pins the reload->gauge
+// wiring: a notes reload must refresh trip2g_mcp_dynamic_tools_registered from
+// the loaded note index, without requiring any tools/list MCP call.
+func TestPrepareLatestNotes_RefreshesMCPDynamicToolsGauge(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	a := &app{appState: &appState{
+		pageCache:  pagecache.New(),
+		mcpMetrics: metrics.NewMCPMetrics(reg),
+	}}
+	a.latestNoteLoader = noteloader.New("latest", mcpToolNoteLoaderEnv{}, mdloader.Config{})
+
+	_, err := a.PrepareLatestNotes(context.Background(), true)
+	require.NoError(t, err)
+
+	require.InDelta(t, 1, gaugeValue(t, reg, "trip2g_mcp_dynamic_tools_registered"), 1e-9,
+		"PrepareLatestNotes must refresh the dynamic tools gauge from the note index")
+}

--- a/internal/case/mcp/endpoint.go
+++ b/internal/case/mcp/endpoint.go
@@ -35,12 +35,14 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 	}
 
 	// Enforce federation hop depth limit. Depth is observed for every request:
-	// no header (or a malformed one) counts as 0 = direct client.
+	// no header, a malformed value or a negative one all count as 0 = direct client.
 	resolveCtx := context.Context(req.Req)
 	depthHeader := req.Req.Request.Header.Peek("X-MCP-Federation-Depth")
 	incomingDepth := 0
 	if len(depthHeader) > 0 {
-		incomingDepth, _ = strconv.Atoi(string(depthHeader))
+		if v, parseErr := strconv.Atoi(string(depthHeader)); parseErr == nil && v > 0 {
+			incomingDepth = v
+		}
 	}
 	m.ObserveFederationDepth(incomingDepth)
 	if len(depthHeader) > 0 {
@@ -76,7 +78,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 	rpcReq.MethodOverride = string(req.Req.Request.URI().QueryArgs().Peek("method"))
 	resolveCtx = ContextWithMetrics(resolveCtx, m)
 	resp := Resolve(resolveCtx, env, rpcReq)
-	recordRequestMetrics(resolveCtx, m, env, rpcReq, userToken != nil, resp, time.Since(start).Seconds())
+	recordRequestMetrics(resolveCtx, m, rpcReq, userToken != nil, resp, time.Since(start).Seconds())
 	return writeJSONResponse(req, resp)
 }
 

--- a/internal/case/mcp/endpoint.go
+++ b/internal/case/mcp/endpoint.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"trip2g/internal/appreq"
 )
@@ -29,11 +30,14 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 		return writeJSONResponse(req, resp)
 	}
 
+	m := env.MCPMetrics()
+
 	// Enforce federation hop depth limit.
 	resolveCtx := context.Context(req.Req)
 	depthHeader := req.Req.Request.Header.Peek("X-MCP-Federation-Depth")
 	if len(depthHeader) > 0 {
 		incomingDepth, _ := strconv.Atoi(string(depthHeader))
+		m.ObserveFederationDepth(incomingDepth)
 		if incomingDepth >= env.FederationMaxDepth() {
 			resp := errorResponse(rpcReq.ID, ErrCodeInternal, "federation max depth exceeded")
 			return writeJSONResponse(req, resp)
@@ -61,7 +65,10 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 
 	// Handle request
 	rpcReq.MethodOverride = string(req.Req.Request.URI().QueryArgs().Peek("method"))
+	resolveCtx = ContextWithMetrics(resolveCtx, m)
+	start := time.Now()
 	resp := Resolve(resolveCtx, env, rpcReq)
+	recordRequestMetrics(resolveCtx, m, env, rpcReq, userToken != nil, resp, time.Since(start).Seconds())
 	return writeJSONResponse(req, resp)
 }
 

--- a/internal/case/mcp/endpoint.go
+++ b/internal/case/mcp/endpoint.go
@@ -15,6 +15,7 @@ type Endpoint struct{}
 
 func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 	env := req.Env.(Env)
+	start := time.Now()
 
 	// Parse JSON-RPC request
 	var rpcReq Request
@@ -24,22 +25,28 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 		return writeJSONResponse(req, resp)
 	}
 
+	m := env.MCPMetrics()
+
 	// Validate JSON-RPC version
 	if rpcReq.JSONRPC != "2.0" {
 		resp := errorResponse(rpcReq.ID, ErrCodeInvalidRequest, "Invalid JSON-RPC version")
+		recordRejectedRequest(m, rpcReq, authAnonymous, time.Since(start).Seconds())
 		return writeJSONResponse(req, resp)
 	}
 
-	m := env.MCPMetrics()
-
-	// Enforce federation hop depth limit.
+	// Enforce federation hop depth limit. Depth is observed for every request:
+	// no header (or a malformed one) counts as 0 = direct client.
 	resolveCtx := context.Context(req.Req)
 	depthHeader := req.Req.Request.Header.Peek("X-MCP-Federation-Depth")
+	incomingDepth := 0
 	if len(depthHeader) > 0 {
-		incomingDepth, _ := strconv.Atoi(string(depthHeader))
-		m.ObserveFederationDepth(incomingDepth)
+		incomingDepth, _ = strconv.Atoi(string(depthHeader))
+	}
+	m.ObserveFederationDepth(incomingDepth)
+	if len(depthHeader) > 0 {
 		if incomingDepth >= env.FederationMaxDepth() {
 			resp := errorResponse(rpcReq.ID, ErrCodeInternal, "federation max depth exceeded")
+			recordRejectedRequest(m, rpcReq, authAnonymous, time.Since(start).Seconds())
 			return writeJSONResponse(req, resp)
 		}
 		resolveCtx = contextWithFederationDepth(resolveCtx, incomingDepth)
@@ -52,12 +59,14 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 	userToken, utErr := req.UserToken()
 	if utErr != nil {
 		resp := errorResponse(rpcReq.ID, ErrCodeInternal, "Auth failed: "+utErr.Error())
+		recordRejectedRequest(m, rpcReq, authToken, time.Since(start).Seconds())
 		return writeJSONResponse(req, resp)
 	}
 
 	if userToken == nil {
-		newCtx, errResp := authenticateAnonymousRequest(resolveCtx, req, env, rpcReq.ID)
+		newCtx, authAttempt, errResp := authenticateAnonymousRequest(resolveCtx, req, env, rpcReq.ID)
 		if errResp != nil {
+			recordRejectedRequest(m, rpcReq, authAttempt, time.Since(start).Seconds())
 			return writeJSONResponse(req, *errResp)
 		}
 		resolveCtx = newCtx
@@ -66,7 +75,6 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 	// Handle request
 	rpcReq.MethodOverride = string(req.Req.Request.URI().QueryArgs().Peek("method"))
 	resolveCtx = ContextWithMetrics(resolveCtx, m)
-	start := time.Now()
 	resp := Resolve(resolveCtx, env, rpcReq)
 	recordRequestMetrics(resolveCtx, m, env, rpcReq, userToken != nil, resp, time.Since(start).Seconds())
 	return writeJSONResponse(req, resp)
@@ -74,20 +82,21 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 
 // authenticateAnonymousRequest resolves API-key or federation-JWT auth when no
 // personal token is present. It returns the augmented context, or an error
-// response to send back unchanged when auth fails.
-func authenticateAnonymousRequest(ctx context.Context, req *appreq.Request, env Env, id any) (context.Context, *Response) {
+// response to send back unchanged when auth fails, plus the attempted auth
+// kind for metric labels (an invalid API key is still auth=api_key traffic).
+func authenticateAnonymousRequest(ctx context.Context, req *appreq.Request, env Env, id any) (context.Context, string, *Response) {
 	apiKeyValue := strings.TrimSpace(string(req.Req.Request.Header.Peek("X-API-Key")))
 	if apiKeyValue != "" {
 		apiKey, keyErr := env.ResolveAPIKey(req.Req, apiKeyValue, "mcp")
 		if keyErr != nil {
 			resp := errorResponse(id, ErrCodeInternal, "Auth failed: "+keyErr.Error())
-			return ctx, &resp
+			return ctx, authAPIKey, &resp
 		}
 		adminTools := apiKey.EnableMcpAdminTools != nil && *apiKey.EnableMcpAdminTools
 		// Attribute internal admin GraphQL calls (WithAdminToken) to the API
 		// key owner so mutations like createAdmin record a real granted_by.
 		req.AdminActorUserID = int(apiKey.CreatedBy)
-		return contextWithMCPAPIKeyAuth(ctx, adminTools), nil
+		return contextWithMCPAPIKeyAuth(ctx, adminTools), authAPIKey, nil
 	}
 
 	authHeader := strings.TrimSpace(string(req.Req.Request.Header.Peek("Authorization")))
@@ -95,17 +104,17 @@ func authenticateAnonymousRequest(ctx context.Context, req *appreq.Request, env 
 	token = strings.TrimSpace(token)
 	if authHeader != "" && (!isBearerToken || token == "") {
 		resp := errorResponse(id, ErrCodeInternal, "Federation auth failed: malformed bearer token")
-		return ctx, &resp
+		return ctx, authFederation, &resp
 	}
 	if !isBearerToken || token == "" {
-		return ctx, nil
+		return ctx, authAnonymous, nil
 	}
 	kid, allowedSubgraphs, verifyErr := verifyInbound(req.Req, env, token)
 	if verifyErr != nil {
 		resp := errorResponse(id, ErrCodeInternal, "Federation auth failed: "+verifyErr.Error())
-		return ctx, &resp
+		return ctx, authFederation, &resp
 	}
-	return contextWithFederationAuth(ctx, kid, allowedSubgraphs), nil
+	return contextWithFederationAuth(ctx, kid, allowedSubgraphs), authFederation, nil
 }
 
 func writeJSONResponse(req *appreq.Request, resp Response) (interface{}, error) {

--- a/internal/case/mcp/endpoint_dispatch_test.go
+++ b/internal/case/mcp/endpoint_dispatch_test.go
@@ -11,6 +11,7 @@ import (
 	"trip2g/internal/db"
 	"trip2g/internal/features"
 	"trip2g/internal/logger"
+	"trip2g/internal/metrics"
 	appmodel "trip2g/internal/model"
 	"trip2g/internal/usertoken"
 
@@ -61,6 +62,7 @@ func buildDispatchEnv(t *testing.T, verifyInboundWillFail bool) *EnvMock {
 		FeaturesFunc:                func() features.Features { return features.Features{} },
 		CanReadNoteFunc:             func(_ context.Context, _ *appmodel.NoteView) (bool, error) { return true, nil },
 		FederatedGraphQLEnabledFunc: func() bool { return false },
+		MCPMetricsFunc:              func() *metrics.MCPMetrics { return nil },
 	}
 	if verifyInboundWillFail {
 		env.FederationSecretByKIDFunc = func(_ context.Context, _ string) (db.FederationSecret, bool, error) {

--- a/internal/case/mcp/federated_graphql_test.go
+++ b/internal/case/mcp/federated_graphql_test.go
@@ -8,6 +8,7 @@ import (
 	"trip2g/internal/db"
 	"trip2g/internal/features"
 	"trip2g/internal/logger"
+	"trip2g/internal/metrics"
 	"trip2g/internal/model"
 	"trip2g/internal/openai"
 
@@ -35,6 +36,7 @@ func (e *fedGQLEnv) GraphQLRequest(ctx context.Context, query string, variables 
 	}
 	panic("unexpected admin GraphQLRequest call — security violation: must NOT reach admin path under fedAuth")
 }
+func (e *fedGQLEnv) MCPMetrics() *metrics.MCPMetrics     { return nil }
 func (e *fedGQLEnv) Features() features.Features         { panic("unexpected") }
 func (e *fedGQLEnv) LatestNoteViews() *model.NoteViews   { panic("unexpected") }
 func (e *fedGQLEnv) LatestNoteChunks() []model.NoteChunk { panic("unexpected") }

--- a/internal/case/mcp/federation_handlers.go
+++ b/internal/case/mcp/federation_handlers.go
@@ -33,6 +33,15 @@ func handleFederatedSearch(ctx context.Context, env Env, id any, argsRaw json.Ra
 		results := fanout(ctx, env, selected, func(ctx context.Context, client model.Federation) (model.FederationResult, error) {
 			return client.Search(ctx, model.FederationSearchParams{Query: args.Query})
 		})
+		m := metricsFromContext(ctx)
+		touched := 0
+		for _, r := range results {
+			m.RecordFederatedRequest(federatedStatus(r.Err))
+			if r.Err == nil {
+				touched++
+			}
+		}
+		m.ObserveFanoutBases(touched)
 		return successResponse(id, aggregateFederationResults(results))
 	}
 
@@ -53,6 +62,7 @@ func handleFederatedSearch(ctx context.Context, env Env, id any, argsRaw json.Ra
 		params.KBID = rest
 		result, err = client.FederatedSearch(ctx, params)
 	}
+	metricsFromContext(ctx).RecordFederatedRequest(federatedStatus(err))
 	if err != nil {
 		return errorResponse(id, ErrCodeInternal, err.Error())
 	}
@@ -84,6 +94,7 @@ func callFederatedSingleKB(
 		return errorResponse(id, ErrCodeInternal, err.Error())
 	}
 	result, err := call(client, rest)
+	metricsFromContext(ctx).RecordFederatedRequest(federatedStatus(err))
 	if err != nil {
 		return errorResponse(id, ErrCodeInternal, err.Error())
 	}

--- a/internal/case/mcp/federation_handlers.go
+++ b/internal/case/mcp/federation_handlers.go
@@ -52,6 +52,9 @@ func handleFederatedSearch(ctx context.Context, env Env, id any, argsRaw json.Ra
 	var client model.Federation
 	client, err = env.FederationClient(ctx, kb.ID)
 	if err != nil {
+		// A client that can't be built is still a failed outbound attempt,
+		// same as on the fan-out path.
+		metricsFromContext(ctx).RecordFederatedRequest(federatedStatus(err))
 		return errorResponse(id, ErrCodeInternal, err.Error())
 	}
 	params := model.FederationSearchParams{Query: args.Query}
@@ -91,6 +94,9 @@ func callFederatedSingleKB(
 	}
 	client, err := env.FederationClient(ctx, kb.ID)
 	if err != nil {
+		// A client that can't be built is still a failed outbound attempt,
+		// same as on the fan-out path.
+		metricsFromContext(ctx).RecordFederatedRequest(federatedStatus(err))
 		return errorResponse(id, ErrCodeInternal, err.Error())
 	}
 	result, err := call(client, rest)

--- a/internal/case/mcp/graphql_tools_test.go
+++ b/internal/case/mcp/graphql_tools_test.go
@@ -9,6 +9,7 @@ import (
 	"trip2g/internal/db"
 	"trip2g/internal/features"
 	"trip2g/internal/logger"
+	"trip2g/internal/metrics"
 	"trip2g/internal/model"
 	"trip2g/internal/openai"
 
@@ -24,6 +25,7 @@ type gqlRequestEnv struct {
 func (e *gqlRequestEnv) GraphQLRequest(ctx context.Context, query string, variables map[string]any) ([]byte, error) {
 	return e.graphqlFunc(ctx, query, variables)
 }
+func (e *gqlRequestEnv) MCPMetrics() *metrics.MCPMetrics     { return nil }
 func (e *gqlRequestEnv) Features() features.Features         { panic("unexpected") }
 func (e *gqlRequestEnv) LatestNoteViews() *model.NoteViews   { panic("unexpected") }
 func (e *gqlRequestEnv) LatestNoteChunks() []model.NoteChunk { panic("unexpected") }

--- a/internal/case/mcp/metrics.go
+++ b/internal/case/mcp/metrics.go
@@ -1,0 +1,125 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"trip2g/internal/metrics"
+)
+
+type mcpMetricsContextKey struct{}
+
+// ContextWithMetrics stores MCP metrics in ctx so tool handlers can record
+// tool-specific observations (fan-out width, result counts, dynamic tools).
+func ContextWithMetrics(ctx context.Context, m *metrics.MCPMetrics) context.Context {
+	return context.WithValue(ctx, mcpMetricsContextKey{}, m)
+}
+
+// metricsFromContext returns the MCP metrics from ctx, or nil (all record
+// methods are nil-safe).
+func metricsFromContext(ctx context.Context) *metrics.MCPMetrics {
+	m, _ := ctx.Value(mcpMetricsContextKey{}).(*metrics.MCPMetrics)
+	return m
+}
+
+// recordRequestMetrics records the per-request metrics after Resolve.
+func recordRequestMetrics(ctx context.Context, m *metrics.MCPMetrics, env Env, req Request, hasUserToken bool, resp Response, seconds float64) {
+	if m == nil {
+		return
+	}
+
+	auth := authKind(ctx, hasUserToken)
+	method := methodLabel(req.Method)
+
+	tool := ""
+	if req.Method == mcpMethodToolsCall {
+		var params CallToolParams
+		if json.Unmarshal(req.Params, &params) == nil {
+			tool = toolLabel(env, params.Name)
+		}
+	}
+
+	status := "ok"
+	if resp.Error != nil {
+		status = "error"
+	}
+
+	m.RecordMCPRequest(method, tool, auth, status, seconds)
+	if req.Method == mcpMethodToolsList {
+		m.RecordToolsList(auth)
+	}
+	if req.Method == mcpMethodToolsCall && resp.Error != nil {
+		m.RecordToolError(tool, errorReason(resp.Error.Code))
+	}
+}
+
+// authKind classifies the request auth for metric labels.
+func authKind(ctx context.Context, hasUserToken bool) string {
+	switch {
+	case hasUserToken:
+		return "token"
+	case mcpAPIKeyAuthed(ctx):
+		return "api_key"
+	default:
+		if _, ok := federationAuthFromContext(ctx); ok {
+			return "federation"
+		}
+		return "anonymous"
+	}
+}
+
+// otherLabel is the bounded fallback for free-form client input in labels.
+const otherLabel = "other"
+
+// methodLabel bounds the method label to the known JSON-RPC method set.
+func methodLabel(method string) string {
+	switch method {
+	case MCPMethodInitialize, "notifications/initialized", mcpMethodToolsList, mcpMethodToolsCall:
+		return method
+	default:
+		return otherLabel
+	}
+}
+
+// toolLabel bounds the tool label: built-in tools and note-registered dynamic
+// tools keep their name, anything else (arbitrary client input) becomes "other".
+func toolLabel(env Env, name string) string {
+	if reservedMCPTools[name] {
+		return name
+	}
+	if nvs := env.LatestNoteViews(); nvs != nil {
+		for _, note := range nvs.List {
+			if note.MCPMethod == name {
+				return name
+			}
+		}
+	}
+	return otherLabel
+}
+
+// errorReason maps a JSON-RPC error code to a bounded reason label.
+func errorReason(code int) string {
+	switch code {
+	case ErrCodeInvalidParams:
+		return "invalid_params"
+	case ErrCodeMethodNotFound:
+		return "not_found"
+	case ErrCodeInternal:
+		return "internal"
+	default:
+		return otherLabel
+	}
+}
+
+// federatedStatus maps an outbound federated call error to ok|error|timeout.
+func federatedStatus(err error) string {
+	if err == nil {
+		return "ok"
+	}
+	var timeout interface{ Timeout() bool }
+	if errors.Is(err, context.DeadlineExceeded) || (errors.As(err, &timeout) && timeout.Timeout()) {
+		return "timeout"
+	}
+	return "error"
+}

--- a/internal/case/mcp/metrics.go
+++ b/internal/case/mcp/metrics.go
@@ -25,7 +25,7 @@ func metricsFromContext(ctx context.Context) *metrics.MCPMetrics {
 }
 
 // recordRequestMetrics records the per-request metrics after Resolve.
-func recordRequestMetrics(ctx context.Context, m *metrics.MCPMetrics, env Env, req Request, hasUserToken bool, resp Response, seconds float64) {
+func recordRequestMetrics(ctx context.Context, m *metrics.MCPMetrics, req Request, hasUserToken bool, resp Response, seconds float64) {
 	if m == nil {
 		return
 	}
@@ -37,7 +37,7 @@ func recordRequestMetrics(ctx context.Context, m *metrics.MCPMetrics, env Env, r
 	if req.Method == mcpMethodToolsCall {
 		var params CallToolParams
 		if json.Unmarshal(req.Params, &params) == nil {
-			tool = toolLabel(env, params.Name)
+			tool = toolLabel(params.Name, resp)
 		}
 	}
 
@@ -64,8 +64,8 @@ func recordRejectedRequest(m *metrics.MCPMetrics, req Request, auth string, seco
 }
 
 // DynamicToolCount returns how many notes expose a dynamic (mcp_method) tool,
-// excluding names shadowed by built-in tools. The app refreshes the
-// trip2g_mcp_dynamic_tools_registered gauge with it on every notes reload.
+// excluding names shadowed by built-in tools. The app wires it as the
+// scrape-time source of the trip2g_mcp_dynamic_tools_registered gauge.
 func DynamicToolCount(nvs *model.NoteViews) int {
 	if nvs == nil {
 		return 0
@@ -105,6 +105,11 @@ func authKind(ctx context.Context, hasUserToken bool) string {
 // otherLabel is the bounded fallback for free-form client input in labels.
 const otherLabel = "other"
 
+// dynamicLabel is the fixed label for note-registered (mcp_method) tools:
+// frontmatter names are author-controlled and unbounded, so they never become
+// label values.
+const dynamicLabel = "dynamic"
+
 // methodLabel bounds the method label to the known JSON-RPC method set.
 func methodLabel(method string) string {
 	switch method {
@@ -115,20 +120,17 @@ func methodLabel(method string) string {
 	}
 }
 
-// toolLabel bounds the tool label: built-in tools and note-registered dynamic
-// tools keep their name, anything else (arbitrary client input) becomes "other".
-func toolLabel(env Env, name string) string {
+// toolLabel bounds the tool label: built-in tools keep their name (fixed set);
+// a name Resolve rejected as unknown maps to "other"; anything else Resolve
+// accepted is a note-registered dynamic tool and maps to "dynamic".
+func toolLabel(name string, resp Response) string {
 	if reservedMCPTools[name] {
 		return name
 	}
-	if nvs := env.LatestNoteViews(); nvs != nil {
-		for _, note := range nvs.List {
-			if note.MCPMethod == name {
-				return name
-			}
-		}
+	if resp.Error != nil && resp.Error.Code == ErrCodeMethodNotFound {
+		return otherLabel
 	}
-	return otherLabel
+	return dynamicLabel
 }
 
 // errorReason maps a JSON-RPC error code to a bounded reason label.

--- a/internal/case/mcp/metrics.go
+++ b/internal/case/mcp/metrics.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	"trip2g/internal/metrics"
+	"trip2g/internal/model"
 )
 
 type mcpMetricsContextKey struct{}
@@ -54,18 +55,50 @@ func recordRequestMetrics(ctx context.Context, m *metrics.MCPMetrics, env Env, r
 	}
 }
 
+// recordRejectedRequest counts a request rejected before Resolve (depth limit,
+// auth failures) so error and abusive traffic shows up in the request counters.
+// auth is the attempted auth kind; the tool label stays empty since the call
+// never reached tool dispatch.
+func recordRejectedRequest(m *metrics.MCPMetrics, req Request, auth string, seconds float64) {
+	m.RecordMCPRequest(methodLabel(req.Method), "", auth, "error", seconds)
+}
+
+// DynamicToolCount returns how many notes expose a dynamic (mcp_method) tool,
+// excluding names shadowed by built-in tools. The app refreshes the
+// trip2g_mcp_dynamic_tools_registered gauge with it on every notes reload.
+func DynamicToolCount(nvs *model.NoteViews) int {
+	if nvs == nil {
+		return 0
+	}
+	n := 0
+	for _, note := range nvs.List {
+		if note.MCPMethod != "" && !reservedMCPTools[note.MCPMethod] {
+			n++
+		}
+	}
+	return n
+}
+
+// Auth kinds for the auth metric label.
+const (
+	authToken      = "token"
+	authAPIKey     = "api_key"
+	authFederation = "federation"
+	authAnonymous  = "anonymous"
+)
+
 // authKind classifies the request auth for metric labels.
 func authKind(ctx context.Context, hasUserToken bool) string {
 	switch {
 	case hasUserToken:
-		return "token"
+		return authToken
 	case mcpAPIKeyAuthed(ctx):
-		return "api_key"
+		return authAPIKey
 	default:
 		if _, ok := federationAuthFromContext(ctx); ok {
-			return "federation"
+			return authFederation
 		}
-		return "anonymous"
+		return authAnonymous
 	}
 }
 

--- a/internal/case/mcp/metrics_flow_test.go
+++ b/internal/case/mcp/metrics_flow_test.go
@@ -3,6 +3,7 @@ package mcp_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"trip2g/internal/appreq"
@@ -56,11 +57,12 @@ func requireCounter(t *testing.T, g prometheus.Gatherer, name string, labels map
 	require.InDelta(t, want, m.GetCounter().GetValue(), 1e-9, "counter %s %v", name, labels)
 }
 
-func requireHistogram(t *testing.T, g prometheus.Gatherer, name string, labels map[string]string, wantCount uint64, wantSum float64) {
+// requireHistogram asserts the histogram holds exactly one sample of wantSum.
+func requireHistogram(t *testing.T, g prometheus.Gatherer, name string, labels map[string]string, wantSum float64) {
 	t.Helper()
 	m := findRegMetric(t, g, name, labels)
 	require.NotNil(t, m, "metric %s with labels %v not found", name, labels)
-	require.Equal(t, wantCount, m.GetHistogram().GetSampleCount(), "histogram count %s %v", name, labels)
+	require.Equal(t, uint64(1), m.GetHistogram().GetSampleCount(), "histogram count %s %v", name, labels)
 	require.InDelta(t, wantSum, m.GetHistogram().GetSampleSum(), 1e-9, "histogram sum %s %v", name, labels)
 }
 
@@ -103,11 +105,12 @@ func withFederationEnv(env *EnvMock) {
 
 func TestMCPEndpointMetrics(t *testing.T) {
 	cases := []struct {
-		name    string
-		body    []byte
-		headers map[string]string
-		setup   func(t *testing.T, env *EnvMock)
-		assert  func(t *testing.T, reg *prometheus.Registry)
+		name     string
+		body     []byte
+		headers  map[string]string
+		resolver appreq.PersonalTokenResolver
+		setup    func(t *testing.T, env *EnvMock)
+		assert   func(t *testing.T, reg *prometheus.Registry)
 	}{
 		{
 			name: "anonymous search records request, auth and result count",
@@ -122,7 +125,7 @@ func TestMCPEndpointMetrics(t *testing.T) {
 				m := findRegMetric(t, reg, "trip2g_mcp_request_duration_seconds", map[string]string{"tool": "search"})
 				require.NotNil(t, m, "duration histogram for tool=search not found")
 				require.Equal(t, uint64(1), m.GetHistogram().GetSampleCount())
-				requireHistogram(t, reg, "trip2g_mcp_search_results_returned", map[string]string{"tool": "search"}, 1, 1)
+				requireHistogram(t, reg, "trip2g_mcp_search_results_returned", map[string]string{"tool": "search"}, 1)
 			},
 		},
 		{
@@ -148,7 +151,7 @@ func TestMCPEndpointMetrics(t *testing.T) {
 				withFederationEnv(env)
 			},
 			assert: func(t *testing.T, reg *prometheus.Registry) {
-				requireHistogram(t, reg, "trip2g_mcp_fanout_bases", map[string]string{}, 1, 2)
+				requireHistogram(t, reg, "trip2g_mcp_fanout_bases", map[string]string{}, 2)
 				requireCounter(t, reg, "trip2g_mcp_federated_requests_total", map[string]string{"status": "ok"}, 2)
 				requireCounter(t, reg, "trip2g_mcp_requests_total",
 					map[string]string{"method": "tools/call", "tool": "federated_search", "auth": "anonymous", "status": "ok"}, 1)
@@ -202,7 +205,63 @@ func TestMCPEndpointMetrics(t *testing.T) {
 				env.FederationMaxDepthFunc = func() int { return 5 }
 			},
 			assert: func(t *testing.T, reg *prometheus.Registry) {
-				requireHistogram(t, reg, "trip2g_mcp_federation_depth", map[string]string{}, 1, 2)
+				requireHistogram(t, reg, "trip2g_mcp_federation_depth", map[string]string{}, 2)
+			},
+		},
+		{
+			name: "direct request without depth header observes depth 0",
+			body: mcpInitBody,
+			assert: func(t *testing.T, reg *prometheus.Registry) {
+				requireHistogram(t, reg, "trip2g_mcp_federation_depth", map[string]string{}, 0)
+			},
+		},
+		{
+			name:     "invalid personal token records rejected request",
+			body:     mcpInitBody,
+			headers:  map[string]string{"Authorization": "Bearer t2g_revoked"},
+			resolver: &testPersonalTokenResolver{err: errors.New("token revoked")},
+			assert: func(t *testing.T, reg *prometheus.Registry) {
+				requireCounter(t, reg, "trip2g_mcp_requests_total",
+					map[string]string{"method": "initialize", "tool": "", "auth": "token", "status": "error"}, 1)
+				requireCounter(t, reg, "trip2g_mcp_auth_total", map[string]string{"auth": "token"}, 1)
+			},
+		},
+		{
+			name:    "exceeded federation depth records rejected request",
+			body:    mcpInitBody,
+			headers: map[string]string{"X-MCP-Federation-Depth": "5"},
+			setup: func(_ *testing.T, env *EnvMock) {
+				env.FederationMaxDepthFunc = func() int { return 5 }
+			},
+			assert: func(t *testing.T, reg *prometheus.Registry) {
+				requireCounter(t, reg, "trip2g_mcp_requests_total",
+					map[string]string{"method": "initialize", "tool": "", "auth": "anonymous", "status": "error"}, 1)
+				requireCounter(t, reg, "trip2g_mcp_auth_total", map[string]string{"auth": "anonymous"}, 1)
+			},
+		},
+		{
+			name:    "invalid api key records rejected request as auth=api_key",
+			body:    mcpInitBody,
+			headers: map[string]string{"X-API-Key": "bad-key"},
+			setup: func(_ *testing.T, env *EnvMock) {
+				env.ResolveAPIKeyFunc = func(_ context.Context, _, _ string) (*db.ApiKey, error) {
+					return nil, errors.New("invalid API key")
+				}
+			},
+			assert: func(t *testing.T, reg *prometheus.Registry) {
+				requireCounter(t, reg, "trip2g_mcp_requests_total",
+					map[string]string{"method": "initialize", "tool": "", "auth": "api_key", "status": "error"}, 1)
+				requireCounter(t, reg, "trip2g_mcp_auth_total", map[string]string{"auth": "api_key"}, 1)
+			},
+		},
+		{
+			name:    "failed federation bearer records rejected request as auth=federation",
+			body:    mcpInitBody,
+			headers: map[string]string{"Authorization": "Basic not-a-bearer"},
+			assert: func(t *testing.T, reg *prometheus.Registry) {
+				requireCounter(t, reg, "trip2g_mcp_requests_total",
+					map[string]string{"method": "initialize", "tool": "", "auth": "federation", "status": "error"}, 1)
+				requireCounter(t, reg, "trip2g_mcp_auth_total", map[string]string{"auth": "federation"}, 1)
 			},
 		},
 	}
@@ -222,7 +281,7 @@ func TestMCPEndpointMetrics(t *testing.T) {
 			for k, v := range tc.headers {
 				fasthttpCtx.Request.Header.Set(k, v)
 			}
-			req := wiredRequest(fasthttpCtx, env, nil)
+			req := wiredRequest(fasthttpCtx, env, tc.resolver)
 			defer appreq.Release(req)
 
 			_, err := (&mcp.Endpoint{}).Handle(req)

--- a/internal/case/mcp/metrics_flow_test.go
+++ b/internal/case/mcp/metrics_flow_test.go
@@ -66,13 +66,6 @@ func requireHistogram(t *testing.T, g prometheus.Gatherer, name string, labels m
 	require.InDelta(t, wantSum, m.GetHistogram().GetSampleSum(), 1e-9, "histogram sum %s %v", name, labels)
 }
 
-func requireGauge(t *testing.T, g prometheus.Gatherer, name string, labels map[string]string, want float64) {
-	t.Helper()
-	m := findRegMetric(t, g, name, labels)
-	require.NotNil(t, m, "metric %s with labels %v not found", name, labels)
-	require.InDelta(t, want, m.GetGauge().GetValue(), 1e-9, "gauge %s %v", name, labels)
-}
-
 // withSearchEnv wires the env funcs needed by the search tool: one readable
 // note returned by text search, vector search disabled.
 func withSearchEnv(env *EnvMock) {
@@ -181,7 +174,7 @@ func TestMCPEndpointMetrics(t *testing.T) {
 			},
 		},
 		{
-			name: "tools list records discovery counter and dynamic tools gauge",
+			name: "tools list records discovery counter",
 			body: mcpToolsListBody(t),
 			setup: func(_ *testing.T, env *EnvMock) {
 				dyn := &appmodel.NoteView{Path: "tools/my.md", MCPMethod: "my_tool", Title: "My tool"}
@@ -194,7 +187,6 @@ func TestMCPEndpointMetrics(t *testing.T) {
 			},
 			assert: func(t *testing.T, reg *prometheus.Registry) {
 				requireCounter(t, reg, "trip2g_mcp_tools_list_total", map[string]string{"auth": "anonymous"}, 1)
-				requireGauge(t, reg, "trip2g_mcp_dynamic_tools_registered", map[string]string{}, 1)
 			},
 		},
 		{
@@ -213,6 +205,61 @@ func TestMCPEndpointMetrics(t *testing.T) {
 			body: mcpInitBody,
 			assert: func(t *testing.T, reg *prometheus.Registry) {
 				requireHistogram(t, reg, "trip2g_mcp_federation_depth", map[string]string{}, 0)
+			},
+		},
+		{
+			name:    "malformed depth header observes depth 0",
+			body:    mcpInitBody,
+			headers: map[string]string{"X-MCP-Federation-Depth": "abc"},
+			setup: func(_ *testing.T, env *EnvMock) {
+				env.FederationMaxDepthFunc = func() int { return 5 }
+			},
+			assert: func(t *testing.T, reg *prometheus.Registry) {
+				requireHistogram(t, reg, "trip2g_mcp_federation_depth", map[string]string{}, 0)
+			},
+		},
+		{
+			name:    "negative depth header observes depth 0",
+			body:    mcpInitBody,
+			headers: map[string]string{"X-MCP-Federation-Depth": "-3"},
+			setup: func(_ *testing.T, env *EnvMock) {
+				env.FederationMaxDepthFunc = func() int { return 5 }
+			},
+			assert: func(t *testing.T, reg *prometheus.Registry) {
+				requireHistogram(t, reg, "trip2g_mcp_federation_depth", map[string]string{}, 0)
+			},
+		},
+		{
+			name: "dynamic tool call is labeled dynamic, never by frontmatter name",
+			body: mcpToolsCallBody(t, "my_dynamic_tool", map[string]any{}),
+			setup: func(_ *testing.T, env *EnvMock) {
+				dyn := &appmodel.NoteView{Path: "tools/my.md", MCPMethod: "my_dynamic_tool", Content: []byte("body")}
+				env.LatestNoteViewsFunc = func() *appmodel.NoteViews {
+					return &appmodel.NoteViews{
+						List:    []*appmodel.NoteView{dyn},
+						PathMap: map[string]*appmodel.NoteView{dyn.Path: dyn},
+					}
+				}
+			},
+			assert: func(t *testing.T, reg *prometheus.Registry) {
+				requireCounter(t, reg, "trip2g_mcp_requests_total",
+					map[string]string{"method": "tools/call", "tool": "dynamic", "auth": "anonymous", "status": "ok"}, 1)
+				require.Nil(t, findRegMetric(t, reg, "trip2g_mcp_requests_total",
+					map[string]string{"method": "tools/call", "tool": "my_dynamic_tool", "auth": "anonymous", "status": "ok"}),
+					"frontmatter-derived tool name must not become a label value")
+			},
+		},
+		{
+			name: "single-kb federation client failure counts an outbound error",
+			body: mcpToolsCallBody(t, "federated_search", map[string]any{"query": "alpha", "kb_id": "alice"}),
+			setup: func(_ *testing.T, env *EnvMock) {
+				withFederationEnv(env)
+				env.FederationClientFunc = func(_ context.Context, _ string) (appmodel.Federation, error) {
+					return nil, errors.New("no active federation secret")
+				}
+			},
+			assert: func(t *testing.T, reg *prometheus.Registry) {
+				requireCounter(t, reg, "trip2g_mcp_federated_requests_total", map[string]string{"status": "error"}, 1)
 			},
 		},
 		{
@@ -292,5 +339,40 @@ func TestMCPEndpointMetrics(t *testing.T) {
 
 			tc.assert(t, reg)
 		})
+	}
+}
+
+// TestDynamicToolLabelBounded pins the cardinality bound: calls to different
+// mcp_method tools share one "dynamic" series instead of minting one series
+// per author-controlled frontmatter name.
+func TestDynamicToolLabelBounded(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := metrics.NewMCPMetrics(reg)
+
+	dynA := &appmodel.NoteView{Path: "a.md", MCPMethod: "tool_a", Content: []byte("a")}
+	dynB := &appmodel.NoteView{Path: "b.md", MCPMethod: "tool_b", Content: []byte("b")}
+	env := buildDispatchEnv(t, false)
+	env.MCPMetricsFunc = func() *metrics.MCPMetrics { return m }
+	env.LatestNoteViewsFunc = func() *appmodel.NoteViews {
+		return &appmodel.NoteViews{
+			List:    []*appmodel.NoteView{dynA, dynB},
+			PathMap: map[string]*appmodel.NoteView{dynA.Path: dynA, dynB.Path: dynB},
+		}
+	}
+
+	for _, tool := range []string{"tool_a", "tool_b"} {
+		fasthttpCtx := buildMCPFasthttpCtx(mcpToolsCallBody(t, tool, map[string]any{}), "")
+		req := wiredRequest(fasthttpCtx, env, nil)
+		_, err := (&mcp.Endpoint{}).Handle(req)
+		appreq.Release(req)
+		require.NoError(t, err)
+	}
+
+	requireCounter(t, reg, "trip2g_mcp_requests_total",
+		map[string]string{"method": "tools/call", "tool": "dynamic", "auth": "anonymous", "status": "ok"}, 2)
+	for _, name := range []string{"tool_a", "tool_b"} {
+		require.Nil(t, findRegMetric(t, reg, "trip2g_mcp_requests_total",
+			map[string]string{"method": "tools/call", "tool": name, "auth": "anonymous", "status": "ok"}),
+			"per-name series %q must not exist", name)
 	}
 }

--- a/internal/case/mcp/metrics_flow_test.go
+++ b/internal/case/mcp/metrics_flow_test.go
@@ -1,0 +1,237 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"trip2g/internal/appreq"
+	"trip2g/internal/case/mcp"
+	"trip2g/internal/db"
+	"trip2g/internal/metrics"
+	appmodel "trip2g/internal/model"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+// findRegMetric gathers the registry and returns the metric with the given
+// name and exact label set, or nil if absent.
+func findRegMetric(t *testing.T, g prometheus.Gatherer, name string, labels map[string]string) *dto.Metric {
+	t.Helper()
+	families, err := g.Gather()
+	require.NoError(t, err)
+	for _, mf := range families {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			got := map[string]string{}
+			for _, lp := range m.GetLabel() {
+				got[lp.GetName()] = lp.GetValue()
+			}
+			if len(got) != len(labels) {
+				continue
+			}
+			match := true
+			for k, v := range labels {
+				if got[k] != v {
+					match = false
+					break
+				}
+			}
+			if match {
+				return m
+			}
+		}
+	}
+	return nil
+}
+
+func requireCounter(t *testing.T, g prometheus.Gatherer, name string, labels map[string]string, want float64) {
+	t.Helper()
+	m := findRegMetric(t, g, name, labels)
+	require.NotNil(t, m, "metric %s with labels %v not found", name, labels)
+	require.InDelta(t, want, m.GetCounter().GetValue(), 1e-9, "counter %s %v", name, labels)
+}
+
+func requireHistogram(t *testing.T, g prometheus.Gatherer, name string, labels map[string]string, wantCount uint64, wantSum float64) {
+	t.Helper()
+	m := findRegMetric(t, g, name, labels)
+	require.NotNil(t, m, "metric %s with labels %v not found", name, labels)
+	require.Equal(t, wantCount, m.GetHistogram().GetSampleCount(), "histogram count %s %v", name, labels)
+	require.InDelta(t, wantSum, m.GetHistogram().GetSampleSum(), 1e-9, "histogram sum %s %v", name, labels)
+}
+
+func requireGauge(t *testing.T, g prometheus.Gatherer, name string, labels map[string]string, want float64) {
+	t.Helper()
+	m := findRegMetric(t, g, name, labels)
+	require.NotNil(t, m, "metric %s with labels %v not found", name, labels)
+	require.InDelta(t, want, m.GetGauge().GetValue(), 1e-9, "gauge %s %v", name, labels)
+}
+
+// withSearchEnv wires the env funcs needed by the search tool: one readable
+// note returned by text search, vector search disabled.
+func withSearchEnv(env *EnvMock) {
+	note := &appmodel.NoteView{Title: "Alpha", Path: "alpha.md", PathID: 1}
+	env.SearchLatestNotesFunc = func(_ string) ([]appmodel.SearchResult, error) {
+		return []appmodel.SearchResult{{NoteView: note, URL: "/alpha", HighlightedContent: []string{"snippet"}}}, nil
+	}
+	env.LatestNoteChunksFunc = func() []appmodel.NoteChunk { return nil }
+	env.NoteURLFunc = func(n *appmodel.NoteView) string { return "https://x/" + n.Path }
+}
+
+// withFederationEnv wires two federation KB notes whose clients answer search.
+func withFederationEnv(env *EnvMock) {
+	kbA := &appmodel.NoteView{PathID: 11, MCPFederationKBURL: "https://a.example/_system/mcp", MCPFederationKBID: "alice"}
+	kbB := &appmodel.NoteView{PathID: 12, MCPFederationKBURL: "https://b.example/_system/mcp", MCPFederationKBID: "bob"}
+	nvs := appmodel.NewNoteViews()
+	nvs.MCPFederationNotes = []*appmodel.MCPFederationNote{
+		appmodel.NewMCPFederationNote(kbA),
+		appmodel.NewMCPFederationNote(kbB),
+	}
+	env.LatestNoteViewsFunc = func() *appmodel.NoteViews { return nvs }
+	env.FederationClientFunc = func(_ context.Context, _ string) (appmodel.Federation, error) {
+		return &federationMock{
+			searchFunc: func(_ context.Context, _ appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+				return appmodel.FederationResult{Content: []appmodel.FederationContent{{Type: "text", Text: "remote"}}}, nil
+			},
+		}, nil
+	}
+}
+
+func TestMCPEndpointMetrics(t *testing.T) {
+	cases := []struct {
+		name    string
+		body    []byte
+		headers map[string]string
+		setup   func(t *testing.T, env *EnvMock)
+		assert  func(t *testing.T, reg *prometheus.Registry)
+	}{
+		{
+			name: "anonymous search records request, auth and result count",
+			body: mcpToolsCallBody(t, "search", map[string]any{"query": "alpha"}),
+			setup: func(_ *testing.T, env *EnvMock) {
+				withSearchEnv(env)
+			},
+			assert: func(t *testing.T, reg *prometheus.Registry) {
+				requireCounter(t, reg, "trip2g_mcp_requests_total",
+					map[string]string{"method": "tools/call", "tool": "search", "auth": "anonymous", "status": "ok"}, 1)
+				requireCounter(t, reg, "trip2g_mcp_auth_total", map[string]string{"auth": "anonymous"}, 1)
+				m := findRegMetric(t, reg, "trip2g_mcp_request_duration_seconds", map[string]string{"tool": "search"})
+				require.NotNil(t, m, "duration histogram for tool=search not found")
+				require.Equal(t, uint64(1), m.GetHistogram().GetSampleCount())
+				requireHistogram(t, reg, "trip2g_mcp_search_results_returned", map[string]string{"tool": "search"}, 1, 1)
+			},
+		},
+		{
+			name:    "api key tools call records auth=api_key",
+			body:    mcpToolsCallBody(t, "search", map[string]any{"query": "alpha"}),
+			headers: map[string]string{"X-API-Key": "test-api-key"},
+			setup: func(_ *testing.T, env *EnvMock) {
+				withSearchEnv(env)
+				env.ResolveAPIKeyFunc = func(_ context.Context, _, _ string) (*db.ApiKey, error) {
+					return &db.ApiKey{ID: 1}, nil
+				}
+			},
+			assert: func(t *testing.T, reg *prometheus.Registry) {
+				requireCounter(t, reg, "trip2g_mcp_requests_total",
+					map[string]string{"method": "tools/call", "tool": "search", "auth": "api_key", "status": "ok"}, 1)
+				requireCounter(t, reg, "trip2g_mcp_auth_total", map[string]string{"auth": "api_key"}, 1)
+			},
+		},
+		{
+			name: "federated fan-out observes touched bases and outbound requests",
+			body: mcpToolsCallBody(t, "federated_search", map[string]any{"query": "alpha"}),
+			setup: func(_ *testing.T, env *EnvMock) {
+				withFederationEnv(env)
+			},
+			assert: func(t *testing.T, reg *prometheus.Registry) {
+				requireHistogram(t, reg, "trip2g_mcp_fanout_bases", map[string]string{}, 1, 2)
+				requireCounter(t, reg, "trip2g_mcp_federated_requests_total", map[string]string{"status": "ok"}, 2)
+				requireCounter(t, reg, "trip2g_mcp_requests_total",
+					map[string]string{"method": "tools/call", "tool": "federated_search", "auth": "anonymous", "status": "ok"}, 1)
+			},
+		},
+		{
+			name: "tool error records status=error and tool_errors_total",
+			body: mcpToolsCallBody(t, "search", map[string]any{}),
+			setup: func(_ *testing.T, env *EnvMock) {
+				withSearchEnv(env)
+			},
+			assert: func(t *testing.T, reg *prometheus.Registry) {
+				requireCounter(t, reg, "trip2g_mcp_requests_total",
+					map[string]string{"method": "tools/call", "tool": "search", "auth": "anonymous", "status": "error"}, 1)
+				requireCounter(t, reg, "trip2g_mcp_tool_errors_total",
+					map[string]string{"tool": "search", "reason": "invalid_params"}, 1)
+			},
+		},
+		{
+			name: "unknown tool is labeled other",
+			body: mcpToolsCallBody(t, "totally_unknown_tool", map[string]any{}),
+			assert: func(t *testing.T, reg *prometheus.Registry) {
+				requireCounter(t, reg, "trip2g_mcp_requests_total",
+					map[string]string{"method": "tools/call", "tool": "other", "auth": "anonymous", "status": "error"}, 1)
+				requireCounter(t, reg, "trip2g_mcp_tool_errors_total",
+					map[string]string{"tool": "other", "reason": "not_found"}, 1)
+			},
+		},
+		{
+			name: "tools list records discovery counter and dynamic tools gauge",
+			body: mcpToolsListBody(t),
+			setup: func(_ *testing.T, env *EnvMock) {
+				dyn := &appmodel.NoteView{Path: "tools/my.md", MCPMethod: "my_tool", Title: "My tool"}
+				env.LatestNoteViewsFunc = func() *appmodel.NoteViews {
+					return &appmodel.NoteViews{
+						List:    []*appmodel.NoteView{dyn},
+						PathMap: map[string]*appmodel.NoteView{dyn.Path: dyn},
+					}
+				}
+			},
+			assert: func(t *testing.T, reg *prometheus.Registry) {
+				requireCounter(t, reg, "trip2g_mcp_tools_list_total", map[string]string{"auth": "anonymous"}, 1)
+				requireGauge(t, reg, "trip2g_mcp_dynamic_tools_registered", map[string]string{}, 1)
+			},
+		},
+		{
+			name:    "federation depth header is observed",
+			body:    mcpInitBody,
+			headers: map[string]string{"X-MCP-Federation-Depth": "2"},
+			setup: func(_ *testing.T, env *EnvMock) {
+				env.FederationMaxDepthFunc = func() int { return 5 }
+			},
+			assert: func(t *testing.T, reg *prometheus.Registry) {
+				requireHistogram(t, reg, "trip2g_mcp_federation_depth", map[string]string{}, 1, 2)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := prometheus.NewRegistry()
+			m := metrics.NewMCPMetrics(reg)
+
+			env := buildDispatchEnv(t, false)
+			env.MCPMetricsFunc = func() *metrics.MCPMetrics { return m }
+			if tc.setup != nil {
+				tc.setup(t, env)
+			}
+
+			fasthttpCtx := buildMCPFasthttpCtx(tc.body, "")
+			for k, v := range tc.headers {
+				fasthttpCtx.Request.Header.Set(k, v)
+			}
+			req := wiredRequest(fasthttpCtx, env, nil)
+			defer appreq.Release(req)
+
+			_, err := (&mcp.Endpoint{}).Handle(req)
+			require.NoError(t, err)
+
+			var resp mcp.Response
+			require.NoError(t, json.Unmarshal(fasthttpCtx.Response.Body(), &resp))
+
+			tc.assert(t, reg)
+		})
+	}
+}

--- a/internal/case/mcp/metrics_internal_test.go
+++ b/internal/case/mcp/metrics_internal_test.go
@@ -1,0 +1,51 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type timeoutError struct{}
+
+func (timeoutError) Error() string { return "i/o timeout" }
+func (timeoutError) Timeout() bool { return true }
+
+func TestFederatedStatus(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil is ok", nil, "ok"},
+		{"deadline exceeded is timeout", context.DeadlineExceeded, "timeout"},
+		{"wrapped deadline is timeout", errors.New("call: " + context.DeadlineExceeded.Error()), "error"},
+		{"net timeout is timeout", timeoutError{}, "timeout"},
+		{"other error is error", errors.New("boom"), "error"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, federatedStatus(tc.err))
+		})
+	}
+}
+
+func TestErrorReason(t *testing.T) {
+	cases := []struct {
+		name string
+		code int
+		want string
+	}{
+		{"invalid params", ErrCodeInvalidParams, "invalid_params"},
+		{"method not found", ErrCodeMethodNotFound, "not_found"},
+		{"internal", ErrCodeInternal, "internal"},
+		{"unknown code", -1, "other"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, errorReason(tc.code))
+		})
+	}
+}

--- a/internal/case/mcp/mocks_test.go
+++ b/internal/case/mcp/mocks_test.go
@@ -10,6 +10,7 @@ import (
 	"trip2g/internal/db"
 	"trip2g/internal/features"
 	"trip2g/internal/logger"
+	"trip2g/internal/metrics"
 	"trip2g/internal/model"
 	"trip2g/internal/openai"
 )
@@ -65,6 +66,9 @@ var _ mcp.Env = &EnvMock{}
 //			},
 //			LoggerFunc: func() logger.Logger {
 //				panic("mock out the Logger method")
+//			},
+//			MCPMetricsFunc: func() *metrics.MCPMetrics {
+//				panic("mock out the MCPMetrics method")
 //			},
 //			NoteURLFunc: func(note *model.NoteView) string {
 //				panic("mock out the NoteURL method")
@@ -129,6 +133,9 @@ type EnvMock struct {
 
 	// LoggerFunc mocks the Logger method.
 	LoggerFunc func() logger.Logger
+
+	// MCPMetricsFunc mocks the MCPMetrics method.
+	MCPMetricsFunc func() *metrics.MCPMetrics
 
 	// NoteURLFunc mocks the NoteURL method.
 	NoteURLFunc func(note *model.NoteView) string
@@ -225,6 +232,9 @@ type EnvMock struct {
 		// Logger holds details about calls to the Logger method.
 		Logger []struct {
 		}
+		// MCPMetrics holds details about calls to the MCPMetrics method.
+		MCPMetrics []struct {
+		}
 		// NoteURL holds details about calls to the NoteURL method.
 		NoteURL []struct {
 			// Note is the note argument value.
@@ -265,6 +275,7 @@ type EnvMock struct {
 	lockLatestNoteViews                    sync.RWMutex
 	lockListFederationSecretSubgraphsByKID sync.RWMutex
 	lockLogger                             sync.RWMutex
+	lockMCPMetrics                         sync.RWMutex
 	lockNoteURL                            sync.RWMutex
 	lockOpenAI                             sync.RWMutex
 	lockPublicURL                          sync.RWMutex
@@ -727,6 +738,33 @@ func (mock *EnvMock) LoggerCalls() []struct {
 	mock.lockLogger.RLock()
 	calls = mock.calls.Logger
 	mock.lockLogger.RUnlock()
+	return calls
+}
+
+// MCPMetrics calls MCPMetricsFunc.
+func (mock *EnvMock) MCPMetrics() *metrics.MCPMetrics {
+	if mock.MCPMetricsFunc == nil {
+		panic("EnvMock.MCPMetricsFunc: method is nil but Env.MCPMetrics was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockMCPMetrics.Lock()
+	mock.calls.MCPMetrics = append(mock.calls.MCPMetrics, callInfo)
+	mock.lockMCPMetrics.Unlock()
+	return mock.MCPMetricsFunc()
+}
+
+// MCPMetricsCalls gets all the calls that were made to MCPMetrics.
+// Check the length with:
+//
+//	len(mockedEnv.MCPMetricsCalls())
+func (mock *EnvMock) MCPMetricsCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockMCPMetrics.RLock()
+	calls = mock.calls.MCPMetrics
+	mock.lockMCPMetrics.RUnlock()
 	return calls
 }
 

--- a/internal/case/mcp/resolve.go
+++ b/internal/case/mcp/resolve.go
@@ -346,8 +346,6 @@ func handleToolsList(ctx context.Context, env Env, id any) Response { //nolint:f
 			InputSchema: &InputSchema{Type: "object", Properties: map[string]Property{}},
 		})
 	}
-	// Cheap re-sync; the authoritative refresh happens on notes reload.
-	metricsFromContext(ctx).SetDynamicToolsRegistered(DynamicToolCount(env.LatestNoteViews()))
 
 	if env.FederatedGraphQLEnabled() {
 		tools = append(tools, Tool{

--- a/internal/case/mcp/resolve.go
+++ b/internal/case/mcp/resolve.go
@@ -16,6 +16,7 @@ import (
 	"trip2g/internal/db"
 	graphmodel "trip2g/internal/graph/model"
 	"trip2g/internal/logger"
+	"trip2g/internal/metrics"
 	"trip2g/internal/model"
 	"trip2g/internal/openai"
 	"trip2g/internal/ptr"
@@ -40,6 +41,8 @@ const (
 
 	// MCP method names.
 	MCPMethodInitialize = "initialize"
+	mcpMethodToolsList  = "tools/list"
+	mcpMethodToolsCall  = "tools/call"
 )
 
 type Env interface {
@@ -63,6 +66,8 @@ type Env interface {
 	// Federated GraphQL tools
 	GraphQLRequestScoped(ctx context.Context, query string, variables map[string]any, allowedSubgraphs []string) ([]byte, error)
 	FederatedGraphQLEnabled() bool
+	// Prometheus metrics for the MCP endpoint; may be nil (record methods are nil-safe).
+	MCPMetrics() *metrics.MCPMetrics
 }
 
 // unmarshalArgs unmarshals JSON arguments into the target type.
@@ -107,9 +112,9 @@ func Resolve(ctx context.Context, env Env, req Request) Response {
 	case "notifications/initialized":
 		// Client notification, no response needed
 		return Response{JSONRPC: "2.0", ID: req.ID, Result: map[string]any{}}
-	case "tools/list":
+	case mcpMethodToolsList:
 		return handleToolsList(ctx, env, req.ID)
-	case "tools/call":
+	case mcpMethodToolsCall:
 		return handleToolsCall(ctx, env, req)
 	default:
 		return errorResponse(req.ID, ErrCodeMethodNotFound, "Method not found: "+req.Method)
@@ -323,10 +328,12 @@ func handleToolsList(ctx context.Context, env Env, id any) Response { //nolint:f
 	}
 
 	// Append dynamic tools from notes with mcp_method (excluding reserved names)
+	dynamicTools := 0
 	for _, note := range env.LatestNoteViews().List {
 		if note.MCPMethod == "" || reservedMCPTools[note.MCPMethod] {
 			continue
 		}
+		dynamicTools++
 		ok, err := canReadMCPNote(ctx, env, note)
 		if err != nil || !ok {
 			continue
@@ -341,6 +348,7 @@ func handleToolsList(ctx context.Context, env Env, id any) Response { //nolint:f
 			InputSchema: &InputSchema{Type: "object", Properties: map[string]Property{}},
 		})
 	}
+	metricsFromContext(ctx).SetDynamicToolsRegistered(dynamicTools)
 
 	if env.FederatedGraphQLEnabled() {
 		tools = append(tools, Tool{
@@ -487,6 +495,7 @@ func handleSearch(ctx context.Context, env Env, id any, argsRaw json.RawMessage)
 
 	limit, detailLimit := resolveSearchLimits(log, args.Limit, args.DetailLimit)
 	payload := buildSearchPayload(args.Query, results, env.NoteURL, env.LatestNoteChunks(), limit, detailLimit)
+	metricsFromContext(ctx).ObserveSearchResults("search", len(payload.Results))
 
 	// Format response
 	var sb strings.Builder
@@ -823,6 +832,7 @@ func handleSimilar(ctx context.Context, env Env, id any, argsRaw json.RawMessage
 		log.Error("similar search failed", "error", err, "path", input.Path)
 		return errorResponse(id, ErrCodeInternal, "Similar search failed: "+err.Error())
 	}
+	metricsFromContext(ctx).ObserveSearchResults("similar", len(results))
 
 	// Format response
 	var sb strings.Builder

--- a/internal/case/mcp/resolve.go
+++ b/internal/case/mcp/resolve.go
@@ -328,12 +328,10 @@ func handleToolsList(ctx context.Context, env Env, id any) Response { //nolint:f
 	}
 
 	// Append dynamic tools from notes with mcp_method (excluding reserved names)
-	dynamicTools := 0
 	for _, note := range env.LatestNoteViews().List {
 		if note.MCPMethod == "" || reservedMCPTools[note.MCPMethod] {
 			continue
 		}
-		dynamicTools++
 		ok, err := canReadMCPNote(ctx, env, note)
 		if err != nil || !ok {
 			continue
@@ -348,7 +346,8 @@ func handleToolsList(ctx context.Context, env Env, id any) Response { //nolint:f
 			InputSchema: &InputSchema{Type: "object", Properties: map[string]Property{}},
 		})
 	}
-	metricsFromContext(ctx).SetDynamicToolsRegistered(dynamicTools)
+	// Cheap re-sync; the authoritative refresh happens on notes reload.
+	metricsFromContext(ctx).SetDynamicToolsRegistered(DynamicToolCount(env.LatestNoteViews()))
 
 	if env.FederatedGraphQLEnabled() {
 		tools = append(tools, Tool{

--- a/internal/metrics/mcp.go
+++ b/internal/metrics/mcp.go
@@ -1,6 +1,8 @@
 package metrics
 
 import (
+	"sync/atomic"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -16,7 +18,8 @@ type MCPMetrics struct {
 	searchResults     *prometheus.HistogramVec
 	toolErrors        *prometheus.CounterVec
 	auth              *prometheus.CounterVec
-	dynamicTools      prometheus.Gauge
+	dynamicTools      prometheus.GaugeFunc
+	dynamicToolsFn    atomic.Pointer[func() int]
 	toolsList         *prometheus.CounterVec
 }
 
@@ -59,15 +62,24 @@ func NewMCPMetrics(reg prometheus.Registerer) *MCPMetrics {
 			Name: "trip2g_mcp_auth_total",
 			Help: "Total number of MCP requests by auth kind",
 		}, []string{"auth"}),
-		dynamicTools: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "trip2g_mcp_dynamic_tools_registered",
-			Help: "Number of dynamic per-note (mcp_method) tools currently exposed",
-		}),
 		toolsList: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "trip2g_mcp_tools_list_total",
 			Help: "Total number of MCP tools/list calls (discovery signal)",
 		}, []string{"auth"}),
 	}
+
+	// Computed at scrape time from the source set via SetDynamicToolsSource, so
+	// the value always reflects the currently published note snapshot: no
+	// staleness after reloads and no ordering races between concurrent writers.
+	m.dynamicTools = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "trip2g_mcp_dynamic_tools_registered",
+		Help: "Number of dynamic per-note (mcp_method) tools currently exposed",
+	}, func() float64 {
+		if fn := m.dynamicToolsFn.Load(); fn != nil {
+			return float64((*fn)())
+		}
+		return 0
+	})
 
 	reg.MustRegister(
 		m.requests, m.duration, m.fanoutBases, m.federationDepth,
@@ -75,6 +87,15 @@ func NewMCPMetrics(reg prometheus.Registerer) *MCPMetrics {
 		m.dynamicTools, m.toolsList,
 	)
 	return m
+}
+
+// SetDynamicToolsSource wires the function the dynamic-tools gauge reads on
+// every scrape.
+func (m *MCPMetrics) SetDynamicToolsSource(fn func() int) {
+	if m == nil || fn == nil {
+		return
+	}
+	m.dynamicToolsFn.Store(&fn)
 }
 
 // RecordMCPRequest records one MCP request: requests_total, auth_total and the
@@ -139,12 +160,4 @@ func (m *MCPMetrics) ObserveSearchResults(tool string, n int) {
 		return
 	}
 	m.searchResults.WithLabelValues(tool).Observe(float64(n))
-}
-
-// SetDynamicToolsRegistered sets the count of dynamic mcp_method tools.
-func (m *MCPMetrics) SetDynamicToolsRegistered(n int) {
-	if m == nil {
-		return
-	}
-	m.dynamicTools.Set(float64(n))
 }

--- a/internal/metrics/mcp.go
+++ b/internal/metrics/mcp.go
@@ -1,0 +1,150 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// MCPMetrics collects Prometheus metrics for the MCP endpoint (/_system/mcp).
+// All record methods are nil-safe so callers without wired metrics (tests,
+// partial app setups) can call them unconditionally.
+type MCPMetrics struct {
+	requests          *prometheus.CounterVec
+	duration          *prometheus.HistogramVec
+	fanoutBases       prometheus.Histogram
+	federationDepth   prometheus.Histogram
+	federatedRequests *prometheus.CounterVec
+	searchResults     *prometheus.HistogramVec
+	toolErrors        *prometheus.CounterVec
+	auth              *prometheus.CounterVec
+	dynamicTools      prometheus.Gauge
+	toolsList         *prometheus.CounterVec
+}
+
+// NewMCPMetrics creates and registers all MCP Prometheus metrics on reg.
+func NewMCPMetrics(reg prometheus.Registerer) *MCPMetrics {
+	m := &MCPMetrics{
+		requests: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "trip2g_mcp_requests_total",
+			Help: "Total number of MCP JSON-RPC requests",
+		}, []string{"method", "tool", "auth", "status"}),
+		duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "trip2g_mcp_request_duration_seconds",
+			Help:    "MCP request duration in seconds, per tool (or JSON-RPC method for non-tool calls)",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"tool"}),
+		fanoutBases: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "trip2g_mcp_fanout_bases",
+			Help:    "Number of knowledge bases successfully reached by a federated fan-out query",
+			Buckets: []float64{0, 1, 2, 3, 5, 8, 13, 21},
+		}),
+		federationDepth: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "trip2g_mcp_federation_depth",
+			Help:    "X-MCP-Federation-Depth of incoming MCP requests (0 = direct client)",
+			Buckets: []float64{0, 1, 2, 3, 4, 5, 8},
+		}),
+		federatedRequests: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "trip2g_mcp_federated_requests_total",
+			Help: "Total number of outbound federated MCP requests to peer hubs",
+		}, []string{"status"}),
+		searchResults: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "trip2g_mcp_search_results_returned",
+			Help:    "Number of results returned by MCP search tools",
+			Buckets: []float64{0, 1, 3, 5, 10, 20, 50},
+		}, []string{"tool"}),
+		toolErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "trip2g_mcp_tool_errors_total",
+			Help: "Total number of MCP tools/call errors by tool and reason",
+		}, []string{"tool", "reason"}),
+		auth: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "trip2g_mcp_auth_total",
+			Help: "Total number of MCP requests by auth kind",
+		}, []string{"auth"}),
+		dynamicTools: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "trip2g_mcp_dynamic_tools_registered",
+			Help: "Number of dynamic per-note (mcp_method) tools currently exposed",
+		}),
+		toolsList: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "trip2g_mcp_tools_list_total",
+			Help: "Total number of MCP tools/list calls (discovery signal)",
+		}, []string{"auth"}),
+	}
+
+	reg.MustRegister(
+		m.requests, m.duration, m.fanoutBases, m.federationDepth,
+		m.federatedRequests, m.searchResults, m.toolErrors, m.auth,
+		m.dynamicTools, m.toolsList,
+	)
+	return m
+}
+
+// RecordMCPRequest records one MCP request: requests_total, auth_total and the
+// duration histogram. The duration is labeled by tool, falling back to the
+// JSON-RPC method for non-tool calls.
+func (m *MCPMetrics) RecordMCPRequest(method, tool, auth, status string, seconds float64) {
+	if m == nil {
+		return
+	}
+	m.requests.WithLabelValues(method, tool, auth, status).Inc()
+	m.auth.WithLabelValues(auth).Inc()
+	durationTool := tool
+	if durationTool == "" {
+		durationTool = method
+	}
+	m.duration.WithLabelValues(durationTool).Observe(seconds)
+}
+
+// RecordToolsList counts a tools/list call by auth kind.
+func (m *MCPMetrics) RecordToolsList(auth string) {
+	if m == nil {
+		return
+	}
+	m.toolsList.WithLabelValues(auth).Inc()
+}
+
+// RecordToolError counts a failed tools/call by tool and bounded reason.
+func (m *MCPMetrics) RecordToolError(tool, reason string) {
+	if m == nil {
+		return
+	}
+	m.toolErrors.WithLabelValues(tool, reason).Inc()
+}
+
+// ObserveFederationDepth observes the incoming X-MCP-Federation-Depth.
+func (m *MCPMetrics) ObserveFederationDepth(depth int) {
+	if m == nil {
+		return
+	}
+	m.federationDepth.Observe(float64(depth))
+}
+
+// ObserveFanoutBases observes how many bases a federated fan-out query reached.
+func (m *MCPMetrics) ObserveFanoutBases(n int) {
+	if m == nil {
+		return
+	}
+	m.fanoutBases.Observe(float64(n))
+}
+
+// RecordFederatedRequest counts one outbound federated request (ok|error|timeout).
+func (m *MCPMetrics) RecordFederatedRequest(status string) {
+	if m == nil {
+		return
+	}
+	m.federatedRequests.WithLabelValues(status).Inc()
+}
+
+// ObserveSearchResults observes the result count returned by a search tool.
+func (m *MCPMetrics) ObserveSearchResults(tool string, n int) {
+	if m == nil {
+		return
+	}
+	m.searchResults.WithLabelValues(tool).Observe(float64(n))
+}
+
+// SetDynamicToolsRegistered sets the count of dynamic mcp_method tools.
+func (m *MCPMetrics) SetDynamicToolsRegistered(n int) {
+	if m == nil {
+		return
+	}
+	m.dynamicTools.Set(float64(n))
+}

--- a/internal/metrics/mcp_test.go
+++ b/internal/metrics/mcp_test.go
@@ -1,0 +1,179 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+// findMetric gathers the registry and returns the metric with the given name
+// and exact label set, or fails the test.
+func findMetric(t *testing.T, g prometheus.Gatherer, name string, labels map[string]string) *dto.Metric {
+	t.Helper()
+	families, err := g.Gather()
+	require.NoError(t, err)
+	for _, mf := range families {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			got := map[string]string{}
+			for _, lp := range m.GetLabel() {
+				got[lp.GetName()] = lp.GetValue()
+			}
+			if len(got) != len(labels) {
+				continue
+			}
+			match := true
+			for k, v := range labels {
+				if got[k] != v {
+					match = false
+					break
+				}
+			}
+			if match {
+				return m
+			}
+		}
+	}
+	t.Fatalf("metric %s with labels %v not found", name, labels)
+	return nil
+}
+
+func TestNewMCPMetrics_Records(t *testing.T) {
+	f := func(v float64) *float64 { return &v }
+	u := func(v uint64) *uint64 { return &v }
+
+	cases := []struct {
+		name   string
+		record func(m *MCPMetrics)
+		metric string
+		labels map[string]string
+
+		wantCounter   *float64
+		wantGauge     *float64
+		wantHistCount *uint64
+		wantHistSum   *float64
+	}{
+		{
+			name:        "requests_total counts by method tool auth status",
+			record:      func(m *MCPMetrics) { m.RecordMCPRequest("tools/call", "search", "anonymous", "ok", 0.01) },
+			metric:      "trip2g_mcp_requests_total",
+			labels:      map[string]string{"method": "tools/call", "tool": "search", "auth": "anonymous", "status": "ok"},
+			wantCounter: f(1),
+		},
+		{
+			name:          "request_duration observes per tool",
+			record:        func(m *MCPMetrics) { m.RecordMCPRequest("tools/call", "search", "anonymous", "ok", 0.25) },
+			metric:        "trip2g_mcp_request_duration_seconds",
+			labels:        map[string]string{"tool": "search"},
+			wantHistCount: u(1),
+			wantHistSum:   f(0.25),
+		},
+		{
+			name:          "request_duration falls back to method when tool empty",
+			record:        func(m *MCPMetrics) { m.RecordMCPRequest("initialize", "", "token", "ok", 0.5) },
+			metric:        "trip2g_mcp_request_duration_seconds",
+			labels:        map[string]string{"tool": "initialize"},
+			wantHistCount: u(1),
+			wantHistSum:   f(0.5),
+		},
+		{
+			name:        "auth_total counts by auth kind",
+			record:      func(m *MCPMetrics) { m.RecordMCPRequest("tools/list", "", "anonymous", "ok", 0.01) },
+			metric:      "trip2g_mcp_auth_total",
+			labels:      map[string]string{"auth": "anonymous"},
+			wantCounter: f(1),
+		},
+		{
+			name:        "tools_list_total counts by auth kind",
+			record:      func(m *MCPMetrics) { m.RecordToolsList("api_key") },
+			metric:      "trip2g_mcp_tools_list_total",
+			labels:      map[string]string{"auth": "api_key"},
+			wantCounter: f(1),
+		},
+		{
+			name:        "tool_errors_total counts by tool and reason",
+			record:      func(m *MCPMetrics) { m.RecordToolError("search", "invalid_params") },
+			metric:      "trip2g_mcp_tool_errors_total",
+			labels:      map[string]string{"tool": "search", "reason": "invalid_params"},
+			wantCounter: f(1),
+		},
+		{
+			name:          "federation_depth observes incoming depth",
+			record:        func(m *MCPMetrics) { m.ObserveFederationDepth(3) },
+			metric:        "trip2g_mcp_federation_depth",
+			labels:        map[string]string{},
+			wantHistCount: u(1),
+			wantHistSum:   f(3),
+		},
+		{
+			name:          "fanout_bases observes touched bases",
+			record:        func(m *MCPMetrics) { m.ObserveFanoutBases(4) },
+			metric:        "trip2g_mcp_fanout_bases",
+			labels:        map[string]string{},
+			wantHistCount: u(1),
+			wantHistSum:   f(4),
+		},
+		{
+			name:        "federated_requests_total counts by status",
+			record:      func(m *MCPMetrics) { m.RecordFederatedRequest("timeout") },
+			metric:      "trip2g_mcp_federated_requests_total",
+			labels:      map[string]string{"status": "timeout"},
+			wantCounter: f(1),
+		},
+		{
+			name:          "search_results_returned observes per tool",
+			record:        func(m *MCPMetrics) { m.ObserveSearchResults("search", 7) },
+			metric:        "trip2g_mcp_search_results_returned",
+			labels:        map[string]string{"tool": "search"},
+			wantHistCount: u(1),
+			wantHistSum:   f(7),
+		},
+		{
+			name:      "dynamic_tools_registered gauge is set",
+			record:    func(m *MCPMetrics) { m.SetDynamicToolsRegistered(5) },
+			metric:    "trip2g_mcp_dynamic_tools_registered",
+			labels:    map[string]string{},
+			wantGauge: f(5),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := prometheus.NewRegistry()
+			m := NewMCPMetrics(reg)
+			tc.record(m)
+
+			metric := findMetric(t, reg, tc.metric, tc.labels)
+			if tc.wantCounter != nil {
+				require.InDelta(t, *tc.wantCounter, metric.GetCounter().GetValue(), 1e-9)
+			}
+			if tc.wantGauge != nil {
+				require.InDelta(t, *tc.wantGauge, metric.GetGauge().GetValue(), 1e-9)
+			}
+			if tc.wantHistCount != nil {
+				require.Equal(t, *tc.wantHistCount, metric.GetHistogram().GetSampleCount())
+			}
+			if tc.wantHistSum != nil {
+				require.InDelta(t, *tc.wantHistSum, metric.GetHistogram().GetSampleSum(), 1e-9)
+			}
+		})
+	}
+}
+
+func TestMCPMetrics_NilSafe(t *testing.T) {
+	var m *MCPMetrics
+	require.NotPanics(t, func() {
+		m.RecordMCPRequest("tools/call", "search", "anonymous", "ok", 0.01)
+		m.RecordToolsList("anonymous")
+		m.RecordToolError("search", "internal")
+		m.ObserveFederationDepth(1)
+		m.ObserveFanoutBases(2)
+		m.RecordFederatedRequest("ok")
+		m.ObserveSearchResults("similar", 3)
+		m.SetDynamicToolsRegistered(4)
+	})
+}

--- a/internal/metrics/mcp_test.go
+++ b/internal/metrics/mcp_test.go
@@ -133,8 +133,8 @@ func TestNewMCPMetrics_Records(t *testing.T) {
 			wantHistSum:   f(7),
 		},
 		{
-			name:      "dynamic_tools_registered gauge is set",
-			record:    func(m *MCPMetrics) { m.SetDynamicToolsRegistered(5) },
+			name:      "dynamic_tools_registered gauge reads its source at scrape time",
+			record:    func(m *MCPMetrics) { m.SetDynamicToolsSource(func() int { return 5 }) },
 			metric:    "trip2g_mcp_dynamic_tools_registered",
 			labels:    map[string]string{},
 			wantGauge: f(5),
@@ -174,6 +174,27 @@ func TestMCPMetrics_NilSafe(t *testing.T) {
 		m.ObserveFanoutBases(2)
 		m.RecordFederatedRequest("ok")
 		m.ObserveSearchResults("similar", 3)
-		m.SetDynamicToolsRegistered(4)
+		m.SetDynamicToolsSource(func() int { return 4 })
 	})
+}
+
+// TestDynamicToolsGauge_TracksSourceAcrossScrapes pins that the gauge value
+// follows the source on every scrape, so a note reload changing the underlying
+// count is visible immediately, with no explicit gauge update anywhere.
+func TestDynamicToolsGauge_TracksSourceAcrossScrapes(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewMCPMetrics(reg)
+
+	// Without a source the gauge reads 0.
+	metric := findMetric(t, reg, "trip2g_mcp_dynamic_tools_registered", map[string]string{})
+	require.InDelta(t, 0, metric.GetGauge().GetValue(), 1e-9)
+
+	count := 2
+	m.SetDynamicToolsSource(func() int { return count })
+	metric = findMetric(t, reg, "trip2g_mcp_dynamic_tools_registered", map[string]string{})
+	require.InDelta(t, 2, metric.GetGauge().GetValue(), 1e-9)
+
+	count = 7
+	metric = findMetric(t, reg, "trip2g_mcp_dynamic_tools_registered", map[string]string{})
+	require.InDelta(t, 7, metric.GetGauge().GetValue(), 1e-9)
 }

--- a/internal/model/note.go
+++ b/internal/model/note.go
@@ -1026,7 +1026,12 @@ func NewNoteViews() *NoteViews {
 	}
 }
 
+// Copy is nil-safe: before the first notes load the snapshot is nil and
+// scrape-time readers (metrics) must not panic.
 func (nv *NoteViews) Copy() *NoteViews {
+	if nv == nil {
+		return nil
+	}
 	res := *nv
 	return &res
 }


### PR DESCRIPTION
Adds Prometheus metrics for the MCP endpoint. Until now `/metrics` (internal `:8082`) counted GraphQL, notes and DB, but **nothing about MCP** — so there was no way to see how many MCP requests hit a hub, which tools were called, or how much anonymous public-hub traffic there is. This adds 10 metric families at a few choke points, following the existing `internal/metrics/graphql.go` pattern.

Per-hub slicing is free: one process = one hub = one scrape target, so no hub label is needed.

## Metrics

| Metric | Type | Labels |
|--------|------|--------|
| `trip2g_mcp_requests_total` | CounterVec | method, tool, auth, status |
| `trip2g_mcp_request_duration_seconds` | HistogramVec | tool (method fallback) |
| `trip2g_mcp_fanout_bases` | Histogram | — (how many KBs a federated query reached) |
| `trip2g_mcp_federation_depth` | Histogram | — (X-MCP-Federation-Depth) |
| `trip2g_mcp_federated_requests_total` | CounterVec | status (ok\|error\|timeout) |
| `trip2g_mcp_search_results_returned` | HistogramVec | tool (search\|similar) |
| `trip2g_mcp_tool_errors_total` | CounterVec | tool, reason |
| `trip2g_mcp_auth_total` | CounterVec | auth (anonymous\|token\|api_key\|federation) |
| `trip2g_mcp_dynamic_tools_registered` | Gauge | — |
| `trip2g_mcp_tools_list_total` | CounterVec | auth |

**Cardinality guards:** `method`/`tool` are bounded to known values (else `other`); no user-id, IP or hub labels anywhere; no free-form query text or note paths in labels.

## Notes on scope
- `fanout_bases` counts bases that responded without error on the federated path; `federation_depth` is recorded before the max-depth rejection so exceeded hops stay visible.
- `search_results_returned` covers `search`/`similar` (local); federated result payloads are opaque peer JSON, so per-KB reach is covered by `fanout_bases`/`federated_requests_total` instead.
- `tool_errors_total.reason` maps from JSON-RPC error codes (`invalid_params|not_found|internal|other`); access denials are deliberately masked as not-found upstream, so there's no `access_denied` reason by design.
- Wired app-implements-Env (`MCPMetrics()` on the mcp Env), matching the house pattern.

## Tests
TDD, written red first. Table-driven `TestMCPEndpointMetrics` drives the real `Endpoint.Handle` and asserts each family (anonymous search, api-key tools/call, federated fan-out reaching 2 bases, tool error, unknown tool, tools/list, depth header). `internal/metrics/mcp_test.go` covers each family + nil-safety. `go build ./...`, full `go test ./...`, `go vet`, `make lint` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
