### PR TITLE
fix(mcp): resolve match_id and absolute-URL href in note reads

### DIFF
--- a/internal/case/mcp/federation_handlers_test.go
+++ b/internal/case/mcp/federation_handlers_test.go
@@ -172,6 +172,58 @@ func TestFederatedNoteHTMLToleratesStringPID(t *testing.T) {
 	require.Zero(t, gotParams.PID)
 }
 
+func TestFederatedNoteHTMLForwardsMatchIDOnly(t *testing.T) {
+	// federated_search's description tells agents to open a found chunk with
+	// federated_note_html(kb_id=..., match_id=...) — the hub must forward a
+	// match_id-only read instead of rejecting it.
+	kbNote := &appmodel.NoteView{
+		PathID:             17,
+		MCPFederationKBURL: "https://bob.example/_system/mcp",
+		MCPFederationKBID:  "nietzsche",
+	}
+	nvs := appmodel.NewNoteViews()
+	nvs.MCPFederationNotes = []*appmodel.MCPFederationNote{appmodel.NewMCPFederationNote(kbNote)}
+
+	var gotParams appmodel.FederationNoteHTMLParams
+	federation := &federationMock{
+		noteHTMLFunc: func(ctx context.Context, params appmodel.FederationNoteHTMLParams) (appmodel.FederationResult, error) {
+			gotParams = params
+			return appmodel.FederationResult{
+				Content: []appmodel.FederationContent{{Type: "text", Text: "focused chunk"}},
+			}, nil
+		},
+	}
+	env := &EnvMock{
+		LatestNoteViewsFunc: func() *appmodel.NoteViews {
+			return nvs
+		},
+		CanReadNoteFunc: func(ctx context.Context, note *appmodel.NoteView) (bool, error) {
+			return true, nil
+		},
+		FederationClientFunc: func(_ context.Context, kbID string) (appmodel.Federation, error) {
+			return federation, nil
+		},
+	}
+
+	params := mcp.CallToolParams{
+		Name:      "federated_note_html",
+		Arguments: json.RawMessage(`{"kb_id":"nietzsche","match_id":"p12:c0","note_id":""}`),
+	}
+	paramsJSON, _ := json.Marshal(params)
+	resp := mcp.Resolve(context.Background(), env, mcp.Request{
+		JSONRPC: "2.0",
+		Method:  "tools/call",
+		Params:  paramsJSON,
+		ID:      1,
+	})
+
+	require.Nil(t, resp.Error)
+	result := resp.Result.(mcp.CallToolResult)
+	require.Equal(t, "focused chunk", result.Content[0].Text)
+	require.Equal(t, "p12:c0", gotParams.MatchID)
+	require.Empty(t, gotParams.NoteID)
+}
+
 func TestFederatedSearchDelegatesNestedKBID(t *testing.T) {
 	kbNote := &appmodel.NoteView{
 		PathID:             17,

--- a/internal/case/mcp/resolve.go
+++ b/internal/case/mcp/resolve.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -217,12 +218,12 @@ func handleToolsList(ctx context.Context, env Env, id any) Response { //nolint:f
 		},
 		{
 			Name:        "note_html",
-			Description: "Read a note by pid, note_id, href, or path. Use match_id for a focused chunk window around a specific search hit. Use toc_path (from a search match's toc_path, or from expand) to read an exact section: search -> breadcrumb (approximate) -> toc_path (precise) -> note_html(toc_path=[...]).",
+			Description: "Read a note by pid, note_id, href, path, or match_id. Use match_id for a focused chunk window around a specific search hit; match_id alone is enough to resolve the note. Use toc_path (from a search match's toc_path, or from expand) to read an exact section: search -> breadcrumb (approximate) -> toc_path (precise) -> note_html(toc_path=[...]).",
 			InputSchema: &InputSchema{
 				Type: "object",
 				Properties: map[string]Property{
 					"path":          {Type: "string", Description: "Note path from search results"},
-					"href":          {Type: "string", Description: "Note href from search results"},
+					"href":          {Type: "string", Description: "Note href or absolute URL from search results"},
 					"pid":           {Type: "number", Description: "Stable note id from search results or HTML data-pid"},
 					"note_id":       {Type: "number", Description: "Stable note id from search results"},
 					"match_id":      {Type: "string", Description: "Focused match id from search results, such as p32:c4"},
@@ -312,10 +313,10 @@ func handleToolsList(ctx context.Context, env Env, id any) Response { //nolint:f
 							`(e.g. "philosophers/nietzsche" routes through the 'philosophers' peer, recursively)`,
 					},
 					"path":     {Type: "string", Description: "Remote note path"},
-					"href":     {Type: "string", Description: "Remote note href"},
+					"href":     {Type: "string", Description: "Remote note href or absolute URL from search results"},
 					"pid":      {Type: "number", Description: "Remote stable note id"},
 					"note_id":  {Type: "string", Description: "Remote stable note id (uint64 string)"},
-					"match_id": {Type: "string", Description: "Focused match id from remote search results"},
+					"match_id": {Type: "string", Description: "Focused match id from remote search results; match_id alone is enough"},
 				},
 				Required: []string{"kb_id"},
 			},
@@ -918,14 +919,15 @@ func handleNoteHTML(ctx context.Context, env Env, id any, argsRaw json.RawMessag
 		return *errResp
 	}
 
-	if args.Path == "" && args.Href == "" && args.PID.Value == 0 && args.PID.Raw == "" && args.NoteID == 0 {
-		return errorResponse(id, ErrCodeInvalidParams, "one of pid, note_id, path, or href is required")
+	if args.Path == "" && args.Href == "" && args.PID.Value == 0 && args.PID.Raw == "" &&
+		args.NoteID.Value == 0 && args.NoteID.Raw == "" && args.MatchID == "" {
+		return errorResponse(id, ErrCodeInvalidParams, "one of pid, note_id, path, href, or match_id is required")
 	}
 
 	noteViews := env.LatestNoteViews()
 	note := resolveNoteReference(noteViews, *args)
 	if note == nil {
-		log.Warn("note not found", "path", args.Path, "href", args.Href, "pid", args.PID.Value, "pid_raw", args.PID.Raw, "note_id", args.NoteID)
+		log.Warn("note not found", "path", args.Path, "href", args.Href, "pid", args.PID.Value, "pid_raw", args.PID.Raw, "note_id", args.NoteID.Value)
 		if args.PID.Raw != "" && args.PID.Value == 0 {
 			return errorResponse(id, ErrCodeInvalidParams,
 				fmt.Sprintf("pid %q is not a note id; note ids are numbers from search results — chunk refs like \"p36:c2\" go in match_id", args.PID.Raw))
@@ -938,7 +940,7 @@ func handleNoteHTML(ctx context.Context, env Env, id any, argsRaw json.RawMessag
 		return errorResponse(id, ErrCodeInternal, "Note HTML failed: "+err.Error())
 	}
 	if !canRead {
-		log.Warn("note access denied", "path", args.Path, "href", args.Href, "pid", args.PID.Value, "note_id", args.NoteID)
+		log.Warn("note access denied", "path", args.Path, "href", args.Href, "pid", args.PID.Value, "note_id", args.NoteID.Value)
 		return errorResponse(id, ErrCodeInvalidParams, "Note not found")
 	}
 
@@ -1009,7 +1011,7 @@ func handleExpand(ctx context.Context, env Env, id any, argsRaw json.RawMessage)
 		Path:   args.Path,
 		Href:   args.Href,
 		PID:    PID{Value: args.PID},
-		NoteID: args.NoteID,
+		NoteID: PID{Value: args.NoteID},
 	})
 	if note == nil {
 		log.Warn("note not found", "path", args.Path, "href", args.Href, "pid", args.PID, "note_id", args.NoteID)
@@ -1103,7 +1105,7 @@ func parseChunkMatchID(matchID string) (int64, int, bool) {
 func resolveNoteReference(noteViews *model.NoteViews, args NoteHTMLArguments) *model.NoteView {
 	id := args.PID.Value
 	if id == 0 {
-		id = args.NoteID
+		id = args.NoteID.Value
 	}
 	if id != 0 {
 		if note := noteViews.GetByPathID(id); note != nil {
@@ -1118,9 +1120,29 @@ func resolveNoteReference(noteViews *model.NoteViews, args NoteHTMLArguments) *m
 		}
 	}
 	if args.Href != "" {
-		return noteViews.GetByPath(args.Href)
+		if note := noteViews.GetByPath(normalizeHref(args.Href)); note != nil {
+			return note
+		}
+	}
+	// A match_id like "p12:c0" carries the note id — search results hand it
+	// back as the primary pointer, so it must resolve on its own.
+	if pathID, _, ok := parseChunkMatchID(args.MatchID); ok {
+		return noteViews.GetByPathID(pathID)
 	}
 	return nil
+}
+
+// normalizeHref reduces an absolute URL (the url field of search results) to
+// its path component so it resolves like a relative href.
+func normalizeHref(href string) string {
+	if !strings.Contains(href, "://") {
+		return href
+	}
+	u, err := url.Parse(href)
+	if err != nil || u.Path == "" {
+		return href
+	}
+	return u.Path
 }
 
 func handleDynamicMethod(ctx context.Context, env Env, id any, methodName string) Response {

--- a/internal/case/mcp/resolve_test.go
+++ b/internal/case/mcp/resolve_test.go
@@ -934,6 +934,110 @@ func TestHandleNoteHtml(t *testing.T) {
 		require.NotContains(t, result.Content[0].Text, "FULL NOTE HTML")
 	})
 
+	t.Run("match_id alone resolves the note and returns its focused chunk", func(t *testing.T) {
+		// Search results hand back match_id as the primary pointer and the
+		// tool description advertises note reads by match_id — a match_id-only
+		// call must resolve the note instead of demanding another ref.
+		note := &appmodel.NoteView{
+			Path:      "Книги/Книга 06.md",
+			PathID:    32,
+			Permalink: "/knigi/kniga_06",
+			HTML:      "<h1>Книга 06</h1><p>FULL NOTE HTML</p>",
+		}
+
+		env := &EnvMock{
+			LatestNoteViewsFunc: func() *appmodel.NoteViews {
+				noteViews := appmodel.NewNoteViews()
+				noteViews.RegisterNote(note)
+				return noteViews
+			},
+			LatestNoteChunksFunc: func() []appmodel.NoteChunk {
+				return []appmodel.NoteChunk{
+					{
+						NotePath:   note.Path,
+						ChunkIndex: 1,
+						Content:    "Книга 06\n\nЛучший способ отомстить - не уподобляться обидчику.",
+					},
+				}
+			},
+			LoggerFunc: func() logger.Logger {
+				return &logger.DummyLogger{}
+			},
+			CanReadNoteFunc: func(ctx context.Context, note *appmodel.NoteView) (bool, error) {
+				return true, nil
+			},
+		}
+
+		params := mcp.CallToolParams{
+			Name:      "note_html",
+			Arguments: json.RawMessage(`{"match_id": "p32:c1"}`),
+		}
+		paramsJSON, _ := json.Marshal(params)
+
+		resp := mcp.Resolve(context.Background(), env, mcp.Request{
+			JSONRPC: "2.0", Method: "tools/call", Params: paramsJSON, ID: 30,
+		})
+
+		require.Nil(t, resp.Error)
+		result := resp.Result.(mcp.CallToolResult)
+		require.Contains(t, result.Content[0].Text, "Лучший способ отомстить - не уподобляться обидчику.")
+		require.NotContains(t, result.Content[0].Text, "FULL NOTE HTML")
+	})
+
+	t.Run("absolute URL href resolves", func(t *testing.T) {
+		// Search results return absolute URLs in their url field; models feed
+		// them back as href — the path component must resolve like a relative href.
+		note := &appmodel.NoteView{
+			Path:      "concepts/sverkhchelovek.md",
+			PathID:    12,
+			Permalink: "/concepts/sverkhchelovek",
+			HTML:      "<h1>Сверхчеловек</h1>",
+		}
+
+		env := noteHTMLEnv(note)
+
+		params := mcp.CallToolParams{
+			Name:      "note_html",
+			Arguments: json.RawMessage(`{"href": "https://nietzsche.2pub.me/concepts/sverkhchelovek"}`),
+		}
+		paramsJSON, _ := json.Marshal(params)
+
+		resp := mcp.Resolve(context.Background(), env, mcp.Request{
+			JSONRPC: "2.0", Method: "tools/call", Params: paramsJSON, ID: 31,
+		})
+
+		require.Nil(t, resp.Error)
+		result := resp.Result.(mcp.CallToolResult)
+		require.Contains(t, result.Content[0].Text, "Сверхчеловек")
+	})
+
+	t.Run("empty note_id string does not break resolution via href", func(t *testing.T) {
+		// Live repro: {kb_id, href: absolute URL, match_id, note_id: ""} —
+		// the empty note_id must fall through, not fail the whole call.
+		note := &appmodel.NoteView{
+			Path:      "concepts/sverkhchelovek.md",
+			PathID:    12,
+			Permalink: "/concepts/sverkhchelovek",
+			HTML:      "<h1>Сверхчеловек</h1>",
+		}
+
+		env := noteHTMLEnv(note)
+
+		params := mcp.CallToolParams{
+			Name:      "note_html",
+			Arguments: json.RawMessage(`{"note_id": "", "href": "https://nietzsche.2pub.me/concepts/sverkhchelovek"}`),
+		}
+		paramsJSON, _ := json.Marshal(params)
+
+		resp := mcp.Resolve(context.Background(), env, mcp.Request{
+			JSONRPC: "2.0", Method: "tools/call", Params: paramsJSON, ID: 32,
+		})
+
+		require.Nil(t, resp.Error)
+		result := resp.Result.(mcp.CallToolResult)
+		require.Contains(t, result.Content[0].Text, "Сверхчеловек")
+	})
+
 	t.Run("bad toc_path returns error with top-level sections, not the full note", func(t *testing.T) {
 		note := &appmodel.NoteView{
 			Path:      "Книги/Книга 06.md",

--- a/internal/case/mcp/types.go
+++ b/internal/case/mcp/types.go
@@ -237,7 +237,7 @@ type NoteHTMLArguments struct {
 	Path         string   `json:"path,omitempty"`
 	Href         string   `json:"href,omitempty"`
 	PID          PID      `json:"pid,omitzero"`
-	NoteID       int64    `json:"note_id,omitempty"`
+	NoteID       PID      `json:"note_id,omitzero"`
 	MatchID      string   `json:"match_id,omitempty"`
 	ContextWords int      `json:"context_words,omitempty"`
 	TocPath      []string `json:"toc_path,omitempty"`


### PR DESCRIPTION
Two live-reproduced note-read dead-ends (against trip2g.com/_system/mcp, kb_id="philosophers/nietzsche"):

**(A) match_id-only reads were rejected.** `federated_note_html {kb_id, match_id: "p12:c0"}` returned "one of pid, note_id, path, or href is required" — while the federated_search tool description explicitly tells agents to open a found chunk with `federated_note_html(kb_id=..., match_id=...)`. Models follow the description and dead-end (observed in a real gpt-5.4-nano walk: 5 failed read attempts, walk aborted). A match_id like `pN:cM` carries the note id; `note_html` now resolves it as a last-resort reference and returns the focused chunk window as usual.

**(B) absolute-URL href didn't resolve.** `{href: "https://nietzsche.2pub.me/concepts/sverkhchelovek"}` — exactly what search results hand back in their `url` field — returned "Note not found". Hrefs are now normalized on receipt: an absolute URL is reduced to its path component and resolved like a relative href. Receipt-side normalization means peers benefit as soon as they upgrade, without hub changes.

Also hardened per the tolerant-PID (#170) semantics: `note_id` on `note_html` now uses the same tolerant PID type, so `note_id: ""` (which live clients send) falls through instead of failing the whole call at unmarshal — previously it was a hard `cannot unmarshal string into int64` error.

**Principle:** tools/list must never promise what the server rejects. The descriptions were left truthful and behavior was brought up to match (`note_html` now advertises match_id as a full reference; href fields document absolute-URL acceptance).

Tests: repro tests for (A) match_id-only local read + federated match_id-only forward, (B) absolute-URL href, and empty-string note_id fall-through. `go test ./internal/case/mcp/ ./internal/federation/...` green; build + vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)