### PR TITLE
fix(security): HTTPS-only secrets + loopback internal listener + gated embedding debug

### DIFF
--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -182,7 +182,17 @@ func (a *app) GetSecretValues(ctx context.Context, like string) (map[string]stri
 }
 
 func (a *app) SetSecretValue(ctx context.Context, key, value string) error {
-	return setsecret.Resolve(ctx, a, key, value)
+	errPayload, err := setsecret.Resolve(ctx, a, key, value)
+	if err != nil {
+		return err
+	}
+	if errPayload != nil {
+		if len(errPayload.ByFields) > 0 {
+			return fmt.Errorf("%s: %s", errPayload.ByFields[0].Name, errPayload.ByFields[0].Value)
+		}
+		return fmt.Errorf("%s", errPayload.Message)
+	}
+	return nil
 }
 
 func (a *app) DeleteSecretValue(ctx context.Context, key string) error {

--- a/cmd/server/debug_embedding.go
+++ b/cmd/server/debug_embedding.go
@@ -8,14 +8,19 @@ import (
 	"trip2g/internal/mdchunk"
 )
 
+// debugEmbeddingEnabled gates /debug/embedding registration: vector search
+// must be on, and — since the endpoint is unauthenticated and can burn
+// embedding API/CPU — dev mode or the explicit --debug-embedding flag too.
+func (a *app) debugEmbeddingEnabled() bool {
+	return a.openaiClient != nil && (a.config.DevMode || a.config.DebugEmbedding)
+}
+
 // handleDebugEmbedding provides a step-by-step view of the indexing pipeline:
 // chunk splitting → embedding → response with timing and vector samples.
 //
 // POST /debug/embedding
 //
 //	{"title": "My Note", "content": "# Heading\n\nParagraph text..."}
-//
-// Only available on the internal server when vector search is enabled.
 func (a *app) handleDebugEmbedding(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "POST only", http.StatusMethodNotAllowed)

--- a/cmd/server/debug_embedding_test.go
+++ b/cmd/server/debug_embedding_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+
+	"trip2g/internal/appconfig"
+	"trip2g/internal/openai"
+
+	"github.com/stretchr/testify/require"
+)
+
+// /debug/embedding is unauthenticated and lets a caller burn embedding
+// API/CPU, so it must stay off in production unless explicitly enabled.
+func TestDebugEmbeddingEnabled(t *testing.T) {
+	client := &openai.Client{}
+
+	tests := []struct {
+		name           string
+		client         *openai.Client
+		devMode        bool
+		debugEmbedding bool
+		want           bool
+	}{
+		{"off in production by default", client, false, false, false},
+		{"on in dev mode", client, true, false, true},
+		{"on with explicit flag", client, false, true, true},
+		{"off without vector search even in dev", nil, true, true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &app{appState: &appState{
+				config:       &appconfig.Config{DevMode: tt.devMode, DebugEmbedding: tt.debugEmbedding},
+				openaiClient: tt.client,
+			}}
+			require.Equal(t, tt.want, a.debugEmbeddingEnabled())
+		})
+	}
+}

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -316,8 +316,7 @@ func (a *app) startInternalServer() {
 	debugMux.Handle("/debug/pprof/allocs", pprof.Handler("allocs"))
 
 	// Embedding debug endpoint — step-by-step pipeline: split → embed → JSON result.
-	// Only registered when vector search is enabled.
-	if a.openaiClient != nil {
+	if a.debugEmbeddingEnabled() {
 		debugMux.HandleFunc("/debug/embedding", a.handleDebugEmbedding)
 	}
 

--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -66,6 +66,10 @@ type Config struct {
 	WriterAcquireTimeout    time.Duration
 	GlobalQueuePollInterval time.Duration
 	InternalListenAddr      string
+	// DebugEmbedding exposes the unauthenticated /debug/embedding endpoint on
+	// the internal listener outside dev mode. It can drive arbitrary embedding
+	// API/CPU load, so it is off by default in production.
+	DebugEmbedding bool
 	// LeaderAddr, when non-empty, puts this instance in read-only replica mode:
 	// it serves safe (GET/HEAD/OPTIONS) requests locally off a replicated DB and
 	// reverse-proxies every mutating request to the leader's internal address
@@ -193,7 +197,10 @@ type CronJobsConfig struct {
 
 // Default values for configuration.
 const (
-	DefaultListenAddr           = ":8081"
+	DefaultListenAddr = ":8081"
+	// Loopback by default: the internal listener serves unauthenticated
+	// /metrics, pprof and debug endpoints and must not be world-exposed.
+	DefaultInternalListenAddr   = "127.0.0.1:8082"
 	DefaultDatabaseFile         = "data.sqlite3"
 	DefaultAdminJSURL           = "/assets/ui/admin/-/web.js"
 	DefaultLogLevel             = "info"
@@ -235,6 +242,7 @@ func DefaultStorageConfig() miniostorage.Config {
 func DefaultConfig() *Config {
 	return &Config{
 		ListenAddr:           DefaultListenAddr,
+		InternalListenAddr:   DefaultInternalListenAddr,
 		DatabaseFile:         DefaultDatabaseFile,
 		DevMode:              DefaultDevMode,
 		AdminJSURL:           DefaultAdminJSURL,
@@ -495,7 +503,9 @@ func (c *Config) defineServerFlags() {
 		"0 * * * * *",
 		"Cron schedule (6-field, with seconds) for the send_scheduled_telegram_publishposts job. Default every minute; the public cloud sets it hourly.",
 	)
-	flag.StringVar(&c.InternalListenAddr, "internal-listen-addr", ":8082", "Internal listen address (for health checks etc.)")
+	flag.StringVar(&c.InternalListenAddr, "internal-listen-addr", c.InternalListenAddr, "Internal listen address (for health checks etc.)")
+	flag.BoolVar(&c.DebugEmbedding, "debug-embedding", false,
+		"Expose the unauthenticated /debug/embedding endpoint on the internal listener (always on in --dev)")
 	flag.StringVar(
 		&c.LeaderAddr,
 		"leader-addr",

--- a/internal/appconfig/config_test.go
+++ b/internal/appconfig/config_test.go
@@ -1,0 +1,17 @@
+package appconfig
+
+import (
+	"strings"
+	"testing"
+)
+
+// The internal listener serves unauthenticated /metrics, pprof and debug
+// endpoints. Its default must bind loopback only, never all interfaces.
+func TestDefaultInternalListenAddrIsLoopback(t *testing.T) {
+	t.Parallel()
+
+	addr := DefaultConfig().InternalListenAddr
+	if !strings.HasPrefix(addr, "127.0.0.1:") {
+		t.Fatalf("internal listen default must be loopback (127.0.0.1:port), got %q", addr)
+	}
+}

--- a/internal/case/admin/setsecret/mocks_test.go
+++ b/internal/case/admin/setsecret/mocks_test.go
@@ -21,14 +21,23 @@ var _ setsecret.Env = &EnvMock{}
 //
 //		// make and configure a mocked setsecret.Env
 //		mockedEnv := &EnvMock{
+//			CronWebhookByIDFunc: func(ctx context.Context, id int64) (db.CronWebhook, error) {
+//				panic("mock out the CronWebhookByID method")
+//			},
 //			CurrentAdminUserTokenFunc: func(ctx context.Context) (*usertoken.Data, error) {
 //				panic("mock out the CurrentAdminUserToken method")
 //			},
 //			EncryptDataFunc: func(plaintext []byte) ([]byte, error) {
 //				panic("mock out the EncryptData method")
 //			},
+//			IsDevModeFunc: func() bool {
+//				panic("mock out the IsDevMode method")
+//			},
 //			UpsertSecretFunc: func(ctx context.Context, arg db.UpsertSecretParams) (db.Secret, error) {
 //				panic("mock out the UpsertSecret method")
+//			},
+//			WebhookByIDFunc: func(ctx context.Context, id int64) (db.ChangeWebhook, error) {
+//				panic("mock out the WebhookByID method")
 //			},
 //		}
 //
@@ -37,17 +46,33 @@ var _ setsecret.Env = &EnvMock{}
 //
 //	}
 type EnvMock struct {
+	// CronWebhookByIDFunc mocks the CronWebhookByID method.
+	CronWebhookByIDFunc func(ctx context.Context, id int64) (db.CronWebhook, error)
+
 	// CurrentAdminUserTokenFunc mocks the CurrentAdminUserToken method.
 	CurrentAdminUserTokenFunc func(ctx context.Context) (*usertoken.Data, error)
 
 	// EncryptDataFunc mocks the EncryptData method.
 	EncryptDataFunc func(plaintext []byte) ([]byte, error)
 
+	// IsDevModeFunc mocks the IsDevMode method.
+	IsDevModeFunc func() bool
+
 	// UpsertSecretFunc mocks the UpsertSecret method.
 	UpsertSecretFunc func(ctx context.Context, arg db.UpsertSecretParams) (db.Secret, error)
 
+	// WebhookByIDFunc mocks the WebhookByID method.
+	WebhookByIDFunc func(ctx context.Context, id int64) (db.ChangeWebhook, error)
+
 	// calls tracks calls to the methods.
 	calls struct {
+		// CronWebhookByID holds details about calls to the CronWebhookByID method.
+		CronWebhookByID []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ID is the id argument value.
+			ID int64
+		}
 		// CurrentAdminUserToken holds details about calls to the CurrentAdminUserToken method.
 		CurrentAdminUserToken []struct {
 			// Ctx is the ctx argument value.
@@ -58,6 +83,9 @@ type EnvMock struct {
 			// Plaintext is the plaintext argument value.
 			Plaintext []byte
 		}
+		// IsDevMode holds details about calls to the IsDevMode method.
+		IsDevMode []struct {
+		}
 		// UpsertSecret holds details about calls to the UpsertSecret method.
 		UpsertSecret []struct {
 			// Ctx is the ctx argument value.
@@ -65,10 +93,56 @@ type EnvMock struct {
 			// Arg is the arg argument value.
 			Arg db.UpsertSecretParams
 		}
+		// WebhookByID holds details about calls to the WebhookByID method.
+		WebhookByID []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ID is the id argument value.
+			ID int64
+		}
 	}
+	lockCronWebhookByID       sync.RWMutex
 	lockCurrentAdminUserToken sync.RWMutex
 	lockEncryptData           sync.RWMutex
+	lockIsDevMode             sync.RWMutex
 	lockUpsertSecret          sync.RWMutex
+	lockWebhookByID           sync.RWMutex
+}
+
+// CronWebhookByID calls CronWebhookByIDFunc.
+func (mock *EnvMock) CronWebhookByID(ctx context.Context, id int64) (db.CronWebhook, error) {
+	if mock.CronWebhookByIDFunc == nil {
+		panic("EnvMock.CronWebhookByIDFunc: method is nil but Env.CronWebhookByID was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+		ID  int64
+	}{
+		Ctx: ctx,
+		ID:  id,
+	}
+	mock.lockCronWebhookByID.Lock()
+	mock.calls.CronWebhookByID = append(mock.calls.CronWebhookByID, callInfo)
+	mock.lockCronWebhookByID.Unlock()
+	return mock.CronWebhookByIDFunc(ctx, id)
+}
+
+// CronWebhookByIDCalls gets all the calls that were made to CronWebhookByID.
+// Check the length with:
+//
+//	len(mockedEnv.CronWebhookByIDCalls())
+func (mock *EnvMock) CronWebhookByIDCalls() []struct {
+	Ctx context.Context
+	ID  int64
+} {
+	var calls []struct {
+		Ctx context.Context
+		ID  int64
+	}
+	mock.lockCronWebhookByID.RLock()
+	calls = mock.calls.CronWebhookByID
+	mock.lockCronWebhookByID.RUnlock()
+	return calls
 }
 
 // CurrentAdminUserToken calls CurrentAdminUserTokenFunc.
@@ -135,6 +209,33 @@ func (mock *EnvMock) EncryptDataCalls() []struct {
 	return calls
 }
 
+// IsDevMode calls IsDevModeFunc.
+func (mock *EnvMock) IsDevMode() bool {
+	if mock.IsDevModeFunc == nil {
+		panic("EnvMock.IsDevModeFunc: method is nil but Env.IsDevMode was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockIsDevMode.Lock()
+	mock.calls.IsDevMode = append(mock.calls.IsDevMode, callInfo)
+	mock.lockIsDevMode.Unlock()
+	return mock.IsDevModeFunc()
+}
+
+// IsDevModeCalls gets all the calls that were made to IsDevMode.
+// Check the length with:
+//
+//	len(mockedEnv.IsDevModeCalls())
+func (mock *EnvMock) IsDevModeCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockIsDevMode.RLock()
+	calls = mock.calls.IsDevMode
+	mock.lockIsDevMode.RUnlock()
+	return calls
+}
+
 // UpsertSecret calls UpsertSecretFunc.
 func (mock *EnvMock) UpsertSecret(ctx context.Context, arg db.UpsertSecretParams) (db.Secret, error) {
 	if mock.UpsertSecretFunc == nil {
@@ -168,5 +269,41 @@ func (mock *EnvMock) UpsertSecretCalls() []struct {
 	mock.lockUpsertSecret.RLock()
 	calls = mock.calls.UpsertSecret
 	mock.lockUpsertSecret.RUnlock()
+	return calls
+}
+
+// WebhookByID calls WebhookByIDFunc.
+func (mock *EnvMock) WebhookByID(ctx context.Context, id int64) (db.ChangeWebhook, error) {
+	if mock.WebhookByIDFunc == nil {
+		panic("EnvMock.WebhookByIDFunc: method is nil but Env.WebhookByID was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+		ID  int64
+	}{
+		Ctx: ctx,
+		ID:  id,
+	}
+	mock.lockWebhookByID.Lock()
+	mock.calls.WebhookByID = append(mock.calls.WebhookByID, callInfo)
+	mock.lockWebhookByID.Unlock()
+	return mock.WebhookByIDFunc(ctx, id)
+}
+
+// WebhookByIDCalls gets all the calls that were made to WebhookByID.
+// Check the length with:
+//
+//	len(mockedEnv.WebhookByIDCalls())
+func (mock *EnvMock) WebhookByIDCalls() []struct {
+	Ctx context.Context
+	ID  int64
+} {
+	var calls []struct {
+		Ctx context.Context
+		ID  int64
+	}
+	mock.lockWebhookByID.RLock()
+	calls = mock.calls.WebhookByID
+	mock.lockWebhookByID.RUnlock()
 	return calls
 }

--- a/internal/case/admin/setsecret/resolve.go
+++ b/internal/case/admin/setsecret/resolve.go
@@ -4,27 +4,94 @@ package setsecret
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"trip2g/internal/db"
+	"trip2g/internal/graph/model"
 	"trip2g/internal/usertoken"
+	"trip2g/internal/webhookutil"
 )
 
 type Env interface {
+	IsDevMode() bool
+	WebhookByID(ctx context.Context, id int64) (db.ChangeWebhook, error)
+	CronWebhookByID(ctx context.Context, id int64) (db.CronWebhook, error)
 	UpsertSecret(ctx context.Context, arg db.UpsertSecretParams) (db.Secret, error)
 	CurrentAdminUserToken(ctx context.Context) (*usertoken.Data, error)
 	EncryptData(plaintext []byte) ([]byte, error)
 }
 
-func Resolve(ctx context.Context, env Env, key, value string) error {
+// webhookTarget parses keys in the model.SecretPrefix format
+// ("change_webhooks:<id>:<name>" / "cron_webhooks:<id>:<name>").
+func webhookTarget(key string) (string, int64, bool) {
+	parts := strings.SplitN(key, ":", 3)
+	if len(parts) != 3 {
+		return "", 0, false
+	}
+	if parts[0] != "change_webhooks" && parts[0] != "cron_webhooks" {
+		return "", 0, false
+	}
+	id, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil || id <= 0 {
+		return "", 0, false
+	}
+	return parts[0], id, true
+}
+
+// validateWebhookURL rejects attaching a secret to a webhook whose URL is not
+// HTTPS: delivery would send the decrypted secret over cleartext. Same rule as
+// create/update webhook with pass_api_key.
+func validateWebhookURL(ctx context.Context, env Env, key string) (*model.ErrorPayload, error) {
+	entity, id, ok := webhookTarget(key)
+	if !ok {
+		return nil, nil
+	}
+
+	var whURL string
+	switch entity {
+	case "change_webhooks":
+		wh, err := env.WebhookByID(ctx, id)
+		if errors.Is(err, sql.ErrNoRows) {
+			return model.NewFieldError("key", fmt.Sprintf("webhook %d not found", id)), nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to load webhook %d: %w", id, err)
+		}
+		whURL = wh.Url
+	case "cron_webhooks":
+		wh, err := env.CronWebhookByID(ctx, id)
+		if errors.Is(err, sql.ErrNoRows) {
+			return model.NewFieldError("key", fmt.Sprintf("cron webhook %d not found", id)), nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to load cron webhook %d: %w", id, err)
+		}
+		whURL = wh.Url
+	}
+
+	if msg := webhookutil.RequireHTTPSUnlessDevMode(whURL, env.IsDevMode()); msg != "" {
+		return model.NewFieldError("key", msg), nil
+	}
+	return nil, nil
+}
+
+func Resolve(ctx context.Context, env Env, key, value string) (*model.ErrorPayload, error) {
 	token, err := env.CurrentAdminUserToken(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get current admin user token: %w", err)
+		return nil, fmt.Errorf("failed to get current admin user token: %w", err)
+	}
+
+	if errPayload, verr := validateWebhookURL(ctx, env, key); errPayload != nil || verr != nil {
+		return errPayload, verr
 	}
 
 	encrypted, err := env.EncryptData([]byte(value))
 	if err != nil {
-		return fmt.Errorf("failed to encrypt secret: %w", err)
+		return nil, fmt.Errorf("failed to encrypt secret: %w", err)
 	}
 
 	_, err = env.UpsertSecret(ctx, db.UpsertSecretParams{
@@ -33,8 +100,8 @@ func Resolve(ctx context.Context, env Env, key, value string) error {
 		CreatedBy:  int64(token.ID),
 	})
 	if err != nil {
-		return fmt.Errorf("failed to upsert secret: %w", err)
+		return nil, fmt.Errorf("failed to upsert secret: %w", err)
 	}
 
-	return nil
+	return nil, nil
 }

--- a/internal/case/admin/setsecret/resolve_test.go
+++ b/internal/case/admin/setsecret/resolve_test.go
@@ -33,6 +33,11 @@ func TestResolve(t *testing.T) {
 				mock.CurrentAdminUserTokenFunc = func(ctx context.Context) (*usertoken.Data, error) {
 					return &usertoken.Data{ID: 1}, nil
 				}
+				mock.IsDevModeFunc = func() bool { return false }
+				mock.WebhookByIDFunc = func(ctx context.Context, id int64) (db.ChangeWebhook, error) {
+					require.Equal(t, int64(1), id)
+					return db.ChangeWebhook{ID: 1, Url: "https://example.com/hook"}, nil
+				}
 				mock.EncryptDataFunc = func(plaintext []byte) ([]byte, error) {
 					return []byte("encrypted"), nil
 				}
@@ -98,7 +103,8 @@ func TestResolve(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			err := setsecret.Resolve(context.Background(), tt.mockFunc(), tt.key, tt.value)
+			errPayload, err := setsecret.Resolve(context.Background(), tt.mockFunc(), tt.key, tt.value)
+			require.Nil(t, errPayload)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -106,4 +112,100 @@ func TestResolve(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveRejectsNonHTTPSWebhook(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		key      string
+		mockFunc func() *envMock
+	}{
+		{
+			name: "http change webhook rejected",
+			key:  "change_webhooks:7:auth_token",
+			mockFunc: func() *envMock {
+				mock := &envMock{}
+				mock.CurrentAdminUserTokenFunc = func(ctx context.Context) (*usertoken.Data, error) {
+					return &usertoken.Data{ID: 1}, nil
+				}
+				mock.IsDevModeFunc = func() bool { return false }
+				mock.WebhookByIDFunc = func(ctx context.Context, id int64) (db.ChangeWebhook, error) {
+					require.Equal(t, int64(7), id)
+					return db.ChangeWebhook{ID: 7, Url: "http://evil.example.com/hook"}, nil
+				}
+				return mock
+			},
+		},
+		{
+			name: "uppercase HTTP change webhook rejected",
+			key:  "change_webhooks:7:auth_token",
+			mockFunc: func() *envMock {
+				mock := &envMock{}
+				mock.CurrentAdminUserTokenFunc = func(ctx context.Context) (*usertoken.Data, error) {
+					return &usertoken.Data{ID: 1}, nil
+				}
+				mock.IsDevModeFunc = func() bool { return false }
+				mock.WebhookByIDFunc = func(ctx context.Context, id int64) (db.ChangeWebhook, error) {
+					return db.ChangeWebhook{ID: 7, Url: "HTTP://evil.example.com/hook"}, nil
+				}
+				return mock
+			},
+		},
+		{
+			name: "http cron webhook rejected",
+			key:  "cron_webhooks:3:auth_token",
+			mockFunc: func() *envMock {
+				mock := &envMock{}
+				mock.CurrentAdminUserTokenFunc = func(ctx context.Context) (*usertoken.Data, error) {
+					return &usertoken.Data{ID: 1}, nil
+				}
+				mock.IsDevModeFunc = func() bool { return false }
+				mock.CronWebhookByIDFunc = func(ctx context.Context, id int64) (db.CronWebhook, error) {
+					require.Equal(t, int64(3), id)
+					return db.CronWebhook{ID: 3, Url: "http://evil.example.com/cron"}, nil
+				}
+				return mock
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mock := tt.mockFunc()
+			errPayload, err := setsecret.Resolve(context.Background(), mock, tt.key, "Bearer secret123")
+			require.NoError(t, err)
+			require.NotNil(t, errPayload)
+			require.Len(t, errPayload.ByFields, 1)
+			require.Equal(t, "key", errPayload.ByFields[0].Name)
+			require.Contains(t, errPayload.ByFields[0].Value, "https is required")
+			require.Empty(t, mock.UpsertSecretCalls(), "secret must not be stored for a non-HTTPS webhook")
+		})
+	}
+}
+
+func TestResolveDevModeAllowsHTTPWebhook(t *testing.T) {
+	t.Parallel()
+
+	mock := &envMock{}
+	mock.CurrentAdminUserTokenFunc = func(ctx context.Context) (*usertoken.Data, error) {
+		return &usertoken.Data{ID: 1}, nil
+	}
+	mock.IsDevModeFunc = func() bool { return true }
+	mock.WebhookByIDFunc = func(ctx context.Context, id int64) (db.ChangeWebhook, error) {
+		return db.ChangeWebhook{ID: 7, Url: "http://fleet:9099/deliver"}, nil
+	}
+	mock.EncryptDataFunc = func(plaintext []byte) ([]byte, error) {
+		return []byte("enc"), nil
+	}
+	mock.UpsertSecretFunc = func(ctx context.Context, arg db.UpsertSecretParams) (db.Secret, error) {
+		return db.Secret{Key: arg.Key}, nil
+	}
+
+	errPayload, err := setsecret.Resolve(context.Background(), mock, "change_webhooks:7:auth_token", "v")
+	require.NoError(t, err)
+	require.Nil(t, errPayload)
+	require.Len(t, mock.UpsertSecretCalls(), 1)
 }

--- a/internal/graph/schema.resolvers.go
+++ b/internal/graph/schema.resolvers.go
@@ -1328,8 +1328,17 @@ func (r *adminMutationResolver) RenderLayout(ctx context.Context, obj *appmodel.
 
 // SetSecret is the resolver for the setSecret field.
 func (r *adminMutationResolver) SetSecret(ctx context.Context, obj *appmodel.AdminMutation, input model.SetSecretInput) (*model.SetSecretPayload, error) {
-	if err := setsecret.Resolve(ctx, r.env(ctx), input.Key, input.Value); err != nil {
+	errPayload, err := setsecret.Resolve(ctx, r.env(ctx), input.Key, input.Value)
+	if err != nil {
 		return nil, err
+	}
+	// SetSecretPayload has no ErrorPayload union; surface validation failures
+	// as a GraphQL error so the client still sees the reason.
+	if errPayload != nil {
+		if len(errPayload.ByFields) > 0 {
+			return nil, fmt.Errorf("%s: %s", errPayload.ByFields[0].Name, errPayload.ByFields[0].Value)
+		}
+		return nil, fmt.Errorf("%s", errPayload.Message)
 	}
 	return &model.SetSecretPayload{Key: input.Key}, nil
 }

--- a/internal/webhookutil/https.go
+++ b/internal/webhookutil/https.go
@@ -13,19 +13,26 @@ import (
 // (e.g. e2e Docker compose where the fleet container is reachable only via its
 // compose service name, which is not a loopback address).
 func RequireHTTPS(rawURL string) string {
-	if !strings.HasPrefix(rawURL, "http://") {
-		return "" // https:// or non-http: let other validators handle it
-	}
-	u, err := url.Parse(rawURL)
+	u, err := url.Parse(strings.TrimSpace(rawURL))
 	if err != nil {
+		// Unparseable AND smells like plain http (any case, any spacing):
+		// fail closed rather than let a mangled cleartext URL through.
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(rawURL)), "http://") {
+			return httpsRequiredMsg
+		}
 		return "" // malformed URL handled elsewhere
+	}
+	if !strings.EqualFold(u.Scheme, "http") {
+		return "" // https:// or non-http: let other validators handle it
 	}
 	h := u.Hostname()
 	if h == "localhost" || h == "127.0.0.1" || h == "::1" {
 		return "" // loopback allowed in dev
 	}
-	return "https is required when pass_api_key is enabled (secrets and tokens must not travel over cleartext)"
+	return httpsRequiredMsg
 }
+
+const httpsRequiredMsg = "https is required when pass_api_key is enabled (secrets and tokens must not travel over cleartext)"
 
 // RequireHTTPSUnlessDevMode is like RequireHTTPS but skips the check when
 // devMode is true. Use this in use-case resolvers that have access to the

--- a/internal/webhookutil/https_test.go
+++ b/internal/webhookutil/https_test.go
@@ -18,6 +18,9 @@ func TestRequireHTTPS(t *testing.T) {
 		{"http 127.0.0.1 allows", "http://127.0.0.1/hook", false},
 		{"http ::1 allows", "http://[::1]/hook", false},
 		{"other scheme silent", "ftp://example.com", false},
+		{"HTTP uppercase rejects", "HTTP://example.com/hook", true},
+		{"HtTp mixed case rejects", "HtTp://example.com/hook", true},
+		{"http with leading whitespace rejects", "  http://example.com/hook", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Two P1 security findings from the audit, test-first.

**1. Secret could be attached to a cleartext (HTTP) webhook; scheme check was case-sensitive.** `webhookutil.RequireHTTPS` used `strings.HasPrefix(url, "http://")`, so `HTTP://` / `HtTp://` slipped through. And `setSecret` never re-checked the target webhook's scheme (HTTPS was only enforced at create/update). Fix: `RequireHTTPS` now `url.Parse`s and compares scheme with `EqualFold`; `setsecret.Resolve` loads the target webhook (from the `change_webhooks:<id>:`/`cron_webhooks:<id>:` key prefix) and rejects attaching a secret unless it's HTTPS (dev-mode exempt, same as create/update). Tests: `TestRequireHTTPS` uppercase/mixed-case/whitespace cases + `TestResolveRejectsNonHTTPSWebhook`.

**2. Internal listener bound all interfaces; debug-embedding endpoint was unauthenticated.** Default `InternalListenAddr` was `:8082` (0.0.0.0), exposing /metrics, pprof, and an unauthenticated embedding-debug endpoint (embedding-API/CPU burn). Fix: default changed to `127.0.0.1:8082` (still overridable via flag/env); `/debug/embedding` now gated behind `DevMode || --debug-embedding` (off in prod), mirroring the existing DevMode/EnableNotFoundTracking gating. Tests: `TestDefaultInternalListenAddrIsLoopback`, `TestDebugEmbeddingEnabled`.

No SQL migration. `go build ./...`, full `go test ./...`, `go vet`, `make lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)