### PR TITLE
fix(search): cut snippet window on rune boundaries

### DIFF
--- a/internal/case/mcp/toc_path.go
+++ b/internal/case/mcp/toc_path.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"trip2g/internal/model"
 
@@ -239,6 +240,25 @@ func markedContext(snippet string) string {
 	if hi > len(snippet) {
 		hi = len(snippet)
 	}
+
+	// Snap to rune boundaries: the byte window above is computed from
+	// strings.Index offsets and can land inside a multi-byte UTF-8 sequence
+	// (e.g. Cyrillic). Advance lo past any leading continuation byte, and
+	// pull hi back before any trailing partial rune, so the slice below is
+	// always valid UTF-8.
+	for lo < len(snippet) && !utf8.RuneStart(snippet[lo]) {
+		lo++
+	}
+	for hi > 0 && hi < len(snippet) && !utf8.RuneStart(snippet[hi]) {
+		hi--
+	}
+	if lo > hi {
+		// Degenerate window (shouldn't happen with window=120 and short
+		// runes) — fall back to the exact match, which is always a valid
+		// boundary since <mark>/</mark> are ASCII.
+		return snippet[start:end]
+	}
+
 	return snippet[lo:hi]
 }
 

--- a/internal/case/mcp/toc_path_test.go
+++ b/internal/case/mcp/toc_path_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/require"
 
