### PR TITLE
docs(mcp): document nested kb_id path syntax in federated tool descriptions

### DIFF
--- a/docs/_mcp_initialize.md
+++ b/docs/_mcp_initialize.md
@@ -27,7 +27,7 @@ note_html(pid=658, toc_path=["Adding a private peer (two-step exchange)"])
 ## Other tools — one-line triggers
 
 - `similar(pid=N)` — you found one good note and want its neighbors. Example: after the federation guide, `similar(pid=658)` surfaces the protocol guide and the RU twin.
-- `federated_search(query)` — local `search` found nothing relevant, or a result had `kind: "federation_kb"` (a pointer to a connected base). It fans the query out across all connected bases; pass `kb_id="..."` to target one. Follow-up reads go through `federated_note_html` / `federated_expand` / `federated_similar`, and each of those requires the `kb_id`.
+- `federated_search(query)` — local `search` found nothing relevant, or a result had `kind: "federation_kb"` (a pointer to a connected base). It fans the query out across all connected bases; pass `kb_id="..."` to target one. Nested bases use `/`: `kb_id="philosophers/nietzsche"` routes through the `philosophers` peer into the base it federates (recursive). Follow-up reads go through `federated_note_html` / `federated_expand` / `federated_similar`, and each of those requires the `kb_id`.
 
 Call the `instructions` tool for the full argument reference.
 

--- a/docs/_mcp_instructions.md
+++ b/docs/_mcp_instructions.md
@@ -53,6 +53,7 @@ Trigger: you have one good note and want its neighbors — related guides, the o
 This base can be connected to peer knowledge bases. The federated variants mirror the local ones, with a `kb_id` targeting a peer:
 
 - `federated_search(query, kb_id?, kb_ids?, limit?, detail_limit?)` — omit `kb_id` to fan out across all connected bases in parallel; pass `kb_id` for one base, `kb_ids` for a chosen set.
+- Nested bases: a peer's own peers are addressed with `/` — `kb_id="philosophers/nietzsche"` routes through the `philosophers` peer into the base it federates (recursive; `kb_ids` accepts the same form).
 - `federated_note_html(kb_id, ...)`, `federated_expand(kb_id, ...)`, `federated_similar(kb_id, ...)` — same arguments as their local twins, `kb_id` required.
 
 Trigger: local `search` came up empty after one rephrase, or a local result had `kind: "federation_kb"`. Results from a peer name their `kb_id` — keep passing it on every follow-up call.

