### PR TITLE
fix: remaining audit red tests (webhook scope, signin limit, search privacy, secret leak, embed, docker)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,9 @@ RUN mkdir fragment && \
 
 COPY ./assets/ui ./trip2g
 
-RUN npm install
+# typescript 7 dropped convertCompilerOptionsFromJson which the mam builder uses;
+# pin via overrides so the `npm update` inside `npm start` can't bump it
+RUN npm pkg set overrides.typescript=6.0.3 && npm install
 
 RUN npm start trip2g && \
     npm start trip2g/user && \

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -519,7 +519,6 @@ func parseFlags(ctx context.Context) (cliFlags, error) {
 		FlagSet:           fs,
 		EnvPrefix:         "TRIP2G_FLEET_",
 		ShowEnvKeyInUsage: true,
-		ShowEnvValInUsage: true,
 	})
 
 	if err := ef.Parse(ctx, os.Args[1:]); err != nil {

--- a/internal/appconfig/envflag.go
+++ b/internal/appconfig/envflag.go
@@ -20,7 +20,6 @@ type EnvFlag struct {
 	minLength         int
 	envFlagDict       map[string]string
 	showEnvKeyInUsage bool
-	showEnvValInUsage bool
 	envPrefix         string
 	logger            logger.Logger
 }
@@ -31,7 +30,6 @@ type EnvFlagConfig struct {
 	MinLength         int
 	EnvFlagDict       map[string]string
 	ShowEnvKeyInUsage bool
-	ShowEnvValInUsage bool
 	// EnvPrefix, when set, restricts processing to env vars with this prefix.
 	// Prefixed vars that don't match any flag are treated as errors (likely typos).
 	// Example: "TRIP2G_" makes TRIP2G_LISTEN_ADDR map to flag listen-addr.
@@ -46,7 +44,6 @@ func DefaultEnvFlagConfig() EnvFlagConfig {
 		MinLength:         3,
 		EnvFlagDict:       make(map[string]string),
 		ShowEnvKeyInUsage: true,
-		ShowEnvValInUsage: true,
 		EnvPrefix:         "TRIP2G_",
 		Logger:            &logger.DummyLogger{},
 	}
@@ -69,21 +66,20 @@ func New(cfg EnvFlagConfig) *EnvFlag {
 		minLength:         cfg.MinLength,
 		envFlagDict:       cfg.EnvFlagDict,
 		showEnvKeyInUsage: cfg.ShowEnvKeyInUsage,
-		showEnvValInUsage: cfg.ShowEnvValInUsage,
 		envPrefix:         cfg.EnvPrefix,
 		logger:            cfg.Logger,
 	}
 }
 
 // ProcessError represents an error that occurred during flag processing.
+// The value is intentionally omitted — env-loaded values may be secrets.
 type ProcessError struct {
-	Flag  string
-	Value string
-	Err   error
+	Flag string
+	Err  error
 }
 
 func (e *ProcessError) Error() string {
-	return fmt.Sprintf("error setting flag %q to %q: %v", e.Flag, e.Value, e.Err)
+	return fmt.Sprintf("error setting flag %q: %v", e.Flag, e.Err)
 }
 
 func (e *ProcessError) Unwrap() error {
@@ -228,11 +224,9 @@ func (ef *EnvFlag) processEnvLine(envLine string, _ map[string]string) (string, 
 		return "", nil
 	}
 
-	ef.logger.Debug("processing environment variable", "envKey", key, "flagKey", flagKey, "value", value)
-
-	if ef.showEnvValInUsage {
-		f.DefValue = value
-	}
+	// Never log or expose the value: env-loaded values may be secrets, and
+	// setting them as the flag's printable default would leak them via --help.
+	ef.logger.Debug("processing environment variable", "envKey", key, "flagKey", flagKey)
 
 	err := ef.flagSet.Set(flagKey, value)
 	if err != nil {
@@ -240,13 +234,11 @@ func (ef *EnvFlag) processEnvLine(envLine string, _ map[string]string) (string, 
 			"failed to set flag from environment variable",
 			"envKey", key,
 			"flagKey", flagKey,
-			"value", value,
 			"error", err,
 		)
 		return "", &ProcessError{
-			Flag:  flagKey,
-			Value: value,
-			Err:   err,
+			Flag: flagKey,
+			Err:  err,
 		}
 	}
 
@@ -335,11 +327,6 @@ func SetEnvFlagDict(v map[string]string) {
 // SetShowEnvKeyInUsage controls whether environment variable names are shown in usage.
 func SetShowEnvKeyInUsage(v bool) {
 	std.showEnvKeyInUsage = v
-}
-
-// SetShowEnvValInUsage controls whether environment variable values are shown as defaults.
-func SetShowEnvValInUsage(v bool) {
-	std.showEnvValInUsage = v
 }
 
 // SetLogger sets the logger for the standard instance.

--- a/internal/appconfig/envflag_test.go
+++ b/internal/appconfig/envflag_test.go
@@ -1,0 +1,32 @@
+package appconfig
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Environment-backed secrets may configure a flag, but they must never become
+// that flag's printable default: flag.PrintDefaults is what powers --help.
+func TestProcessWithEnv_HelpDoesNotExposeSecretValue(t *testing.T) {
+	const secret = "ENV-SECRET-CANARY"
+	t.Setenv("REGRESSION_JWT_SECRET", secret)
+
+	var usage bytes.Buffer
+	flags := flag.NewFlagSet("env-help", flag.ContinueOnError)
+	flags.SetOutput(&usage)
+	flags.String("jwt-secret", "", "JWT signing secret")
+
+	cfg := DefaultEnvFlagConfig()
+	cfg.FlagSet = flags
+	cfg.EnvPrefix = "REGRESSION_"
+	envFlags := New(cfg)
+
+	require.NoError(t, envFlags.ProcessWithEnv(context.Background()))
+	flags.PrintDefaults()
+	require.NotContains(t, usage.String(), secret,
+		"--help output must not expose secret values loaded from the environment")
+}

--- a/internal/case/backjob/deliverchangewebhook/resolve.go
+++ b/internal/case/backjob/deliverchangewebhook/resolve.go
@@ -92,7 +92,7 @@ func Resolve(ctx context.Context, env Env, params handlenotewebhooks.DeliverChan
 		readPatterns, rpErr := webhookutil.ParseJSONStringArray(wh.ReadPatterns)
 		if rpErr != nil {
 			log.Error("failed to parse read_patterns", "webhook_id", wh.ID, "error", rpErr)
-			readPatterns = []string{"**"}
+			readPatterns = []string{} // fail closed: malformed scope grants nothing
 		}
 
 		ttl := time.Duration(wh.TimeoutSeconds)*time.Second + tokenTTLMargin

--- a/internal/case/backjob/deliverchangewebhook/resolve_test.go
+++ b/internal/case/backjob/deliverchangewebhook/resolve_test.go
@@ -14,6 +14,7 @@ import (
 	"trip2g/internal/db"
 	"trip2g/internal/logger"
 	"trip2g/internal/model"
+	"trip2g/internal/shortapitoken"
 	"trip2g/internal/webhookutil"
 
 	"github.com/stretchr/testify/require"
@@ -127,6 +128,39 @@ func TestResolve_TokenTTLHasNoSixtyMinuteFloor(t *testing.T) {
 	tok, _ := payload["api_token"].(string)
 	require.NotEmpty(t, tok)
 	require.Less(t, tokenLifetimeSeconds(t, tok), int64(300), "60-min floor must be gone; TTL ~= timeout + margin")
+}
+
+// A malformed scope is invalid configuration, not permission to read every
+// note. If delivery continues with a token, that token must be deny-all.
+func TestResolve_MalformedReadPatternsFailClosed(t *testing.T) {
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	env := baseEnv(t, srv.URL, nil)
+	env.WebhookByIDFunc = func(_ context.Context, id int64) (db.ChangeWebhook, error) {
+		return db.ChangeWebhook{
+			ID: id, Url: srv.URL, TimeoutSeconds: 10, PassApiKey: true,
+			ReadPatterns: `{malformed`, WritePatterns: `[]`,
+		}, nil
+	}
+
+	err := deliverchangewebhook.Resolve(context.Background(), env,
+		handlenotewebhooks.DeliverChangeWebhookParams{WebhookID: 1, DeliveryID: 101, Attempt: 1})
+	require.NoError(t, err)
+
+	var payload struct {
+		APIToken string `json:"api_token"`
+	}
+	require.NoError(t, json.Unmarshal(body, &payload))
+	require.NotEmpty(t, payload.APIToken)
+	claims, err := shortapitoken.Parse(payload.APIToken, "test-secret")
+	require.NoError(t, err)
+	require.Empty(t, claims.ReadPatterns,
+		"malformed read_patterns must not become an all-notes scope")
 }
 
 func TestResolve_LoggedRequestBodyRedactsTokenAndSecrets(t *testing.T) {

--- a/internal/case/backjob/delivercronwebhook/resolve.go
+++ b/internal/case/backjob/delivercronwebhook/resolve.go
@@ -133,7 +133,7 @@ func Resolve(ctx context.Context, env Env, params DeliverCronParams) error {
 		readPatterns, rpErr := webhookutil.ParseJSONStringArray(wh.ReadPatterns)
 		if rpErr != nil {
 			log.Error("failed to parse read_patterns", "cron_webhook_id", wh.ID, "error", rpErr)
-			readPatterns = []string{"**"}
+			readPatterns = []string{} // fail closed: malformed scope grants nothing
 		}
 
 		ttl := time.Duration(wh.TimeoutSeconds)*time.Second + tokenTTLMargin

--- a/internal/case/backjob/delivercronwebhook/resolve_test.go
+++ b/internal/case/backjob/delivercronwebhook/resolve_test.go
@@ -11,6 +11,7 @@ import (
 	"trip2g/internal/db"
 	"trip2g/internal/logger"
 	"trip2g/internal/model"
+	"trip2g/internal/shortapitoken"
 	"trip2g/internal/webhookutil"
 
 	"github.com/stretchr/testify/require"
@@ -108,6 +109,39 @@ func TestResolve_NoSecrets_FieldOmitted(t *testing.T) {
 	require.NoError(t, json.Unmarshal(body, &payload))
 	_, hasSecrets := payload["secrets"]
 	require.False(t, hasSecrets, "secrets field should be omitted when no secrets exist")
+}
+
+// Cron webhooks share the scoped token path with change webhooks. Invalid JSON
+// must not silently widen the token to read every note.
+func TestResolve_MalformedReadPatternsFailClosed(t *testing.T) {
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	env := baseEnv(t, srv.URL, nil)
+	env.CronWebhookByIDFunc = func(_ context.Context, id int64) (db.CronWebhook, error) {
+		return db.CronWebhook{
+			ID: id, Url: srv.URL, TimeoutSeconds: 10, PassApiKey: true,
+			ReadPatterns: `{malformed`, WritePatterns: `[]`,
+		}, nil
+	}
+
+	err := delivercronwebhook.Resolve(context.Background(), env,
+		delivercronwebhook.DeliverCronParams{CronWebhookID: 1, DeliveryID: 601, Attempt: 1})
+	require.NoError(t, err)
+
+	var payload struct {
+		APIToken string `json:"api_token"`
+	}
+	require.NoError(t, json.Unmarshal(body, &payload))
+	require.NotEmpty(t, payload.APIToken)
+	claims, err := shortapitoken.Parse(payload.APIToken, "test-secret")
+	require.NoError(t, err)
+	require.Empty(t, claims.ReadPatterns,
+		"malformed read_patterns must not become an all-notes scope")
 }
 
 // F2: applyCronAgentChanges with empty write_patterns must deny all writes (was: allow all).

--- a/internal/case/requestemailsignin/resolve.go
+++ b/internal/case/requestemailsignin/resolve.go
@@ -102,7 +102,7 @@ func Resolve(ctx context.Context, env Env, input Input, remoteIP string) (model.
 		return nil, fmt.Errorf("failed to count active signin codes: %w", err)
 	}
 
-	if count > env.MaxActiveSignInCodes() {
+	if count >= env.MaxActiveSignInCodes() {
 		return &model.ErrorPayload{Message: "too_many_sign_in_codes"}, nil
 	}
 

--- a/internal/case/requestemailsignin/resolve_test.go
+++ b/internal/case/requestemailsignin/resolve_test.go
@@ -143,3 +143,21 @@ func TestMaxActiveSignInCodes_BelowLimit(t *testing.T) {
 	require.True(t, ok, "expected RequestEmailSignInCodePayload, got %T", result)
 	require.True(t, payload.Success)
 }
+
+// At count == limit, creating one more code would exceed the configured
+// maximum. The boundary therefore has to reject before CreateSignInCode.
+func TestMaxActiveSignInCodes_AtLimitRejected(t *testing.T) {
+	env := fullFlowEnv("")
+	env.MaxActiveSignInCodesFunc = func() int64 { return 3 }
+	env.CountActiveSignInCodesFunc = func(_ context.Context, _ int64) (int64, error) {
+		return 3, nil
+	}
+
+	result, err := Resolve(context.Background(), env, Input{Email: "user@example.com"}, "")
+	require.NoError(t, err)
+
+	errPayload, ok := result.(*model.ErrorPayload)
+	require.True(t, ok, "count == limit must return ErrorPayload, got %T", result)
+	require.Equal(t, "too_many_sign_in_codes", errPayload.Message)
+	require.Empty(t, env.CreateSignInCodeCalls(), "must not create a code once the limit is reached")
+}

--- a/internal/enclavefix/enclavefix_test.go
+++ b/internal/enclavefix/enclavefix_test.go
@@ -71,7 +71,7 @@ func TestTradingViewSymbolCannotBreakOutOfScript(t *testing.T) {
 	html := buf.String()
 	require.NotContains(t, html, `<script`)
 	require.NotContains(t, html, `";alert`)
-	require.Contains(t, html, `&#34;;alert(1);//`)
+	require.NotContains(t, html, `alert(1)`, "rejected symbols are redacted, not echoed")
 	require.Contains(t, html, "Failed to load tradingview")
 }
 

--- a/internal/enclavefix/render.go
+++ b/internal/enclavefix/render.go
@@ -22,7 +22,18 @@ var (
 	imageSizePattern         = regexp.MustCompile(`^[0-9]+(?:%|px|rem)?$`)
 	unitlessImageSizePattern = regexp.MustCompile(`^[0-9]+$`)
 	difyPathPattern          = regexp.MustCompile(`^/chatbot/[A-Za-z0-9_-]+/?$`)
+	errorEchoIDPattern       = regexp.MustCompile(`^[A-Za-z0-9@/_:.,~-]*$`)
 )
+
+// SafeErrorEchoID returns an embed ID safe to echo in an error message.
+// A rejected ID may carry markup or attribute fragments; those are replaced
+// with a placeholder instead of being reflected back into the page.
+func SafeErrorEchoID(id string) string {
+	if errorEchoIDPattern.MatchString(id) {
+		return id
+	}
+	return "(invalid id)"
+}
 
 // ValidEmbedID reports whether an embed identifier is safe for the provider's
 // downstream HTML/JavaScript template. It is shared with mdloader, which has a
@@ -290,7 +301,7 @@ func styleImageDimension(value string) string {
 func (r *HTMLRenderer) wrapEnclaveErrorHtml(enclaveName, objectID string) string {
 	html := fmt.Sprintf(
 		`<div class="enclave-object-wrapper normal-wrapper"><div class="enclave-object %s-enclave-object error">Failed to load %s from %s</div></div>`,
-		html.EscapeString(enclaveName), html.EscapeString(enclaveName), html.EscapeString(objectID),
+		html.EscapeString(enclaveName), html.EscapeString(enclaveName), html.EscapeString(SafeErrorEchoID(objectID)),
 	)
 	return html
 }

--- a/internal/enclavefix/security_test.go
+++ b/internal/enclavefix/security_test.go
@@ -1,0 +1,30 @@
+package enclavefix_test
+
+import (
+	"bytes"
+	"testing"
+
+	"trip2g/internal/enclavefix"
+
+	enclavecore "github.com/quailyquaily/goldmark-enclave/core"
+	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark"
+)
+
+func TestYouTubeVideoIDCannotInjectHTMLAttribute(t *testing.T) {
+	md := goldmark.New(
+		goldmark.WithExtensions(
+			enclavefix.New(&enclavecore.Config{}),
+		),
+	)
+
+	// Once decoded as a query parameter, the video ID closes the generated
+	// src attribute and attempts to add another HTML attribute.
+	source := []byte(`![](https://www.youtube.com/watch?v=video-id%22%20onload%3D%22trip2g-marker%22%20data-x%3D%22)`)
+
+	var buf bytes.Buffer
+	require.NoError(t, md.Convert(source, &buf))
+
+	require.NotContains(t, buf.String(), " onload=",
+		"an untrusted YouTube video ID must remain data inside the src attribute")
+}

--- a/internal/noteloader/loader.go
+++ b/internal/noteloader/loader.go
@@ -83,8 +83,9 @@ type Loader struct {
 
 	layouts *model.Layouts
 
-	searchIndex   bleve.Index
-	contentHashes map[int64][32]byte // PathID -> content hash for incremental indexing
+	searchIndex       bleve.Index
+	contentHashes     map[int64][32]byte // PathID -> content hash for incremental indexing
+	indexedPermalinks map[int64]string   // PathID -> permalink of docs currently in the index
 
 	chunks []model.NoteChunk // per-chunk embeddings for vector search
 

--- a/internal/noteloader/search.go
+++ b/internal/noteloader/search.go
@@ -69,9 +69,27 @@ func contentHash(note *model.NoteView) [32]byte {
 	h := sha256.New()
 	h.Write([]byte(note.Title))
 	h.Write(note.Content)
+	// Visibility is part of the hash: toggling search:false alone must not be
+	// skipped as "unchanged".
+	if note.ExcludeSearch {
+		h.Write([]byte{1})
+	}
 	var result [32]byte
 	copy(result[:], h.Sum(nil))
 	return result
+}
+
+// removeFromIndex deletes a previously indexed document, if any.
+func (l *Loader) removeFromIndex(index bleve.Index, pathID int64) error {
+	permalink, ok := l.indexedPermalinks[pathID]
+	if !ok {
+		return nil
+	}
+	if err := index.Delete(permalink); err != nil {
+		return fmt.Errorf("failed to delete note %s from index: %w", permalink, err)
+	}
+	delete(l.indexedPermalinks, pathID)
+	return nil
 }
 
 func (l *Loader) buildSearchIndex(notes *model.NoteViews) (bleve.Index, error) {
@@ -91,6 +109,9 @@ func (l *Loader) buildSearchIndex(notes *model.NoteViews) (bleve.Index, error) {
 	if l.contentHashes == nil {
 		l.contentHashes = make(map[int64][32]byte)
 	}
+	if l.indexedPermalinks == nil {
+		l.indexedPermalinks = make(map[int64]string)
+	}
 
 	// Track current PathIDs to detect deleted notes
 	currentPathIDs := make(map[int64]struct{})
@@ -109,13 +130,13 @@ func (l *Loader) buildSearchIndex(notes *model.NoteViews) (bleve.Index, error) {
 			continue
 		}
 
-		if note.ExcludeSearch {
-			continue
-		}
-
-		// Raw files (.canvas, .base, .excalidraw) have no AST — skip indexing.
-		// They aren't markdown, no meaningful text to search anyway.
-		if note.Ast() == nil {
+		// Raw files (.canvas, .base, .excalidraw) have no AST — nothing to index.
+		// A note that became hidden or raw may still be in the index — delete it.
+		if note.ExcludeSearch || note.Ast() == nil {
+			if delErr := l.removeFromIndex(index, note.PathID); delErr != nil {
+				return nil, delErr
+			}
+			l.contentHashes[note.PathID] = hash
 			continue
 		}
 
@@ -130,6 +151,7 @@ func (l *Loader) buildSearchIndex(notes *model.NoteViews) (bleve.Index, error) {
 		}
 
 		l.contentHashes[note.PathID] = hash
+		l.indexedPermalinks[note.PathID] = note.Permalink
 		indexed++
 	}
 
@@ -137,8 +159,9 @@ func (l *Loader) buildSearchIndex(notes *model.NoteViews) (bleve.Index, error) {
 	deleted := 0
 	for pathID := range l.contentHashes {
 		if _, exists := currentPathIDs[pathID]; !exists {
-			// Note was deleted, but we don't have permalink to delete from index
-			// Just remove from hashes map
+			if delErr := l.removeFromIndex(index, pathID); delErr != nil {
+				return nil, delErr
+			}
 			delete(l.contentHashes, pathID)
 			deleted++
 		}

--- a/internal/noteloader/search_test.go
+++ b/internal/noteloader/search_test.go
@@ -139,6 +139,42 @@ func TestEnglishStemming(t *testing.T) {
 	require.True(t, hasURL(resRu, "/ru-note"), "russian query should still match russian note")
 }
 
+// Toggling search:false is an access decision even when title/content did not
+// change. An incremental rebuild must remove the document already in Bleve.
+func TestIncrementalIndexing_RemovesNoteWhenSearchDisabled(t *testing.T) {
+	loader := &Loader{log: &logger.TestLogger{}}
+	const canary = "privacysearchcanary"
+
+	visible := createNoteWithAST(42, "/private-later", "Initially searchable", []byte(canary))
+	before := model.NewNoteViews()
+	before.List = []*model.NoteView{visible}
+	before.Map[visible.Permalink] = visible
+
+	index, err := loader.buildSearchIndex(before)
+	require.NoError(t, err)
+	loader.searchIndex = index
+	loader.nvs = before
+
+	results, err := loader.Search(canary)
+	require.NoError(t, err)
+	require.Len(t, results, 1, "precondition: note must initially be indexed")
+
+	hidden := createNoteWithAST(42, "/private-later", "Initially searchable", []byte(canary))
+	hidden.ExcludeSearch = true
+	after := model.NewNoteViews()
+	after.List = []*model.NoteView{hidden}
+	after.Map[hidden.Permalink] = hidden
+
+	index, err = loader.buildSearchIndex(after)
+	require.NoError(t, err)
+	loader.searchIndex = index
+	loader.nvs = after
+
+	results, err = loader.Search(canary)
+	require.NoError(t, err)
+	require.Empty(t, results, "search:false must remove an already-indexed document")
+}
+
 func hasURL(res []model.SearchResult, url string) bool {
 	for _, r := range res {
 		if r.URL == url {


### PR DESCRIPTION
Closes the remaining red tests from the audit, each landed test-first as an atomic commit.

- **fail closed on malformed read_patterns** (deliverchange/delivercron webhooks) — invalid scope JSON no longer fails open to an all-notes `[**]` token; it now denies. `TestResolve_MalformedReadPatternsFailClosed`.
- **reject sign-in code creation at the active-code limit** — off-by-one (`count > max` → `>=`), so the Nth code isn't created past the cap. `TestMaxActiveSignInCodes_AtLimitRejected`.
- **remove an already-indexed note when search is disabled or the note is deleted** — toggling `search:false` now drops the doc from the Bleve index (was still searchable). `TestIncrementalIndexing_RemovesNoteWhenSearchDisabled`.
- **stop exposing env-loaded flag values in --help and logs** — env-backed secrets no longer become the printable flag default or land in debug/error logs. `TestProcessWithEnv_HelpDoesNotExposeSecretValue`.
- **redact rejected embed IDs from enclave error messages** — the residual embed-XSS vector at the enclave transformer/render layer (not covered by the earlier renderer fix). `TestYouTubeVideoIDCannotInjectHTMLAttribute`.
- **pin typescript 6.0.3 for the mam builder** — TS 7 dropped `convertCompilerOptionsFromJson`; Dockerfile pins via `npm pkg set overrides`.

`go build ./...`, full `go test ./...`, `go vet`, `make lint` all clean. No SQL migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)