@@ -253,4 +254,77 @@ func TestStripMarkdownInline(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestMarkedContextRuneSafety verifies that markedContext, which windows ±120
+// bytes around the first <mark>...</mark> block, never splits a multi-byte
+// UTF-8 rune — regardless of where the byte offsets land relative to
+// variable-width characters (e.g. 2-byte Cyrillic).
+func TestMarkedContextRuneSafety(t *testing.T) {
+	t.Run("leading orphan continuation byte at window start", func(t *testing.T) {
+		// 60 Cyrillic chars (120 bytes) + 1 ASCII byte = 121-byte prefix.
+		// window=120 means lo = start-120 = 1, which is the second (continuation)
+		// byte of the first Cyrillic rune under naive byte slicing.
+		prefix := strings.Repeat("б", 60) + "A"
+		content := prefix + "<mark>совпадение</mark>"
+
+		snippet := markedContext(content)
+
+		require.True(t, utf8.ValidString(snippet), "snippet must be valid UTF-8, got %q", snippet)
+		require.NotContains(t, snippet, "�", "no replacement char should be introduced")
+		require.Contains(t, snippet, "<mark>совпадение</mark>", "mark tag must still wrap the matched term")
+	})
+
+	t.Run("trailing half character at window end", func(t *testing.T) {
+		// Symmetric case: 1 ASCII byte + 60 Cyrillic chars (120 bytes) after
+		// the closing tag. window=120 means hi = end+120 lands on the
+		// continuation byte of the last Cyrillic rune under naive slicing.
+		suffix := "A" + strings.Repeat("б", 60)
+		content := "<mark>совпадение</mark>" + suffix
+
+		snippet := markedContext(content)
+
+		require.True(t, utf8.ValidString(snippet), "snippet must be valid UTF-8, got %q", snippet)
+		require.NotContains(t, snippet, "�", "no replacement char should be introduced")
+		require.Contains(t, snippet, "<mark>совпадение</mark>", "mark tag must still wrap the matched term")
+	})
+
+	t.Run("both edges misaligned", func(t *testing.T) {
+		prefix := strings.Repeat("б", 60) + "A"
+		suffix := "A" + strings.Repeat("б", 60)
+		content := prefix + "<mark>совпадение</mark>" + suffix
+
+		snippet := markedContext(content)
+
+		require.True(t, utf8.ValidString(snippet), "snippet must be valid UTF-8, got %q", snippet)
+		require.NotContains(t, snippet, "�", "no replacement char should be introduced")
+		require.Contains(t, snippet, "<mark>совпадение</mark>", "mark tag must still wrap the matched term")
+	})
+
+	t.Run("ASCII-only content is unchanged (no regression)", func(t *testing.T) {
+		prefix := strings.Repeat("word ", 40)
+		suffix := strings.Repeat(" word", 40)
+		content := prefix + "<mark>match</mark>" + suffix
+
+		snippet := markedContext(content)
+
+		start := strings.Index(content, "<mark>")
+		end := strings.LastIndex(content, "</mark>") + len("</mark>")
+		lo := start - 120
+		if lo < 0 {
+			lo = 0
+		}
+		hi := end + 120
+		if hi > len(content) {
+			hi = len(content)
+		}
+		want := content[lo:hi]
+
+		require.Equal(t, want, snippet, "ASCII-only content must match the original byte-window behavior exactly")
+	})
+
+	t.Run("no mark tags returns snippet unchanged", func(t *testing.T) {
+		content := "no marks here at all"
+		require.Equal(t, content, markedContext(content))
+	})
 }


### PR DESCRIPTION
## Problem

An external benchmark against trip2g's search API observed the search snippet highlighter deterministically crashing clients with `UnicodeDecodeError` on roughly 30% of Cyrillic queries. The benchmark worked around it client-side; this fixes the root cause server-side.

## Root cause

`markedContext` in `internal/case/mcp/toc_path.go:225` (called from `tocPathForSnippet` at `toc_path.go:74`) builds a ±120-byte context window around the `<mark>...</mark>` match location using raw byte offsets:

```go
start := strings.Index(snippet, "<mark>")
end := strings.LastIndex(snippet, "</mark>")
...
lo := start - window
hi := end + window
return snippet[lo:hi]
```

`start`/`end` are byte offsets and `window` is a byte count, so for non-ASCII (Cyrillic, 2-byte UTF-8) content the window edges routinely land mid-rune — producing a snippet that starts with an orphaned UTF-8 continuation byte or ends with a truncated multi-byte sequence. That invalid-UTF-8 string then flows into the fuzzy TOC-path matching and downstream response.

`sitesearch.SnippetFromChunk` (`retrieve.go:203`) was already rune-safe (uses `[]rune`) — this was a separate, unguarded byte-window function.

## Fix

After computing the byte window, snap both edges to valid rune boundaries with `unicode/utf8.RuneStart`: advance `lo` forward past any leading continuation bytes, pull `hi` back before any trailing partial rune. `<mark>` highlighting behavior and the word-count/window semantics are unchanged; ASCII-only content produces byte-identical output (verified by test).

## Test evidence

Red (before fix):
```
=== RUN   TestMarkedContextRuneSafety/leading_orphan_continuation_byte_at_window_start
    Error: Should be true — snippet must be valid UTF-8, got "\xb1бб...A<mark>совпадение</mark>"
=== RUN   TestMarkedContextRuneSafety/trailing_half_character_at_window_end
    Error: Should be true — snippet must be valid UTF-8, got "<mark>совпадение</mark>Aбб...\xd0"
--- FAIL: TestMarkedContextRuneSafety (0.00s)
```

Green (after fix):
```
$ go test ./internal/case/mcp/... -run TestMarkedContextRuneSafety -v
=== RUN   TestMarkedContextRuneSafety
=== RUN   TestMarkedContextRuneSafety/leading_orphan_continuation_byte_at_window_start
=== RUN   TestMarkedContextRuneSafety/trailing_half_character_at_window_end
=== RUN   TestMarkedContextRuneSafety/both_edges_misaligned
=== RUN   TestMarkedContextRuneSafety/ASCII-only_content_is_unchanged_(no_regression)
=== RUN   TestMarkedContextRuneSafety/no_mark_tags_returns_snippet_unchanged
--- PASS: TestMarkedContextRuneSafety (0.00s)
PASS
ok  	trip2g/internal/case/mcp	0.005s
```

Full suite:
```
$ go test ./internal/case/mcp/... ./internal/case/sitesearch/... ./internal/noteloader/...
ok  	trip2g/internal/case/mcp	0.206s
ok  	trip2g/internal/case/sitesearch	0.009s
ok  	trip2g/internal/noteloader	0.012s
```

`go build ./internal/...` (relevant packages), `go vet`, and `golangci-lint run` are clean on the changed files.

## Test plan
- [x] `go build ./internal/case/mcp/... ./internal/case/sitesearch/... ./internal/noteloader/... ./internal/model/...`
- [x] `go vet ./internal/case/mcp/... ./internal/case/sitesearch/... ./internal/noteloader/...`
- [x] `go test ./internal/case/mcp/... ./internal/case/sitesearch/... ./internal/noteloader/...`
- [x] `golangci-lint run` on changed package — 0 issues