### PR TITLE
test(search): golden retrieval coverage + federation-JWT corpus; sync design docs

### DIFF
--- a/docs/dev/search_transport_consolidation.md
+++ b/docs/dev/search_transport_consolidation.md
@@ -1,17 +1,25 @@
 # Search Transports: GraphQL vs MCP — Consolidation Analysis
 
-**TL;DR.** Do NOT move the site frontend to MCP search. The premise "both are thin wrappers over shared internals" is half-wrong: GraphQL `search` is a 1-line wrapper over `sitesearch.Resolve`, but MCP `search` is a **separate ~200-line duplicate retrieval pipeline** that only shares low-level primitives. The right move is the inverse consolidation (option c): extract one shared retrieval engine, keep both transports as thin adapters. Effort ≈ 0.5–1 day. Bonus: it fixes a real behavioral divergence (MCP always searches *latest* notes, even for anonymous clients, where the site correctly serves *live*).
+**TL;DR.** Do NOT move the site frontend to MCP search. The premise "both are thin wrappers over shared internals" was half-wrong: GraphQL `search` was a 1-line wrapper over `sitesearch.Resolve`, but MCP `search` was a **separate ~200-line duplicate retrieval pipeline** that only shared low-level primitives. The right move was the inverse consolidation (option c): extract one shared retrieval engine, keep both transports as thin adapters. It also fixed a real behavioral divergence (MCP always searched *latest* notes, even for anonymous clients, where the site correctly serves *live*).
 
-Status: analysis only, nothing changed. Written 2026-07-11.
+Status: **IMPLEMENTED** in PR #176 (merged 2026-07-11). Sections 1–3 describe the pre-change state and are kept as the rationale record; the shipped architecture is in §0.
 
-## 1. The actual call graph
+## 0. Implemented architecture (PR #176)
 
-There are **three** consumers of search, not two:
+- **One core:** `sitesearch.Retrieve(ctx, env RetrieveEnv, query, useLatest) ([]model.SearchResult, merged bool, error)` (`internal/case/sitesearch/retrieve.go`) — text lane (bleve) + vector lane (dot similarity, dim-mismatch guard, deterministic tie-breaks) + RRF fusion + optional blended CE rerank.
+- **Site adapter:** `sitesearch.Resolve` = corpus choice (`ShowDraftVersions || admin` → latest) → `Retrieve` → scope/permission filter → "Закрытый материал." placeholders → post-ACL output caps.
+- **MCP adapter:** `handleSearch` = corpus choice (`mcpAPIKeyAuthed` → latest; anonymous and federation-JWT clients → live) → `Retrieve` → `filterSearchResults`/`canReadMCPNote` → `buildSearchPayload` (`match_id`, `toc_path`).
+- The unused server-rendered `/search` page (`internal/case/rendersearchpage`) is **deleted**; GraphQL search remains the transport for the site widget and `notePaths(filter:{search})`.
+- Cross-transport parity is locked by `TestSearchRankingMatchesSiteSearch` plus golden retrieval tests (`internal/case/sitesearch/golden_test.go`); corpus selection and the dim guard have dedicated tests on both surfaces.
+
+## 1. The call graph (pre-change)
+
+There were **three** consumers of search, not two:
 
 | Surface | Entry point | Engine used |
 |---------|-------------|-------------|
 | GraphQL `search(input:)` | `internal/graph/schema.resolvers.go:3205-3207` | `sitesearch.Resolve` — literally one line |