--- a/internal/case/mcp/resolve.go
+++ b/internal/case/mcp/resolve.go
@@ -266,10 +266,19 @@ func handleToolsList(ctx context.Context, env Env, id any) Response { //nolint:f
 			InputSchema: &InputSchema{
 				Type: "object",
 				Properties: map[string]Property{
-					"query":  {Type: "string", Description: "Search query"},
-					"kb_id":  {Type: "string", Description: "Target knowledge base id; nested bases use '/' (e.g. \"philosophers/nietzsche\" routes through the 'philosophers' peer, recursively)"},
-					"kb_ids": {Type: "array", Description: "Target knowledge base ids; each accepts the same nested 'peer/base' form as kb_id", Items: &Property{Type: "string"}},
-					"limit":  {Type: "number", Description: "Max number of results to return (default 6)"},
+					"query": {Type: "string", Description: "Search query"},
+					"kb_id": {
+						Type: "string",
+						Description: "Target knowledge base id; nested bases use '/' " +
+							`(e.g. "philosophers/nietzsche" routes through the 'philosophers' peer, recursively)`,
+					},
+					"kb_ids": {
+						Type: "array",
+						Description: "Target knowledge base ids; each accepts the same " +
+							"nested 'peer/base' form as kb_id",
+						Items: &Property{Type: "string"},
+					},
+					"limit": {Type: "number", Description: "Max number of results to return (default 6)"},
 					"detail_limit": {
 						Type:        "number",
 						Description: "How many results include full snippet matches; results beyond this are returned as lightweight previews (title, path, score) to save context (default 3)",
@@ -284,7 +293,11 @@ func handleToolsList(ctx context.Context, env Env, id any) Response { //nolint:f
 			InputSchema: &InputSchema{
 				Type: "object",
 				Properties: map[string]Property{
-					"kb_id":   {Type: "string", Description: "Target knowledge base id; nested bases use '/' (e.g. \"philosophers/nietzsche\" routes through the 'philosophers' peer, recursively)"},
+					"kb_id": {
+						Type: "string",
+						Description: "Target knowledge base id; nested bases use '/' " +
+							`(e.g. "philosophers/nietzsche" routes through the 'philosophers' peer, recursively)`,
+					},
 					"path":    {Type: "string", Description: "Remote note path"},
 					"href":    {Type: "string", Description: "Remote note href"},
 					"pid":     {Type: "number", Description: "Remote stable note id"},
@@ -300,7 +313,11 @@ func handleToolsList(ctx context.Context, env Env, id any) Response { //nolint:f
 			InputSchema: &InputSchema{
 				Type: "object",
 				Properties: map[string]Property{
-					"kb_id":    {Type: "string", Description: "Target knowledge base id; nested bases use '/' (e.g. \"philosophers/nietzsche\" routes through the 'philosophers' peer, recursively)"},
+					"kb_id": {
+						Type: "string",
+						Description: "Target knowledge base id; nested bases use '/' " +
+							`(e.g. "philosophers/nietzsche" routes through the 'philosophers' peer, recursively)`,
+					},
 					"path":     {Type: "string", Description: "Remote note path"},
 					"href":     {Type: "string", Description: "Remote note href"},
 					"pid":      {Type: "number", Description: "Remote stable note id"},
@@ -316,7 +333,11 @@ func handleToolsList(ctx context.Context, env Env, id any) Response { //nolint:f
 			InputSchema: &InputSchema{
 				Type: "object",
 				Properties: map[string]Property{
-					"kb_id":   {Type: "string", Description: "Target knowledge base id; nested bases use '/' (e.g. \"philosophers/nietzsche\" routes through the 'philosophers' peer, recursively)"},
+					"kb_id": {
+						Type: "string",
+						Description: "Target knowledge base id; nested bases use '/' " +
+							`(e.g. "philosophers/nietzsche" routes through the 'philosophers' peer, recursively)`,
+					},
 					"path":    {Type: "string", Description: "Remote note path"},
 					"href":    {Type: "string", Description: "Remote note href"},
 					"pid":     {Type: "number", Description: "Remote stable note id"},
@@ -359,7 +380,11 @@ func handleToolsList(ctx context.Context, env Env, id any) Response { //nolint:f
 			InputSchema: &InputSchema{
 				Type: "object",
 				Properties: map[string]Property{
-					"kb_id":     {Type: "string", Description: "Target knowledge base id; nested bases use '/' (e.g. \"philosophers/nietzsche\" routes through the 'philosophers' peer, recursively)"},
+					"kb_id": {
+						Type: "string",
+						Description: "Target knowledge base id; nested bases use '/' " +
+							`(e.g. "philosophers/nietzsche" routes through the 'philosophers' peer, recursively)`,
+					},
 					"query":     {Type: "string", Description: "Read-only GraphQL query string"},
 					"variables": {Type: "object", Description: "Optional variables map"},
 				},

--- a/internal/case/mcp/resolve.go
+++ b/internal/case/mcp/resolve.go
@@ -262,13 +262,13 @@ func handleToolsList(ctx context.Context, env Env, id any) Response { //nolint:f
 		},
 		{
 			Name:        "federated_search",
-			Description: "Search connected knowledge bases. Returns snippets with heading breadcrumbs (title > section > subsection) and a precise toc_path per match, same as search. Pass kb_id for one base, kb_ids for selected bases, or omit both to fan out. Use the breadcrumb to locate the approximate section; use federated_note_html(kb_id=..., match_id=...) to open the focused chunk.",
+			Description: "Search connected knowledge bases. Returns snippets with heading breadcrumbs (title > section > subsection) and a precise toc_path per match, same as search. Pass kb_id for one base, kb_ids for selected bases, or omit both to fan out. Nested bases are addressed with '/': kb_id \"philosophers/nietzsche\" routes through the 'philosophers' peer to the base it federates (recursive). Use the breadcrumb to locate the approximate section; use federated_note_html(kb_id=..., match_id=...) to open the focused chunk.",
 			InputSchema: &InputSchema{
 				Type: "object",
 				Properties: map[string]Property{
 					"query":  {Type: "string", Description: "Search query"},
-					"kb_id":  {Type: "string", Description: "Target knowledge base id"},
-					"kb_ids": {Type: "array", Description: "Target knowledge base ids", Items: &Property{Type: "string"}},
+					"kb_id":  {Type: "string", Description: "Target knowledge base id; nested bases use '/' (e.g. \"philosophers/nietzsche\" routes through the 'philosophers' peer, recursively)"},
+					"kb_ids": {Type: "array", Description: "Target knowledge base ids; each accepts the same nested 'peer/base' form as kb_id", Items: &Property{Type: "string"}},
 					"limit":  {Type: "number", Description: "Max number of results to return (default 6)"},
 					"detail_limit": {
 						Type:        "number",
@@ -284,7 +284,7 @@ func handleToolsList(ctx context.Context, env Env, id any) Response { //nolint:f
 			InputSchema: &InputSchema{
 				Type: "object",
 				Properties: map[string]Property{
-					"kb_id":   {Type: "string", Description: "Target knowledge base id"},
+					"kb_id":   {Type: "string", Description: "Target knowledge base id; nested bases use '/' (e.g. \"philosophers/nietzsche\" routes through the 'philosophers' peer, recursively)"},
 					"path":    {Type: "string", Description: "Remote note path"},
 					"href":    {Type: "string", Description: "Remote note href"},
 					"pid":     {Type: "number", Description: "Remote stable note id"},
@@ -300,7 +300,7 @@ func handleToolsList(ctx context.Context, env Env, id any) Response { //nolint:f
 			InputSchema: &InputSchema{
 				Type: "object",
 				Properties: map[string]Property{
-					"kb_id":    {Type: "string", Description: "Target knowledge base id"},
+					"kb_id":    {Type: "string", Description: "Target knowledge base id; nested bases use '/' (e.g. \"philosophers/nietzsche\" routes through the 'philosophers' peer, recursively)"},
 					"path":     {Type: "string", Description: "Remote note path"},
 					"href":     {Type: "string", Description: "Remote note href"},
 					"pid":      {Type: "number", Description: "Remote stable note id"},
@@ -316,7 +316,7 @@ func handleToolsList(ctx context.Context, env Env, id any) Response { //nolint:f
 			InputSchema: &InputSchema{
 				Type: "object",
 				Properties: map[string]Property{
-					"kb_id":   {Type: "string", Description: "Target knowledge base id"},
+					"kb_id":   {Type: "string", Description: "Target knowledge base id; nested bases use '/' (e.g. \"philosophers/nietzsche\" routes through the 'philosophers' peer, recursively)"},
 					"path":    {Type: "string", Description: "Remote note path"},
 					"href":    {Type: "string", Description: "Remote note href"},
 					"pid":     {Type: "number", Description: "Remote stable note id"},
@@ -359,7 +359,7 @@ func handleToolsList(ctx context.Context, env Env, id any) Response { //nolint:f
 			InputSchema: &InputSchema{
 				Type: "object",
 				Properties: map[string]Property{
-					"kb_id":     {Type: "string", Description: "Target knowledge base id"},
+					"kb_id":     {Type: "string", Description: "Target knowledge base id; nested bases use '/' (e.g. \"philosophers/nietzsche\" routes through the 'philosophers' peer, recursively)"},
 					"query":     {Type: "string", Description: "Read-only GraphQL query string"},
 					"variables": {Type: "object", Description: "Optional variables map"},
 				},


### PR DESCRIPTION
Federation already supports nested kb_ids with '/' as separator — `federated_search(kb_id="philosophers/nietzsche")` routes through the `philosophers` peer to the corpus it federates, recursively (splitKBID in internal/case/mcp/federation_helpers.go). It was implemented and verified live but undocumented: in a 15-model study every model (haiku/sonnet/opus/fable/gpt) failed to reach level-3 bases through the root hub because nobody guesses an undocumented convention. This is a description-only change: the nested syntax is now stated in the kb_id/kb_ids parameter descriptions of all federated tools and in the federated_search tool description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)