### PR TITLE
fix(graphql): MCP mutations in tx middleware + @skipTx in fragments

### DIFF
--- a/internal/case/insertnote/actor_test.go
+++ b/internal/case/insertnote/actor_test.go
@@ -62,10 +62,12 @@ func latestVersion(t *testing.T, rq *db.Queries, pathID int64) db.NoteVersion {
 }
 
 func TestInsertNoteRecordsUserActor(t *testing.T) {
+	conn := setupActorDB(t)
+
+	// Timeout starts after setup: migrations can take seconds on slow CI runners.
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	conn := setupActorDB(t)
 	wq := db.NewWriteQueries(conn)
 	rq := db.New(conn)
 
@@ -96,10 +98,11 @@ func TestInsertNoteRecordsUserActor(t *testing.T) {
 }
 
 func TestInsertNoteRecordsAPIKeyActor(t *testing.T) {
+	conn := setupActorDB(t)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	conn := setupActorDB(t)
 	wq := db.NewWriteQueries(conn)
 	rq := db.New(conn)
 
@@ -140,10 +143,11 @@ func TestInsertNoteRecordsAPIKeyActor(t *testing.T) {
 }
 
 func TestInsertNoteRecordsNoActorAsNull(t *testing.T) {
+	conn := setupActorDB(t)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	conn := setupActorDB(t)
 	wq := db.NewWriteQueries(conn)
 	rq := db.New(conn)
 
@@ -165,10 +169,11 @@ func TestInsertNoteRecordsNoActorAsNull(t *testing.T) {
 }
 
 func TestInsertNoteRecordsClientHeader(t *testing.T) {
+	conn := setupActorDB(t)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	conn := setupActorDB(t)
 	wq := db.NewWriteQueries(conn)
 	rq := db.New(conn)
 

--- a/internal/graph/executor_tx_test.go
+++ b/internal/graph/executor_tx_test.go
@@ -1,0 +1,122 @@
+package graph
+
+// The programmatic executor (NewExecutor, used by the MCP graphql_request
+// tools) must run operations through the same tx middleware as the HTTP
+// handler. Without it, multi-step mutations dispatched over MCP run outside a
+// transaction and a mid-way failure leaves partial writes committed.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	graphql "github.com/99designs/gqlgen/graphql"
+	"github.com/99designs/gqlgen/graphql/executor"
+	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/ast"
+
+	"trip2g/internal/logger"
+)
+
+// recordingTxEnv implements the tx-lifecycle subset of Env used by the
+// operation middleware. The embedded Env stays nil: resolvers touching
+// anything else panic, which gqlgen recovers into a response error — enough
+// to drive the rollback path.
+type recordingTxEnv struct {
+	Env
+	acquired      bool
+	released      bool
+	releaseCommit bool
+}
+
+func (e *recordingTxEnv) Logger() logger.Logger       { return &logger.DummyLogger{} }
+func (e *recordingTxEnv) IsDevMode() bool             { return true }
+func (e *recordingTxEnv) ShortAPITokenSecret() string { return "test-secret" }
+
+func (e *recordingTxEnv) AcquireTxEnvInRequest(_ context.Context, _ string) error {
+	e.acquired = true
+	return nil
+}
+
+func (e *recordingTxEnv) ReleaseTxEnvInRequest(_ context.Context, commit bool) error {
+	e.released = true
+	e.releaseCommit = commit
+	return nil
+}
+
+func dispatchProgrammatic(t *testing.T, exec *executor.Executor, query string) *graphql.Response {
+	t.Helper()
+
+	ctx := graphql.StartOperationTrace(context.Background())
+	now := graphql.Now()
+
+	opCtx, errList := exec.CreateOperationContext(ctx, &graphql.RawParams{
+		Query:    query,
+		ReadTime: graphql.TraceTiming{Start: now, End: now},
+	})
+	require.Empty(t, errList)
+
+	rh, respCtx := exec.DispatchOperation(ctx, opCtx)
+	return rh(respCtx)
+}
+
+func TestNewExecutor_MutationRunsInsideTxWrapper(t *testing.T) {
+	env := &recordingTxEnv{}
+	exec := NewExecutor(env)
+
+	resp := dispatchProgrammatic(t, exec, `mutation { signOut { __typename } }`)
+
+	require.NotEmpty(t, resp.Errors, "resolver must fail without an appreq in context")
+	require.True(t, env.acquired,
+		"programmatic executor must open the request tx for mutations")
+	require.True(t, env.released,
+		"programmatic executor must release the request tx")
+	require.False(t, env.releaseCommit,
+		"a failed mutation must roll back, not commit")
+}
+
+func TestNewExecutor_SkipTxMutationDoesNotOpenTx(t *testing.T) {
+	env := &recordingTxEnv{}
+	exec := NewExecutor(env)
+
+	// runCronJob waits on the single writer: opening a tx first would deadlock.
+	_ = dispatchProgrammatic(t, exec,
+		`mutation { admin { runCronJob(input: {id: 1}) { __typename } } }`)
+
+	require.False(t, env.acquired, "@skipTx mutation must not open a transaction")
+}
+
+// commitFailOpsEnv acquires fine but fails on commit.
+type commitFailOpsEnv struct {
+	stubOpsEnv
+}
+
+func (e *commitFailOpsEnv) AcquireTxEnvInRequest(_ context.Context, _ string) error { return nil }
+
+func (e *commitFailOpsEnv) ReleaseTxEnvInRequest(_ context.Context, commit bool) error {
+	if commit {
+		return errors.New("disk full")
+	}
+	return nil
+}
+
+func TestMakeAroundOperations_CommitErrorBecomesGraphQLError(t *testing.T) {
+	env := &commitFailOpsEnv{stubOpsEnv: stubOpsEnv{devMode: true}}
+	middleware := makeAroundOperations(&logger.DummyLogger{}, map[string]struct{}{}, env, nil)
+
+	opCtx := &graphql.OperationContext{
+		Operation: &ast.OperationDefinition{
+			Operation: ast.Mutation,
+			Name:      "TestMutation",
+		},
+	}
+	ctx := graphql.WithOperationContext(context.Background(), opCtx)
+
+	rh := middleware(ctx, func(_ context.Context) graphql.ResponseHandler {
+		return func(_ context.Context) *graphql.Response { return &graphql.Response{} }
+	})
+	resp := rh(ctx)
+
+	require.NotEmpty(t, resp.Errors,
+		"a failed commit must surface as a GraphQL error, not a silent success")
+}

--- a/internal/graph/handler.go
+++ b/internal/graph/handler.go
@@ -223,6 +223,9 @@ func selectionHasSkipTx(sel ast.SelectionSet, skipTx map[string]struct{}) bool {
 	for _, s := range sel {
 		switch sel := s.(type) {
 		case *ast.Field:
+			if staticallyExcluded(sel.Directives) {
+				continue
+			}
 			if _, skip := skipTx[sel.Name]; skip {
 				return true
 			}
@@ -230,15 +233,47 @@ func selectionHasSkipTx(sel ast.SelectionSet, skipTx map[string]struct{}) bool {
 				return true
 			}
 		case *ast.InlineFragment:
+			if staticallyExcluded(sel.Directives) {
+				continue
+			}
 			if selectionHasSkipTx(sel.SelectionSet, skipTx) {
 				return true
 			}
 		case *ast.FragmentSpread:
+			if staticallyExcluded(sel.Directives) {
+				continue
+			}
 			// Definition is resolved by the validator; fragment cycles are
 			// rejected before this runs, so plain recursion is safe.
 			if sel.Definition != nil && selectionHasSkipTx(sel.Definition.SelectionSet, skipTx) {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+// staticallyExcluded reports whether @skip(if: true) or @include(if: false)
+// with a literal boolean removes the selection from execution. Variable-driven
+// conditions can't be evaluated here (no variables at this layer), so they are
+// treated as potentially executing.
+func staticallyExcluded(directives ast.DirectiveList) bool {
+	for _, d := range directives {
+		var excludeWhen bool
+		switch d.Name {
+		case "skip":
+			excludeWhen = true
+		case "include":
+			excludeWhen = false
+		default:
+			continue
+		}
+		arg := d.Arguments.ForName("if")
+		if arg == nil || arg.Value == nil || arg.Value.Kind != ast.BooleanValue {
+			continue
+		}
+		if (arg.Value.Raw == "true") == excludeWhen {
+			return true
 		}
 	}
 	return false

--- a/internal/graph/handler.go
+++ b/internal/graph/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/99designs/gqlgen/graphql/handler/lru"
 	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 // buildSkipTxMap collects all field names (at any nesting level under Mutation)
@@ -93,20 +94,22 @@ func NewHandler(env Env) *handler.Server {
 		Cache: lru.New[string](100),
 	})
 
-	graphqlErr := func(err error) graphql.ResponseHandler {
+	logger := logger.WithPrefix(env.Logger(), "GraphQL:")
+	skipTxMutations := buildSkipTxMap(schema)
+
+	srv.AroundOperations(makeAroundOperations(logger, skipTxMutations, env, makeGraphqlErr(log)))
+
+	return srv
+}
+
+func makeGraphqlErr(log logger.Logger) func(err error) graphql.ResponseHandler {
+	return func(err error) graphql.ResponseHandler {
 		log.Error("graphql error", "error", err)
 
 		return func(ctx context.Context) *graphql.Response {
 			return graphql.ErrorResponse(ctx, "%s", err.Error())
 		}
 	}
-
-	logger := logger.WithPrefix(env.Logger(), "GraphQL:")
-	skipTxMutations := buildSkipTxMap(schema)
-
-	srv.AroundOperations(makeAroundOperations(logger, skipTxMutations, env, graphqlErr))
-
-	return srv
 }
 
 func disableIntrospection(ctx context.Context, opCtx *graphql.OperationContext, env operationsEnv) {
@@ -195,6 +198,8 @@ func makeAroundOperations(
 			commitErr := env.ReleaseTxEnvInRequest(ctx, true)
 			if commitErr != nil {
 				log.Error("failed to release transactioned env with commit", "error", commitErr)
+				// The writes are lost; the caller must not see a success response.
+				resp.Errors = append(resp.Errors, gqlerror.Errorf("failed to commit transaction: %s", commitErr))
 			} else {
 				log.Debug("released transactioned env with commit")
 			}
@@ -216,15 +221,24 @@ func shouldSkipTx(op *ast.OperationDefinition, skipTxMutations map[string]struct
 // operation — nested mutations like AdminMutation.runCronJob are covered.
 func selectionHasSkipTx(sel ast.SelectionSet, skipTx map[string]struct{}) bool {
 	for _, s := range sel {
-		field, ok := s.(*ast.Field)
-		if !ok {
-			continue
-		}
-		if _, skip := skipTx[field.Name]; skip {
-			return true
-		}
-		if selectionHasSkipTx(field.SelectionSet, skipTx) {
-			return true
+		switch sel := s.(type) {
+		case *ast.Field:
+			if _, skip := skipTx[sel.Name]; skip {
+				return true
+			}
+			if selectionHasSkipTx(sel.SelectionSet, skipTx) {
+				return true
+			}
+		case *ast.InlineFragment:
+			if selectionHasSkipTx(sel.SelectionSet, skipTx) {
+				return true
+			}
+		case *ast.FragmentSpread:
+			// Definition is resolved by the validator; fragment cycles are
+			// rejected before this runs, so plain recursion is safe.
+			if sel.Definition != nil && selectionHasSkipTx(sel.Definition.SelectionSet, skipTx) {
+				return true
+			}
 		}
 	}
 	return false
@@ -242,5 +256,12 @@ func NewExecutor(env Env) *executor.Executor {
 	schema := NewExecutableSchema(config)
 	exec := executor.New(schema)
 	exec.Use(extension.Introspection{})
+
+	// Programmatic (MCP) dispatch must share the HTTP path's tx lifecycle:
+	// without this middleware, multi-step mutations run outside a transaction
+	// and a mid-way failure leaves partial writes committed.
+	log := logger.WithPrefix(env.Logger(), "GraphQL:")
+	exec.AroundOperations(makeAroundOperations(log, buildSkipTxMap(schema), env, makeGraphqlErr(env.Logger())))
+
 	return exec
 }

--- a/internal/graph/skiptx_fragment_test.go
+++ b/internal/graph/skiptx_fragment_test.go
@@ -1,0 +1,82 @@
+package graph
+
+// @skipTx fields must be detected regardless of selection shape: a mutation
+// reaching runCronJob through a fragment spread or inline fragment must NOT
+// open the request transaction, or it deadlocks against the single writer.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	gqlparser "github.com/vektah/gqlparser/v2"
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/validator/rules"
+)
+
+// loadTestOperation parses and validates query against the real executable
+// schema, so FragmentSpread.Definition is resolved exactly as gqlgen does it.
+func loadTestOperation(t *testing.T, query string) *ast.OperationDefinition {
+	t.Helper()
+
+	schema := NewExecutableSchema(Config{Resolvers: &Resolver{}})
+	doc, errList := gqlparser.LoadQueryWithRules(schema.Schema(), query, rules.NewDefaultRules())
+	require.Empty(t, errList)
+	require.Len(t, doc.Operations, 1)
+
+	return doc.Operations[0]
+}
+
+func realSkipTxMap() map[string]struct{} {
+	return buildSkipTxMap(NewExecutableSchema(Config{Resolvers: &Resolver{}}))
+}
+
+func TestShouldSkipTx_FragmentSpread(t *testing.T) {
+	op := loadTestOperation(t, `
+		mutation {
+			admin {
+				...CronOps
+			}
+		}
+		fragment CronOps on AdminMutation {
+			runCronJob(input: {id: 1}) {
+				__typename
+			}
+		}
+	`)
+
+	require.True(t, shouldSkipTx(op, realSkipTxMap()),
+		"@skipTx field selected via fragment spread must be detected")
+}
+
+func TestShouldSkipTx_InlineFragment(t *testing.T) {
+	op := loadTestOperation(t, `
+		mutation {
+			admin {
+				... on AdminMutation {
+					runCronJob(input: {id: 1}) {
+						__typename
+					}
+				}
+			}
+		}
+	`)
+
+	require.True(t, shouldSkipTx(op, realSkipTxMap()),
+		"@skipTx field selected via inline fragment must be detected")
+}
+
+func TestShouldSkipTx_FragmentWithoutSkipTxField(t *testing.T) {
+	op := loadTestOperation(t, `
+		mutation {
+			...RootOps
+		}
+		fragment RootOps on Mutation {
+			signOut {
+				__typename
+			}
+		}
+	`)
+
+	require.False(t, shouldSkipTx(op, realSkipTxMap()),
+		"fragment without @skipTx fields must still open the transaction")
+}

--- a/internal/graph/skiptx_fragment_test.go
+++ b/internal/graph/skiptx_fragment_test.go
@@ -65,6 +65,93 @@ func TestShouldSkipTx_InlineFragment(t *testing.T) {
 		"@skipTx field selected via inline fragment must be detected")
 }
 
+func TestShouldSkipTx_FragmentExcludedByInclude(t *testing.T) {
+	op := loadTestOperation(t, `
+		mutation {
+			admin {
+				...CronOps @include(if: false)
+			}
+		}
+		fragment CronOps on AdminMutation {
+			runCronJob(input: {id: 1}) {
+				__typename
+			}
+		}
+	`)
+
+	require.False(t, shouldSkipTx(op, realSkipTxMap()),
+		"@skipTx field in a fragment excluded by @include(if: false) never executes, tx must stay on")
+}
+
+func TestShouldSkipTx_FragmentExcludedBySkip(t *testing.T) {
+	op := loadTestOperation(t, `
+		mutation {
+			admin {
+				...CronOps @skip(if: true)
+			}
+		}
+		fragment CronOps on AdminMutation {
+			runCronJob(input: {id: 1}) {
+				__typename
+			}
+		}
+	`)
+
+	require.False(t, shouldSkipTx(op, realSkipTxMap()),
+		"@skipTx field in a fragment excluded by @skip(if: true) never executes, tx must stay on")
+}
+
+func TestShouldSkipTx_FieldExcludedBySkip(t *testing.T) {
+	op := loadTestOperation(t, `
+		mutation {
+			admin {
+				runCronJob(input: {id: 1}) @skip(if: true) {
+					__typename
+				}
+			}
+		}
+	`)
+
+	require.False(t, shouldSkipTx(op, realSkipTxMap()),
+		"@skipTx field excluded by @skip(if: true) never executes, tx must stay on")
+}
+
+func TestShouldSkipTx_FragmentIncludedByLiteralTrue(t *testing.T) {
+	op := loadTestOperation(t, `
+		mutation {
+			admin {
+				...CronOps @include(if: true)
+			}
+		}
+		fragment CronOps on AdminMutation {
+			runCronJob(input: {id: 1}) {
+				__typename
+			}
+		}
+	`)
+
+	require.True(t, shouldSkipTx(op, realSkipTxMap()),
+		"@include(if: true) does not exclude the fragment, @skipTx must still be detected")
+}
+
+func TestShouldSkipTx_FragmentGuardedByVariable(t *testing.T) {
+	op := loadTestOperation(t, `
+		mutation ($run: Boolean!) {
+			admin {
+				...CronOps @include(if: $run)
+			}
+		}
+		fragment CronOps on AdminMutation {
+			runCronJob(input: {id: 1}) {
+				__typename
+			}
+		}
+	`)
+
+	require.True(t, shouldSkipTx(op, realSkipTxMap()),
+		"variable-guarded fragment may execute, must be treated as skipTx conservatively")
+}
+
 func TestShouldSkipTx_FragmentWithoutSkipTxField(t *testing.T) {
 	op := loadTestOperation(t, `
 		mutation {


### PR DESCRIPTION
Two P1 GraphQL transaction-lifecycle fixes from the audit, test-first.

**1. MCP admin mutations bypassed the transaction lifecycle.** The programmatic executor (`NewExecutor`) was built bare — without the `AroundOperations` middleware the HTTP path uses — so multi-step mutations invoked over MCP ran outside the request transaction and could partially commit. `NewExecutor` now installs the same operation middleware (same skipTx map, same env, same error handling), so an acquire failure surfaces as a GraphQL error just like HTTP. Tests: `TestNewExecutor_MutationRunsInsideTxWrapper` (asserts the tx is opened and rolled back on resolver failure), `TestMakeAroundOperations_CommitErrorBecomesGraphQLError`.

**2. `@skipTx` was not detected inside fragments.** `selectionHasSkipTx` only inspected top-level `*ast.Field`, so a `runCronJob`/queue-control mutation selected via an inline fragment or fragment spread would open a transaction and deadlock on the single writer. It now walks `*ast.InlineFragment` and `*ast.FragmentSpread` (resolved definition, nil-guarded; cycles are rejected by the validator upstream). Tests: `TestShouldSkipTx_FragmentSpread`, `TestShouldSkipTx_InlineFragment`, with a negative control.

**Behavior note for review:** the commit-error→GraphQL-error change lives in the shared middleware, so the HTTP path is also affected — but only when a commit *fails*, which previously returned a silent success after losing the writes (a data-integrity lie). Surfacing it was the point; sharing the path kept HTTP/MCP from diverging.

Deadlock analysis covered: skipTx (incl. the new fragment walk) stays active on the MCP executor; MCP requests carry an `appreq` so `AcquireTxEnvInRequest` works; nested-tx cases hit the same guard as HTTP.

`go build ./...`, full `go test ./...`, `go vet`, `make lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)