### PR TITLE
fix(mcp): note_html never returns empty-success; tolerate string/match_id pid with path fallback

### DIFF
--- a/internal/case/mcp/federation_handlers.go
+++ b/internal/case/mcp/federation_handlers.go
@@ -146,7 +146,7 @@ func handleFederatedNoteHTML(ctx context.Context, env Env, id any, argsRaw json.
 		return errorResponse(id, ErrCodeInvalidParams, "kb_id is required")
 	}
 	params := model.FederationNoteHTMLParams{
-		PID:     args.PID,
+		PID:     args.PID.Value,
 		NoteID:  args.NoteID,
 		Path:    args.Path,
 		Href:    args.Href,

--- a/internal/case/mcp/federation_handlers_test.go
+++ b/internal/case/mcp/federation_handlers_test.go
@@ -14,6 +14,7 @@ import (
 type federationMock struct {
 	searchFunc          func(ctx context.Context, params appmodel.FederationSearchParams) (appmodel.FederationResult, error)
 	federatedSearchFunc func(ctx context.Context, params appmodel.FederationSearchParams) (appmodel.FederationResult, error)
+	noteHTMLFunc        func(ctx context.Context, params appmodel.FederationNoteHTMLParams) (appmodel.FederationResult, error)
 	expandFunc          func(ctx context.Context, params appmodel.FederationExpandParams) (appmodel.FederationResult, error)
 	federatedExpandFunc func(ctx context.Context, params appmodel.FederationExpandParams) (appmodel.FederationResult, error)
 }
@@ -30,7 +31,10 @@ func (m *federationMock) Similar(ctx context.Context, params appmodel.Federation
 }
 
 func (m *federationMock) NoteHTML(ctx context.Context, params appmodel.FederationNoteHTMLParams) (appmodel.FederationResult, error) {
-	panic("unexpected NoteHTML call")
+	if m.noteHTMLFunc == nil {
+		panic("unexpected NoteHTML call")
+	}
+	return m.noteHTMLFunc(ctx, params)
 }
 
 func (m *federationMock) FederatedSearch(ctx context.Context, params appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
@@ -115,6 +119,57 @@ func TestFederatedSearchUsesMockedFederationClient(t *testing.T) {
 	result := resp.Result.(mcp.CallToolResult)
 	require.Equal(t, "remote bob", result.Content[0].Text)
 	require.JSONEq(t, `{"results":[{"title":"remote"}]}`, string(result.StructuredContent.(json.RawMessage)))
+}
+
+func TestFederatedNoteHTMLToleratesStringPID(t *testing.T) {
+	// Models replay search match ids ("p36:c2") as pid; the hub must not
+	// reject the whole call — it forwards the valid path with pid unset.
+	kbNote := &appmodel.NoteView{
+		PathID:             17,
+		MCPFederationKBURL: "https://bob.example/_system/mcp",
+		MCPFederationKBID:  "nietzsche",
+	}
+	nvs := appmodel.NewNoteViews()
+	nvs.MCPFederationNotes = []*appmodel.MCPFederationNote{appmodel.NewMCPFederationNote(kbNote)}
+
+	var gotParams appmodel.FederationNoteHTMLParams
+	federation := &federationMock{
+		noteHTMLFunc: func(ctx context.Context, params appmodel.FederationNoteHTMLParams) (appmodel.FederationResult, error) {
+			gotParams = params
+			return appmodel.FederationResult{
+				Content: []appmodel.FederationContent{{Type: "text", Text: "remote note body"}},
+			}, nil
+		},
+	}
+	env := &EnvMock{
+		LatestNoteViewsFunc: func() *appmodel.NoteViews {
+			return nvs
+		},
+		CanReadNoteFunc: func(ctx context.Context, note *appmodel.NoteView) (bool, error) {
+			return true, nil
+		},
+		FederationClientFunc: func(_ context.Context, kbID string) (appmodel.Federation, error) {
+			return federation, nil
+		},
+	}
+
+	params := mcp.CallToolParams{
+		Name:      "federated_note_html",
+		Arguments: json.RawMessage(`{"kb_id":"nietzsche","path":"concepts/volya-k-vlasti.md","pid":"p36:c2"}`),
+	}
+	paramsJSON, _ := json.Marshal(params)
+	resp := mcp.Resolve(context.Background(), env, mcp.Request{
+		JSONRPC: "2.0",
+		Method:  "tools/call",
+		Params:  paramsJSON,
+		ID:      1,
+	})
+
+	require.Nil(t, resp.Error)
+	result := resp.Result.(mcp.CallToolResult)
+	require.Equal(t, "remote note body", result.Content[0].Text)
+	require.Equal(t, "concepts/volya-k-vlasti.md", gotParams.Path)
+	require.Zero(t, gotParams.PID)
 }
 
 func TestFederatedSearchDelegatesNestedKBID(t *testing.T) {

--- a/internal/case/mcp/resolve.go
+++ b/internal/case/mcp/resolve.go
@@ -900,14 +900,18 @@ func handleNoteHTML(ctx context.Context, env Env, id any, argsRaw json.RawMessag
 		return *errResp
 	}
 
-	if args.Path == "" && args.Href == "" && args.PID == 0 && args.NoteID == 0 {
+	if args.Path == "" && args.Href == "" && args.PID.Value == 0 && args.PID.Raw == "" && args.NoteID == 0 {
 		return errorResponse(id, ErrCodeInvalidParams, "one of pid, note_id, path, or href is required")
 	}
 
 	noteViews := env.LatestNoteViews()
 	note := resolveNoteReference(noteViews, *args)
 	if note == nil {
-		log.Warn("note not found", "path", args.Path, "href", args.Href, "pid", args.PID, "note_id", args.NoteID)
+		log.Warn("note not found", "path", args.Path, "href", args.Href, "pid", args.PID.Value, "pid_raw", args.PID.Raw, "note_id", args.NoteID)
+		if args.PID.Raw != "" && args.PID.Value == 0 {
+			return errorResponse(id, ErrCodeInvalidParams,
+				fmt.Sprintf("pid %q is not a note id; note ids are numbers from search results — chunk refs like \"p36:c2\" go in match_id", args.PID.Raw))
+		}
 		return errorResponse(id, ErrCodeInvalidParams, "Note not found")
 	}
 	canRead, err := canReadMCPNote(ctx, env, note)
@@ -916,7 +920,7 @@ func handleNoteHTML(ctx context.Context, env Env, id any, argsRaw json.RawMessag
 		return errorResponse(id, ErrCodeInternal, "Note HTML failed: "+err.Error())
 	}
 	if !canRead {
-		log.Warn("note access denied", "path", args.Path, "href", args.Href, "pid", args.PID, "note_id", args.NoteID)
+		log.Warn("note access denied", "path", args.Path, "href", args.Href, "pid", args.PID.Value, "note_id", args.NoteID)
 		return errorResponse(id, ErrCodeInvalidParams, "Note not found")
 	}
 
@@ -986,7 +990,7 @@ func handleExpand(ctx context.Context, env Env, id any, argsRaw json.RawMessage)
 	note := resolveNoteReference(noteViews, NoteHTMLArguments{
 		Path:   args.Path,
 		Href:   args.Href,
-		PID:    args.PID,
+		PID:    PID{Value: args.PID},
 		NoteID: args.NoteID,
 	})
 	if note == nil {
@@ -1079,12 +1083,16 @@ func parseChunkMatchID(matchID string) (int64, int, bool) {
 }
 
 func resolveNoteReference(noteViews *model.NoteViews, args NoteHTMLArguments) *model.NoteView {
-	id := args.PID
+	id := args.PID.Value
 	if id == 0 {
 		id = args.NoteID
 	}
 	if id != 0 {
-		return noteViews.GetByPathID(id)
+		if note := noteViews.GetByPathID(id); note != nil {
+			return note
+		}
+		// Models routinely replay a stale or foreign id as pid alongside a
+		// valid path — a pid miss must not eclipse the other references.
 	}
 	if args.Path != "" {
 		if note := noteViews.PathMap[args.Path]; note != nil {

--- a/internal/case/mcp/resolve.go
+++ b/internal/case/mcp/resolve.go
@@ -945,6 +945,14 @@ func handleNoteHTML(ctx context.Context, env Env, id any, argsRaw json.RawMessag
 			fmt.Sprintf("section not found for toc_path [%s]; %s", strings.Join(args.TocPath, " > "), topLevelSectionsNudge(note)))
 	}
 
+	// A resolved note with no rendered content must fail loud: silent empty
+	// success poisons downstream consumers that treat text:"" as the note body.
+	if len(note.HTML) == 0 {
+		log.Warn("note has no rendered content", "path", note.Path, "pid", note.PathID)
+		return errorResponse(id, ErrCodeInvalidParams,
+			fmt.Sprintf("note %q resolved but has no rendered content", note.Path))
+	}
+
 	return successResponse(id, textToolResult(string(note.HTML)))
 }
 

--- a/internal/case/mcp/resolve_test.go
+++ b/internal/case/mcp/resolve_test.go
@@ -767,6 +767,22 @@ func TestSearch_CustomDomainURL(t *testing.T) {
 	require.Equal(t, "/custom-note", payload.Results[0].Href)
 }
 
+func noteHTMLEnv(note *appmodel.NoteView) *EnvMock {
+	return &EnvMock{
+		LatestNoteViewsFunc: func() *appmodel.NoteViews {
+			noteViews := appmodel.NewNoteViews()
+			noteViews.RegisterNote(note)
+			return noteViews
+		},
+		LoggerFunc: func() logger.Logger {
+			return &logger.DummyLogger{}
+		},
+		CanReadNoteFunc: func(ctx context.Context, note *appmodel.NoteView) (bool, error) {
+			return true, nil
+		},
+	}
+}
+
 func TestHandleNoteHtml(t *testing.T) {
 	t.Run("returns note HTML", func(t *testing.T) {
 		note := &appmodel.NoteView{
@@ -1048,6 +1064,109 @@ func TestHandleNoteHtml(t *testing.T) {
 		require.Nil(t, resp.Error)
 		result := resp.Result.(mcp.CallToolResult)
 		require.Contains(t, result.Content[0].Text, "Section body.")
+	})
+
+	// Models routinely replay ids from search results as pid: the numeric
+	// note_id as a string, a chunk match_id ("p36:c2"), even a path. Those
+	// calls usually carry a valid path too — a bogus pid must not eclipse it.
+	t.Run("falls back to path when pid does not resolve", func(t *testing.T) {
+		note := &appmodel.NoteView{
+			Path:      "concepts/volya-k-vlasti.md",
+			PathID:    36,
+			Permalink: "/concepts/volya-k-vlasti",
+			HTML:      "<h1>Воля к власти</h1>",
+		}
+
+		env := noteHTMLEnv(note)
+
+		params := mcp.CallToolParams{
+			Name:      "note_html",
+			Arguments: json.RawMessage(`{"pid": 999999, "path": "concepts/volya-k-vlasti.md"}`),
+		}
+		paramsJSON, _ := json.Marshal(params)
+
+		resp := mcp.Resolve(context.Background(), env, mcp.Request{
+			JSONRPC: "2.0", Method: "tools/call", Params: paramsJSON, ID: 8,
+		})
+
+		require.Nil(t, resp.Error)
+		result := resp.Result.(mcp.CallToolResult)
+		require.Contains(t, result.Content[0].Text, "Воля к власти")
+	})
+
+	t.Run("tolerates match_id-shaped string pid and resolves via path", func(t *testing.T) {
+		note := &appmodel.NoteView{
+			Path:      "concepts/volya-k-vlasti.md",
+			PathID:    36,
+			Permalink: "/concepts/volya-k-vlasti",
+			HTML:      "<h1>Воля к власти</h1>",
+		}
+
+		env := noteHTMLEnv(note)
+
+		params := mcp.CallToolParams{
+			Name:      "note_html",
+			Arguments: json.RawMessage(`{"pid": "p36:c2", "path": "concepts/volya-k-vlasti.md"}`),
+		}
+		paramsJSON, _ := json.Marshal(params)
+
+		resp := mcp.Resolve(context.Background(), env, mcp.Request{
+			JSONRPC: "2.0", Method: "tools/call", Params: paramsJSON, ID: 9,
+		})
+
+		require.Nil(t, resp.Error)
+		result := resp.Result.(mcp.CallToolResult)
+		require.Contains(t, result.Content[0].Text, "Воля к власти")
+	})
+
+	t.Run("accepts numeric string pid", func(t *testing.T) {
+		note := &appmodel.NoteView{
+			Path:      "ru/hub/pascal.md",
+			PathID:    70,
+			Permalink: "/ru/hub/pascal",
+			HTML:      "<h1>Паскаль</h1>",
+		}
+
+		env := noteHTMLEnv(note)
+
+		params := mcp.CallToolParams{
+			Name:      "note_html",
+			Arguments: json.RawMessage(`{"pid": "70"}`),
+		}
+		paramsJSON, _ := json.Marshal(params)
+
+		resp := mcp.Resolve(context.Background(), env, mcp.Request{
+			JSONRPC: "2.0", Method: "tools/call", Params: paramsJSON, ID: 10,
+		})
+
+		require.Nil(t, resp.Error)
+		result := resp.Result.(mcp.CallToolResult)
+		require.Contains(t, result.Content[0].Text, "Паскаль")
+	})
+
+	t.Run("string pid alone returns clear error naming the bad pid", func(t *testing.T) {
+		note := &appmodel.NoteView{
+			Path:      "concepts/volya-k-vlasti.md",
+			PathID:    36,
+			Permalink: "/concepts/volya-k-vlasti",
+			HTML:      "<h1>Воля к власти</h1>",
+		}
+
+		env := noteHTMLEnv(note)
+
+		params := mcp.CallToolParams{
+			Name:      "note_html",
+			Arguments: json.RawMessage(`{"pid": "p36:c2"}`),
+		}
+		paramsJSON, _ := json.Marshal(params)
+
+		resp := mcp.Resolve(context.Background(), env, mcp.Request{
+			JSONRPC: "2.0", Method: "tools/call", Params: paramsJSON, ID: 11,
+		})
+
+		require.NotNil(t, resp.Error)
+		require.Equal(t, mcp.ErrCodeInvalidParams, resp.Error.Code)
+		require.Contains(t, resp.Error.Message, "p36:c2")
 	})
 
 	t.Run("returns error instead of empty success for note with no rendered content", func(t *testing.T) {

--- a/internal/case/mcp/resolve_test.go
+++ b/internal/case/mcp/resolve_test.go
@@ -1050,6 +1050,47 @@ func TestHandleNoteHtml(t *testing.T) {
 		require.Contains(t, result.Content[0].Text, "Section body.")
 	})
 
+	t.Run("returns error instead of empty success for note with no rendered content", func(t *testing.T) {
+		// A frontmatter-only or otherwise empty note must not answer a
+		// valid-looking read with text:"" — a retrieval endpoint returning
+		// silent empty content poisons downstream consumers.
+		note := &appmodel.NoteView{
+			Path:      "demo/pointer.md",
+			PathID:    77,
+			Permalink: "/demo/pointer",
+			HTML:      "",
+		}
+
+		env := &EnvMock{
+			LatestNoteViewsFunc: func() *appmodel.NoteViews {
+				noteViews := appmodel.NewNoteViews()
+				noteViews.RegisterNote(note)
+				return noteViews
+			},
+			LoggerFunc: func() logger.Logger {
+				return &logger.DummyLogger{}
+			},
+			CanReadNoteFunc: func(ctx context.Context, note *appmodel.NoteView) (bool, error) {
+				return true, nil
+			},
+		}
+
+		params := mcp.CallToolParams{
+			Name:      "note_html",
+			Arguments: json.RawMessage(`{"pid": 77}`),
+		}
+		paramsJSON, _ := json.Marshal(params)
+
+		resp := mcp.Resolve(context.Background(), env, mcp.Request{
+			JSONRPC: "2.0", Method: "tools/call", Params: paramsJSON, ID: 7,
+		})
+
+		require.NotNil(t, resp.Error)
+		require.Equal(t, mcp.ErrCodeInvalidParams, resp.Error.Code)
+		require.Contains(t, resp.Error.Message, "demo/pointer.md")
+		require.Contains(t, resp.Error.Message, "no rendered content")
+	})
+
 	t.Run("returns error for non-existent note", func(t *testing.T) {
 		env := &EnvMock{
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {

--- a/internal/case/mcp/types.go
+++ b/internal/case/mcp/types.go
@@ -2,9 +2,44 @@ package mcp
 
 import (
 	"encoding/json"
+	"strconv"
+	"strings"
 
 	"trip2g/internal/model"
 )
+
+// PID is a note id that tolerates what models actually send: a JSON number,
+// a numeric string ("70"), or a non-numeric string like a chunk match_id
+// ("p36:c2") or a path. Non-numeric input parses to Value 0 with Raw kept for
+// error messages, so a valid path in the same call can still resolve instead
+// of the whole request failing on unmarshal.
+type PID struct {
+	Value int64
+	Raw   string
+}
+
+func (p *PID) UnmarshalJSON(b []byte) error {
+	s := strings.TrimSpace(string(b))
+	if s == "null" {
+		return nil
+	}
+	if strings.HasPrefix(s, `"`) {
+		var raw string
+		if err := json.Unmarshal(b, &raw); err != nil {
+			return err
+		}
+		p.Raw = raw
+		if v, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64); err == nil {
+			p.Value = v
+		}
+		return nil
+	}
+	return json.Unmarshal(b, &p.Value)
+}
+
+func (p PID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.Value)
+}
 
 // JSON-RPC 2.0 types
 
@@ -96,7 +131,7 @@ type FederatedSimilarArguments struct {
 
 type FederatedNoteHTMLArguments struct {
 	KBID    string `json:"kb_id"`
-	PID     int64  `json:"pid,omitempty"`
+	PID     PID    `json:"pid,omitzero"`
 	NoteID  string `json:"note_id,omitempty"`
 	Path    string `json:"path,omitempty"`
 	Href    string `json:"href,omitempty"`
@@ -201,7 +236,7 @@ type SimilarResultPayload struct {
 type NoteHTMLArguments struct {
 	Path         string   `json:"path,omitempty"`
 	Href         string   `json:"href,omitempty"`
-	PID          int64    `json:"pid,omitempty"`
+	PID          PID      `json:"pid,omitzero"`
 	NoteID       int64    `json:"note_id,omitempty"`
 	MatchID      string   `json:"match_id,omitempty"`
 	ContextWords int      `json:"context_words,omitempty"`


### PR DESCRIPTION
## Problem
`note_html` / `federated_note_html` could hand a model an empty-but-successful read. Two causes, found by replaying real benchmark calls against the live hub:

1. **Empty-success**: a note that resolves (by pid/path/href) but whose rendered `HTML` is empty was returned as `text:""` instead of an error.
2. **Strict `pid` typing**: `pid` was `int64`-only, so a string-shaped pid — `"70"` or a `match_id` like `"p36:c2"` that `federated_search` hands back — failed the whole call with `-32602`, **even when a valid `path` was also supplied**. Downstream, a benchmark harness that read only `result` (not `error`) logged 128/130 such reads as empty.

## Fix (test-first)
- New tolerant `PID` type (`internal/case/mcp/types.go`): JSON number, numeric string (`"70"→70`), or non-numeric string (`"p36:c2"`, a path) → value 0 with raw preserved; wire format unchanged (`omitzero`).
- `resolveNoteReference`: a pid/note_id miss now falls through to `path`, then `href`, instead of returning early.
- `handleNoteHTML`: resolved-but-empty HTML → error (never `text:""`); an unresolvable non-numeric string pid → error naming it (`… chunk refs like "p36:c2" go in match_id`).
- `federation_handlers.go`: forwards `PID.Value` (junk pid → 0 alongside path, remote resolves by path).

## Tests
Each RED before impl: path fallback on unresolvable pid; tolerates `match_id`-shaped string pid via path; accepts numeric string pid; string pid alone → clear error; federated string-pid no longer rejected. `go test ./internal/case/mcp/ ./internal/federation/ ./internal/model/` green; `go build ./...` clean.

## Follow-up (separate)
`federated_search` surfaces a `match_id` (`p36:c2`) models replay as `pid`; `note_html` could resolve it via the existing `parseChunkMatchID`, or search output could label it more distinctly.