### PR TITLE
feat(mcp): bound federated-search fan-out (concurrency + cap + partial results)

### DIFF
--- a/cmd/server/federation.go
+++ b/cmd/server/federation.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"time"
+
 	"trip2g/internal/case/mcp"
 	"trip2g/internal/db"
 	"trip2g/internal/federation"
@@ -104,6 +106,18 @@ func (a *app) FederationClient(reqCtx context.Context, kbID string) (model.Feder
 
 func (a *app) FederationMaxDepth() int {
 	return a.config.MCPFederationMaxDepth
+}
+
+func (a *app) FederatedFanoutConcurrency() int {
+	return a.config.FederatedFanoutConcurrency
+}
+
+func (a *app) FederatedFanoutLimit() int {
+	return a.config.FederatedFanoutLimit
+}
+
+func (a *app) FederatedFanoutTimeout() time.Duration {
+	return a.config.FederatedFanoutTimeout
 }
 
 func (a *app) MCPMetrics() *metrics.MCPMetrics {

--- a/docs/dev/federation_agent_setup.md
+++ b/docs/dev/federation_agent_setup.md
@@ -282,7 +282,9 @@ Used by visualization (the simplepanel graph) and by the agent for verification 
 ## 8. What depends on the deployment
 
 - **Fan-out depth** — `MCP_FEDERATION_MAX_DEPTH` (default 3). Limits hub→hub→member chains and prevents loops. Plan multi-level hubs against the limit. See [selfhosted](https://trip2g.com/docs/en/user/selfhosted).
-- **Per-peer timeout** — `MCP_FEDERATION_FANOUT_TIMEOUT` (default 2s). Slow/unreachable peers are skipped.
+- **Per-peer timeout** — `FEDERATED_FANOUT_TIMEOUT` (default 5s). Slow/unreachable peers are reported as errors without blocking the rest.
+- **Fan-out parallelism** — `FEDERATED_FANOUT_CONCURRENCY` (default 5). Max peers queried at once.
+- **Blind fan-out cap** — `FEDERATED_FANOUT_LIMIT` (default 7). A `federated_search` without `kb_id`/`kb_ids` queries at most this many peers; the rest are listed in the response's `skipped` field for direct follow-up.
 - **Default kb_id** = host of the instance's public URL (override with `mcp_federation_kb_id` in the KB-note). Public URL is instance config.
 - **Transport** — HMAC-SHA256 only, JWT exp ~30s, no mTLS/OAuth, no replay cache. TLS is not enforced by the hub — use HTTPS peer URLs in production.
 - **Control plane** — path §1.1 requires a deployed simplepanel with the pool master secret; §1.2 requires a key with `enable_mcp_admin_tools`. Without either, configuration is manual.

--- a/docs/dev/federation_protocol.md
+++ b/docs/dev/federation_protocol.md
@@ -14,7 +14,9 @@
 - Request body: JSON-RPC 2.0 envelope.
 - Response body: JSON-RPC 2.0 envelope.
 - Content-Type: `application/json` both directions.
-- Hub default fan-out timeout: 2 seconds per peer (`MCP_FEDERATION_FANOUT_TIMEOUT` env on hub).
+- Hub per-peer fan-out timeout: 5 seconds (`FEDERATED_FANOUT_TIMEOUT` env on hub; the underlying HTTP client also enforces a 2s request timeout).
+- Hub fan-out parallelism: 5 peers at a time (`FEDERATED_FANOUT_CONCURRENCY`).
+- Blind fan-out peer cap: 7 (`FEDERATED_FANOUT_LIMIT`); peers over the cap come back in the response's `skipped` list. Explicit `kb_id`/`kb_ids` calls are not capped.
 - Recursion depth limit (hub-enforced): 3 (`MCP_FEDERATION_MAX_DEPTH`).
 
 A peer is a black box behind one URL. There is no separate metadata endpoint; everything goes through `tools/list` and `tools/call`.

--- a/docs/dev/mcp_federation.md
+++ b/docs/dev/mcp_federation.md
@@ -204,6 +204,12 @@ A per-request filter `accessibleKBNotes(ctx, env, user)` runs `canreadnote.Resol
 
 **Fan-out mode** — global env `MCP_FEDERATION_MAX_DEPTH` (default `3`) caps recursion depth. Self-skip: hub ignores its own URL among KB-notes. That's enough for this scale.
 
+A blind fan-out (no `kb_id`/`kb_ids`) is bounded by three knobs:
+
+- `FEDERATED_FANOUT_LIMIT` (default `7`) — max peers a blind fan-out touches, in registration order. Peers beyond the limit are returned in the response's `skipped` list (reason `fanout_limit`) so the caller can query them directly with `kb_id`; they are never dropped silently. Explicit `kb_id`/`kb_ids` calls are not capped.
+- `FEDERATED_FANOUT_CONCURRENCY` (default `5`) — max peers queried in parallel.
+- `FEDERATED_FANOUT_TIMEOUT` (default `5s`) — per-peer timeout for the whole call (client build + request); a hung peer is reported in `errors[]` and never blocks the others.
+
 If real cycles ever bite (10+ peers actively cross-referencing), add `__visited` array to proxied requests as a Stage 2 hardening. Not in MVP.
 
 ---

--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -75,6 +75,9 @@ type Config struct {
 	MCPFederationMaxDepth      int
 	MCPFederationAllowPrivate  bool
 	MCPFederatedGraphQLEnabled bool
+	FederatedFanoutConcurrency int
+	FederatedFanoutLimit       int
+	FederatedFanoutTimeout     time.Duration
 
 	CronExecuteWebhooksSchedule string
 	CronTelegramPublishSchedule string
@@ -511,6 +514,12 @@ func (c *Config) defineServerFlags() {
 	)
 	flag.BoolVar(&c.MCPFederatedGraphQLEnabled, "mcp-federated-graphql", false,
 		"Enable the federated_graphql_request MCP tool (query-only, subgraph-scoped). Off by default.")
+	flag.IntVar(&c.FederatedFanoutConcurrency, "federated-fanout-concurrency", 5,
+		"Max peers queried in parallel by a federated_search fan-out (0 = unlimited)")
+	flag.IntVar(&c.FederatedFanoutLimit, "federated-fanout-limit", 7,
+		"Max peers a blind (no kb_id) federated_search fan-out touches; the rest are reported as skipped (0 = unlimited)")
+	flag.DurationVar(&c.FederatedFanoutTimeout, "federated-fanout-timeout", 5*time.Second,
+		"Per-peer timeout for federated fan-out requests (0 = no extra timeout)")
 	flag.BoolVar(&c.SimpleBackup.Enabled, "simple-backup", false, "Enable simple backup system (hourly backups to S3-compatible storage)")
 	flag.BoolVar(
 		&c.SimpleBackup.BackupOnShutdown,

--- a/internal/case/mcp/endpoint_dispatch_test.go
+++ b/internal/case/mcp/endpoint_dispatch_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"trip2g/internal/appreq"
 	"trip2g/internal/case/mcp"
@@ -34,6 +35,8 @@ func (r *testPersonalTokenResolver) Resolve(_ context.Context, _ string) (*usert
 // buildMCPFasthttpCtx builds a *fasthttp.RequestCtx with the given body and Authorization header.
 func buildMCPFasthttpCtx(body []byte, authHeader string) *fasthttp.RequestCtx {
 	ctx := &fasthttp.RequestCtx{}
+	// Wire the fake server so ctx works as a context.Context (Done() panics on a bare RequestCtx).
+	ctx.Init2(nil, nil, true)
 	ctx.Request.Header.SetMethod("POST")
 	ctx.Request.SetRequestURI("/_system/mcp")
 	ctx.Request.Header.SetContentType("application/json")
@@ -63,6 +66,10 @@ func buildDispatchEnv(t *testing.T, verifyInboundWillFail bool) *EnvMock {
 		CanReadNoteFunc:             func(_ context.Context, _ *appmodel.NoteView) (bool, error) { return true, nil },
 		FederatedGraphQLEnabledFunc: func() bool { return false },
 		MCPMetricsFunc:              func() *metrics.MCPMetrics { return nil },
+
+		FederatedFanoutConcurrencyFunc: func() int { return 5 },
+		FederatedFanoutLimitFunc:       func() int { return 7 },
+		FederatedFanoutTimeoutFunc:     func() time.Duration { return 5 * time.Second },
 	}
 	if verifyInboundWillFail {
 		env.FederationSecretByKIDFunc = func(_ context.Context, _ string) (db.FederationSecret, bool, error) {

--- a/internal/case/mcp/federated_graphql_test.go
+++ b/internal/case/mcp/federated_graphql_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"trip2g/internal/db"
 	"trip2g/internal/features"
@@ -62,6 +63,11 @@ func (e *fedGQLEnv) ListFederationSecretSubgraphsByKID(_ context.Context, _ stri
 }
 func (e *fedGQLEnv) DecryptData(_ []byte) ([]byte, error) { panic("unexpected") }
 func (e *fedGQLEnv) FederationMaxDepth() int              { panic("unexpected") }
+func (e *fedGQLEnv) FederatedFanoutConcurrency() int      { panic("unexpected") }
+func (e *fedGQLEnv) FederatedFanoutLimit() int            { panic("unexpected") }
+func (e *fedGQLEnv) FederatedFanoutTimeout() time.Duration {
+	panic("unexpected")
+}
 func (e *fedGQLEnv) ResolveAPIKey(_ context.Context, _, _ string) (*db.ApiKey, error) {
 	panic("unexpected")
 }

--- a/internal/case/mcp/federation.go
+++ b/internal/case/mcp/federation.go
@@ -26,20 +26,21 @@ func fanout(
 	ctx context.Context,
 	env federationFanoutEnv,
 	kbs []*model.MCPFederationNote,
+	concurrency int,
+	timeout time.Duration,
 	call func(ctx context.Context, client model.Federation) (model.FederationResult, error),
 ) []ProxiedResult {
 	results := make([]ProxiedResult, len(kbs))
 	var g errgroup.Group
+	if concurrency > 0 {
+		g.SetLimit(concurrency)
+	}
 
 	for i, kb := range kbs {
 		results[i].KB = kb
 		g.Go(func() error {
 			start := time.Now()
-			client, err := env.FederationClient(ctx, kb.ID)
-			if err == nil {
-				results[i].Result, err = call(ctx, client)
-			}
-			results[i].Err = err
+			results[i].Result, results[i].Err = callPeer(ctx, env, kb.ID, timeout, call)
 			results[i].Latency = time.Since(start)
 			return nil
 		})
@@ -47,6 +48,53 @@ func fanout(
 
 	_ = g.Wait()
 	return results
+}
+
+// callPeer calls one peer under a per-peer timeout. The call runs in its own
+// goroutine so a hung client that ignores ctx cancellation still releases the
+// fan-out concurrency slot when the timeout fires.
+func callPeer(
+	ctx context.Context,
+	env federationFanoutEnv,
+	kbID string,
+	timeout time.Duration,
+	call func(ctx context.Context, client model.Federation) (model.FederationResult, error),
+) (model.FederationResult, error) {
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	type outcome struct {
+		result model.FederationResult
+		err    error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		client, err := env.FederationClient(ctx, kbID)
+		var result model.FederationResult
+		if err == nil {
+			result, err = call(ctx, client)
+		}
+		done <- outcome{result: result, err: err}
+	}()
+
+	select {
+	case o := <-done:
+		return o.result, o.err
+	case <-ctx.Done():
+		return model.FederationResult{}, ctx.Err()
+	}
+}
+
+// capBlindFanout caps a blind fan-out at limit peers (registration order),
+// returning the peers to query and those skipped for reporting.
+func capBlindFanout(kbs []*model.MCPFederationNote, limit int) ([]*model.MCPFederationNote, []*model.MCPFederationNote) {
+	if limit > 0 && len(kbs) > limit {
+		return kbs[:limit], kbs[limit:]
+	}
+	return kbs, nil
 }
 
 func selectFederationKBs(kbs []*model.MCPFederationNote, kbID string, kbIDs []string) []*model.MCPFederationNote {
@@ -100,8 +148,14 @@ func federationResultToToolResult(result model.FederationResult) CallToolResult 
 	}
 }
 
-func aggregateFederationResults(results []ProxiedResult) CallToolResult {
+func aggregateFederationResults(results []ProxiedResult, skipped []*model.MCPFederationNote) CallToolResult {
 	payload := FederatedCallPayload{}
+	for _, kb := range skipped {
+		payload.Skipped = append(payload.Skipped, FederatedCallSkipped{
+			KBID:   kb.ID,
+			Reason: "fanout_limit",
+		})
+	}
 	var text strings.Builder
 	for _, result := range results {
 		kbID := ""
@@ -135,6 +189,14 @@ func aggregateFederationResults(results []ProxiedResult) CallToolResult {
 	}
 	if text.Len() == 0 {
 		text.WriteString("No federation results")
+	}
+	if len(skipped) > 0 {
+		ids := make([]string, 0, len(skipped))
+		for _, kb := range skipped {
+			ids = append(ids, kb.ID)
+		}
+		_, _ = fmt.Fprintf(&text, "\n\n%d bases were not queried due to the fan-out limit — query them directly with kb_id: %s",
+			len(ids), strings.Join(ids, ", "))
 	}
 
 	toolResult := structuredToolResult(text.String(), payload)

--- a/internal/case/mcp/federation_fanout_test.go
+++ b/internal/case/mcp/federation_fanout_test.go
@@ -1,0 +1,186 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"trip2g/internal/case/mcp"
+	appmodel "trip2g/internal/model"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fanoutSearchFn = func(context.Context, appmodel.FederationSearchParams) (appmodel.FederationResult, error)
+
+// fanoutEnv builds an env with n federation KB notes (kb1..kbn, registration
+// order) whose clients answer Search via searchFunc, plus the fan-out knobs.
+func fanoutEnv(
+	n int,
+	limit, concurrency int,
+	timeout time.Duration,
+	searchFunc func(kbID string) fanoutSearchFn,
+) *EnvMock {
+	nvs := appmodel.NewNoteViews()
+	for i := 1; i <= n; i++ {
+		kbID := fmt.Sprintf("kb%d", i)
+		note := &appmodel.NoteView{
+			PathID:             int64(i),
+			MCPFederationKBURL: fmt.Sprintf("https://%s.example/_system/mcp", kbID),
+			MCPFederationKBID:  kbID,
+		}
+		nvs.MCPFederationNotes = append(nvs.MCPFederationNotes, appmodel.NewMCPFederationNote(note))
+	}
+	return &EnvMock{
+		LatestNoteViewsFunc: func() *appmodel.NoteViews { return nvs },
+		CanReadNoteFunc: func(_ context.Context, _ *appmodel.NoteView) (bool, error) {
+			return true, nil
+		},
+		FederationClientFunc: func(_ context.Context, kbID string) (appmodel.Federation, error) {
+			return &federationMock{searchFunc: searchFunc(kbID)}, nil
+		},
+		FederatedFanoutLimitFunc:       func() int { return limit },
+		FederatedFanoutConcurrencyFunc: func() int { return concurrency },
+		FederatedFanoutTimeoutFunc:     func() time.Duration { return timeout },
+	}
+}
+
+func callFederatedSearch(t *testing.T, env *EnvMock, arguments string) mcp.CallToolResult {
+	t.Helper()
+	params := mcp.CallToolParams{
+		Name:      "federated_search",
+		Arguments: json.RawMessage(arguments),
+	}
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+	resp := mcp.Resolve(context.Background(), env, mcp.Request{
+		JSONRPC: "2.0",
+		Method:  "tools/call",
+		Params:  paramsJSON,
+		ID:      1,
+	})
+	require.Nil(t, resp.Error)
+	result, ok := resp.Result.(mcp.CallToolResult)
+	require.True(t, ok, "expected CallToolResult, got %T", resp.Result)
+	return result
+}
+
+func fanoutPayload(t *testing.T, result mcp.CallToolResult) mcp.FederatedCallPayload {
+	t.Helper()
+	payload, ok := result.StructuredContent.(mcp.FederatedCallPayload)
+	require.True(t, ok, "expected FederatedCallPayload, got %T", result.StructuredContent)
+	return payload
+}
+
+func TestFederatedSearchBlindFanoutCapsPeersAndReportsSkipped(t *testing.T) {
+	var mu sync.Mutex
+	queried := map[string]bool{}
+	env := fanoutEnv(5, 3, 5, time.Second, func(kbID string) fanoutSearchFn {
+		return func(_ context.Context, _ appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+			mu.Lock()
+			queried[kbID] = true
+			mu.Unlock()
+			return appmodel.FederationResult{Content: []appmodel.FederationContent{{Type: "text", Text: "hit " + kbID}}}, nil
+		}
+	})
+
+	result := callFederatedSearch(t, env, `{"query":"status"}`)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, queried, 3, "blind fan-out must query at most the limit")
+	require.Equal(t, map[string]bool{"kb1": true, "kb2": true, "kb3": true}, queried,
+		"cap must keep the first peers in registration order")
+
+	payload := fanoutPayload(t, result)
+	require.Empty(t, payload.Errors)
+	skippedIDs := make([]string, 0, len(payload.Skipped))
+	for _, s := range payload.Skipped {
+		require.Equal(t, "fanout_limit", s.Reason)
+		skippedIDs = append(skippedIDs, s.KBID)
+	}
+	require.Equal(t, []string{"kb4", "kb5"}, skippedIDs,
+		"un-queried peers must be reported, not dropped silently")
+}
+
+func TestFederatedSearchFanoutConcurrencyBounded(t *testing.T) {
+	var inflight, peak atomic.Int64
+	env := fanoutEnv(6, 10, 2, 5*time.Second, func(kbID string) fanoutSearchFn {
+		return func(_ context.Context, _ appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+			cur := inflight.Add(1)
+			for {
+				old := peak.Load()
+				if cur <= old || peak.CompareAndSwap(old, cur) {
+					break
+				}
+			}
+			time.Sleep(30 * time.Millisecond)
+			inflight.Add(-1)
+			return appmodel.FederationResult{Content: []appmodel.FederationContent{{Type: "text", Text: kbID}}}, nil
+		}
+	})
+
+	result := callFederatedSearch(t, env, `{"query":"status"}`)
+
+	payload := fanoutPayload(t, result)
+	require.Len(t, payload.Results, 6)
+	require.LessOrEqual(t, peak.Load(), int64(2),
+		"no more than FederatedFanoutConcurrency peers may be in flight at once")
+}
+
+func TestFederatedSearchHungPeerTimesOutOthersReturn(t *testing.T) {
+	hung := make(chan struct{})
+	t.Cleanup(func() { close(hung) })
+	env := fanoutEnv(3, 10, 5, 100*time.Millisecond, func(kbID string) fanoutSearchFn {
+		return func(_ context.Context, _ appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+			if kbID == "kb2" {
+				<-hung
+				return appmodel.FederationResult{}, context.Canceled
+			}
+			return appmodel.FederationResult{Content: []appmodel.FederationContent{{Type: "text", Text: "fast " + kbID}}}, nil
+		}
+	})
+
+	start := time.Now()
+	result := callFederatedSearch(t, env, `{"query":"status"}`)
+	require.Less(t, time.Since(start), 2*time.Second, "a hung peer must not block the fan-out")
+
+	payload := fanoutPayload(t, result)
+	gotResults := make([]string, 0, len(payload.Results))
+	for _, r := range payload.Results {
+		gotResults = append(gotResults, r.KBID)
+	}
+	require.ElementsMatch(t, []string{"kb1", "kb3"}, gotResults, "fast peers must still return results")
+	require.Len(t, payload.Errors, 1)
+	require.Equal(t, "kb2", payload.Errors[0].KBID)
+	require.Contains(t, payload.Errors[0].Error, "deadline exceeded", "hung peer must be reported as timed-out")
+	require.Empty(t, payload.Skipped, "a timed-out peer is not a cap-skipped peer")
+}
+
+func TestFederatedSearchExplicitKBIDsIgnoreFanoutLimit(t *testing.T) {
+	var mu sync.Mutex
+	queried := map[string]bool{}
+	env := fanoutEnv(5, 2, 5, time.Second, func(kbID string) fanoutSearchFn {
+		return func(_ context.Context, _ appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+			mu.Lock()
+			queried[kbID] = true
+			mu.Unlock()
+			return appmodel.FederationResult{Content: []appmodel.FederationContent{{Type: "text", Text: kbID}}}, nil
+		}
+	})
+
+	result := callFederatedSearch(t, env, `{"query":"status","kb_ids":["kb1","kb2","kb3","kb4"]}`)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, map[string]bool{"kb1": true, "kb2": true, "kb3": true, "kb4": true}, queried,
+		"explicit kb_ids targeting must not be capped by the fan-out limit")
+
+	payload := fanoutPayload(t, result)
+	require.Len(t, payload.Results, 4)
+	require.Empty(t, payload.Skipped)
+}

--- a/internal/case/mcp/federation_handlers.go
+++ b/internal/case/mcp/federation_handlers.go
@@ -30,9 +30,15 @@ func handleFederatedSearch(ctx context.Context, env Env, id any, argsRaw json.Ra
 		if len(selected) == 0 {
 			return federationNotConfiguredResponse(id, "")
 		}
-		results := fanout(ctx, env, selected, func(ctx context.Context, client model.Federation) (model.FederationResult, error) {
-			return client.Search(ctx, model.FederationSearchParams{Query: args.Query})
-		})
+		// The limit only caps blind fan-outs; explicit kb_ids targeting is precise.
+		var skipped []*model.MCPFederationNote
+		if len(args.KBIDs) == 0 {
+			selected, skipped = capBlindFanout(selected, env.FederatedFanoutLimit())
+		}
+		results := fanout(ctx, env, selected, env.FederatedFanoutConcurrency(), env.FederatedFanoutTimeout(),
+			func(ctx context.Context, client model.Federation) (model.FederationResult, error) {
+				return client.Search(ctx, model.FederationSearchParams{Query: args.Query})
+			})
 		m := metricsFromContext(ctx)
 		touched := 0
 		for _, r := range results {
@@ -42,7 +48,7 @@ func handleFederatedSearch(ctx context.Context, env Env, id any, argsRaw json.Ra
 			}
 		}
 		m.ObserveFanoutBases(touched)
-		return successResponse(id, aggregateFederationResults(results))
+		return successResponse(id, aggregateFederationResults(results, skipped))
 	}
 
 	kb, rest := findFederationKB(kbs, args.KBID)

--- a/internal/case/mcp/graphql_tools_test.go
+++ b/internal/case/mcp/graphql_tools_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"trip2g/internal/db"
 	"trip2g/internal/features"
@@ -53,6 +54,11 @@ func (e *gqlRequestEnv) ListFederationSecretSubgraphsByKID(_ context.Context, _ 
 }
 func (e *gqlRequestEnv) DecryptData(_ []byte) ([]byte, error) { panic("unexpected") }
 func (e *gqlRequestEnv) FederationMaxDepth() int              { panic("unexpected") }
+func (e *gqlRequestEnv) FederatedFanoutConcurrency() int      { panic("unexpected") }
+func (e *gqlRequestEnv) FederatedFanoutLimit() int            { panic("unexpected") }
+func (e *gqlRequestEnv) FederatedFanoutTimeout() time.Duration {
+	panic("unexpected")
+}
 func (e *gqlRequestEnv) ResolveAPIKey(_ context.Context, _, _ string) (*db.ApiKey, error) {
 	panic("unexpected")
 }

--- a/internal/case/mcp/mocks_test.go
+++ b/internal/case/mcp/mocks_test.go
@@ -6,6 +6,7 @@ package mcp_test
 import (
 	"context"
 	"sync"
+	"time"
 	"trip2g/internal/case/mcp"
 	"trip2g/internal/db"
 	"trip2g/internal/features"
@@ -33,6 +34,15 @@ var _ mcp.Env = &EnvMock{}
 //			},
 //			FeaturesFunc: func() features.Features {
 //				panic("mock out the Features method")
+//			},
+//			FederatedFanoutConcurrencyFunc: func() int {
+//				panic("mock out the FederatedFanoutConcurrency method")
+//			},
+//			FederatedFanoutLimitFunc: func() int {
+//				panic("mock out the FederatedFanoutLimit method")
+//			},
+//			FederatedFanoutTimeoutFunc: func() time.Duration {
+//				panic("mock out the FederatedFanoutTimeout method")
 //			},
 //			FederatedGraphQLEnabledFunc: func() bool {
 //				panic("mock out the FederatedGraphQLEnabled method")
@@ -101,6 +111,15 @@ type EnvMock struct {
 	// FeaturesFunc mocks the Features method.
 	FeaturesFunc func() features.Features
 
+	// FederatedFanoutConcurrencyFunc mocks the FederatedFanoutConcurrency method.
+	FederatedFanoutConcurrencyFunc func() int
+
+	// FederatedFanoutLimitFunc mocks the FederatedFanoutLimit method.
+	FederatedFanoutLimitFunc func() int
+
+	// FederatedFanoutTimeoutFunc mocks the FederatedFanoutTimeout method.
+	FederatedFanoutTimeoutFunc func() time.Duration
+
 	// FederatedGraphQLEnabledFunc mocks the FederatedGraphQLEnabled method.
 	FederatedGraphQLEnabledFunc func() bool
 
@@ -168,6 +187,15 @@ type EnvMock struct {
 		}
 		// Features holds details about calls to the Features method.
 		Features []struct {
+		}
+		// FederatedFanoutConcurrency holds details about calls to the FederatedFanoutConcurrency method.
+		FederatedFanoutConcurrency []struct {
+		}
+		// FederatedFanoutLimit holds details about calls to the FederatedFanoutLimit method.
+		FederatedFanoutLimit []struct {
+		}
+		// FederatedFanoutTimeout holds details about calls to the FederatedFanoutTimeout method.
+		FederatedFanoutTimeout []struct {
 		}
 		// FederatedGraphQLEnabled holds details about calls to the FederatedGraphQLEnabled method.
 		FederatedGraphQLEnabled []struct {
@@ -264,6 +292,9 @@ type EnvMock struct {
 	lockCanReadNote                        sync.RWMutex
 	lockDecryptData                        sync.RWMutex
 	lockFeatures                           sync.RWMutex
+	lockFederatedFanoutConcurrency         sync.RWMutex
+	lockFederatedFanoutLimit               sync.RWMutex
+	lockFederatedFanoutTimeout             sync.RWMutex
 	lockFederatedGraphQLEnabled            sync.RWMutex
 	lockFederationClient                   sync.RWMutex
 	lockFederationMaxDepth                 sync.RWMutex
@@ -375,6 +406,87 @@ func (mock *EnvMock) FeaturesCalls() []struct {
 	mock.lockFeatures.RLock()
 	calls = mock.calls.Features
 	mock.lockFeatures.RUnlock()
+	return calls
+}
+
+// FederatedFanoutConcurrency calls FederatedFanoutConcurrencyFunc.
+func (mock *EnvMock) FederatedFanoutConcurrency() int {
+	if mock.FederatedFanoutConcurrencyFunc == nil {
+		panic("EnvMock.FederatedFanoutConcurrencyFunc: method is nil but Env.FederatedFanoutConcurrency was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockFederatedFanoutConcurrency.Lock()
+	mock.calls.FederatedFanoutConcurrency = append(mock.calls.FederatedFanoutConcurrency, callInfo)
+	mock.lockFederatedFanoutConcurrency.Unlock()
+	return mock.FederatedFanoutConcurrencyFunc()
+}
+
+// FederatedFanoutConcurrencyCalls gets all the calls that were made to FederatedFanoutConcurrency.
+// Check the length with:
+//
+//	len(mockedEnv.FederatedFanoutConcurrencyCalls())
+func (mock *EnvMock) FederatedFanoutConcurrencyCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockFederatedFanoutConcurrency.RLock()
+	calls = mock.calls.FederatedFanoutConcurrency
+	mock.lockFederatedFanoutConcurrency.RUnlock()
+	return calls
+}
+
+// FederatedFanoutLimit calls FederatedFanoutLimitFunc.
+func (mock *EnvMock) FederatedFanoutLimit() int {
+	if mock.FederatedFanoutLimitFunc == nil {
+		panic("EnvMock.FederatedFanoutLimitFunc: method is nil but Env.FederatedFanoutLimit was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockFederatedFanoutLimit.Lock()
+	mock.calls.FederatedFanoutLimit = append(mock.calls.FederatedFanoutLimit, callInfo)
+	mock.lockFederatedFanoutLimit.Unlock()
+	return mock.FederatedFanoutLimitFunc()
+}
+
+// FederatedFanoutLimitCalls gets all the calls that were made to FederatedFanoutLimit.
+// Check the length with:
+//
+//	len(mockedEnv.FederatedFanoutLimitCalls())
+func (mock *EnvMock) FederatedFanoutLimitCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockFederatedFanoutLimit.RLock()
+	calls = mock.calls.FederatedFanoutLimit
+	mock.lockFederatedFanoutLimit.RUnlock()
+	return calls
+}
+
+// FederatedFanoutTimeout calls FederatedFanoutTimeoutFunc.
+func (mock *EnvMock) FederatedFanoutTimeout() time.Duration {
+	if mock.FederatedFanoutTimeoutFunc == nil {
+		panic("EnvMock.FederatedFanoutTimeoutFunc: method is nil but Env.FederatedFanoutTimeout was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockFederatedFanoutTimeout.Lock()
+	mock.calls.FederatedFanoutTimeout = append(mock.calls.FederatedFanoutTimeout, callInfo)
+	mock.lockFederatedFanoutTimeout.Unlock()
+	return mock.FederatedFanoutTimeoutFunc()
+}
+
+// FederatedFanoutTimeoutCalls gets all the calls that were made to FederatedFanoutTimeout.
+// Check the length with:
+//
+//	len(mockedEnv.FederatedFanoutTimeoutCalls())
+func (mock *EnvMock) FederatedFanoutTimeoutCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockFederatedFanoutTimeout.RLock()
+	calls = mock.calls.FederatedFanoutTimeout
+	mock.lockFederatedFanoutTimeout.RUnlock()
 	return calls
 }
 

--- a/internal/case/mcp/resolve.go
+++ b/internal/case/mcp/resolve.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"trip2g/internal/case/canreadnote"
 	"trip2g/internal/case/similarnotes"
@@ -59,6 +60,9 @@ type Env interface {
 	ListFederationSecretSubgraphsByKID(ctx context.Context, kid string) ([]string, error)
 	DecryptData([]byte) ([]byte, error)
 	FederationMaxDepth() int
+	FederatedFanoutConcurrency() int
+	FederatedFanoutLimit() int
+	FederatedFanoutTimeout() time.Duration
 	// API key auth
 	ResolveAPIKey(ctx context.Context, value, action string) (*db.ApiKey, error)
 	// Admin GraphQL tools

--- a/internal/case/mcp/types.go
+++ b/internal/case/mcp/types.go
@@ -129,8 +129,9 @@ type FederationStatusPayload struct {
 }
 
 type FederatedCallPayload struct {
-	Results []FederatedCallResult `json:"results,omitempty"`
-	Errors  []FederatedCallError  `json:"errors,omitempty"`
+	Results []FederatedCallResult  `json:"results,omitempty"`
+	Errors  []FederatedCallError   `json:"errors,omitempty"`
+	Skipped []FederatedCallSkipped `json:"skipped,omitempty"`
 }
 
 type FederatedCallResult struct {
@@ -142,6 +143,14 @@ type FederatedCallResult struct {
 type FederatedCallError struct {
 	KBID  string `json:"kb_id"`
 	Error string `json:"error"`
+}
+
+// FederatedCallSkipped lists a peer that was not queried at all (e.g. cut off
+// by the blind fan-out limit) — distinct from Errors, which are peers that
+// were queried and failed. Query these directly with kb_id.
+type FederatedCallSkipped struct {
+	KBID   string `json:"kb_id"`
+	Reason string `json:"reason"`
 }
 
 type SearchResultPayload struct {


### PR DESCRIPTION
Blind `federated_search` (no `kb_id`) fans out to every registered peer at once. On a real hub (~21+ peers) the unbounded parallelism self-DoSes — most peers time out even though each is fast solo. This bounds it.

## Three config knobs (internal/appconfig)
| Env | Default | Meaning |
|---|---|---|
| `FEDERATED_FANOUT_CONCURRENCY` | 5 | max peers queried in parallel |
| `FEDERATED_FANOUT_LIMIT` | 7 | max peers a blind (no-kb_id) fan-out touches |
| `FEDERATED_FANOUT_TIMEOUT` | 5s | per-peer timeout |

## Behavior
- **Bounded concurrency** via `errgroup.SetLimit` — the hub never opens N simultaneous outbound calls; a hung peer frees its slot at the timeout and is reported (metrics map it to `timeout`).
- **Cap without silent truncation** — a blind fan-out queries only the first `limit` peers; the rest are returned in a new `skipped: [{kb_id, reason:"fanout_limit"}]` field (distinct from `errors[]` = queried-but-failed), and the text appends "N bases were not queried due to the fan-out limit — query them directly with kb_id: …". Explicit `kb_id`/`kb_ids` calls are **not** capped.
- Existing MCP metrics (`trip2g_mcp_fanout_bases`, `federated_requests_total{status}`) preserved.

Selecting *which* peers when over the cap is registration-order for now; relevance-based routing (option B) is a future follow-up.

## Tests (TDD)
`TestFederatedSearchBlindFanoutCapsPeersAndReportsSkipped`, `...ConcurrencyBounded` (peak in-flight ≤ concurrency), `...HungPeerTimesOutOthersReturn`, `...ExplicitKBIDsIgnoreFanoutLimit`. `go build`, `go test ./...`, `-race` on the touched packages, `go vet`, `make lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)