### PR TITLE
fix: critical security & access findings from the audit (tests-first)

### DIFF
--- a/internal/case/backjob/sendsignincode/resolve.go
+++ b/internal/case/backjob/sendsignincode/resolve.go
@@ -21,7 +21,7 @@ type Env interface {
 }
 
 func Resolve(ctx context.Context, env Env, task Params) error {
-	env.Logger().Info("Sending sign-in code", "email", task.Email, "code", task.Code)
+	env.Logger().Info("Sending sign-in code", "email", task.Email)
 
 	var buf bytes.Buffer
 	WritePlainView(&buf, task)

--- a/internal/case/backjob/sendsignincode/resolve_test.go
+++ b/internal/case/backjob/sendsignincode/resolve_test.go
@@ -1,0 +1,67 @@
+package sendsignincode
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trip2g/internal/logger"
+	"trip2g/internal/model"
+)
+
+type signInCodeCaptureLogger struct {
+	lines []string
+}
+
+func (l *signInCodeCaptureLogger) record(msg string, keysAndValues ...interface{}) {
+	l.lines = append(l.lines, fmt.Sprint(msg, keysAndValues))
+}
+
+func (l *signInCodeCaptureLogger) Info(msg string, keysAndValues ...interface{}) {
+	l.record(msg, keysAndValues...)
+}
+
+func (l *signInCodeCaptureLogger) Error(msg string, keysAndValues ...interface{}) {
+	l.record(msg, keysAndValues...)
+}
+
+func (l *signInCodeCaptureLogger) Debug(msg string, keysAndValues ...interface{}) {
+	l.record(msg, keysAndValues...)
+}
+
+func (l *signInCodeCaptureLogger) Warn(msg string, keysAndValues ...interface{}) {
+	l.record(msg, keysAndValues...)
+}
+
+type signInCodeTestEnv struct {
+	log  *signInCodeCaptureLogger
+	mail []model.Mail
+}
+
+func (e *signInCodeTestEnv) Logger() logger.Logger {
+	return e.log
+}
+
+func (e *signInCodeTestEnv) SendMail(_ context.Context, mail model.Mail) error {
+	e.mail = append(e.mail, mail)
+	return nil
+}
+
+func TestResolveDoesNotLogSignInCode(t *testing.T) {
+	const code = "otp-secret-927451"
+	env := &signInCodeTestEnv{log: &signInCodeCaptureLogger{}}
+
+	err := Resolve(context.Background(), env, Params{
+		Email: "reader@example.com",
+		Code:  code,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, env.mail, 1, "the successful SMTP path must be exercised")
+	require.Contains(t, string(env.mail[0].Plain), code, "the code must still be delivered by email")
+	require.NotContains(t, strings.Join(env.log.lines, "\n"), code,
+		"one-time sign-in codes are credentials and must not be written to application logs")
+}

--- a/internal/case/processnowpaymentsipn/resolve.go
+++ b/internal/case/processnowpaymentsipn/resolve.go
@@ -49,7 +49,7 @@ func Resolve(ctx context.Context, env Env, req nowpayments.IPNRequest) (*Respons
 
 	env.Logger().Info("purchase updated", "order_id", req.OrderID, "status", req.PaymentStatus)
 
-	if req.PaymentStatus == nowpayments.PaymentStatusConfirmed { //nolint:nestif // I don't know how to avoid this nesting
+	if req.PaymentStatus.IsSuccessful() { //nolint:nestif // I don't know how to avoid this nesting
 		accessCount, countErr := env.CountUserSubgraphAccessByPurchaseID(ctx, &purchase.ID)
 		if countErr != nil {
 			return nil, fmt.Errorf("failed to count user subgraph access by purchase ID: %w", countErr)

--- a/internal/case/processnowpaymentsipn/resolve_test.go
+++ b/internal/case/processnowpaymentsipn/resolve_test.go
@@ -1,0 +1,105 @@
+package processnowpaymentsipn
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trip2g/internal/db"
+	"trip2g/internal/logger"
+	"trip2g/internal/nowpayments"
+)
+
+type successfulPaymentEnv struct {
+	createdAccesses []db.CreateUserSubgraphAccessParams
+	notifications   int
+}
+
+func (e *successfulPaymentEnv) NowpaymentsIPNSecret() string {
+	return "secret"
+}
+
+func (e *successfulPaymentEnv) Now() time.Time {
+	return time.Date(2026, time.July, 10, 12, 0, 0, 0, time.UTC)
+}
+
+func (e *successfulPaymentEnv) Logger() logger.Logger {
+	return &logger.DummyLogger{}
+}
+
+func (e *successfulPaymentEnv) PurchaseByID(_ context.Context, id string) (db.Purchase, error) {
+	return db.Purchase{
+		ID:          id,
+		PaymentData: `[]`,
+		OfferID:     42,
+		Email:       "buyer@example.com",
+	}, nil
+}
+
+func (e *successfulPaymentEnv) OfferByID(_ context.Context, id int64) (db.Offer, error) {
+	return db.Offer{ID: id}, nil
+}
+
+func (e *successfulPaymentEnv) UpdatePurchaseStatus(_ context.Context, _ db.UpdatePurchaseStatusParams) error {
+	return nil
+}
+
+func (e *successfulPaymentEnv) ListSubgraphsByOfferID(_ context.Context, _ int64) ([]db.Subgraph, error) {
+	return []db.Subgraph{{ID: 7, Name: "paid"}}, nil
+}
+
+func (e *successfulPaymentEnv) UserByEmail(_ context.Context, email string) (db.User, error) {
+	return db.User{ID: 9, Email: &email}, nil
+}
+
+func (e *successfulPaymentEnv) InsertUserWithEmail(_ context.Context, params db.InsertUserWithEmailParams) (db.User, error) {
+	return db.User{ID: 9, Email: &params.Email}, nil
+}
+
+func (e *successfulPaymentEnv) CountUserSubgraphAccessByPurchaseID(_ context.Context, _ *string) (int64, error) {
+	return 0, nil
+}
+
+func (e *successfulPaymentEnv) CreateUserSubgraphAccess(
+	_ context.Context,
+	params db.CreateUserSubgraphAccessParams,
+) (db.UserSubgraphAccess, error) {
+	e.createdAccesses = append(e.createdAccesses, params)
+	return db.UserSubgraphAccess{
+		UserID:     params.UserID,
+		SubgraphID: params.SubgraphID,
+		PurchaseID: params.PurchaseID,
+	}, nil
+}
+
+func (e *successfulPaymentEnv) NotifyPuchaseUpdated(_ string) {
+	e.notifications++
+}
+
+func TestResolveGrantsAccessForEverySuccessfulPaymentStatus(t *testing.T) {
+	for _, status := range []nowpayments.PaymentStatus{
+		nowpayments.PaymentStatusConfirmed,
+		nowpayments.PaymentStatusSending,
+		nowpayments.PaymentStatusFinished,
+	} {
+		t.Run(string(status), func(t *testing.T) {
+			require.True(t, status.IsSuccessful(), "the status contract classifies this payment as successful")
+			env := &successfulPaymentEnv{}
+
+			response, err := Resolve(context.Background(), env, nowpayments.IPNRequest{
+				OrderID:       "purchase-1",
+				PaymentStatus: status,
+			})
+
+			require.NoError(t, err)
+			require.NotNil(t, response)
+			require.True(t, response.Success)
+			require.Len(t, env.createdAccesses, 1,
+				"every successful payment status must grant the purchased subgraph access exactly once")
+			require.Equal(t, int64(7), env.createdAccesses[0].SubgraphID)
+			require.Equal(t, "purchase-1", *env.createdAccesses[0].PurchaseID)
+		})
+	}
+}

--- a/internal/db/boosty_access_test.go
+++ b/internal/db/boosty_access_test.go
@@ -1,0 +1,71 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trip2g/internal/db"
+)
+
+func TestListActiveBoostySubgraphNamesAcceptsWriterActiveStatus(t *testing.T) {
+	ctx := context.Background()
+	conn, queries, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	writeQueries := db.NewWriteQueries(conn)
+	adminID := insertTestAdminUser(t, conn)
+
+	var userID int64
+	err := conn.QueryRowContext(ctx, `
+		insert into users (email, created_via)
+		values ('boosty-reader@example.com', 'boosty')
+		returning id
+	`).Scan(&userID)
+	require.NoError(t, err)
+
+	require.NoError(t, writeQueries.InsertSubgraph(ctx, "boosty-paid"))
+	subgraph, err := queries.SubgraphByName(ctx, "boosty-paid")
+	require.NoError(t, err)
+
+	credentials, err := writeQueries.InsertBoostyCredentials(ctx, db.InsertBoostyCredentialsParams{
+		CreatedBy: adminID,
+		AuthData:  `{}`,
+		DeviceID:  "device-1",
+		BlogName:  "test-blog",
+	})
+	require.NoError(t, err)
+
+	const boostyTierID int64 = 101
+	require.NoError(t, writeQueries.UpsertBoostyTier(ctx, db.UpsertBoostyTierParams{
+		CredentialsID: credentials.ID,
+		BoostyID:      boostyTierID,
+		Name:          "Paid tier",
+		Data:          `{}`,
+	}))
+	tierID, err := queries.GetBoostyTierIDByCredentialsAndBoostyID(ctx, db.GetBoostyTierIDByCredentialsAndBoostyIDParams{
+		CredentialsID: credentials.ID,
+		BoostyID:      boostyTierID,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, writeQueries.InsertBoostyTierSubgraph(ctx, db.InsertBoostyTierSubgraphParams{
+		TierID:     tierID,
+		SubgraphID: subgraph.ID,
+		CreatedBy:  adminID,
+	}))
+	require.NoError(t, writeQueries.UpsertBoostyMember(ctx, db.UpsertBoostyMemberParams{
+		CredentialsID: credentials.ID,
+		BoostyID:      202,
+		Email:         "boosty-reader@example.com",
+		Status:        "active",
+		Data:          `{}`,
+		CurrentTierID: &tierID,
+	}))
+
+	got, err := queries.ListActiveBoostySubgraphNamesByUserID(ctx, userID)
+	require.NoError(t, err)
+	require.Equal(t, []string{"boosty-paid"}, got,
+		"an active Boosty member written by refreshboostydata must receive the tier's subgraphs")
+}

--- a/internal/db/queries.read.sql.go
+++ b/internal/db/queries.read.sql.go
@@ -3039,7 +3039,7 @@ select distinct s.name
   join boosty_tier_subgraphs bts on bm.current_tier_id = bts.tier_id
   join subgraphs s on bts.subgraph_id = s.id
  where u.id = ? -- if we select by user_id, the sqlc will generate a sql.Null64 arg
-   and bm.status = 'active_patron'
+   and bm.status = 'active'
  order by s.name
 `
 

--- a/internal/gitapi/api.go
+++ b/internal/gitapi/api.go
@@ -265,6 +265,8 @@ func (api *API) HandleRequest(ctx *fasthttp.RequestCtx) bool {
 	hdr, ok := handlers[path[len(api.config.BasePath):]]
 	if !ok {
 		api.logger.Warn("unsupported path", "path", path)
+		ctx.SetStatusCode(fasthttp.StatusNotFound)
+		return true
 	}
 
 	api.mu.Lock()

--- a/internal/gitapi/api_security_test.go
+++ b/internal/gitapi/api_security_test.go
@@ -1,0 +1,39 @@
+package gitapi
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+func TestHandleRequestAuthenticatedUnknownPathReturnsClientError(t *testing.T) {
+	env := &fakeEnv{}
+	cfg := DefaultConfig()
+	cfg.RepoPath = t.TempDir()
+
+	api, err := New(context.Background(), cfg, env)
+	require.NoError(t, err)
+	require.NotNil(t, api)
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetRequestURI("/_system/git/not-a-git-endpoint")
+	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+	credentials := base64.StdEncoding.EncodeToString([]byte("user:valid-test-token"))
+	ctx.Request.Header.Set("Authorization", "Basic "+credentials)
+
+	var panicValue any
+	var handled bool
+	func() {
+		defer func() {
+			panicValue = recover()
+		}()
+		handled = api.HandleRequest(ctx)
+	}()
+
+	require.Nil(t, panicValue, "an authenticated unknown Git path must not call a nil handler")
+	require.True(t, handled)
+	require.Contains(t, []int{fasthttp.StatusNotFound, fasthttp.StatusMethodNotAllowed}, ctx.Response.StatusCode())
+}

--- a/queries.read.sql
+++ b/queries.read.sql
@@ -160,7 +160,7 @@ select distinct s.name
   join boosty_tier_subgraphs bts on bm.current_tier_id = bts.tier_id
   join subgraphs s on bts.subgraph_id = s.id
  where u.id = ? -- if we select by user_id, the sqlc will generate a sql.Null64 arg
-   and bm.status = 'active_patron'
+   and bm.status = 'active'
  order by s.name;
 
 -- name: ListAllUserSubgraphAccesses :many


### PR DESCRIPTION
Fixes the four highest-impact unaddressed findings from a security/reliability audit, each landed test-first (the failing regression test is committed with its fix).

## Fixes

**1. Git nil-handler panic → DoS (P1).** An authenticated Git request to an unknown path was logged but not aborted, then reached a nil handler and crashed the process. `HandleRequest` now returns `404` before repo init when the path is unknown/handler is nil. Test: `TestHandleRequestAuthenticatedUnknownPathReturnsClientError`.

**2. One-time sign-in code leaked to logs (P1).** `sendsignincode` logged the OTP at INFO. Removed the code from the log fields (email metadata kept). Test: `TestResolveDoesNotLogSignInCode`.

**3. NOWPayments granted access only on `confirmed` (P1).** `status.go` treats `sending` and `finished` as successful too, so a valid paid webhook in those states granted no entitlement. The grant now uses `PaymentStatus.IsSuccessful()`, matching the success contract. Test: `TestResolveGrantsAccessForEverySuccessfulPaymentStatus`.

**4. Boosty active patron got no subgraphs (P1).** The writer stores `active`, but the reader query filtered `active_patron` (a Patreon-only value), so active Boosty patrons saw nothing. Reader query aligned to `'active'` (least-churn, reader-only); `make sqlc` regenerated. Test: `TestListActiveBoostySubgraphNamesAcceptsWriterActiveStatus`.

## Deliberately out of scope
The NOWPayments finding also flagged non-atomic access grants. The existing count-then-insert idempotence check now covers all successful statuses, so a `sending`→`finished` sequence grants exactly once. A truly concurrent double-IPN race remains possible; closing it cleanly needs a **SQL migration** (unique index on `(user_id, subgraph_id, purchase_id)` + `on conflict do nothing`), which per project rules needs explicit sign-off — recommended as a follow-up.

`go build ./...`, full `go test ./...`, `go vet`, `make lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
