### PR TITLE
chore: remove decorative banner comments from Go sources

### DIFF
--- a/cmd/businessdemo/main.go
+++ b/cmd/businessdemo/main.go
@@ -109,7 +109,7 @@ var connections = map[string]int64{} //nolint:gochecknoglobals // demo command s
 // pull from LatestNoteViews after the ingestion phase lands.
 var canvas *Canvas //nolint:gochecknoglobals // demo command state
 
-// ------------------------- nav state -----------------------------------------
+// nav state
 
 type navState struct {
 	current   string
@@ -125,7 +125,7 @@ func stateKey(chatID int64, bcID string) string {
 	return strconv.FormatInt(chatID, 10) + "|" + bcID
 }
 
-// ------------------------- rendering -----------------------------------------
+// rendering
 
 const (
 	telegramMessageMax = 3800
@@ -188,7 +188,7 @@ func emptyMarkup() string {
 	return string(j)
 }
 
-// ------------------------- send helpers --------------------------------------
+// send helpers
 
 func sendText(bot *tgbotapi.BotAPI, chatID int64, bcID, text, markup string) error {
 	p := tgbotapi.Params{
@@ -313,7 +313,7 @@ func answerCallback(bot *tgbotapi.BotAPI, callbackID, text string, alert bool) e
 	return err
 }
 
-// ------------------------- handlers ------------------------------------------
+// handlers
 
 func startBrowse(bot *tgbotapi.BotAPI, chatID int64, bcID string) error {
 	entry := canvas.entry()
@@ -429,8 +429,6 @@ func handleCallback(bot *tgbotapi.BotAPI, cq *bizCallbackQuery) error {
 	}
 	return answerCallback(bot, cq.ID, "", false)
 }
-
-// ------------------------- main loop -----------------------------------------
 
 func main() {
 	token := os.Getenv("TELEGRAM_BOT_TOKEN")

--- a/cmd/exporttgchannel/export.go
+++ b/cmd/exporttgchannel/export.go
@@ -319,7 +319,7 @@ func frontmatter(channelID int64, msg *tg.Message) string {
 	return sb.String()
 }
 
-// ---- title / filename helpers (adapted from importtelegramchannel) ----
+// title / filename helpers (adapted from importtelegramchannel)
 
 var (
 	rCustomEmoji    = regexp.MustCompile(`!\[[^\]]*\]\((tg://emoji\?id=\d+|https://ce\.trip2g\.com/\d+\.webp)\)`)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -382,14 +382,12 @@ func main() {
 
 	a.auditLogger = auditlogger.New(ctx, a, a.config.AuditLog)
 
-	// ========================================================================
 	// BLOCK A — read-only warmup. Everything here is safe to run WITHOUT the
 	// SQLite writer slot: it only reads the DB (or touches no DB at all), so a
 	// new instance can fully warm up (load notes, build in-memory indexes,
 	// construct handlers) while the OLD instance keeps serving, including
 	// writes. No writer subsystem (queues, cron, patreon/boosty refresh) is
 	// started here. /readyz stays 503 until Block B finishes.
-	// ========================================================================
 
 	// No-DB construction halves (client managers, job handlers).
 	a.constructPatreon()
@@ -470,13 +468,12 @@ func main() {
 	a.personalTokenResolver = personaltoken.NewResolver(a)
 	a.setFileStorageExpiringCallback()
 
-	// ========================================================================
 	// WRITER SLOT — acquire before starting any writer subsystem. This is an
 	// honest-but-minimal probe (BEGIN IMMEDIATE; COMMIT) that the SQLite write
 	// lock is currently grabbable; the OLD instance releases it on SIGTERM
 	// after stopping its own writers. It does NOT hold the lock open and does
 	// NOT guarantee hard cross-process single-writer (deferred to Phase 2).
-	// ========================================================================
+	//
 	// Read-only replica: never acquire the writer slot or start any writer
 	// subsystem. The replica serves reads off the replicated DB and forwards
 	// every mutating request to the leader (--leader-addr). It becomes ready as
@@ -497,10 +494,8 @@ func main() {
 
 	log.Info("writer slot acquired, starting writer subsystems")
 
-	// ========================================================================
 	// BLOCK B — writer-only. Runs only after the writer slot is acquired.
 	// Everything here writes to the DB or starts a background loop that does.
-	// ========================================================================
 
 	// createOwnerIfNotExists inserts the owner user+admin (WRITE).
 	err = a.createOwnerIfNotExists(ctx)

--- a/internal/mdchunk/chunk_test.go
+++ b/internal/mdchunk/chunk_test.go
@@ -5,10 +5,6 @@ import (
 	"testing"
 )
 
-// ---------------------------------------------------------------------------
-// StripFrontmatter tests
-// ---------------------------------------------------------------------------
-
 func TestStripFrontmatter(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -62,9 +58,7 @@ func TestStripFrontmatter(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // Split tests
-// ---------------------------------------------------------------------------
 
 // searchAstronomyContent mirrors docs/demo/search_astronomy.md (body after frontmatter).
 const searchAstronomyContent = `---

--- a/internal/russkayalatinica2/latinica.go
+++ b/internal/russkayalatinica2/latinica.go
@@ -14,9 +14,7 @@ import (
 	"unicode"
 )
 
-// ---------------------------------------------------------------------------
 // Element & context types
-// ---------------------------------------------------------------------------
 
 type elementType uint8
 
@@ -65,9 +63,7 @@ func (c contextType) matches(et elementType) bool {
 	return false
 }
 
-// ---------------------------------------------------------------------------
 // Engine
-// ---------------------------------------------------------------------------
 
 type engine struct {
 	cyrlCells map[rune][]cell      // lowercase Cyrillic rune → cells (forward)
@@ -152,9 +148,7 @@ func (e *engine) latnElemType(s string) elementType {
 	return nonLetter
 }
 
-// ---------------------------------------------------------------------------
 // Forward: Cyrillic → Latin
-// ---------------------------------------------------------------------------
 
 type fwdElem struct {
 	srcRune rune
@@ -214,9 +208,7 @@ func (e *engine) translit(input string) string {
 	return b.String()
 }
 
-// ---------------------------------------------------------------------------
 // Reverse: Latin → Cyrillic
-// ---------------------------------------------------------------------------
 
 type revElem struct {
 	source string // original Latin (preserves case)
@@ -290,9 +282,7 @@ func (e *engine) revert(input string) string {
 	return b.String()
 }
 
-// ---------------------------------------------------------------------------
 // Case resolution (Swift multi-pass algorithm)
-// ---------------------------------------------------------------------------
 
 type charCase int8
 

--- a/internal/russkayalatinica2/table.go
+++ b/internal/russkayalatinica2/table.go
@@ -24,13 +24,13 @@ type cell struct {
 //
 //nolint:gochecknoglobals
 var ruTable = [...]cell{
-	// ── Simple vowels (type: vowel) ────────────────────────────
+	// Simple vowels (type: vowel)
 	{cyrl: 'а', latn: "a", typ: vowel},
 	{cyrl: 'и', latn: "i", typ: vowel},
 	{cyrl: 'о', latn: "o", typ: vowel},
 	{cyrl: 'у', latn: "u", typ: vowel},
 
-	// ── Consonants ─────────────────────────────────────────────
+	// Consonants
 	{cyrl: 'б', latn: "b", typ: consonant},
 	{cyrl: 'в', latn: "v", typ: consonant},
 	{cyrl: 'г', latn: "g", typ: consonant},
@@ -52,7 +52,7 @@ var ruTable = [...]cell{
 	{cyrl: 'ш', latn: "sh", typ: consonant},
 	{cyrl: 'щ', latn: "sjh", typ: consonant},
 
-	// ── Compound/iotated vowels (type: other per Swift) ────────
+	// Compound/iotated vowels (type: other per Swift)
 	// These are NOT typed as vowel because in the Swift ru table
 	// their cells use default type (.other). This matters for
 	// postfixContext matching on ъ (nonVowel vs vowel).
@@ -61,29 +61,29 @@ var ruTable = [...]cell{
 	{cyrl: 'ё', latn: "yo", typ: other},
 	{cyrl: 'ы', latn: "yi", typ: other},
 
-	// ── Context-dependent: э ───────────────────────────────────
+	// Context-dependent: э
 	// First cell → element type: vowel.
 	// After non-consonant: "e". After consonant: "ye".
 	{cyrl: 'э', latn: "e", typ: vowel, prefix: ctxNonConsonant},
 	{cyrl: 'э', latn: "ye", typ: other, prefix: ctxConsonant},
 
-	// ── Context-dependent: е ───────────────────────────────────
+	// Context-dependent: е
 	// First cell → element type: other (NOT vowel — matches Swift).
 	// After consonant: "e". After non-consonant: "ye".
 	{cyrl: 'е', latn: "e", typ: other, prefix: ctxConsonant},
 	{cyrl: 'е', latn: "ye", typ: other, prefix: ctxNonConsonant},
 
-	// ── Context-dependent: й ───────────────────────────────────
+	// Context-dependent: й
 	// First cell → element type: vowel.
 	{cyrl: 'й', latn: "j", typ: vowel, prefix: ctxNonConsonant},
 	{cyrl: 'й', latn: "yj", typ: other, prefix: ctxConsonant},
 
-	// ── Context-dependent: ь (soft sign) ───────────────────────
+	// Context-dependent: ь (soft sign)
 	// First cell → element type: vowel (matches Swift).
 	{cyrl: 'ь', latn: "j", typ: vowel, prefix: ctxConsonant},
 	{cyrl: 'ь', latn: "hj", typ: vowel, prefix: ctxNonConsonant},
 
-	// ── Context-dependent: ъ (hard sign) ───────────────────────
+	// Context-dependent: ъ (hard sign)
 	// 4 rules based on prefix (consonant/non) × postfix (vowel/non).
 	// First cell → element type: other.
 	{cyrl: 'ъ', latn: "y", typ: other, prefix: ctxConsonant, postfix: ctxNonVowel},
@@ -91,6 +91,6 @@ var ruTable = [...]cell{
 	{cyrl: 'ъ', latn: "yh", typ: other, prefix: ctxConsonant, postfix: ctxVowel},
 	{cyrl: 'ъ', latn: "hyh", typ: other, prefix: ctxNonConsonant, postfix: ctxVowel},
 
-	// ── Historical ─────────────────────────────────────────────
+	// Historical
 	{cyrl: 'ѵ', latn: "y", typ: other},
 }


### PR DESCRIPTION
Removes decorative banner/divider comments (`// ====`, `// ── x ──`, `// ----`) from hand-written Go files, per the CLAUDE.md rule ("NO decorative/banner dividers — they go stale and clutter").

35 divider lines removed across 6 files. Meaningful section labels are kept as plain comments (`// nav state`, `// Split tests`); dividers that only restated the next declaration were deleted outright. Generated files untouched.

`gofmt`, `go build ./...`, `go test` on touched packages, `go vet`, and `make lint` all clean; final grep shows zero remaining banners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)