### PR TITLE
feat(retriever): Metal/MPS device support + fp16/empty_cache/micro-batch stability

### DIFF
--- a/retriever/README.md
+++ b/retriever/README.md
@@ -24,6 +24,28 @@ Reranker backend is selected by `RERANKER_MODEL` (one per boot):
 One python/sentence-transformers process, both models, runs natively on arm64 and amd64.
 `memcli up --embedded` builds and runs it automatically (image `trip2g-embedding-server`).
 
+## Device selection (Metal/MPS)
+
+`DEVICE` picks the torch device explicitly (`cpu`, `mps`, `cuda`); unset, the
+server auto-detects `mps` -> `cuda` -> `cpu`. This mainly matters for running
+the server natively on Apple-silicon dev boxes (Docker on macOS has no Metal
+access, so Metal only helps outside the container).
+
+On non-CPU devices the `Qwen3Reranker` backend loads in fp16 (softmax math
+still runs in fp32) and the `/rerank` endpoint calls `torch.mps.empty_cache()`
+after each request — torch's MPS allocator otherwise grows unbounded across
+requests of different sizes. `RERANK_BATCH` (default 8) chunks the pairs
+passed to the reranker so a single large batch doesn't make lm_head
+materialize a batch x seq x vocab logits tensor and OOM.
+
+All inference (`/v1/embeddings` and `/rerank`) is serialized behind a single
+process-wide lock — FastAPI runs sync endpoints in a threadpool, and
+concurrent calls into the same model crashed the MPS graph compiler. This is
+a deliberate throughput-for-stability tradeoff; it also applies on CPU/CUDA,
+where it costs nothing today since nothing else contends for it. CPU
+behavior (default, no `DEVICE` set) is unchanged: fp32, no device moves, no
+`empty_cache` calls.
+
 ## Model cache
 
 Models (~2GB each) are cached under `HF_HOME` (`/data` inside the container).

--- a/retriever/server.py
+++ b/retriever/server.py
@@ -1,15 +1,53 @@
 import os
+import threading
 import time
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from sentence_transformers import CrossEncoder, SentenceTransformer
 
+
+def pick_device():
+    """DEVICE env wins; otherwise auto-detect mps -> cuda -> cpu.
+
+    torch is optional here: the wire-contract test tier runs without it
+    (see README), so a missing torch just means no MPS/CUDA, i.e. cpu.
+    """
+    env_device = os.environ.get("DEVICE")
+    if env_device:
+        return env_device
+    try:
+        import torch
+    except ImportError:
+        return "cpu"
+    if torch.backends.mps.is_available():
+        return "mps"
+    if torch.cuda.is_available():
+        return "cuda"
+    return "cpu"
+
+
+device = pick_device()
+
+# Single process-wide inference lock: FastAPI runs sync endpoints in a
+# threadpool, so concurrent requests can hit the same model object at once.
+# On MPS this caused a SIGABRT in the graph compiler; serializing inference
+# trades throughput for stability.
+inference_lock = threading.Lock()
+
 embed_model_name = os.environ.get("MODEL_NAME", "BAAI/bge-m3")
-print(f"Loading embedding model {embed_model_name}...")
+print(f"Loading embedding model {embed_model_name} on {device}...")
 t0 = time.time()
-embed_model = SentenceTransformer(embed_model_name)
+embed_model = SentenceTransformer(embed_model_name, device=device)
+embed_model.encode(["warmup"], normalize_embeddings=True)  # pay JIT/compile cost at boot
 print(f"Embedding model loaded in {time.time() - t0:.1f}s")
