### PR TITLE
feat(mcp): federation hop-rewrite — results & errors carry caller-frame kb_id

### DIFF
--- a/docs/_mcp_initialize.md
+++ b/docs/_mcp_initialize.md
@@ -27,7 +27,7 @@ note_html(pid=658, toc_path=["Adding a private peer (two-step exchange)"])
 ## Other tools — one-line triggers
 
 - `similar(pid=N)` — you found one good note and want its neighbors. Example: after the federation guide, `similar(pid=658)` surfaces the protocol guide and the RU twin.
-- `federated_search(query)` — local `search` found nothing relevant, or a result had `kind: "federation_kb"` (a pointer to a connected base). It fans the query out across all connected bases; pass `kb_id="..."` to target one. Nested bases use `/`: `kb_id="philosophers/nietzsche"` routes through the `philosophers` peer into the base it federates (recursive). Follow-up reads go through `federated_note_html` / `federated_expand` / `federated_similar`, and each of those requires the `kb_id`.
+- `federated_search(query)` — local `search` found nothing relevant, or a result had `kind: "federation_kb"` (a pointer to a connected base). It fans the query out across all connected bases; pass `kb_id="..."` to target one. Nested bases use `/`: `kb_id="philosophers/nietzsche"` routes through the `philosophers` peer into the base it federates (recursive). A base reached _through_ a hub is addressed `<hub>/<base>` (a `philosophers` hub note advertising `kb_id: montaigne` is `philosophers/montaigne` from here). Every result carries an absolute `kb_id` in your frame — use it verbatim. Follow-up reads go through `federated_note_html` / `federated_expand` / `federated_similar`, and each of those requires the `kb_id`.
 
 Call the `instructions` tool for the full argument reference.
 

--- a/docs/_mcp_instructions.md
+++ b/docs/_mcp_instructions.md
@@ -53,10 +53,10 @@ Trigger: you have one good note and want its neighbors — related guides, the o
 This base can be connected to peer knowledge bases. The federated variants mirror the local ones, with a `kb_id` targeting a peer:
 
 - `federated_search(query, kb_id?, kb_ids?, limit?, detail_limit?)` — omit `kb_id` to fan out across all connected bases in parallel; pass `kb_id` for one base, `kb_ids` for a chosen set.
-- Nested bases: a peer's own peers are addressed with `/` — `kb_id="philosophers/nietzsche"` routes through the `philosophers` peer into the base it federates (recursive; `kb_ids` accepts the same form).
+- Nested bases: a peer's own peers are addressed with `/` — `kb_id="philosophers/nietzsche"` routes through the `philosophers` peer into the base it federates (recursive; `kb_ids` accepts the same form). A base reached _through_ a hub is addressed `<hub>/<base>`: a `philosophers` hub note advertising `kb_id: montaigne` is `philosophers/montaigne` from an outer hub, not `montaigne`.
 - `federated_note_html(kb_id, ...)`, `federated_expand(kb_id, ...)`, `federated_similar(kb_id, ...)` — same arguments as their local twins, `kb_id` required.
 
-Trigger: local `search` came up empty after one rephrase, or a local result had `kind: "federation_kb"`. Results from a peer name their `kb_id` — keep passing it on every follow-up call.
+Trigger: local `search` came up empty after one rephrase, or a local result had `kind: "federation_kb"`. Every search result now carries an absolute `kb_id` in the caller's frame — use it verbatim to open or re-search that result; keep passing it on every follow-up call.
 
 **Discovering connected bases.** For a browsable directory of the peers instead of blind fan-out, read the hub index: `search("hub")` or `note_html(path="en/hub/_index.md")`. It links one note per base (e.g. `en/hub/foragent.md`), and each of those names its `kb_id` in the frontmatter. Use that to pick a target for `federated_search(kb_id="foragent")` deliberately, rather than fanning out to every peer or waiting for a `kind: "federation_kb"` pointer to surface.
 

--- a/internal/case/mcp/federation.go
+++ b/internal/case/mcp/federation.go
@@ -169,6 +169,10 @@ func aggregateFederationResults(results []ProxiedResult, skipped []*model.MCPFed
 			})
 			continue
 		}