-| HTML `/search?q=` page | `internal/case/rendersearchpage/endpoint.go:35` | `sitesearch.Resolve` (64-line endpoint, `Env = sitesearch.Env`) |
+| HTML `/search?q=` page | `internal/case/rendersearchpage/endpoint.go:35` | `sitesearch.Resolve` (64-line endpoint; **removed in PR #176**) |
 | MCP `search` tool | `internal/case/mcp/resolve.go:489` (`handleSearch`) | **its own pipeline**, not `sitesearch` |
 
 Also: GraphQL `notePaths(filter:{search})` reuses the Search resolver (`schema.resolvers.go:3230`), so GraphQL search has a second internal consumer.
@@ -50,11 +58,11 @@ Switching this widget to the MCP endpoint would require:
 - a JSON-RPC 2.0 client in the template bundle (MCP is same-origin, so CORS is a non-issue, and anonymous MCP access exists — `internal/case/mcp/endpoint.go:150-154`);
 - losing HTML match highlighting (MCP returns plain snippets — by design, agents must not get injectable remote HTML);
 - losing the "closed material" placeholder UX and the live/latest draft logic;
-- keeping GraphQL search anyway for `notePaths(filter:{search})` and the `/search` HTML page — so nothing gets deleted.
+- keeping GraphQL search anyway for `notePaths(filter:{search})` — so the engine survives regardless. (The `/search` HTML page, a third consumer at analysis time, turned out to be unused and was deleted in PR #176 instead.)
 
 ## 3. Options
 
-**(a) Frontend → MCP, remove GraphQL `search`.** Worst of all worlds. The MCP pipeline is the *less correct* of the two (always-latest corpus, no dim guard); the frontend loses highlighting and hidden-result UX; a JSON-RPC client must be added to the visitor bundle; `notePaths` and `/search` still need the engine so no code is deleted; and it contradicts the federated-search design (`docs/dev/federated_search_ui.md`), which — written today — proposes a **new** `federatedSearch` GraphQL query as the human-visitor transport. Effort: days. Value: negative.
+**(a) Frontend → MCP, remove GraphQL `search`.** Worst of all worlds. The MCP pipeline was the *less correct* of the two (always-latest corpus, no dim guard); the frontend loses highlighting and hidden-result UX; a JSON-RPC client must be added to the visitor bundle; `notePaths` still needs the engine so no code is deleted; and it contradicts the federated-search design (`docs/dev/federated_search_ui.md`), which — written the same day — proposes a **new** `federatedSearch` GraphQL query as the human-visitor transport. Effort: days. Value: negative.
 
 **(b) Status quo.** Zero immediate effort, but the "two thin transports" framing is false — it is two *engines*, and they have already drifted (table above). Every retrieval improvement (reranker tuning, RRF changes, embedding-model migration) must be applied twice or silently applies once.
 
@@ -62,9 +70,9 @@ Switching this widget to the MCP endpoint would require:
 
 ## 4. Recommendation
 
-**Option (c).** The owner's self-correction was directionally right but factually optimistic — the internals are *not* shared today, and that is precisely the problem worth fixing. Removing GraphQL search solves nothing (the engine must survive for `/search` and `notePaths`, and the fed-search UI plan builds *on* GraphQL), while unifying the retrieval core removes ~200 duplicated lines from `internal/case/mcp`, closes the dot/cosine and dim-guard drift, and gives the federated-search work a single engine to call. This also matches the in-flight `internal/fedsearch` extraction proposed in `docs/dev/federated_search_ui.md` §3 — the same service-package move, one layer down.
+**Option (c).** The owner's self-correction was directionally right but factually optimistic — the internals were *not* shared at the time, and that was precisely the problem worth fixing. Removing GraphQL search solves nothing (the engine must survive for `notePaths`, and the fed-search UI plan builds *on* GraphQL), while unifying the retrieval core removed ~200 duplicated lines from `internal/case/mcp`, closed the dot/cosine and dim-guard drift, and gives the federated-search work a single engine to call. This also matches the in-flight `internal/fedsearch` extraction proposed in `docs/dev/federated_search_ui.md` §3 — the same service-package move, one layer down.
 
-**Migration sketch (0.5–1 day):**
+**Migration sketch (implemented as written, in PR #176):**
 
 1. Extract `retrieve(ctx, env, query, useLatest) ([]model.SearchResult, passageByURL, error)` — the text+vector+RRF+rerank core — from `sitesearch` (either exported from `sitesearch` or a new `internal/search` service package per the gitapi pattern). `sitesearch.Env` already declares everything it needs.
 2. `sitesearch.Resolve` becomes: corpus choice → `retrieve` → scope/permission filter → placeholders → caps. (Mostly unchanged.)
@@ -73,15 +81,15 @@ Switching this widget to the MCP endpoint would require:
 
 **Trade-offs of (c):** the shared engine gains a `useLatest` parameter and both callers' expectations become coupled — a retrieval change now affects agents and visitors simultaneously (that is the point, but it means rerank experiments hit both surfaces; if a surface ever needs different retrieval behavior, add an options struct, don't re-fork). The latest→live change for anonymous MCP is a user-visible behavior change for agent clients on draft-showing sites; it should be called out in the changelog.
 
-## References
+## References (post-PR #176; pre-change line numbers in §1-3 are historical)
 
-- `internal/case/sitesearch/resolve.go:50` — the site engine (text+vector+RRF+rerank+ACL)
-- `internal/graph/schema.resolvers.go:3205` — GraphQL wrapper (1 line)
-- `internal/graph/schema.resolvers.go:3230` — `notePaths(search:)` reuses it
-- `internal/case/rendersearchpage/endpoint.go:35` — `/search` HTML page, third consumer
-- `internal/case/mcp/resolve.go:489` — MCP `handleSearch`, parallel pipeline
-- `internal/case/mcp/resolve.go:1216-1421` — duplicated vector/RRF/snippet code
-- `internal/case/mcp/resolve.go:502,513` — MCP always-latest corpus
+- `internal/case/sitesearch/retrieve.go` — the shared retrieval core (`Retrieve`)
+- `internal/case/sitesearch/resolve.go` — site adapter (ACL, placeholders, caps)
+- `internal/case/mcp/resolve.go` — MCP adapter (`handleSearch`: corpus choice, `filterSearchResults`, `buildSearchPayload`)
+- `internal/case/sitesearch/golden_test.go` — golden retrieval rankings
+- `internal/case/mcp/search_corpus_test.go` — corpus selection + cross-transport parity tests
+- `internal/graph/schema.resolvers.go` — GraphQL wrapper (1 line) and `notePaths(search:)` reuse
 - `assets/ui/user/search/search.view.ts:2` — frontend uses GraphQL `search`
 - `internal/defaulttemplate/views.html:421` — template mounts the widget
 - `docs/dev/federated_search_ui.md` — in-flight design that extends GraphQL search
+- `docs/dev/todo_remove_old_layout.md` — `rendersearchpage` removal recorded there (step 1 done)

--- a/docs/dev/todo_remove_old_layout.md
+++ b/docs/dev/todo_remove_old_layout.md
@@ -5,17 +5,18 @@ Several older server-rendered cases and templates are partially or fully
 superseded. This doc records what can be removed, what must stay, and the
 cascade for each — so the cleanup can be done later as its own change.
 
-> Status: investigation only. Nothing removed yet. Verify each "candidate"
+> Status: step 1 (`rendersearchpage`) DONE in PR #176 (2026-07-11), which also
+> unblocks step 2. Steps 2-4 still pending. Verify each remaining "candidate"
 > against live traffic / external links before deleting.
 
 ## Verdicts
 
 | Target | Verdict | Why |
 |--------|---------|-----|
-| `internal/case/rendersearchpage` | **Remove (candidate)** | GET `/search` server-rendered page. The user-facing search uses the GraphQL `search()` query (`assets/ui/user/search/search.view.ts`), not this page. Only reference is the router registration. |
+| `internal/case/rendersearchpage` | **DONE — removed in PR #176** | GET `/search` server-rendered page. The user-facing search uses the GraphQL `search()` query (`assets/ui/user/search/search.view.ts`), not this page. Package deleted and router regenerated. |
 | `internal/case/admin/renderlayoutpreview` | **Remove (candidate)** | Registered endpoint only. No internal callers, not referenced by GraphQL resolvers. No telegram/tg code inside. |
 | `internal/case/rendernotepage/view.html` | **Trim** | Of ~350 lines only `LayoutError` is still used (`endpoint.go:291`). The rest (`Note`, `NoteContent`, `Sidebar`, `ReadingMeta`, `ReadingComplexityStars`, `LatestBanner`, `TurboNote`) has zero callers — superseded by `defaulttemplate`. |
-| `internal/case/renderlayout` (`Handle` + `views.html`) | **Remove after `rendersearchpage`** | `renderlayout.Handle` has exactly one caller: `rendersearchpage`. Once that is gone, `Handle` / `WriteBeginLayout` / `views.html(.go)` are dead. **Keep the `Env`/`Params` types** — still used by `render404`, `rendernotepage` (`buildDefaultTemplateCtx`), and admin previews. |
+| `internal/case/renderlayout` (`Handle` + `views.html`) | **Remove (unblocked)** | `renderlayout.Handle` had exactly one caller: `rendersearchpage`, removed in PR #176 — so `Handle` / `WriteBeginLayout` / `views.html(.go)` are now dead. **Keep the `Env`/`Params` types** — still used by `render404`, `rendernotepage` (`buildDefaultTemplateCtx`), and admin previews. |
 | `internal/case/admin/renderpreview` | **KEEP — do NOT remove** | Active admin live-preview, NOT telegram. Wired into: GraphQL resolver (`schema.resolvers.go:1293` → `renderpreview.Resolve`), `PreviewBuffer` (`cmd/server/main.go` `previewBuffer`, `PreviewBuffer()`), and its own config section (`appconfig/config.go` `RenderPreview`). |
 
 Note: the original assumption that `renderpreview` / `renderlayoutpreview` "were
@@ -25,12 +26,10 @@ admin layout preview endpoint with no remaining callers.
 
 ## Removal steps (when doing the cleanup)
 
-1. **rendersearchpage**
-   - Delete `internal/case/rendersearchpage/`.
-   - Regenerate the router: `go generate ./internal/router/...` (registration list is built by `internal/router/gencmd`).
-   - Before deleting: confirm nothing links to `GET /search` (sitemap, templates, external SEO). The search UI itself is unaffected (GraphQL).
+1. **rendersearchpage** — DONE (PR #176): package deleted, router regenerated,
+   no remaining `/search?q=` links found in templates or docs.
 
-2. **renderlayout Handle + template** (only after step 1)
+2. **renderlayout Handle + template** (unblocked by step 1)
    - Remove `Handle`, `WriteBeginLayout`/`WriteFinishLayout`/TG-layout funcs, and `internal/case/renderlayout/views.html` + `views.html.go`.
    - Keep `render.go`'s `Env`, `Params`, `HrefLang` types (still imported elsewhere).
 

--- a/internal/case/mcp/search_corpus_internal_test.go
+++ b/internal/case/mcp/search_corpus_internal_test.go
@@ -1,0 +1,52 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trip2g/internal/features"
+	"trip2g/internal/model"
+)
+
+// fedCorpusEnv extends the panicking fedGQLEnv stub with just what an
+// anonymous-shaped search needs. SearchLatestNotes stays a panic, so touching
+// the latest (draft) corpus fails loudly.
+type fedCorpusEnv struct {
+	fedGQLEnv
+	live *model.NoteView
+}
+
+func (e *fedCorpusEnv) SearchLiveNotes(string) ([]model.SearchResult, error) {
+	return []model.SearchResult{{
+		NoteView: e.live, URL: e.live.Permalink,
+		HighlightedContent: []string{"published snippet"},
+	}}, nil
+}
+func (e *fedCorpusEnv) LiveNoteChunks() []model.NoteChunk { return nil }
+func (e *fedCorpusEnv) Features() features.Features       { return features.Features{} }
+func (e *fedCorpusEnv) NoteURL(n *model.NoteView) string  { return "https://x.test" + n.Permalink }
+
+// Federation-JWT clients must search the LIVE corpus, like anonymous clients —
+// only API-key (admin) auth gets the latest (draft) corpus.
+func TestSearchFederationJWTUsesLiveCorpus(t *testing.T) {
+	env := &fedCorpusEnv{
+		// Free note: readable through the federation subgraph ACL without extra deps.
+		live: &model.NoteView{Path: "published.md", PathID: 2, Title: "Published", Permalink: "/published", Free: true},
+	}
+
+	ctx := contextWithFederationAuth(context.Background(), "kid1", []string{"subA"})
+	require.False(t, mcpAPIKeyAuthed(ctx), "federation auth must not count as API-key auth")
+
+	resp := handleSearch(ctx, env, 1, json.RawMessage(`{"query":"x"}`))
+
+	require.Nil(t, resp.Error)
+	result, ok := resp.Result.(CallToolResult)
+	require.True(t, ok)
+	payload, ok := result.StructuredContent.(SearchResultPayload)
+	require.True(t, ok)
+	require.Len(t, payload.Results, 1)
+	require.Equal(t, "Published", payload.Results[0].Title)
+}

--- a/internal/case/sitesearch/golden_test.go
+++ b/internal/case/sitesearch/golden_test.go
@@ -1,0 +1,260 @@
+package sitesearch_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"trip2g/internal/appreq"
+	"trip2g/internal/case/sitesearch"
+	"trip2g/internal/features"
+	"trip2g/internal/graph/model"
+	"trip2g/internal/logger"
+	appmodel "trip2g/internal/model"
+	"trip2g/internal/openai"
+	"trip2g/internal/usertoken"
+)
+
+// Golden retrieval tests: fixed fixtures with hand-computed expected rankings,
+// characterising the shared Retrieve core (and Resolve's ACL/capping layer)
+// against the behavior both transports had before the PR #176 consolidation.
+// If a retrieval change reorders these goldens, that is a ranking change for
+// BOTH the site search and the MCP search — update them deliberately.
+//
+// Fixture: query embedding [1,0]; text lane returns [B, A, E]; vector chunks
+// score C=1.0, D=0.9, A=0.8 (dot product), E is stale (3-dim vs 2-dim query)
+// and F has an empty embedding — both must be skipped by the dim guard.
+//
+// RRF (k=60, 1-indexed ranks):
+//
+//	A = 1/62 (text#2) + 1/63 (vector#3) ≈ 0.032002
+//	B = 1/61 (text#1) ≈ 0.016393   ┐ exact tie, broken
+//	C = 1/61 (vector#1) ≈ 0.016393 ┘ by URL: /b < /c
+//	D = 1/62 (vector#2) ≈ 0.016129
+//	E = 1/63 (text#3) ≈ 0.015873
+func goldenEnv(t *testing.T, embURL string) *EnvMock {
+	t.Helper()
+
+	mk := func(path, permalink, title string) *appmodel.NoteView {
+		return &appmodel.NoteView{
+			Path: path, Permalink: permalink, Title: title,
+			Content: []byte("content of " + title),
+		}
+	}
+	notes := map[string]*appmodel.NoteView{
+		"a.md": mk("a.md", "/a", "A"),
+		"b.md": mk("b.md", "/b", "B"),
+		"c.md": mk("c.md", "/c", "C"),
+		"d.md": mk("d.md", "/d", "D"),
+		"e.md": mk("e.md", "/e", "E"),
+		"f.md": mk("f.md", "/f", "F"),
+	}
+
+	return &EnvMock{
+		SearchLiveNotesFunc: func(string) ([]appmodel.SearchResult, error) {
+			return []appmodel.SearchResult{
+				{NoteView: notes["b.md"], URL: "/b", HighlightedContent: []string{"hit b"}},
+				{NoteView: notes["a.md"], URL: "/a", HighlightedContent: []string{"hit a"}},
+				{NoteView: notes["e.md"], URL: "/e", HighlightedContent: []string{"hit e"}},
+			}, nil
+		},
+		LiveNoteChunksFunc: func() []appmodel.NoteChunk {
+			return []appmodel.NoteChunk{
+				{NotePath: "c.md", ChunkIndex: 0, Content: "C\n\nbody c", Embedding: []float32{1, 0}},
+				{NotePath: "d.md", ChunkIndex: 0, Content: "D\n\nbody d", Embedding: []float32{0.9, 0.435889894}},
+				{NotePath: "a.md", ChunkIndex: 0, Content: "A\n\nbody a", Embedding: []float32{0.8, 0.6}},
+				{NotePath: "e.md", ChunkIndex: 0, Content: "E\n\nbody e", Embedding: []float32{1, 0, 0}}, // stale dims
+				{NotePath: "f.md", ChunkIndex: 0, Content: "F\n\nbody f", Embedding: []float32{}},        // empty
+			}
+		},
+		LiveNoteViewsFunc: func() *appmodel.NoteViews {
+			return &appmodel.NoteViews{PathMap: notes}
+		},
+		FeaturesFunc: func() features.Features {
+			return features.Features{VectorSearch: features.VectorSearchConfig{Enabled: true}}
+		},
+		OpenAIFunc: func() *openai.Client { return openai.New("test-key", "test-model", embURL+"/v1") },
+		LoggerFunc: func() logger.Logger { return &logger.DummyLogger{} },
+	}
+}
+
+func urlsOf(results []appmodel.SearchResult) []string {
+	urls := make([]string, len(results))
+	for i, r := range results {
+		urls[i] = r.URL
+	}
+	return urls
+}
+
+func TestGoldenRetrieve_TextOnly(t *testing.T) {
+	srv := newEmbeddingServer(t, []float32{1, 0})
+	defer srv.Close()
+
+	env := goldenEnv(t, srv.URL)
+	env.FeaturesFunc = func() features.Features { return features.Features{} } // vector disabled
+
+	results, merged, err := sitesearch.Retrieve(context.Background(), env, "q", false)
+	require.NoError(t, err)
+	require.False(t, merged)
+	require.Equal(t, []string{"/b", "/a", "/e"}, urlsOf(results))
+}
+
+func TestGoldenRetrieve_HybridRRF(t *testing.T) {
+	srv := newEmbeddingServer(t, []float32{1, 0})
+	defer srv.Close()
+
+	results, merged, err := sitesearch.Retrieve(context.Background(), goldenEnv(t, srv.URL), "q", false)
+	require.NoError(t, err)
+	require.True(t, merged)
+	require.Equal(t, []string{"/a", "/b", "/c", "/d", "/e"}, urlsOf(results))
+
+	// /b and /c tie exactly on RRF (both 1/61); order comes from the URL tie-break.
+	require.InDelta(t, results[1].Score, results[2].Score, 1e-12, "/b and /c must tie on RRF score")
+	// Stale (3-dim) and empty embeddings never surface as candidates.
+	require.NotContains(t, urlsOf(results), "/f")
+}
+
+// goldenCEServer scores rerank docs by substring, TEI wire shape.
+func goldenCEServer(t *testing.T, scoreFor func(doc string) float64) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Texts []string `json:"texts"`
+		}
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&req)) {
+			return
+		}
+		type result struct {
+			Index int     `json:"index"`
+			Score float64 `json:"score"`
+		}
+		out := make([]result, 0, len(req.Texts))
+		for i, d := range req.Texts {
+			out = append(out, result{Index: i, Score: scoreFor(d)})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(out))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// Reranker ON (BlendWeight 0.5): CE strongly prefers D (0.95) over C (0.2) and
+// A (0.1); B and E have no vector passage so they blend against the neutral CE
+// midpoint 0.5. Blended scores: D≈0.508, A=0.500, B≈0.266, E=0.250, C≈0.075.
+func TestGoldenRetrieve_RerankerBlends(t *testing.T) {
+	embSrv := newEmbeddingServer(t, []float32{1, 0})
+	defer embSrv.Close()
+
+	ceScores := map[string]float64{"body a": 0.1, "body c": 0.2, "body d": 0.95}
+	ceSrv := goldenCEServer(t, func(doc string) float64 {
+		for sub, score := range ceScores {
+			if strings.Contains(doc, sub) {
+				return score
+			}
+		}
+		t.Fatalf("unexpected rerank doc: %q", doc)
+		return 0
+	})
+
+	env := goldenEnv(t, embSrv.URL)
+	env.FeaturesFunc = func() features.Features {
+		return features.Features{VectorSearch: features.VectorSearchConfig{
+			Enabled: true,
+			Reranker: features.RerankerConfig{
+				Enabled:     true,
+				BaseURL:     ceSrv.URL + "/rerank",
+				TopN:        10,
+				BlendWeight: 0.5,
+			},
+		}}
+	}
+
+	results, _, err := sitesearch.Retrieve(context.Background(), env, "q", false)
+	require.NoError(t, err)
+	require.Equal(t, []string{"/d", "/a", "/b", "/e", "/c"}, urlsOf(results))
+}
+
+func anonSiteEnv(env *EnvMock) *EnvMock {
+	env.CurrentUserTokenFunc = func(context.Context) (*usertoken.Data, error) {
+		return &usertoken.Data{}, nil
+	}
+	env.SiteConfigFunc = func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} }
+	return env
+}
+
+// ACL layer: unreadable notes become "Закрытый материал." placeholders pushed
+// to the end, in fused-rank order, after the readable results.
+func TestGoldenResolve_ACLPlaceholders(t *testing.T) {
+	srv := newEmbeddingServer(t, []float32{1, 0})
+	defer srv.Close()
+
+	env := anonSiteEnv(goldenEnv(t, srv.URL))
+	env.CanReadNoteFunc = func(_ context.Context, nv *appmodel.NoteView) (bool, error) {
+		return nv.Path != "a.md" && nv.Path != "c.md", nil
+	}
+
+	ctx := appreq.NewContext(context.Background(), &appreq.Request{})
+	conn, err := sitesearch.Resolve(ctx, env, model.SearchInput{Query: "q"})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"/b", "/d", "/e", "/a", "/c"}, urlsOf(conn.Nodes))
+	for _, hidden := range conn.Nodes[3:] {
+		require.Nil(t, hidden.NoteView)
+		require.Equal(t, []string{"Закрытый материал."}, hidden.HighlightedContent)
+	}
+}
+
+// Capping layer: the hybrid cap (20) applies AFTER permission filtering, so
+// with 24 fused candidates whose top 4 are unreadable, exactly the 20 readable
+// ones surface and the placeholders are cut, not the readable tail.
+func TestGoldenResolve_PostACLCap(t *testing.T) {
+	srv := newEmbeddingServer(t, []float32{1, 0})
+	defer srv.Close()
+
+	var textResults []appmodel.SearchResult
+	pathMap := map[string]*appmodel.NoteView{}
+	for i := 1; i <= 24; i++ {
+		note := &appmodel.NoteView{
+			Path:      fmt.Sprintf("n%02d.md", i),
+			Permalink: fmt.Sprintf("/n%02d", i),
+			Title:     fmt.Sprintf("N%02d", i),
+		}
+		pathMap[note.Path] = note
+		textResults = append(textResults, appmodel.SearchResult{NoteView: note, URL: note.Permalink})
+	}
+
+	env := anonSiteEnv(goldenEnv(t, srv.URL))
+	env.SearchLiveNotesFunc = func(string) ([]appmodel.SearchResult, error) { return textResults, nil }
+	env.LiveNoteViewsFunc = func() *appmodel.NoteViews { return &appmodel.NoteViews{PathMap: pathMap} }
+	env.LiveNoteChunksFunc = func() []appmodel.NoteChunk {
+		// One chunk for the top text hit: triggers the hybrid merge (and its cap)
+		// without reordering anything else.
+		return []appmodel.NoteChunk{
+			{NotePath: "n01.md", ChunkIndex: 0, Content: "N01\n\nbody", Embedding: []float32{1, 0}},
+		}
+	}
+	env.CanReadNoteFunc = func(_ context.Context, nv *appmodel.NoteView) (bool, error) {
+		return nv.Path > "n04.md", nil // n01..n04 unreadable
+	}
+
+	ctx := appreq.NewContext(context.Background(), &appreq.Request{})
+	conn, err := sitesearch.Resolve(ctx, env, model.SearchInput{Query: "q"})
+	require.NoError(t, err)
+
+	expected := make([]string, 0, 20)
+	for i := 5; i <= 24; i++ {
+		expected = append(expected, fmt.Sprintf("/n%02d", i))
+	}
+	require.Equal(t, expected, urlsOf(conn.Nodes))
+	for _, n := range conn.Nodes {
+		require.NotNil(t, n.NoteView, "placeholders must be cut by the cap, not readable results")
+	}
+}


