### PR TITLE
fix(mcp): search corpus follows ShowDraftVersions like the site

### DIFF
--- a/internal/case/mcp/endpoint_dispatch_test.go
+++ b/internal/case/mcp/endpoint_dispatch_test.go
@@ -66,6 +66,7 @@ func buildDispatchEnv(t *testing.T, verifyInboundWillFail bool) *EnvMock {
 		CanReadNoteFunc:             func(_ context.Context, _ *appmodel.NoteView) (bool, error) { return true, nil },
 		FederatedGraphQLEnabledFunc: func() bool { return false },
 		MCPMetricsFunc:              func() *metrics.MCPMetrics { return nil },
+		SiteConfigFunc:              func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 
 		FederatedFanoutConcurrencyFunc: func() int { return 5 },
 		FederatedFanoutLimitFunc:       func() int { return 7 },

--- a/internal/case/mcp/federated_graphql_test.go
+++ b/internal/case/mcp/federated_graphql_test.go
@@ -52,6 +52,7 @@ func (e *fedGQLEnv) SearchLiveNotes(_ string) ([]model.SearchResult, error)   { 
 func (e *fedGQLEnv) LiveNoteChunks() []model.NoteChunk                        { panic("unexpected") }
 func (e *fedGQLEnv) LiveNoteViews() *model.NoteViews                          { panic("unexpected") }
 func (e *fedGQLEnv) OpenAI() *openai.Client                                   { panic("unexpected") }
+func (e *fedGQLEnv) SiteConfig(_ context.Context) model.SiteConfig            { panic("unexpected") }
 func (e *fedGQLEnv) PublicURL() string                                        { panic("unexpected") }
 func (e *fedGQLEnv) NoteURL(_ *model.NoteView) string                         { panic("unexpected") }
 func (e *fedGQLEnv) Logger() logger.Logger                                    { return &logger.DummyLogger{} }

--- a/internal/case/mcp/graphql_tools_test.go
+++ b/internal/case/mcp/graphql_tools_test.go
@@ -42,12 +42,13 @@ func (e *gqlRequestEnv) SearchLatestNotes(_ string) ([]model.SearchResult, error
 func (e *gqlRequestEnv) SearchLiveNotes(_ string) ([]model.SearchResult, error) {
 	panic("unexpected")
 }
-func (e *gqlRequestEnv) LiveNoteChunks() []model.NoteChunk { panic("unexpected") }
-func (e *gqlRequestEnv) LiveNoteViews() *model.NoteViews   { panic("unexpected") }
-func (e *gqlRequestEnv) OpenAI() *openai.Client            { panic("unexpected") }
-func (e *gqlRequestEnv) PublicURL() string                 { panic("unexpected") }
-func (e *gqlRequestEnv) NoteURL(_ *model.NoteView) string  { panic("unexpected") }
-func (e *gqlRequestEnv) Logger() logger.Logger             { return &logger.DummyLogger{} }
+func (e *gqlRequestEnv) LiveNoteChunks() []model.NoteChunk             { panic("unexpected") }
+func (e *gqlRequestEnv) LiveNoteViews() *model.NoteViews               { panic("unexpected") }
+func (e *gqlRequestEnv) OpenAI() *openai.Client                        { panic("unexpected") }
+func (e *gqlRequestEnv) SiteConfig(_ context.Context) model.SiteConfig { panic("unexpected") }
+func (e *gqlRequestEnv) PublicURL() string                             { panic("unexpected") }
+func (e *gqlRequestEnv) NoteURL(_ *model.NoteView) string              { panic("unexpected") }
+func (e *gqlRequestEnv) Logger() logger.Logger                         { return &logger.DummyLogger{} }
 func (e *gqlRequestEnv) FederationSecretByKBURL(_ context.Context, _ string) (db.FederationSecret, bool, error) {
 	panic("unexpected")
 }

--- a/internal/case/mcp/mocks_test.go
+++ b/internal/case/mcp/mocks_test.go
@@ -104,6 +104,9 @@ var _ mcp.Env = &EnvMock{}
 //			SearchLiveNotesFunc: func(query string) ([]model.SearchResult, error) {
 //				panic("mock out the SearchLiveNotes method")
 //			},
+//			SiteConfigFunc: func(ctx context.Context) model.SiteConfig {
+//				panic("mock out the SiteConfig method")
+//			},
 //		}
 //
 //		// use mockedEnv in code that requires mcp.Env
@@ -188,6 +191,9 @@ type EnvMock struct {
 
 	// SearchLiveNotesFunc mocks the SearchLiveNotes method.
 	SearchLiveNotesFunc func(query string) ([]model.SearchResult, error)
+
+	// SiteConfigFunc mocks the SiteConfig method.
+	SiteConfigFunc func(ctx context.Context) model.SiteConfig
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -317,6 +323,11 @@ type EnvMock struct {
 			// Query is the query argument value.
 			Query string
 		}
+		// SiteConfig holds details about calls to the SiteConfig method.
+		SiteConfig []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+		}
 	}
 	lockCanReadNote                        sync.RWMutex
 	lockDecryptData                        sync.RWMutex
@@ -344,6 +355,7 @@ type EnvMock struct {
 	lockResolveAPIKey                      sync.RWMutex
 	lockSearchLatestNotes                  sync.RWMutex
 	lockSearchLiveNotes                    sync.RWMutex
+	lockSiteConfig                         sync.RWMutex
 }
 
 // CanReadNote calls CanReadNoteFunc.
@@ -1153,5 +1165,37 @@ func (mock *EnvMock) SearchLiveNotesCalls() []struct {
 	mock.lockSearchLiveNotes.RLock()
 	calls = mock.calls.SearchLiveNotes
 	mock.lockSearchLiveNotes.RUnlock()
+	return calls
+}
+
+// SiteConfig calls SiteConfigFunc.
+func (mock *EnvMock) SiteConfig(ctx context.Context) model.SiteConfig {
+	if mock.SiteConfigFunc == nil {
+		panic("EnvMock.SiteConfigFunc: method is nil but Env.SiteConfig was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+	}{
+		Ctx: ctx,
+	}
+	mock.lockSiteConfig.Lock()
+	mock.calls.SiteConfig = append(mock.calls.SiteConfig, callInfo)
+	mock.lockSiteConfig.Unlock()
+	return mock.SiteConfigFunc(ctx)
+}
+
+// SiteConfigCalls gets all the calls that were made to SiteConfig.
+// Check the length with:
+//
+//	len(mockedEnv.SiteConfigCalls())
+func (mock *EnvMock) SiteConfigCalls() []struct {
+	Ctx context.Context
+} {
+	var calls []struct {
+		Ctx context.Context
+	}
+	mock.lockSiteConfig.RLock()
+	calls = mock.calls.SiteConfig
+	mock.lockSiteConfig.RUnlock()
 	return calls
 }

--- a/internal/case/mcp/rerank_test.go
+++ b/internal/case/mcp/rerank_test.go
@@ -99,6 +99,7 @@ func searchRerankEnv(t *testing.T, feats features.Features, embURL string) *EnvM
 		CanReadNoteFunc: func(context.Context, *appmodel.NoteView) (bool, error) {
 			return true, nil
 		},
+		SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 	}
 }
 

--- a/internal/case/mcp/resolve.go
+++ b/internal/case/mcp/resolve.go
@@ -47,6 +47,7 @@ type Env interface {
 	LiveNoteChunks() []model.NoteChunk
 	LiveNoteViews() *model.NoteViews
 	OpenAI() *openai.Client
+	SiteConfig(ctx context.Context) model.SiteConfig
 	PublicURL() string
 	NoteURL(note *model.NoteView) string
 	Logger() logger.Logger
@@ -493,9 +494,11 @@ func handleSearch(ctx context.Context, env Env, id any, argsRaw json.RawMessage)
 	}
 
 	// Shared retrieval core (text + vector + RRF + rerank), same as the site
-	// search. API-key clients are admins and search the latest corpus (drafts
-	// included); everyone else gets the live corpus, like anonymous site visitors.
-	useLatest := mcpAPIKeyAuthed(ctx)
+	// search, and the same corpus rule: instances that show draft versions
+	// search latest for everyone, API-key clients always get latest, everyone
+	// else gets the live corpus, like anonymous site visitors.
+	siteConfig := env.SiteConfig(ctx)
+	useLatest := siteConfig.ShowDraftVersions || mcpAPIKeyAuthed(ctx)
 	results, _, err := sitesearch.Retrieve(ctx, env, args.Query, useLatest)
 	if err != nil {
 		log.Error("search failed", "error", err, "query", args.Query)

--- a/internal/case/mcp/resolve_test.go
+++ b/internal/case/mcp/resolve_test.go
@@ -23,6 +23,7 @@ func TestResolve(t *testing.T) {
 
 	t.Run("initialize returns server info", func(t *testing.T) {
 		env := &EnvMock{
+			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					List:    []*appmodel.NoteView{},
@@ -56,6 +57,7 @@ func TestResolve(t *testing.T) {
 		}
 
 		env := &EnvMock{
+			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					List:    []*appmodel.NoteView{note},
@@ -106,6 +108,7 @@ soul_profile:
 		}
 
 		env := &EnvMock{
+			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					List:    []*appmodel.NoteView{note},
@@ -136,6 +139,7 @@ soul_profile:
 
 	t.Run("tools/list returns static tools", func(t *testing.T) {
 		env := &EnvMock{
+			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					List:    []*appmodel.NoteView{},
@@ -182,6 +186,7 @@ soul_profile:
 		}
 
 		env := &EnvMock{
+			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					List:    []*appmodel.NoteView{note},
@@ -235,6 +240,7 @@ soul_profile:
 
 	t.Run("invalid call params returns error", func(t *testing.T) {
 		env := &EnvMock{
+			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					List:    []*appmodel.NoteView{},
@@ -284,6 +290,7 @@ func TestSearchReturnsStructuredContent(t *testing.T) {
 	}
 
 	env := &EnvMock{
+		SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 		SearchLiveNotesFunc: func(query string) ([]appmodel.SearchResult, error) {
 			return []appmodel.SearchResult{{
 				NoteView:           note,
@@ -361,6 +368,7 @@ func TestExpandReturnsDirectChildren(t *testing.T) {
 	}
 
 	env := &EnvMock{
+		SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 		LatestNoteViewsFunc: func() *appmodel.NoteViews {
 			return &appmodel.NoteViews{
 				List:    []*appmodel.NoteView{note},
@@ -416,6 +424,7 @@ func TestSearchMarksFederationKBNotes(t *testing.T) {
 	}
 
 	env := &EnvMock{
+		SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 		SearchLiveNotesFunc: func(query string) ([]appmodel.SearchResult, error) {
 			return []appmodel.SearchResult{{
 				NoteView:           note,
@@ -486,6 +495,7 @@ func TestSearchHidesInaccessibleFederationKBNotes(t *testing.T) {
 	}
 
 	env := &EnvMock{
+		SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 		SearchLiveNotesFunc: func(query string) ([]appmodel.SearchResult, error) {
 			return []appmodel.SearchResult{
 				{NoteView: federationNote, URL: federationNote.Permalink, Score: 2},
@@ -550,6 +560,7 @@ func TestSearchHidesInaccessibleNotes(t *testing.T) {
 	}
 
 	env := &EnvMock{
+		SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 		SearchLiveNotesFunc: func(query string) ([]appmodel.SearchResult, error) {
 			return []appmodel.SearchResult{
 				{NoteView: privateNote, URL: privateNote.Permalink, Score: 2},
@@ -599,6 +610,7 @@ func TestSearchHidesInaccessibleNotes(t *testing.T) {
 
 func TestFederatedSearchWithoutKBNotesReturnsStructuredStatus(t *testing.T) {
 	env := &EnvMock{
+		SiteConfigFunc:      func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 		LatestNoteViewsFunc: appmodel.NewNoteViews,
 		LoggerFunc: func() logger.Logger {
 			return &logger.DummyLogger{}
@@ -652,6 +664,7 @@ func TestSearchFiltersSystemAndExcludedNotes(t *testing.T) {
 	}
 
 	env := &EnvMock{
+		SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 		SearchLiveNotesFunc: func(query string) ([]appmodel.SearchResult, error) {
 			return []appmodel.SearchResult{
 				{NoteView: systemNote, URL: systemNote.Permalink, Score: 3},
@@ -712,6 +725,7 @@ func TestSearch_CustomDomainURL(t *testing.T) {
 	}
 
 	env := &EnvMock{
+		SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 		SearchLiveNotesFunc: func(query string) ([]appmodel.SearchResult, error) {
 			return []appmodel.SearchResult{{
 				NoteView: note,
@@ -769,6 +783,7 @@ func TestSearch_CustomDomainURL(t *testing.T) {
 
 func noteHTMLEnv(note *appmodel.NoteView) *EnvMock {
 	return &EnvMock{
+		SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 		LatestNoteViewsFunc: func() *appmodel.NoteViews {
 			noteViews := appmodel.NewNoteViews()
 			noteViews.RegisterNote(note)
@@ -791,6 +806,7 @@ func TestHandleNoteHtml(t *testing.T) {
 		}
 
 		env := &EnvMock{
+			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					PathMap: map[string]*appmodel.NoteView{
@@ -837,6 +853,7 @@ func TestHandleNoteHtml(t *testing.T) {
 		}
 
 		env := &EnvMock{
+			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				noteViews := appmodel.NewNoteViews()
 				noteViews.RegisterNote(note)
@@ -879,6 +896,7 @@ func TestHandleNoteHtml(t *testing.T) {
 		}
 
 		env := &EnvMock{
+			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				noteViews := appmodel.NewNoteViews()
 				noteViews.RegisterNote(note)
@@ -946,6 +964,7 @@ func TestHandleNoteHtml(t *testing.T) {
 		}
 
 		env := &EnvMock{
+			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				noteViews := appmodel.NewNoteViews()
 				noteViews.RegisterNote(note)
@@ -1051,6 +1070,7 @@ func TestHandleNoteHtml(t *testing.T) {
 		}
 
 		env := &EnvMock{
+			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				noteViews := appmodel.NewNoteViews()
 				noteViews.RegisterNote(note)
@@ -1094,6 +1114,7 @@ func TestHandleNoteHtml(t *testing.T) {
 		}
 
 		env := &EnvMock{
+			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				noteViews := appmodel.NewNoteViews()
 				noteViews.RegisterNote(note)
@@ -1139,6 +1160,7 @@ func TestHandleNoteHtml(t *testing.T) {
 		}
 
 		env := &EnvMock{
+			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				noteViews := appmodel.NewNoteViews()
 				noteViews.RegisterNote(note)
@@ -1285,6 +1307,7 @@ func TestHandleNoteHtml(t *testing.T) {
 		}
 
 		env := &EnvMock{
+			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				noteViews := appmodel.NewNoteViews()
 				noteViews.RegisterNote(note)
@@ -1316,6 +1339,7 @@ func TestHandleNoteHtml(t *testing.T) {
 
 	t.Run("returns error for non-existent note", func(t *testing.T) {
 		env := &EnvMock{
+			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					PathMap: map[string]*appmodel.NoteView{},
@@ -1373,6 +1397,7 @@ func TestSimilarAcceptsPIDAndReturnsStructuredContent(t *testing.T) {
 	noteViews.List = []*appmodel.NoteView{sourceNote, similarNote}
 
 	env := &EnvMock{
+		SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 		FeaturesFunc: func() features.Features {
 			return features.Features{
 				VectorSearch: features.VectorSearchConfig{Enabled: true},
@@ -1436,6 +1461,7 @@ func TestStripFrontmatter(t *testing.T) {
 		}
 
 		env := &EnvMock{
+			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					List: []*appmodel.NoteView{note},
@@ -1476,6 +1502,7 @@ func TestStripFrontmatter(t *testing.T) {
 		}
 
 		env := &EnvMock{
+			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					List: []*appmodel.NoteView{note},
@@ -1516,6 +1543,7 @@ func TestStripFrontmatter(t *testing.T) {
 		}
 
 		env := &EnvMock{
+			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					List: []*appmodel.NoteView{note},
@@ -1557,6 +1585,7 @@ func TestStripFrontmatter(t *testing.T) {
 		}
 
 		env := &EnvMock{
+			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					List: []*appmodel.NoteView{note},
@@ -1595,6 +1624,7 @@ func TestStripFrontmatter(t *testing.T) {
 func TestHandleSimilarLimitValidation(t *testing.T) {
 	t.Run("uses default when limit is zero", func(t *testing.T) {
 		env := &EnvMock{
+			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					PathMap: map[string]*appmodel.NoteView{
@@ -1645,6 +1675,7 @@ func TestHandleSimilarLimitValidation(t *testing.T) {
 
 	t.Run("caps limit at maximum", func(t *testing.T) {
 		env := &EnvMock{
+			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					PathMap: map[string]*appmodel.NoteView{
@@ -1708,6 +1739,7 @@ func makeSearchNote(pathID int64, path, title string) *appmodel.NoteView {
 func makeSearchEnv(t *testing.T, results []appmodel.SearchResult) *EnvMock {
 	t.Helper()
 	return &EnvMock{
+		SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 		SearchLiveNotesFunc: func(query string) ([]appmodel.SearchResult, error) {
 			return results, nil
 		},

--- a/internal/case/mcp/search_corpus_internal_test.go
+++ b/internal/case/mcp/search_corpus_internal_test.go
@@ -28,6 +28,9 @@ func (e *fedCorpusEnv) SearchLiveNotes(string) ([]model.SearchResult, error) {
 func (e *fedCorpusEnv) LiveNoteChunks() []model.NoteChunk { return nil }
 func (e *fedCorpusEnv) Features() features.Features       { return features.Features{} }
 func (e *fedCorpusEnv) NoteURL(n *model.NoteView) string  { return "https://x.test" + n.Permalink }
+func (e *fedCorpusEnv) SiteConfig(context.Context) model.SiteConfig {
+	return model.SiteConfig{}
+}
 
 // Federation-JWT clients must search the LIVE corpus, like anonymous clients —
 // only API-key (admin) auth gets the latest (draft) corpus.

--- a/internal/case/mcp/search_corpus_test.go
+++ b/internal/case/mcp/search_corpus_test.go
@@ -55,6 +55,7 @@ func corpusEnv() *EnvMock {
 		NoteURLFunc:          func(n *appmodel.NoteView) string { return "https://x.test" + n.Permalink },
 		LoggerFunc:           func() logger.Logger { return &logger.DummyLogger{} },
 		CanReadNoteFunc:      func(context.Context, *appmodel.NoteView) (bool, error) { return true, nil },
+		SiteConfigFunc:       func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 	}
 }
 
@@ -80,6 +81,26 @@ func TestSearchAnonymousUsesLiveCorpus(t *testing.T) {
 	require.Equal(t, "Published", payload.Results[0].Title)
 	require.Empty(t, env.SearchLatestNotesCalls(),
 		"anonymous search must not touch the latest (draft) corpus")
+}
+
+// Instances that show draft versions to site visitors (ShowDraftVersions)
+// must search the latest corpus for anonymous MCP clients too — the corpus
+// choice mirrors the site search rule, not just the auth method. Regression
+// test for the outage where anonymous federated search returned zero results
+// on such instances because the live index is nearly empty.
+func TestSearchAnonymousWithShowDraftVersionsUsesLatestCorpus(t *testing.T) {
+	env := corpusEnv()
+	env.SiteConfigFunc = func(context.Context) appmodel.SiteConfig {
+		return appmodel.SiteConfig{ShowDraftVersions: true}
+	}
+
+	resp := mcp.Resolve(context.Background(), env, searchToolCall(t))
+	payload := searchPayload(t, resp)
+
+	require.Len(t, payload.Results, 1)
+	require.Equal(t, "Draft Only", payload.Results[0].Title)
+	require.Empty(t, env.SearchLiveNotesCalls(),
+		"ShowDraftVersions instance must search the latest corpus, even anonymously")
 }
 
 // API-key (admin) clients keep searching the latest corpus, drafts included.


### PR DESCRIPTION
## Bug (production outage)

PR #176 changed anonymous MCP `search`/`federated_search` to key the corpus choice purely on
API-key auth (`useLatest := mcpAPIKeyAuthed(ctx)`), so all anonymous callers got the LIVE corpus.
The live search index is nearly empty on real instances (live notes are readable but not indexed
for search), so anonymous federated search returned **zero results** across the whole federation.

Verified live before the fix:
`federated_search(kb_id="philosophers/nietzsche", query="маска")` → "No results" — the pre-#176
binary returned matches for the same query. `note_html` reads were unaffected.

## Fix

The corpus choice now mirrors the site search rule (`internal/case/sitesearch/resolve.go:36`):

```go
useLatest := siteConfig.ShowDraftVersions || mcpAPIKeyAuthed(ctx)
```

i.e. search LATEST when the instance shows draft versions to visitors, or the caller is an
authenticated API-key/admin client; otherwise LIVE — same as an anonymous site visitor.

`mcp.Env` gained `SiteConfig(ctx context.Context) model.SiteConfig`, satisfied automatically by
`app` (already embeds `*configregistry.SiteConfigBuilder` for `sitesearch.Env`).

Only one local corpus-decision site exists in the MCP package: `handleSearch` in
`internal/case/mcp/resolve.go`. `federated_search` (`internal/case/mcp/federation_handlers.go`)
never makes its own latest/live decision — for local KBs it forwards straight to
`client.Search`/`FederatedSearch` on the target subgraph client, and for peers it just relays the
request; each peer applies this same rule locally. So this single-site fix covers both handlers.

## Tests (`internal/case/mcp/search_corpus_test.go`, `search_corpus_internal_test.go`)

- `TestSearchAnonymousUsesLiveCorpus` — `ShowDraftVersions=false` + anonymous → LIVE (existing, still green).
- `TestSearchAnonymousWithShowDraftVersionsUsesLatestCorpus` — `ShowDraftVersions=true` + anonymous → LATEST (**new, regression case**).
- `TestSearchAPIKeyUsesLatestCorpus` — API-key client → LATEST regardless (existing, still green).
- `TestSearchFederationJWTUsesLiveCorpus` — federation-JWT client, `ShowDraftVersions=false` → LIVE (existing, still green).

```
go test ./internal/case/mcp/... ./internal/case/sitesearch/...
ok  	trip2g/internal/case/mcp	0.206s
ok  	trip2g/internal/case/sitesearch	0.010s
```

`go build -tags dev ./internal/... ./cmd/...`, `go vet -tags dev ./internal/... ./cmd/...`, and
`golangci-lint run ./internal/case/mcp/... ./internal/case/sitesearch/...` (0 issues) all clean.

Not merging — please review.