+		// Stamp each direct peer's results into this hub's frame before aggregating.
+		if kbID != "" {
+			rewriteFederatedResponse(kbID, &result.Result)
+		}
 		payload.Results = append(payload.Results, FederatedCallResult{
 			KBID:    kbID,
 			Result:  result.Result,

--- a/internal/case/mcp/federation_handlers.go
+++ b/internal/case/mcp/federation_handlers.go
@@ -3,7 +3,6 @@ package mcp
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"trip2g/internal/model"
 )
@@ -75,6 +74,7 @@ func handleFederatedSearch(ctx context.Context, env Env, id any, argsRaw json.Ra
 	if err != nil {
 		return errorResponse(id, ErrCodeInternal, err.Error())
 	}
+	rewriteFederatedResponse(kb.ID, &result)
 	return successResponse(id, federationResultToToolResult(result))
 }
 
@@ -211,13 +211,9 @@ func handleFederatedGraphQLRequest(ctx context.Context, env Env, id any, argsRaw
 }
 
 func federationNotConfiguredResponse(id any, kbID string) Response {
-	message := "Federation is not configured for this hub. No KB-notes were found. To enable federation, create a note with mcp_federation_kb_url frontmatter pointing to another MCP endpoint."
-	status := "federation_not_configured"
-	if kbID != "" {
-		message = fmt.Sprintf("Federation is not configured for kb_id %q.", kbID)
-	}
+	message := notConfiguredMessage(kbID)
 	payload := FederationStatusPayload{
-		Status:  status,
+		Status:  "federation_not_configured",
 		KBID:    kbID,
 		Message: message,
 	}

--- a/internal/case/mcp/federation_handlers_test.go
+++ b/internal/case/mcp/federation_handlers_test.go
@@ -118,7 +118,11 @@ func TestFederatedSearchUsesMockedFederationClient(t *testing.T) {
 	require.Equal(t, "status", gotQuery)
 	result := resp.Result.(mcp.CallToolResult)
 	require.Equal(t, "remote bob", result.Content[0].Text)
-	require.JSONEq(t, `{"results":[{"title":"remote"}]}`, string(result.StructuredContent.(json.RawMessage)))
+	// A directly-federated base stamps kb_id = peer name onto every result.
+	var payload mcp.SearchResultPayload
+	require.NoError(t, json.Unmarshal(result.StructuredContent.(json.RawMessage), &payload))
+	require.Len(t, payload.Results, 1)
+	require.Equal(t, "bob", payload.Results[0].KBID)
 }
 
 func TestFederatedNoteHTMLToleratesStringPID(t *testing.T) {

--- a/internal/case/mcp/federation_helpers.go
+++ b/internal/case/mcp/federation_helpers.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"trip2g/internal/db"
+	"trip2g/internal/model"
 )
 
 var (
@@ -24,6 +25,8 @@ var (
 )
 
 const federationJWTSkew = 5 * time.Second
+
+const contentTypeText = "text"
 
 type federationVerifyEnv interface {
 	FederationSecretByKID(ctx context.Context, kid string) (db.FederationSecret, bool, error)
@@ -165,11 +168,72 @@ func splitKBID(id string) (string, string) {
 	return head, rest
 }
 
+// prefixKBID rewrites every search result into the caller's frame by stamping
+// the local peer segment onto its kb_id. A base's id is relative to the peer
+// that mounts it, so each hop prefixes its own segment: an item with no kb_id
+// yet (a leaf note answered here) becomes localSegment; one that already
+// carries a kb_id (reported by a deeper hop) becomes localSegment/<kb_id>.
+// The pointer ref's kb_id is kept in sync for back-compat.
 func prefixKBID(localSegment string, items []SearchResultItem) {
 	for i := range items {
-		if items[i].Federation == nil || items[i].Federation.KBID == "" {
-			continue
+		if items[i].KBID == "" {
+			items[i].KBID = localSegment
+		} else {
+			items[i].KBID = localSegment + "/" + items[i].KBID
 		}
-		items[i].Federation.KBID = localSegment + "/" + items[i].Federation.KBID
+		if items[i].Federation != nil && items[i].Federation.KBID != "" {
+			items[i].Federation.KBID = localSegment + "/" + items[i].Federation.KBID
+		}
+	}
+}
+
+// rewriteFederatedResponse rewrites a federated response returned by the child
+// reached through localSegment into this hub's frame. Search results get their
+// kb_id prefixed; a not-configured status carries a prefixable hint so the
+// suggested address composes across every hop back to the root.
+func rewriteFederatedResponse(localSegment string, result *model.FederationResult) {
+	if result == nil || len(result.StructuredContent) == 0 {
+		return
+	}
+
+	var status FederationStatusPayload
+	if err := json.Unmarshal(result.StructuredContent, &status); err == nil &&
+		status.Status == "federation_not_configured" && status.KBID != "" {
+		status.KBID = localSegment + "/" + status.KBID
+		status.Message = notConfiguredMessage(status.KBID)
+		if encoded, e := json.Marshal(status); e == nil {
+			result.StructuredContent = encoded
+			result.Content = []model.FederationContent{{Type: contentTypeText, Text: status.Message}}
+		}
+		return
+	}
+
+	var payload SearchResultPayload
+	if err := json.Unmarshal(result.StructuredContent, &payload); err == nil && len(payload.Results) > 0 {
+		prefixKBID(localSegment, payload.Results)
+		if encoded, e := json.Marshal(payload); e == nil {
+			result.StructuredContent = encoded
+		}
+	}
+}
+
+// notConfiguredMessage renders the not-configured hint. A flat kb_id may live
+// under a hub, so the hint tells the caller how nested bases are addressed; a
+// composed (already nested) kb_id is stated verbatim as the address to use.
+func notConfiguredMessage(kbID string) string {
+	switch {
+	case kbID == "":
+		return "Federation is not configured for this hub. No KB-notes were found. To enable federation, create a note with mcp_federation_kb_url frontmatter pointing to another MCP endpoint."
+	case strings.Contains(kbID, "/"):
+		return fmt.Sprintf(
+			"Federation is not configured for kb_id %q. Bases reached through a hub are addressed <hub>/<base> — address this base as %q.",
+			kbID, kbID)
+	default:
+		return fmt.Sprintf(
+			"Federation is not configured for kb_id %q. If %q lives under a hub, address it as <hub>/%s (bases reached through a hub are addressed <hub>/<base>).",
+			kbID,
+			kbID,
+			kbID,
+		)
 	}
 }

--- a/internal/case/mcp/federation_helpers_test.go
+++ b/internal/case/mcp/federation_helpers_test.go
@@ -56,6 +56,7 @@ func TestPrefixKBID(t *testing.T) {
 		{Title: "local"},
 		{
 			Title: "remote",
+			KBID:  "cellbio",
 			Federation: &FederationRef{
 				KBID:             "cellbio",
 				KBURL:            "https://science.example/_system/mcp",
@@ -66,7 +67,11 @@ func TestPrefixKBID(t *testing.T) {
 
 	prefixKBID("science", items)
 
+	// An ordinary leaf note answered here is stamped with the local segment.
+	require.Equal(t, "science", items[0].KBID)
 	require.Nil(t, items[0].Federation)
+	// A pointer note reported one hop down is prefixed into the caller's frame.
+	require.Equal(t, "science/cellbio", items[1].KBID)
 	require.Equal(t, "science/cellbio", items[1].Federation.KBID)
 	require.Equal(t, "https://science.example/_system/mcp", items[1].Federation.KBURL)
 	require.Equal(t, "open remote", items[1].Federation.AgentInstruction)

--- a/internal/case/mcp/federation_hoprewrite_test.go
+++ b/internal/case/mcp/federation_hoprewrite_test.go
@@ -1,0 +1,149 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"trip2g/internal/case/mcp"
+	appmodel "trip2g/internal/model"
+
+	"github.com/stretchr/testify/require"
+)
+
+// singlePeerEnv builds an env exposing one federation peer named kbID whose
+// client is fed. This mirrors a hub with exactly one directly-federated base.
+func singlePeerEnv(kbID string, fed *federationMock) *EnvMock {
+	note := &appmodel.NoteView{
+		PathID:             17,
+		MCPFederationKBURL: "https://" + kbID + ".example/_system/mcp",
+		MCPFederationKBID:  kbID,
+	}
+	nvs := appmodel.NewNoteViews()
+	nvs.MCPFederationNotes = []*appmodel.MCPFederationNote{appmodel.NewMCPFederationNote(note)}
+	return &EnvMock{
+		LatestNoteViewsFunc: func() *appmodel.NoteViews { return nvs },
+		CanReadNoteFunc: func(context.Context, *appmodel.NoteView) (bool, error) {
+			return true, nil
+		},
+		FederationClientFunc: func(context.Context, string) (appmodel.Federation, error) {
+			return fed, nil
+		},
+	}
+}
+
+func fedSingleSearchPayload(t *testing.T, result mcp.CallToolResult) mcp.SearchResultPayload {
+	t.Helper()
+	raw, ok := result.StructuredContent.(json.RawMessage)
+	require.True(t, ok, "expected json.RawMessage, got %T", result.StructuredContent)
+	var payload mcp.SearchResultPayload
+	require.NoError(t, json.Unmarshal(raw, &payload))
+	return payload
+}
+
+// The hub owning child "philosophers" must prefix its own segment onto whatever
+// kb_id the child reported, so a nietzsche note reached through philosophers
+// arrives at the caller addressed philosophers/nietzsche.
+func TestFederatedSearchPrefixesNestedKBID(t *testing.T) {
+	var gotKBID string
+	fed := &federationMock{
+		federatedSearchFunc: func(_ context.Context, params appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+			gotKBID = params.KBID
+			// The philosophers hub already stamped its child segment on the way up.
+			return appmodel.FederationResult{
+				Content:           []appmodel.FederationContent{{Type: "text", Text: "will to power"}},
+				StructuredContent: json.RawMessage(`{"results":[{"title":"WtP","kb_id":"nietzsche"}]}`),
+			}, nil
+		},
+	}
+	env := singlePeerEnv("philosophers", fed)
+
+	result := callFederatedSearch(t, env, `{"query":"power","kb_id":"philosophers/nietzsche"}`)
+
+	require.Equal(t, "nietzsche", gotKBID)
+	payload := fedSingleSearchPayload(t, result)
+	require.Len(t, payload.Results, 1)
+	require.Equal(t, "philosophers/nietzsche", payload.Results[0].KBID)
+}
+
+// The middle hub stamps its own child segment onto a leaf result that carried no
+// kb_id yet. Composed with the outer hop this is what accrues to the full path.
+func TestFederatedSearchStampsMiddleHopSegment(t *testing.T) {
+	fed := &federationMock{
+		searchFunc: func(context.Context, appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+			// A leaf base answers over its own notes: no kb_id yet.
+			return appmodel.FederationResult{
+				Content:           []appmodel.FederationContent{{Type: "text", Text: "leaf"}},
+				StructuredContent: json.RawMessage(`{"results":[{"title":"WtP"}]}`),
+			}, nil
+		},
+	}
+	env := singlePeerEnv("nietzsche", fed)
+
+	result := callFederatedSearch(t, env, `{"query":"power","kb_id":"nietzsche"}`)
+
+	payload := fedSingleSearchPayload(t, result)
+	require.Len(t, payload.Results, 1)
+	require.Equal(t, "nietzsche", payload.Results[0].KBID)
+}
+
+// Blind fan-out results keep the correct per-base kb_id for each direct peer.
+func TestFederatedSearchFanoutStampsPerBaseKBID(t *testing.T) {
+	env := fanoutEnv(2, 10, 5, 0, func(kbID string) fanoutSearchFn {
+		return func(context.Context, appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+			return appmodel.FederationResult{
+				Content:           []appmodel.FederationContent{{Type: "text", Text: "hit " + kbID}},
+				StructuredContent: json.RawMessage(`{"results":[{"title":"` + kbID + `"}]}`),
+			}, nil
+		}
+	})
+
+	result := callFederatedSearch(t, env, `{"query":"status"}`)
+	payload := fanoutPayload(t, result)
+	require.Len(t, payload.Results, 2)
+
+	byBase := map[string]string{}
+	for _, r := range payload.Results {
+		var sp mcp.SearchResultPayload
+		require.NoError(t, json.Unmarshal(r.Result.StructuredContent, &sp))
+		require.Len(t, sp.Results, 1)
+		byBase[r.KBID] = sp.Results[0].KBID
+	}
+	require.Equal(t, map[string]string{"kb1": "kb1", "kb2": "kb2"}, byBase)
+}
+
+// A not-configured error from a child composes across the hop: the parent
+// prefixes its child segment so the suggested address is the caller's full path.
+func TestFederatedSearchComposedNotConfiguredHint(t *testing.T) {
+	fed := &federationMock{
+		federatedSearchFunc: func(context.Context, appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+			return appmodel.FederationResult{
+				Content:           []appmodel.FederationContent{{Type: "text", Text: "not configured"}},
+				StructuredContent: json.RawMessage(`{"status":"federation_not_configured","kb_id":"ghost"}`),
+			}, nil
+		},
+	}
+	env := singlePeerEnv("philosophers", fed)
+
+	result := callFederatedSearch(t, env, `{"query":"x","kb_id":"philosophers/ghost"}`)
+
+	require.Contains(t, result.Content[0].Text, "philosophers/ghost")
+	raw := result.StructuredContent.(json.RawMessage)
+	var status mcp.FederationStatusPayload
+	require.NoError(t, json.Unmarshal(raw, &status))
+	require.Equal(t, "federation_not_configured", status.Status)
+	require.Equal(t, "philosophers/ghost", status.KBID)
+}
+
+// A flat kb_id unknown to this hub keeps a generic hint — the hub cannot invent
+// a specific parent, only tell the caller how nested bases are addressed.
+func TestFederatedSearchFlatNotConfiguredGeneric(t *testing.T) {
+	fed := &federationMock{} // never called: montaigne is not a direct peer
+	env := singlePeerEnv("philosophers", fed)
+
+	result := callFederatedSearch(t, env, `{"query":"x","kb_id":"montaigne"}`)
+
+	text := result.Content[0].Text
+	require.Contains(t, text, "<hub>/montaigne")
+	require.NotContains(t, text, "philosophers/montaigne")
+}

--- a/internal/case/mcp/resolve.go
+++ b/internal/case/mcp/resolve.go
@@ -780,6 +780,9 @@ func searchResultItemFromNote(note *model.NoteView, score float64, noteURL func(
 	}
 	if kb := model.NewMCPFederationNote(note); kb != nil {
 		item.Kind = "federation_kb"
+		// A pointer note's own address, relative to this hub. Federation hops
+		// prefix their local segment onto it on the way back to the caller.
+		item.KBID = kb.ID
 		item.Federation = &FederationRef{
 			KBID:             kb.ID,
 			KBURL:            kb.URL,

--- a/internal/case/mcp/types.go
+++ b/internal/case/mcp/types.go
@@ -195,6 +195,7 @@ type SearchResultPayload struct {
 
 type SearchResultItem struct {
 	Title      string         `json:"title"`
+	KBID       string         `json:"kb_id,omitempty"`
 	NoteID     int64          `json:"note_id"`
 	NotePath   string         `json:"note_path"`
 	Href       string         `json:"href"`


### PR DESCRIPTION
## The bug (observed live)

From the root, a model that wanted a philosopher corpus had no source of the correct nested address `philosophers/montaigne`. Federated search results carried `note_path`/`href`/`url`/`match_id` but **no `kb_id`** telling the caller how to re-address that base. The only `kb_id` a model saw for a leaf was the hub note's *relative* `kb_id: montaigne` — which is wrong two hops out. So the model called `federated_search(kb_id="montaigne")` → `Federation is not configured for kb_id "montaigne"`. The addressing mistake was masked as a boundary; the correct address was `philosophers/montaigne`.

## The principle

A base's id is relative to the peer that mounts it, so **each federation hop rewrites responses into the caller's frame**:

- **Results** — every search result now carries an absolute `kb_id`. A directly-federated base `X` stamps `kb_id = X` on its results; results returning from a nested call `X/Y/...` get `X/` prefixed by the hub that owns child `X`. The prefix accrues at every hop, so a nietzsche note reached via `philosophers` arrives at the root addressed `philosophers/nietzsche`.
- **Errors (the twin)** — the not-configured status carries a prefixable hint. When a child reports not-configured for `Y`, each hub prepends its child segment, so the root renders the caller-frame address (`philosophers/ghost`). A *flat* unknown `kb_id` keeps a generic hint (`if it lives under a hub, address it <hub>/<name>`) — the hub can't invent a specific parent.

The path is always deterministically known (each hub knows its own child's name), so **this replaces any learned/cached address map** — no cache, no learning, just a per-hop prefix on the way back.

## Changes

- `SearchResultItem` gains an absolute `kb_id`; local search stamps pointer notes with their own relative `kb_id`.
- `prefixKBID` generalized to stamp/prefix **all** results (ordinary leaf notes included), not just federation-pointer items.
- `rewriteFederatedResponse` applied on the real response path — the explicit-`kb_id` path and the fan-out aggregation — at every hop.
- Not-configured error carries a composable hint (`notConfiguredMessage`), prefixed across hops.
- `docs/_mcp_instructions.md` + `docs/_mcp_initialize.md`: bases reached through a hub are addressed `<hub>/<base>`; results carry an absolute `kb_id` — use it verbatim.

**Scope note:** the rewrite is applied to `federated_search` (the primary path). `federated_note_html`/`federated_expand` carry body/TOC (no addressable result list). `federated_similar` returns a different payload shape (`source`+`results`) that the search-shaped rewrite would corrupt — scoped out here, a natural follow-up.

## Tests (TDD, `internal/case/mcp`)

- nested 2-hop result carries `kb_id = philosophers/nietzsche` (prefix accrues per hop);
- direct-peer result carries `kb_id = <peer>`;
- fan-out results keep correct per-base `kb_id`;
- composed not-configured yields the caller-frame `philosophers/ghost` hint across the hop;
- flat unknown keeps the generic `<hub>/<name>` message (no invented hub);
- `prefixKBID` now stamps ordinary notes, not just pointers.

Verified: `go build ./internal/case/mcp/...`, `go vet`, `go test -race ./internal/case/mcp/...` (green), golangci-lint `--new-from-rev=origin/main` clean.