### PR DESCRIPTION
Follow-up to #176 (merged), covering the four non-blocking review items.

## Golden retrieval tests — `internal/case/sitesearch/golden_test.go`

Fixed fixtures with hand-computed expected rankings (goldens committed in-code, math documented in comments), characterising the shared core so future retrieval changes that would have been silent drift now flip an explicit golden:

- **Text-only** (`TestGoldenRetrieve_TextOnly`): vector disabled, bleve order preserved, `merged=false`.
- **Hybrid RRF** (`TestGoldenRetrieve_HybridRRF`): text+vector fusion with an **exact RRF tie** (`/b` vs `/c`, both 1/61) resolved by the URL tie-break; asserts the tie is real (`InDelta 1e-12`). Doubles as the **stale/empty-embedding** golden: one 3-dim chunk (dim mismatch) and one empty-embedding chunk must never surface.
- **Reranker ON** (`TestGoldenRetrieve_RerankerBlends`): BlendWeight 0.5, deterministic CE server; blended golden `[/d /a /b /e /c]` including the no-passage neutral-midpoint path for text-only candidates. Reranker OFF is the hybrid golden.
- **ACL placeholders** (`TestGoldenResolve_ACLPlaceholders`): unreadable candidates become "Закрытый материал." placeholders appended after readable results, in fused order.
- **Post-ACL capping** (`TestGoldenResolve_PostACLCap`): 24 fused candidates, top 4 unreadable → exactly the 20 readable surface; placeholders (not the readable tail) are cut by the hybrid cap.

## Federation-JWT corpus test — `internal/case/mcp/search_corpus_internal_test.go`

`TestSearchFederationJWTUsesLiveCorpus`: federation-authenticated search must use the **live** corpus like anonymous clients (only API-key auth gets latest). Built on the panicking `fedGQLEnv` stub, so any touch of `SearchLatestNotes` fails loudly. Completes the anonymous/API-key pair from #176.

## Design-doc sync

- `docs/dev/search_transport_consolidation.md`: status → IMPLEMENTED (PR #176); new §0 documents the shipped architecture (Retrieve core, two adapters, corpus rules); §1–3 kept as the pre-change rationale record; stale "/search page survives" statements and references updated.
- `docs/dev/todo_remove_old_layout.md`: `rendersearchpage` marked DONE (PR #176); `renderlayout.Handle` removal marked unblocked.

Verification: `go build ./...`, `go vet ./...`, `go test ./internal/...` all pass; golangci-lint on both touched packages: 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)