+
+# Micro-batch size for Qwen3Reranker: scoring all pairs in one padded tensor
+# makes lm_head materialize a batch x seq x vocab logits tensor, which OOMs
+# on MPS for large batches (e.g. 50 passages). Each pair's score is
+# independent, so chunking loses nothing.
+RERANK_BATCH = int(os.environ.get("RERANK_BATCH", "8"))
+
 
 class Qwen3Reranker:
     """LLM-logit reranker for Qwen/Qwen3-Reranker-* (not a CrossEncoder).
@@ -27,17 +65,26 @@ class Qwen3Reranker:
     )
     SUFFIX = "<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"
 
-    def __init__(self, model_name):
+    def __init__(self, model_name, device="cpu"):
         import torch
         from transformers import AutoModelForCausalLM, AutoTokenizer
 
         self.torch = torch
+        self.device = device
         self.tokenizer = AutoTokenizer.from_pretrained(model_name, padding_side="left")
-        self.model = AutoModelForCausalLM.from_pretrained(model_name).eval()
+        # fp16 on non-CPU devices halves memory vs fp32; CPU keeps fp32 as before.
+        load_kwargs = {"dtype": torch.float16} if device != "cpu" else {}
+        self.model = AutoModelForCausalLM.from_pretrained(model_name, **load_kwargs).eval().to(device)
         self.token_yes = self.tokenizer.convert_tokens_to_ids("yes")
         self.token_no = self.tokenizer.convert_tokens_to_ids("no")
 
     def predict(self, pairs):
+        scores = []
+        for i in range(0, len(pairs), RERANK_BATCH):
+            scores.extend(self._predict_batch(pairs[i : i + RERANK_BATCH]))
+        return scores
+
+    def _predict_batch(self, pairs):
         texts = [
             f"{self.PREFIX}<Instruct>: {self.INSTRUCT}\n<Query>: {query}\n<Document>: {doc}{self.SUFFIX}"
             for query, doc in pairs
@@ -45,8 +92,9 @@ class Qwen3Reranker:
         inputs = self.tokenizer(
             texts, padding=True, truncation="longest_first", max_length=8192, return_tensors="pt"
         )
+        inputs = {k: v.to(self.model.device) for k, v in inputs.items()}
         with self.torch.no_grad():
-            logits = self.model(**inputs).logits[:, -1, :]
+            logits = self.model(**inputs).logits[:, -1, :].float()
         stacked = self.torch.stack([logits[:, self.token_no], logits[:, self.token_yes]], dim=1)
         return self.torch.nn.functional.softmax(stacked, dim=1)[:, 1].tolist()
 
@@ -63,9 +111,10 @@ def reranker_class(model_name):
 rerank_model = None
 rerank_model_name = os.environ.get("RERANKER_MODEL", "BAAI/bge-reranker-v2-m3")
 if os.environ.get("LOAD_RERANKER", "") not in ("", "0", "false"):
-    print(f"Loading reranker {rerank_model_name}...")
+    print(f"Loading reranker {rerank_model_name} on {device}...")
     t0 = time.time()
-    rerank_model = reranker_class(rerank_model_name)(rerank_model_name)
+    rerank_model = reranker_class(rerank_model_name)(rerank_model_name, device=device)
+    rerank_model.predict([("warmup", "warmup")])  # pay JIT/compile cost at boot
     print(f"Reranker loaded in {time.time() - t0:.1f}s")
 
 app = FastAPI()
@@ -81,7 +130,8 @@ def embed(req: EmbedRequest):
     texts = [req.input] if isinstance(req.input, str) else req.input
     # normalize_embeddings=True: the app's dot-product similarity assumes unit
     # vectors (cosine ≡ dot), same guarantee TEI hardcodes for /v1/embeddings.
-    vecs = embed_model.encode(texts, normalize_embeddings=True).tolist()
+    with inference_lock:
+        vecs = embed_model.encode(texts, normalize_embeddings=True).tolist()
     tokens = sum(len(t.split()) for t in texts)
     return {
         "object": "list",
@@ -109,7 +159,12 @@ def rerank(req: RerankRequest):
     if not req.texts:
         return []
     pairs = [(req.query, text) for text in req.texts]
-    scores = rerank_model.predict(pairs)
+    with inference_lock:
+        scores = rerank_model.predict(pairs)
+        if device == "mps":
+            import torch
+
+            torch.mps.empty_cache()
     results = [
         {"index": i, "score": float(s)}
         for i, s in enumerate(scores)

--- a/retriever/test_server.py
+++ b/retriever/test_server.py
@@ -40,8 +40,9 @@ class FakeEmbedder:
 
     last_kwargs = None
 
-    def __init__(self, model_name):
+    def __init__(self, model_name, device=None):
         self.model_name = model_name
+        self.device = device
 
     def encode(self, texts, **kwargs):
         FakeEmbedder.last_kwargs = kwargs
@@ -56,8 +57,9 @@ class FakeEmbedder:
 class FakeCrossEncoder:
     """Scores a pair high when a query word appears in the text."""
 
-    def __init__(self, model_name):
+    def __init__(self, model_name, device=None):
         self.model_name = model_name
+        self.device = device
 
     def predict(self, pairs):
         scores = []


### PR DESCRIPTION
## Summary

Adds Metal/MPS device support to `retriever/server.py` for running the bundled embedding+reranker server natively on Apple-silicon dev boxes (Docker on macOS has no Metal access). Four fixes, validated live on an M3 Max Mac:

1. **Device selection** — `pick_device()`: `DEVICE` env wins, otherwise auto-detect `mps` -> `cuda` -> `cpu`. Passed to `SentenceTransformer(..., device=device)` and `CrossEncoder(..., device=device)` for the embedder/default reranker, and to `Qwen3Reranker.__init__` (moves the causal LM with `.to(device)`, moves input tensors to `self.model.device`).
2. **Reranker micro-batching** — `RERANK_BATCH` (default 8): `Qwen3Reranker.predict` now chunks pairs instead of scoring all of them in one padded tensor. A single 50-passage batch made lm_head materialize a batch×seq×vocab logits tensor and OOM'd MPS (~19 GiB requested); each pair's score is independent so chunking loses nothing.
3. **Memory stability on non-CPU devices** — `Qwen3Reranker` loads in fp16 when `device != "cpu"` (softmax math stays fp32, logits cast with `.float()` before the softmax). The `/rerank` endpoint calls `torch.mps.empty_cache()` after each request, but only when `device == "mps"` — torch's MPS caching allocator otherwise grows monotonically across differently-sized batches until the process swaps.
4. **Concurrency** — a single process-wide `threading.Lock()` serializes all inference (`/v1/embeddings` and `/rerank`) since FastAPI runs sync endpoints in a threadpool and concurrent calls into the same model object caused a real SIGABRT/heap corruption in the MPS graph compiler. Deliberate throughput-for-stability tradeoff, documented inline. Both models are warmed up with one throwaway inference call at startup so JIT/graph-compile cost happens at boot.

## CPU path unchanged (guarantee)

With no `DEVICE` env and no MPS/CUDA available, every path collapses to today's behavior:
- `pick_device()` returns `"cpu"` (explicit `torch.backends.mps.is_available()` / `torch.cuda.is_available()` checks both False on Linux/CPU; also falls back to `"cpu"` if `torch` isn't importable at all, which keeps the no-torch wire-contract test tier working).
- `Qwen3Reranker.__init__` takes the `device != "cpu"` branch as False, so no `dtype=torch.float16` override — stays fp32, `.to("cpu")` is a no-op on an already-CPU model.
- `logits.float()` before softmax is a no-op on an fp32 model (same dtype, same values).
- `torch.mps.empty_cache()` is behind `if device == "mps"` — never reached on CPU, never imports torch's mps submodule.
- `RERANK_BATCH` micro-batching gives bit-equivalent scores since each pair is scored independently regardless of chunk size (only affects padding/batch shape, not per-pair logits, given the tokenizer's attention mask).
- The new inference lock adds serialization (was implicitly concurrent before) — this is fix #4, intentional on all devices, not a numeric/behavioral regression.

## Validation (M3 Max, from research_fixes.md §4)

After all four fixes, 24-run sweep, n=98 searches, full hybrid search with rerank @ top_n=50:
- median 7.6s, p90 9.1s, max 11s, **zero timeouts**
- vs CPU baseline (bge-reranker-v2-m3 on CPU, same questions): median 37.3s, p90 55.8s

## What I verified locally vs could not verify

Verified (this Linux host, no MPS hardware):
- `python3 -c "import ast; ast.parse(...)"` — syntax OK
- `pytest test_server.py` in a clean venv with only `fastapi httpx pytest` installed (no torch) — 9 passed, 2 skipped (REAL_MODELS, expected). This exercises the exact "no torch" tier documented in the README, confirming `pick_device()`'s `ImportError` fallback keeps that tier working.
- `pyflakes` clean on both changed files.
- Manual read-through of every code path with `device == "cpu"` (see above).

Could NOT verify: actual MPS execution (fp16 load, empty_cache behavior, micro-batching under real memory pressure, the concurrency fix actually preventing the SIGABRT) — no Mac/MPS hardware on this host. Already validated live on an M3 Max by another agent (see `research_fixes.md` §1 and §4).

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('retriever/server.py').read())"`
- [x] `cd retriever && python -m pytest test_server.py` (no-torch venv) — 9 passed, 2 skipped
- [ ] REAL_MODELS=1 run (not attempted — heavy, out of scope for this verification pass)
- [ ] Actual MPS run on Apple-silicon hardware (already done by the Mac agent per research_fixes.md)