### PR TITLE
fix(tg): restrict navigation browser to public live notes

### DIFF
--- a/internal/case/handletgnavigationupdate/mocks_test.go
+++ b/internal/case/handletgnavigationupdate/mocks_test.go
@@ -28,8 +28,8 @@ var _ Env = &EnvMock{}
 //			BotLinkFunc: func() string {
 //				panic("mock out the BotLink method")
 //			},
-//			LatestNoteViewsFunc: func() *model.NoteViews {
-//				panic("mock out the LatestNoteViews method")
+//			LiveNoteViewsFunc: func() *model.NoteViews {
+//				panic("mock out the LiveNoteViews method")
 //			},
 //			LoggerFunc: func() logger.Logger {
 //				panic("mock out the Logger method")
@@ -59,8 +59,8 @@ type EnvMock struct {
 	// BotLinkFunc mocks the BotLink method.
 	BotLinkFunc func() string
 
-	// LatestNoteViewsFunc mocks the LatestNoteViews method.
-	LatestNoteViewsFunc func() *model.NoteViews
+	// LiveNoteViewsFunc mocks the LiveNoteViews method.
+	LiveNoteViewsFunc func() *model.NoteViews
 
 	// LoggerFunc mocks the Logger method.
 	LoggerFunc func() logger.Logger
@@ -85,8 +85,8 @@ type EnvMock struct {
 		// BotLink holds details about calls to the BotLink method.
 		BotLink []struct {
 		}
-		// LatestNoteViews holds details about calls to the LatestNoteViews method.
-		LatestNoteViews []struct {
+		// LiveNoteViews holds details about calls to the LiveNoteViews method.
+		LiveNoteViews []struct {
 		}
 		// Logger holds details about calls to the Logger method.
 		Logger []struct {
@@ -118,7 +118,7 @@ type EnvMock struct {
 	}
 	lockBotID                       sync.RWMutex
 	lockBotLink                     sync.RWMutex
-	lockLatestNoteViews             sync.RWMutex
+	lockLiveNoteViews               sync.RWMutex
 	lockLogger                      sync.RWMutex
 	lockRequest                     sync.RWMutex
 	lockSend                        sync.RWMutex
@@ -180,30 +180,30 @@ func (mock *EnvMock) BotLinkCalls() []struct {
 	return calls
 }
 
-// LatestNoteViews calls LatestNoteViewsFunc.
-func (mock *EnvMock) LatestNoteViews() *model.NoteViews {
-	if mock.LatestNoteViewsFunc == nil {
-		panic("EnvMock.LatestNoteViewsFunc: method is nil but Env.LatestNoteViews was just called")
+// LiveNoteViews calls LiveNoteViewsFunc.
+func (mock *EnvMock) LiveNoteViews() *model.NoteViews {
+	if mock.LiveNoteViewsFunc == nil {
+		panic("EnvMock.LiveNoteViewsFunc: method is nil but Env.LiveNoteViews was just called")
 	}
 	callInfo := struct {
 	}{}
-	mock.lockLatestNoteViews.Lock()
-	mock.calls.LatestNoteViews = append(mock.calls.LatestNoteViews, callInfo)
-	mock.lockLatestNoteViews.Unlock()
-	return mock.LatestNoteViewsFunc()
+	mock.lockLiveNoteViews.Lock()
+	mock.calls.LiveNoteViews = append(mock.calls.LiveNoteViews, callInfo)
+	mock.lockLiveNoteViews.Unlock()
+	return mock.LiveNoteViewsFunc()
 }
 
-// LatestNoteViewsCalls gets all the calls that were made to LatestNoteViews.
+// LiveNoteViewsCalls gets all the calls that were made to LiveNoteViews.
 // Check the length with:
 //
-//	len(mockedEnv.LatestNoteViewsCalls())
-func (mock *EnvMock) LatestNoteViewsCalls() []struct {
+//	len(mockedEnv.LiveNoteViewsCalls())
+func (mock *EnvMock) LiveNoteViewsCalls() []struct {
 } {
 	var calls []struct {
 	}
-	mock.lockLatestNoteViews.RLock()
-	calls = mock.calls.LatestNoteViews
-	mock.lockLatestNoteViews.RUnlock()
+	mock.lockLiveNoteViews.RLock()
+	calls = mock.calls.LiveNoteViews
+	mock.lockLiveNoteViews.RUnlock()
 	return calls
 }
 

--- a/internal/case/handletgnavigationupdate/render.go
+++ b/internal/case/handletgnavigationupdate/render.go
@@ -23,13 +23,13 @@ func RenderNote(noteViews *model.NoteViews, pathID int64, stack []int64, botLink
 	}
 
 	note := noteByPathID(noteViews, pathID)
-	if note == nil {
+	if note == nil || !note.Free {
 		return "", nil, fmt.Errorf("note not found: %d", pathID)
 	}
 
 	converter := &markdownv2.HTMLConverter{}
 	converter.SetLinkResolver(func(target string) (*markdownv2.LinkResolverResult, error) {
-		resolved := resolveBasename(noteViews, target)
+		resolved := resolvePublicBasename(noteViews, target)
 		if resolved == nil {
 			return nil, &markdownv2.LinkResolverError{Target: target, Reason: "not found"}
 		}
@@ -60,7 +60,7 @@ func RenderNote(noteViews *model.NoteViews, pathID int64, stack []int64, botLink
 		if len(links) == 0 {
 			continue
 		}
-		target := resolveBasename(noteViews, links[0].Target)
+		target := resolvePublicBasename(noteViews, links[0].Target)
 		if target == nil {
 			continue
 		}
@@ -95,7 +95,7 @@ func FindStartNote(noteViews *model.NoteViews) *model.NoteView {
 		return nil
 	}
 	for _, note := range noteViews.List {
-		if strings.HasSuffix(note.Path, "_bot_start.md") {
+		if note.Free && strings.HasSuffix(note.Path, "_bot_start.md") {
 			return note
 		}
 	}
@@ -111,11 +111,12 @@ func noteByPathID(noteViews *model.NoteViews, pathID int64) *model.NoteView {
 	return nil
 }
 
-func resolveBasename(noteViews *model.NoteViews, target string) *model.NoteView {
+func resolvePublicBasename(noteViews *model.NoteViews, target string) *model.NoteView {
 	key := strings.ToLower(strings.TrimSuffix(target, ".md"))
-	candidates := noteViews.BasenameMap[key]
-	if len(candidates) > 0 {
-		return candidates[0]
+	for _, candidate := range noteViews.BasenameMap[key] {
+		if candidate.Free {
+			return candidate
+		}
 	}
 	return nil
 }

--- a/internal/case/handletgnavigationupdate/resolve.go
+++ b/internal/case/handletgnavigationupdate/resolve.go
@@ -25,7 +25,7 @@ type Env interface {
 	BotID() int64
 	BotLink() string
 	Logger() logger.Logger
-	LatestNoteViews() *model.NoteViews
+	LiveNoteViews() *model.NoteViews
 	TgUserStateByBotIDAndChatID(ctx context.Context, arg db.TgUserStateByBotIDAndChatIDParams) (db.TgUserState, error)
 	UpsertTgUserState(ctx context.Context, arg db.UpsertTgUserStateParams) error
 }
@@ -185,7 +185,7 @@ func handleBrowseCommand(ctx context.Context, env Env, msg *tgbotapi.Message, ch
 		return sendNote(ctx, env, chatID, pathID, frag, rawState)
 	}
 
-	note := FindStartNote(env.LatestNoteViews())
+	note := FindStartNote(env.LiveNoteViews())
 	if note == nil {
 		reply := tgbotapi.NewMessage(chatID, "No _bot_start.md found in vault.")
 		_, _ = env.Send(reply)
@@ -212,7 +212,7 @@ func parseBrowseDeepLink(args string) (int64, bool) {
 }
 
 func sendNote(ctx context.Context, env Env, chatID, pathID int64, frag *stateFragment, rawState string) error {
-	text, keyboard, err := RenderNote(env.LatestNoteViews(), pathID, frag.Nav.Stack, env.BotLink())
+	text, keyboard, err := RenderNote(env.LiveNoteViews(), pathID, frag.Nav.Stack, env.BotLink())
 	if err != nil {
 		msg := tgbotapi.NewMessage(chatID, fmt.Sprintf("Note not found (%d).", pathID))
 		_, _ = env.Send(msg)

--- a/internal/case/handletgnavigationupdate/resolve_acl_test.go
+++ b/internal/case/handletgnavigationupdate/resolve_acl_test.go
@@ -1,0 +1,117 @@
+package handletgnavigationupdate
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"trip2g/internal/db"
+	"trip2g/internal/logger"
+	"trip2g/internal/model"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/text"
+)
+
+func TestResolveOpenUsesLiveNotesOnly(t *testing.T) {
+	liveViews := noteViewsWith(&model.NoteView{
+		PathID:  7,
+		Path:    "public.md",
+		Title:   "Public",
+		Content: []byte("public body"),
+		Free:    true,
+	})
+
+	sentTexts := make([]string, 0, 2)
+	env := newNavigationTestEnv(t, liveViews, &sentTexts)
+
+	err := ResolveOpen(context.Background(), env, privateStartUpdate("/start browse_99"), 99)
+	require.NoError(t, err)
+	require.Len(t, sentTexts, 1)
+	require.Equal(t, "Note not found (99).", sentTexts[0])
+	require.NotContains(t, sentTexts[0], "private body")
+}
+
+func TestResolveOpenDoesNotRenderPaidLiveNote(t *testing.T) {
+	liveViews := noteViewsWith(&model.NoteView{
+		PathID:  11,
+		Path:    "paid.md",
+		Title:   "Paid",
+		Content: []byte("paid body"),
+		Free:    false,
+	})
+
+	sentTexts := make([]string, 0, 2)
+	env := newNavigationTestEnv(t, liveViews, &sentTexts)
+
+	err := ResolveOpen(context.Background(), env, privateStartUpdate("/start browse_11"), 11)
+	require.NoError(t, err)
+	require.Len(t, sentTexts, 1)
+	require.Equal(t, "Note not found (11).", sentTexts[0])
+	require.NotContains(t, sentTexts[0], "paid body")
+}
+
+func TestResolveOpenRendersLiveNote(t *testing.T) {
+	liveViews := noteViewsWith(&model.NoteView{
+		PathID:  7,
+		Path:    "public.md",
+		Title:   "Public",
+		Content: []byte("public body"),
+		Free:    true,
+	})
+
+	sentTexts := make([]string, 0, 2)
+	env := newNavigationTestEnv(t, liveViews, &sentTexts)
+
+	err := ResolveOpen(context.Background(), env, privateStartUpdate("/start browse_7"), 7)
+	require.NoError(t, err)
+	require.Len(t, sentTexts, 1)
+	require.Contains(t, sentTexts[0], "public body")
+}
+
+func noteViewsWith(notes ...*model.NoteView) *model.NoteViews {
+	nvs := model.NewNoteViews()
+	nvs.BasenameMap = make(map[string][]*model.NoteView)
+	md := goldmark.New()
+	for _, note := range notes {
+		note.SetAst(md.Parser().Parse(text.NewReader(note.Content)))
+		nvs.List = append(nvs.List, note)
+		nvs.PathMap[note.Path] = note
+	}
+	return nvs
+}
+
+func newNavigationTestEnv(t *testing.T, liveViews *model.NoteViews, sentTexts *[]string) *EnvMock {
+	t.Helper()
+	return &EnvMock{
+		BotIDFunc:         func() int64 { return 1 },
+		BotLinkFunc:       func() string { return "https://t.me/test_bot" },
+		LiveNoteViewsFunc: func() *model.NoteViews { return liveViews },
+		LoggerFunc:        func() logger.Logger { return &logger.DummyLogger{} },
+		TgUserStateByBotIDAndChatIDFunc: func(context.Context, db.TgUserStateByBotIDAndChatIDParams) (db.TgUserState, error) {
+			return db.TgUserState{}, sql.ErrNoRows
+		},
+		UpsertTgUserStateFunc: func(context.Context, db.UpsertTgUserStateParams) error { return nil },
+		SendFunc: func(msg tgbotapi.Chattable) (tgbotapi.Message, error) {
+			switch cfg := msg.(type) {
+			case tgbotapi.MessageConfig:
+				*sentTexts = append(*sentTexts, cfg.Text)
+			case tgbotapi.EditMessageTextConfig:
+				*sentTexts = append(*sentTexts, cfg.Text)
+			default:
+				t.Fatalf("unexpected message type %T", msg)
+			}
+			return tgbotapi.Message{MessageID: len(*sentTexts)}, nil
+		},
+	}
+}
+
+func privateStartUpdate(text string) tgbotapi.Update {
+	return tgbotapi.Update{Message: &tgbotapi.Message{
+		MessageID: 1,
+		Text:      text,
+		Chat:      &tgbotapi.Chat{ID: 123, Type: "private"},
+		Entities:  []tgbotapi.MessageEntity{{Type: "bot_command", Offset: 0, Length: 6}},
+	}}
+}

--- a/internal/case/handletgupdate/mocks_test.go
+++ b/internal/case/handletgupdate/mocks_test.go
@@ -70,6 +70,9 @@ var _ Env = &EnvMock{}
 //			ListActiveUserSubgraphsFunc: func(ctx context.Context, userID int64) ([]string, error) {
 //				panic("mock out the ListActiveUserSubgraphs method")
 //			},
+//			LiveNoteViewsFunc: func() *model.NoteViews {
+//				panic("mock out the LiveNoteViews method")
+//			},
 //			LoggerFunc: func() logger.Logger {
 //				panic("mock out the Logger method")
 //			},
@@ -169,6 +172,9 @@ type EnvMock struct {
 
 	// ListActiveUserSubgraphsFunc mocks the ListActiveUserSubgraphs method.
 	ListActiveUserSubgraphsFunc func(ctx context.Context, userID int64) ([]string, error)
+
+	// LiveNoteViewsFunc mocks the LiveNoteViews method.
+	LiveNoteViewsFunc func() *model.NoteViews
 
 	// LoggerFunc mocks the Logger method.
 	LoggerFunc func() logger.Logger
@@ -321,6 +327,9 @@ type EnvMock struct {
 			// UserID is the userID argument value.
 			UserID int64
 		}
+		// LiveNoteViews holds details about calls to the LiveNoteViews method.
+		LiveNoteViews []struct {
+		}
 		// Logger holds details about calls to the Logger method.
 		Logger []struct {
 		}
@@ -435,6 +444,7 @@ type EnvMock struct {
 	lockLatestNoteViews                       sync.RWMutex
 	lockListActiveTgChatSubgraphNamesByChatID sync.RWMutex
 	lockListActiveUserSubgraphs               sync.RWMutex
+	lockLiveNoteViews                         sync.RWMutex
 	lockLogger                                sync.RWMutex
 	lockMarkTgBotChatRemoved                  sync.RWMutex
 	lockRemoveTgChatMember                    sync.RWMutex
@@ -1006,6 +1016,33 @@ func (mock *EnvMock) ListActiveUserSubgraphsCalls() []struct {
 	mock.lockListActiveUserSubgraphs.RLock()
 	calls = mock.calls.ListActiveUserSubgraphs
 	mock.lockListActiveUserSubgraphs.RUnlock()
+	return calls
+}
+
+// LiveNoteViews calls LiveNoteViewsFunc.
+func (mock *EnvMock) LiveNoteViews() *model.NoteViews {
+	if mock.LiveNoteViewsFunc == nil {
+		panic("EnvMock.LiveNoteViewsFunc: method is nil but Env.LiveNoteViews was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockLiveNoteViews.Lock()
+	mock.calls.LiveNoteViews = append(mock.calls.LiveNoteViews, callInfo)
+	mock.lockLiveNoteViews.Unlock()
+	return mock.LiveNoteViewsFunc()
+}
+
+// LiveNoteViewsCalls gets all the calls that were made to LiveNoteViews.
+// Check the length with:
+//
+//	len(mockedEnv.LiveNoteViewsCalls())
+func (mock *EnvMock) LiveNoteViewsCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockLiveNoteViews.RLock()
+	calls = mock.calls.LiveNoteViews
+	mock.lockLiveNoteViews.RUnlock()
 	return calls
 }
 

--- a/internal/case/handletgupdate/resolve.go
+++ b/internal/case/handletgupdate/resolve.go
@@ -38,7 +38,8 @@ type Env interface {
 	InsertTgChatMember(ctx context.Context, arg db.InsertTgChatMemberParams) error
 	RemoveTgChatMember(ctx context.Context, arg db.RemoveTgChatMemberParams) error
 	CalculateSha256(s string) string
-	LatestNoteViews() *model.NoteViews // TODO: read LiveNoteViews for production users
+	LatestNoteViews() *model.NoteViews
+	LiveNoteViews() *model.NoteViews
 	Logger() logger.Logger
 	BotID() int64
 	Send(msg tgbotapi.Chattable) (tgbotapi.Message, error)


### PR DESCRIPTION
### Motivation

- The Telegram navigation flow could render arbitrary latest/draft or paid notes by numeric `pathID` because it used `LatestNoteViews()` and did not perform any `Free`/access checks.
- Deep-linking (`/start browse_<id>`) and `/browse` delegated directly into the navigation handler without enforcing the same `CanReadNote`-style gating that web rendering uses, exposing private content.

### Description

- Switched the navigation handler to use `LiveNoteViews()` instead of `LatestNoteViews()` so the browser only sees released/live notes via `RenderNote` and start-note lookup. 
- Added a public-only guard in `RenderNote` to return an error if the selected note is not `Free`, and changed wikilink/button resolution to use `resolvePublicBasename` that only returns `Free` notes. 
- Updated the `Env` interfaces and generated mocks to expose `LiveNoteViews()` where needed (`handletgnavigationupdate` and `handletgupdate`).
- Added regression tests in `internal/case/handletgnavigationupdate/resolve_acl_test.go` that verify deep-link missing IDs, that paid live notes are not rendered, and that public live notes are rendered.

### Testing

- Ran `go test ./internal/case/handletgnavigationupdate ./internal/case/handletgupdate` and the updated navigation/unit tests passed. 
- Ran `go test ./...` and the test run was mostly green but the top-level run fails in this environment due to missing generated/embed assets (`assets/ui/admin/-/web.js` and `onboarding-vault/vault.zip`) which are unrelated to the changes here.
- Added unit tests `resolve_acl_test.go` which exercise `ResolveOpen` behavior and they pass locally in the test run above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a510ec9a0f8832fa75d65d09c475169)