### PR TITLE
fix: prevalidate agent/webhook batches (CAS + all-or-nothing validation)

### DIFF
--- a/internal/case/backjob/deliverchangewebhook/resolve.go
+++ b/internal/case/backjob/deliverchangewebhook/resolve.go
@@ -355,7 +355,10 @@ func TransformExtVarsForTest(payloadBytes []byte) map[string]string {
 	return transformExtVars(payloadBytes)
 }
 
-// applyAgentChanges parses and applies agent response changes.
+// applyAgentChanges parses, validates, and applies agent response changes.
+// The whole batch is validated (write patterns, expected_hash CAS, patch
+// resolution) before any item is written, so an invalid item rejects the
+// batch without partial application.
 func applyAgentChanges(ctx context.Context, env Env, result webhookutil.DeliveryResult, writePatterns []string) error {
 	agentResp, parseErr := webhookutil.ParseAgentResponse(result.Body)
 	if parseErr != nil {
@@ -365,49 +368,14 @@ func applyAgentChanges(ctx context.Context, env Env, result webhookutil.Delivery
 		return nil
 	}
 
-	// Read the current note views once; needed for patch operations.
-	nvs := env.LatestNoteViews()
+	notes, resolveErr := webhookutil.ResolveAgentChanges(agentResp.Changes, env.LatestNoteViews(), writePatterns)
+	if resolveErr != nil {
+		return resolveErr
+	}
 
-	for _, change := range agentResp.Changes {
-		// Deny-all when write_patterns is empty: a webhook delivery is always a
-		// scoped context, so an empty list means "no writes permitted" rather
-		// than "allow all". Also deny on no-match when non-empty.
-		if len(writePatterns) == 0 || !webhookutil.MatchesAny(change.Path, writePatterns) {
-			return fmt.Errorf("path %q not allowed by write_patterns", change.Path)
-		}
-
-		var content string
-		if change.IsPatch() { //nolint:nestif // patch requires sequential null-checks before string ops
-			// Apply find/replace against the note's current content.
-			// Matches updateNotes Patch semantics: find must be present exactly once.
-			if nvs == nil {
-				return fmt.Errorf("note not found for patch: %s", change.Path)
-			}
-			nv := nvs.PathMap[change.Path]
-			if nv == nil {
-				return fmt.Errorf("note not found for patch: %s", change.Path)
-			}
-			current := string(nv.Content)
-			idx := strings.Index(current, change.Find)
-			if idx == -1 {
-				return fmt.Errorf("patch find string not found in %s", change.Path)
-			}
-			// Reject ambiguous finds (multiple occurrences) to match updateNotes Patch semantics.
-			if strings.Contains(current[idx+len(change.Find):], change.Find) {
-				return fmt.Errorf("patch find string is ambiguous (multiple occurrences) in %s", change.Path)
-			}
-			content = current[:idx] + change.Replace + current[idx+len(change.Find):]
-		} else {
-			// Kind=="" or "upsert": upsert with provided content.
-			content = change.Content
-		}
-
-		_, insertErr := env.InsertNote(ctx, model.RawNote{
-			Path:    change.Path,
-			Content: content,
-		})
-		if insertErr != nil {
-			return fmt.Errorf("failed to apply change for %s: %w", change.Path, insertErr)
+	for _, note := range notes {
+		if _, insertErr := env.InsertNote(ctx, note); insertErr != nil {
+			return fmt.Errorf("failed to apply change for %s: %w", note.Path, insertErr)
 		}
 	}
 

--- a/internal/case/backjob/deliverchangewebhook/resolve_test.go
+++ b/internal/case/backjob/deliverchangewebhook/resolve_test.go
@@ -493,6 +493,130 @@ func TestResolve_AgentChanges_PatchKind_FindReplace(t *testing.T) {
 	require.Equal(t, "# Todo\nHELLO world\n", insertedNote.Content, "patch must replace find→replace in existing content, not empty it")
 }
 
+// P1: a change carrying a stale expected_hash must not overwrite the current note.
+func TestResolve_AgentChanges_StaleExpectedHash_Rejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok","changes":[{"path":"notes/todo.md","content":"clobber","expected_hash":"stale"}]}`))
+	}))
+	defer srv.Close()
+
+	nvs := model.NewNoteViews()
+	nvs.PathMap["notes/todo.md"] = &model.NoteView{Path: "notes/todo.md", Content: []byte("# Todo\ncurrent\n")}
+
+	env := baseEnv(t, srv.URL, nil)
+	env.WebhookByIDFunc = func(_ context.Context, id int64) (db.ChangeWebhook, error) {
+		return db.ChangeWebhook{
+			ID:             id,
+			Url:            srv.URL,
+			TimeoutSeconds: 10,
+			MaxRetries:     1,
+			WritePatterns:  `["notes/**"]`,
+			ReadPatterns:   "[]",
+		}, nil
+	}
+	env.LatestNoteViewsFunc = func() *model.NoteViews { return nvs }
+
+	insertCalled := false
+	env.InsertNoteFunc = func(_ context.Context, _ model.RawNote) (int64, error) {
+		insertCalled = true
+		return 0, nil
+	}
+
+	var got db.UpdateWebhookDeliveryResultParams
+	env.UpdateWebhookDeliveryResultFunc = func(_ context.Context, arg db.UpdateWebhookDeliveryResultParams) error {
+		got = arg
+		return nil
+	}
+
+	err := deliverchangewebhook.Resolve(context.Background(), env,
+		handlenotewebhooks.DeliverChangeWebhookParams{WebhookID: 1, DeliveryID: 30, Attempt: 1})
+	require.NoError(t, err)
+	require.False(t, insertCalled, "InsertNote must not be called when expected_hash is stale")
+	require.Equal(t, "failed", got.Status, "delivery must be marked failed on hash mismatch")
+}
+
+// P1: a change carrying the correct expected_hash must still apply.
+func TestResolve_AgentChanges_MatchingExpectedHash_Applied(t *testing.T) {
+	const noteContent = "# Todo\ncurrent\n"
+	currentHash := webhookutil.HashContent([]byte(noteContent))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		resp := `{"status":"ok","changes":[{"path":"notes/todo.md","content":"updated","expected_hash":"` + currentHash + `"}]}`
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer srv.Close()
+
+	nvs := model.NewNoteViews()
+	nvs.PathMap["notes/todo.md"] = &model.NoteView{Path: "notes/todo.md", Content: []byte(noteContent)}
+
+	env := baseEnv(t, srv.URL, nil)
+	env.WebhookByIDFunc = func(_ context.Context, id int64) (db.ChangeWebhook, error) {
+		return db.ChangeWebhook{
+			ID:             id,
+			Url:            srv.URL,
+			TimeoutSeconds: 10,
+			WritePatterns:  `["notes/**"]`,
+			ReadPatterns:   "[]",
+		}, nil
+	}
+	env.LatestNoteViewsFunc = func() *model.NoteViews { return nvs }
+	env.PrepareLatestNotesFunc = func(_ context.Context, _ bool) (*model.NoteViews, error) { return nvs, nil }
+
+	var insertedNote model.RawNote
+	env.InsertNoteFunc = func(_ context.Context, note model.RawNote) (int64, error) {
+		insertedNote = note
+		return 1, nil
+	}
+
+	err := deliverchangewebhook.Resolve(context.Background(), env,
+		handlenotewebhooks.DeliverChangeWebhookParams{WebhookID: 1, DeliveryID: 31, Attempt: 1})
+	require.NoError(t, err)
+	require.Equal(t, "notes/todo.md", insertedNote.Path)
+	require.Equal(t, "updated", insertedNote.Content)
+}
+
+// P1: a mid-batch failure must not leave a partially applied prefix of the batch.
+func TestResolve_AgentChanges_MidBatchFailure_NoPartialApply(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok","changes":[` +
+			`{"path":"notes/a.md","content":"a"},` +
+			`{"path":"outside.md","content":"b"}]}`))
+	}))
+	defer srv.Close()
+
+	env := baseEnv(t, srv.URL, nil)
+	env.WebhookByIDFunc = func(_ context.Context, id int64) (db.ChangeWebhook, error) {
+		return db.ChangeWebhook{
+			ID:             id,
+			Url:            srv.URL,
+			TimeoutSeconds: 10,
+			MaxRetries:     1,
+			WritePatterns:  `["notes/**"]`,
+			ReadPatterns:   "[]",
+		}, nil
+	}
+
+	insertCalled := false
+	env.InsertNoteFunc = func(_ context.Context, _ model.RawNote) (int64, error) {
+		insertCalled = true
+		return 0, nil
+	}
+
+	var got db.UpdateWebhookDeliveryResultParams
+	env.UpdateWebhookDeliveryResultFunc = func(_ context.Context, arg db.UpdateWebhookDeliveryResultParams) error {
+		got = arg
+		return nil
+	}
+
+	err := deliverchangewebhook.Resolve(context.Background(), env,
+		handlenotewebhooks.DeliverChangeWebhookParams{WebhookID: 1, DeliveryID: 32, Attempt: 1})
+	require.NoError(t, err)
+	require.False(t, insertCalled, "no change may be applied when any change in the batch is invalid")
+	require.Equal(t, "failed", got.Status)
+}
+
 // F8: patch-kind change with a find string absent from the note must error without writing.
 func TestResolve_AgentChanges_PatchKind_FindMissing_Error(t *testing.T) {
 	const noteContent = "# Todo\nhello world\n"

--- a/internal/case/backjob/delivercronwebhook/resolve.go
+++ b/internal/case/backjob/delivercronwebhook/resolve.go
@@ -369,7 +369,10 @@ func transformExtVars(payloadBytes []byte) map[string]string {
 	return ev
 }
 
-// applyCronAgentChanges parses and applies agent response changes.
+// applyCronAgentChanges parses, validates, and applies agent response changes.
+// The whole batch is validated (write patterns, expected_hash CAS, patch
+// resolution) before any item is written, so an invalid item rejects the
+// batch without partial application.
 func applyCronAgentChanges(ctx context.Context, env Env, result webhookutil.DeliveryResult, writePatterns []string) error {
 	agentResp, parseErr := webhookutil.ParseAgentResponse(result.Body)
 	if parseErr != nil {
@@ -379,49 +382,14 @@ func applyCronAgentChanges(ctx context.Context, env Env, result webhookutil.Deli
 		return nil
 	}
 
-	// Read the current note views once; needed for patch operations.
-	nvs := env.LatestNoteViews()
+	notes, resolveErr := webhookutil.ResolveAgentChanges(agentResp.Changes, env.LatestNoteViews(), writePatterns)
+	if resolveErr != nil {
+		return resolveErr
+	}
 
-	for _, change := range agentResp.Changes {
-		// Deny-all when write_patterns is empty: a cron webhook delivery is always a
-		// scoped context, so an empty list means "no writes permitted" rather
-		// than "allow all". Also deny on no-match when non-empty.
-		if len(writePatterns) == 0 || !webhookutil.MatchesAny(change.Path, writePatterns) {
-			return fmt.Errorf("path %q not allowed by write_patterns", change.Path)
-		}
-
-		var content string
-		if change.Kind == "patch" { //nolint:nestif // patch requires sequential null-checks before string ops
-			// Apply find/replace against the note's current content.
-			// Matches updateNotes Patch semantics: find must be present exactly once.
-			if nvs == nil {
-				return fmt.Errorf("note not found for patch: %s", change.Path)
-			}
-			nv := nvs.PathMap[change.Path]
-			if nv == nil {
-				return fmt.Errorf("note not found for patch: %s", change.Path)
-			}
-			current := string(nv.Content)
-			idx := strings.Index(current, change.Find)
-			if idx == -1 {
-				return fmt.Errorf("patch find string not found in %s", change.Path)
-			}
-			// Reject ambiguous finds (multiple occurrences) to match updateNotes Patch semantics.
-			if strings.Contains(current[idx+len(change.Find):], change.Find) {
-				return fmt.Errorf("patch find string is ambiguous (multiple occurrences) in %s", change.Path)
-			}
-			content = current[:idx] + change.Replace + current[idx+len(change.Find):]
-		} else {
-			// Kind=="" or "upsert": upsert with provided content.
-			content = change.Content
-		}
-
-		_, insertErr := env.InsertNote(ctx, model.RawNote{
-			Path:    change.Path,
-			Content: content,
-		})
-		if insertErr != nil {
-			return fmt.Errorf("failed to apply change for %s: %w", change.Path, insertErr)
+	for _, note := range notes {
+		if _, insertErr := env.InsertNote(ctx, note); insertErr != nil {
+			return fmt.Errorf("failed to apply change for %s: %w", note.Path, insertErr)
 		}
 	}
 

--- a/internal/case/backjob/delivercronwebhook/resolve_test.go
+++ b/internal/case/backjob/delivercronwebhook/resolve_test.go
@@ -303,6 +303,129 @@ func TestResolve_CronAgentChanges_PatchKind_FindReplace(t *testing.T) {
 	require.Equal(t, "# Cron\nHELLO world\n", insertedNote.Content, "patch must replace find→replace in existing content, not empty it")
 }
 
+// P1: a change carrying a stale expected_hash must not overwrite the current note.
+func TestResolve_CronAgentChanges_StaleExpectedHash_Rejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok","changes":[{"path":"notes/cron.md","content":"clobber","expected_hash":"stale"}]}`))
+	}))
+	defer srv.Close()
+
+	nvs := model.NewNoteViews()
+	nvs.PathMap["notes/cron.md"] = &model.NoteView{Path: "notes/cron.md", Content: []byte("# Cron\ncurrent\n")}
+
+	env := baseEnv(t, srv.URL, nil)
+	env.CronWebhookByIDFunc = func(_ context.Context, id int64) (db.CronWebhook, error) {
+		return db.CronWebhook{
+			ID:             id,
+			Url:            srv.URL,
+			TimeoutSeconds: 10,
+			MaxRetries:     1,
+			WritePatterns:  `["notes/**"]`,
+			ReadPatterns:   "[]",
+		}, nil
+	}
+	env.LatestNoteViewsFunc = func() *model.NoteViews { return nvs }
+
+	insertCalled := false
+	env.InsertNoteFunc = func(_ context.Context, _ model.RawNote) (int64, error) {
+		insertCalled = true
+		return 0, nil
+	}
+
+	var got db.UpdateCronWebhookDeliveryResultParams
+	env.UpdateCronWebhookDeliveryResultFunc = func(_ context.Context, arg db.UpdateCronWebhookDeliveryResultParams) error {
+		got = arg
+		return nil
+	}
+
+	err := delivercronwebhook.Resolve(context.Background(), env,
+		delivercronwebhook.DeliverCronParams{CronWebhookID: 1, DeliveryID: 30, Attempt: 1})
+	require.NoError(t, err)
+	require.False(t, insertCalled, "InsertNote must not be called when expected_hash is stale")
+	require.Equal(t, "failed", got.Status, "delivery must be marked failed on hash mismatch")
+}
+
+// P1: a change carrying the correct expected_hash must still apply.
+func TestResolve_CronAgentChanges_MatchingExpectedHash_Applied(t *testing.T) {
+	const noteContent = "# Cron\ncurrent\n"
+	currentHash := webhookutil.HashContent([]byte(noteContent))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		resp := `{"status":"ok","changes":[{"path":"notes/cron.md","content":"updated","expected_hash":"` + currentHash + `"}]}`
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer srv.Close()
+
+	nvs := model.NewNoteViews()
+	nvs.PathMap["notes/cron.md"] = &model.NoteView{Path: "notes/cron.md", Content: []byte(noteContent)}
+
+	env := baseEnv(t, srv.URL, nil)
+	env.CronWebhookByIDFunc = func(_ context.Context, id int64) (db.CronWebhook, error) {
+		return db.CronWebhook{
+			ID:             id,
+			Url:            srv.URL,
+			TimeoutSeconds: 10,
+			WritePatterns:  `["notes/**"]`,
+			ReadPatterns:   "[]",
+		}, nil
+	}
+	env.LatestNoteViewsFunc = func() *model.NoteViews { return nvs }
+
+	var insertedNote model.RawNote
+	env.InsertNoteFunc = func(_ context.Context, note model.RawNote) (int64, error) {
+		insertedNote = note
+		return 1, nil
+	}
+
+	err := delivercronwebhook.Resolve(context.Background(), env,
+		delivercronwebhook.DeliverCronParams{CronWebhookID: 1, DeliveryID: 31, Attempt: 1})
+	require.NoError(t, err)
+	require.Equal(t, "notes/cron.md", insertedNote.Path)
+	require.Equal(t, "updated", insertedNote.Content)
+}
+
+// P1: a mid-batch failure must not leave a partially applied prefix of the batch.
+func TestResolve_CronAgentChanges_MidBatchFailure_NoPartialApply(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok","changes":[` +
+			`{"path":"notes/a.md","content":"a"},` +
+			`{"path":"outside.md","content":"b"}]}`))
+	}))
+	defer srv.Close()
+
+	env := baseEnv(t, srv.URL, nil)
+	env.CronWebhookByIDFunc = func(_ context.Context, id int64) (db.CronWebhook, error) {
+		return db.CronWebhook{
+			ID:             id,
+			Url:            srv.URL,
+			TimeoutSeconds: 10,
+			MaxRetries:     1,
+			WritePatterns:  `["notes/**"]`,
+			ReadPatterns:   "[]",
+		}, nil
+	}
+
+	insertCalled := false
+	env.InsertNoteFunc = func(_ context.Context, _ model.RawNote) (int64, error) {
+		insertCalled = true
+		return 0, nil
+	}
+
+	var got db.UpdateCronWebhookDeliveryResultParams
+	env.UpdateCronWebhookDeliveryResultFunc = func(_ context.Context, arg db.UpdateCronWebhookDeliveryResultParams) error {
+		got = arg
+		return nil
+	}
+
+	err := delivercronwebhook.Resolve(context.Background(), env,
+		delivercronwebhook.DeliverCronParams{CronWebhookID: 1, DeliveryID: 32, Attempt: 1})
+	require.NoError(t, err)
+	require.False(t, insertCalled, "no change may be applied when any change in the batch is invalid")
+	require.Equal(t, "failed", got.Status)
+}
+
 // F8: patch-kind change with a find string absent from the note must error without writing.
 func TestResolve_CronAgentChanges_PatchKind_FindMissing_Error(t *testing.T) {
 	const noteContent = "# Cron\nhello world\n"

--- a/internal/case/pushnotes/resolve.go
+++ b/internal/case/pushnotes/resolve.go
@@ -60,11 +60,16 @@ func Resolve(ctx context.Context, env Env, input model.PushNotesInput) (model.Pu
 	skipCommit := input.SkipCommit != nil && *input.SkipCommit
 	pathIDs := []int64{}
 
+	// Validate the whole batch before writing anything: callers (e.g. gitapi's
+	// applyDiff) roll back only their own state on failure, so a partially
+	// inserted prefix would diverge the DB from Git.
 	for _, update := range input.Updates {
 		if errPayload := validateUpdate(log, update); errPayload != nil {
 			return errPayload, nil
 		}
+	}
 
+	for _, update := range input.Updates {
 		note := appmodel.RawNote{
 			Path:    update.Path,
 			Content: update.Content,

--- a/internal/case/pushnotes/resolve_test.go
+++ b/internal/case/pushnotes/resolve_test.go
@@ -277,6 +277,30 @@ func TestResolve(t *testing.T) {
 	}
 }
 
+// P1: a mid-batch validation failure must not leave earlier updates persisted
+// (gitapi rolls back only the git ref on failure, so a partial DB write diverges DB from Git).
+func TestResolve_MidBatchValidationFailure_NoPartialWrite(t *testing.T) {
+	ctx := context.Background()
+	env := newEnvMock(&logger.TestLogger{})
+
+	insertCount := 0
+	env.InsertNoteFunc = func(_ context.Context, _ appmodel.RawNote) (int64, error) {
+		insertCount++
+		return int64(insertCount), nil
+	}
+
+	result, err := pushnotes.Resolve(ctx, env, model.PushNotesInput{
+		Updates: []model.PushNoteInput{
+			{Path: "a.md", Content: "# A\n"},
+			{Path: "b.txt", Content: "not allowed"},
+		},
+	})
+	require.NoError(t, err)
+	_, ok := result.(*model.ErrorPayload)
+	require.True(t, ok, "expected ErrorPayload for invalid second update")
+	require.Equal(t, 0, insertCount, "no update may be persisted when any update in the batch is invalid")
+}
+
 func TestResolve_UpdatedNotes(t *testing.T) {
 	ctx := context.Background()
 	mockLogger := &logger.TestLogger{}

--- a/internal/webhookutil/agentresponse.go
+++ b/internal/webhookutil/agentresponse.go
@@ -1,11 +1,23 @@
 package webhookutil
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
+
+	"trip2g/internal/model"
 
 	ozzo "github.com/go-ozzo/ozzo-validation/v4"
 )
+
+// HashContent returns the base64url sha256 of note content — the hash format
+// agents receive and send back as expected_hash (same as updateNotes CAS).
+func HashContent(content []byte) string {
+	sum := sha256.Sum256(content)
+	return base64.URLEncoding.EncodeToString(sum[:])
+}
 
 // AgentChange kinds. An empty Kind is treated as KindWrite for backward
 // compatibility with existing webhook agents that only send {path, content}.
@@ -51,6 +63,63 @@ func (c AgentChange) Validate() error {
 		ozzo.Field(&c.Path, ozzo.Required),
 		ozzo.Field(&c.Content, ozzo.Required),
 	)
+}
+
+// ResolveAgentChanges validates every change (write patterns, expected_hash
+// CAS, patch resolution) against the current note views and returns the final
+// notes to write. Any invalid change rejects the whole batch, so callers never
+// apply a partial prefix.
+func ResolveAgentChanges(changes []AgentChange, nvs *model.NoteViews, writePatterns []string) ([]model.RawNote, error) {
+	notes := make([]model.RawNote, 0, len(changes))
+	for _, change := range changes {
+		// Deny-all when write_patterns is empty: a webhook delivery is always a
+		// scoped context, so an empty list means "no writes permitted" rather
+		// than "allow all". Also deny on no-match when non-empty.
+		if len(writePatterns) == 0 || !MatchesAny(change.Path, writePatterns) {
+			return nil, fmt.Errorf("path %q not allowed by write_patterns", change.Path)
+		}
+
+		var nv *model.NoteView
+		if nvs != nil {
+			nv = nvs.PathMap[change.Path]
+		}
+
+		// expected_hash gates the write with optimistic concurrency, matching
+		// updateNotes CAS semantics: "" asserts the note is absent (create-only).
+		if change.ExpectedHash != nil {
+			var actualHash string
+			if nv != nil {
+				actualHash = HashContent(nv.Content)
+			}
+			if actualHash != *change.ExpectedHash {
+				return nil, fmt.Errorf("expected_hash mismatch for %s: note changed since it was read", change.Path)
+			}
+		}
+
+		var content string
+		if change.IsPatch() {
+			// Apply find/replace against the note's current content.
+			// Matches updateNotes Patch semantics: find must be present exactly once.
+			if nv == nil {
+				return nil, fmt.Errorf("note not found for patch: %s", change.Path)
+			}
+			current := string(nv.Content)
+			idx := strings.Index(current, change.Find)
+			if idx == -1 {
+				return nil, fmt.Errorf("patch find string not found in %s", change.Path)
+			}
+			if strings.Contains(current[idx+len(change.Find):], change.Find) {
+				return nil, fmt.Errorf("patch find string is ambiguous (multiple occurrences) in %s", change.Path)
+			}
+			content = current[:idx] + change.Replace + current[idx+len(change.Find):]
+		} else {
+			// Kind=="" or "upsert": upsert with provided content.
+			content = change.Content
+		}
+
+		notes = append(notes, model.RawNote{Path: change.Path, Content: content})
+	}
+	return notes, nil
 }
 
 // ParseAgentResponse parses a webhook response body into AgentResponse.


### PR DESCRIPTION
Two P1 data-integrity findings from the audit, test-first. Each closes the validation-caused partial-apply/clobber path; the deeper transactional remainder is flagged (needs DB-tx plumbing, deferred).

**1. Agent `expected_hash` (CAS) not enforced + non-atomic change batches.** Agent responses parsed `expected_hash` but never checked it, so a stale agent write could clobber a newer note revision, and a mid-batch failure left a partial prefix applied. New shared `webhookutil.ResolveAgentChanges()` validates the WHOLE batch first — write patterns, `expected_hash` CAS (same base64url-sha256 semantics as `updatenotes`, incl. `""` = create-only), patch find/replace resolution — and rejects the entire batch before anything is written. Wired into both `deliverchangewebhook` and `delivercronwebhook` (deduped ~40 lines each). Tests: `..._StaleExpectedHash_Rejected`, `..._MidBatchFailure_NoPartialApply` (+ matching-hash guards).

**2. Git ref rollback without DB rollback.** `pushnotes` interleaved validate+insert, so a mid-batch validation failure persisted earlier items while gitapi rolled back only the ref — diverging DB from Git. Now the whole batch is validated before any `InsertNote`, so validation failures leave zero DB writes. Test: `TestResolve_MidBatchValidationFailure_NoPartialWrite`.

**Deferred (flagged, needs a DB transaction spanning multiple InsertNote calls — Env/query plumbing beyond the no-migration scope):** a mid-batch `InsertNote` *DB error* (after prevalidation passes) can still leave a prefix committed; same for `HideNotePaths` failing after PushNotes succeeded. Prevalidation closes the common validation-caused cases; true all-or-nothing on DB errors is a follow-up.

`go build ./...`, touched-package + dependent tests, `go vet`, `make lint` all clean. No migrations. (Note: a pre-existing `internal/case/insertnote` load-flake under heavy concurrent build load is unrelated — verified failing on clean origin/main too.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)