### PR TITLE
fix(mcp): inclusive federation depth (N segments allowed at max=N) + early clean reject

### DIFF
--- a/internal/case/mcp/endpoint.go
+++ b/internal/case/mcp/endpoint.go
@@ -34,8 +34,13 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 		return writeJSONResponse(req, resp)
 	}
 
-	// Enforce federation hop depth limit. Depth is observed for every request:
-	// no header, a malformed value or a negative one all count as 0 = direct client.
+	// Enforce the federation hop-depth limit as a loop-protection backstop. Depth
+	// is observed for every request: no header, a malformed value or a negative one
+	// all count as 0 = direct client. The comparison is inclusive (a path of N
+	// segments reaches depth N and is allowed when N <= max); explicit deep paths
+	// are rejected earlier and more cleanly by federationPathDepthExceeded, so this
+	// counter mainly bounds fan-out cycles where peers federate back with no
+	// explicit segments to count.
 	resolveCtx := context.Context(req.Req)
 	depthHeader := req.Req.Request.Header.Peek("X-MCP-Federation-Depth")
 	incomingDepth := 0
@@ -46,7 +51,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 	}
 	m.ObserveFederationDepth(incomingDepth)
 	if len(depthHeader) > 0 {
-		if incomingDepth >= env.FederationMaxDepth() {
+		if incomingDepth > env.FederationMaxDepth() {
 			resp := errorResponse(rpcReq.ID, ErrCodeInternal, "federation max depth exceeded")
 			recordRejectedRequest(m, rpcReq, authAnonymous, time.Since(start).Seconds())
 			return writeJSONResponse(req, resp)

--- a/internal/case/mcp/endpoint_dispatch_test.go
+++ b/internal/case/mcp/endpoint_dispatch_test.go
@@ -280,9 +280,23 @@ func TestMCPEndpointDepthEnforcement(t *testing.T) {
 		require.Nil(t, resp.Error)
 	})
 
-	t.Run("depth equal to max is rejected", func(t *testing.T) {
+	t.Run("depth equal to max passes through (inclusive limit)", func(t *testing.T) {
+		// A path of N segments reaches depth N; with max=3 the deepest node
+		// receives depth 3, which is allowed (3 > 3 is false).
 		env := buildEnvWithMaxDepth(t, 3)
 		fasthttpCtx := buildCtxWithDepth(mcpInitBody, "3")
+		req := wiredRequest(fasthttpCtx, env, nil)
+		defer appreq.Release(req)
+		_, err := (&mcp.Endpoint{}).Handle(req)
+		require.NoError(t, err)
+		var resp mcp.Response
+		require.NoError(t, json.Unmarshal(fasthttpCtx.Response.Body(), &resp))
+		require.Nil(t, resp.Error)
+	})
+
+	t.Run("depth above max is rejected by the backstop", func(t *testing.T) {
+		env := buildEnvWithMaxDepth(t, 3)
+		fasthttpCtx := buildCtxWithDepth(mcpInitBody, "4")
 		req := wiredRequest(fasthttpCtx, env, nil)
 		defer appreq.Release(req)
 		_, err := (&mcp.Endpoint{}).Handle(req)
@@ -293,7 +307,7 @@ func TestMCPEndpointDepthEnforcement(t *testing.T) {
 		require.Contains(t, resp.Error.Message, "max depth")
 	})
 
-	t.Run("depth above max is rejected", func(t *testing.T) {
+	t.Run("far above max is rejected by the backstop", func(t *testing.T) {
 		env := buildEnvWithMaxDepth(t, 3)
 		fasthttpCtx := buildCtxWithDepth(mcpInitBody, "10")
 		req := wiredRequest(fasthttpCtx, env, nil)
@@ -304,6 +318,125 @@ func TestMCPEndpointDepthEnforcement(t *testing.T) {
 		require.NoError(t, json.Unmarshal(fasthttpCtx.Response.Body(), &resp))
 		require.NotNil(t, resp.Error)
 		require.Contains(t, resp.Error.Message, "max depth")
+	})
+
+	t.Run("maxDepth 1 allows depth 1 at the backstop", func(t *testing.T) {
+		env := buildEnvWithMaxDepth(t, 1)
+		fasthttpCtx := buildCtxWithDepth(mcpInitBody, "1")
+		req := wiredRequest(fasthttpCtx, env, nil)
+		defer appreq.Release(req)
+		_, err := (&mcp.Endpoint{}).Handle(req)
+		require.NoError(t, err)
+		var resp mcp.Response
+		require.NoError(t, json.Unmarshal(fasthttpCtx.Response.Body(), &resp))
+		require.Nil(t, resp.Error)
+	})
+}
+
+// TestFederationPathDepthEarlyReject drives federated_search end-to-end with an
+// explicit nested kb_id and asserts the entry node rejects an over-long path up
+// front — before any outbound federation hop fires — while an in-bounds path is
+// forwarded. outboundCalls counts how many times a federation client is built.
+func TestFederationPathDepthEarlyReject(t *testing.T) {
+	buildEnv := func(t *testing.T, peerID string, maxDepth int, outboundCalls *int) *EnvMock {
+		t.Helper()
+		note := &appmodel.NoteView{
+			PathID:             17,
+			MCPFederationKBURL: "https://" + peerID + ".example/_system/mcp",
+			MCPFederationKBID:  peerID,
+		}
+		nvs := appmodel.NewNoteViews()
+		nvs.MCPFederationNotes = []*appmodel.MCPFederationNote{appmodel.NewMCPFederationNote(note)}
+		env := buildDispatchEnv(t, false)
+		env.LatestNoteViewsFunc = func() *appmodel.NoteViews { return nvs }
+		env.CanReadNoteFunc = func(context.Context, *appmodel.NoteView) (bool, error) { return true, nil }
+		env.FederationMaxDepthFunc = func() int { return maxDepth }
+		env.FederationClientFunc = func(context.Context, string) (appmodel.Federation, error) {
+			*outboundCalls++
+			ok := func(context.Context, appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+				return appmodel.FederationResult{Content: []appmodel.FederationContent{{Type: "text", Text: "ok"}}}, nil
+			}
+			return &federationMock{searchFunc: ok, federatedSearchFunc: ok}, nil
+		}
+		return env
+	}
+
+	callSearch := func(t *testing.T, env *EnvMock, kbID string) mcp.Response {
+		t.Helper()
+		callBody, _ := json.Marshal(mcp.Request{
+			JSONRPC: "2.0",
+			Method:  "tools/call",
+			Params:  mustMarshalRaw(mcp.CallToolParams{Name: "federated_search", Arguments: json.RawMessage(`{"query":"x","kb_id":"` + kbID + `"}`)}),
+			ID:      1,
+		})
+		fasthttpCtx := buildMCPFasthttpCtx(callBody, "")
+		req := wiredRequest(fasthttpCtx, env, nil)
+		defer appreq.Release(req)
+		_, err := (&mcp.Endpoint{}).Handle(req)
+		require.NoError(t, err)
+		var resp mcp.Response
+		require.NoError(t, json.Unmarshal(fasthttpCtx.Response.Body(), &resp))
+		return resp
+	}
+
+	t.Run("3-segment path allowed at maxDepth 3", func(t *testing.T) {
+		calls := 0
+		env := buildEnv(t, "philosophers", 3, &calls)
+		resp := callSearch(t, env, "philosophers/nietzsche/schopenhauer")
+		require.Nil(t, resp.Error)
+		require.Equal(t, 1, calls, "an in-bounds path must fire exactly one outbound hop")
+	})
+
+	t.Run("4-segment path rejected early with a single clean message and no outbound hop", func(t *testing.T) {
+		calls := 0
+		env := buildEnv(t, "philosophers", 3, &calls)
+		resp := callSearch(t, env, "philosophers/nietzsche/schopenhauer/hegel")
+		require.NotNil(t, resp.Error)
+		require.Equal(t, 0, calls, "an over-long path must not fire any outbound hop")
+		require.Contains(t, resp.Error.Message, "exceeds federation max depth")
+		// A single, unwrapped error — not the triple-wrapped -32603 the doomed hops produced.
+		require.NotContains(t, resp.Error.Message, "rpc error")
+	})
+
+	t.Run("fan-out cycle bounded by the runtime backstop", func(t *testing.T) {
+		// A blind fan-out (kb_id="") has 0 explicit segments, so the path-length
+		// check does not apply; a peer that federates back and drives the cumulative
+		// header depth past the limit must still be stopped by the backstop, firing
+		// no local fan-out.
+		calls := 0
+		env := buildEnv(t, "philosophers", 3, &calls)
+		callBody, _ := json.Marshal(mcp.Request{
+			JSONRPC: "2.0",
+			Method:  "tools/call",
+			Params:  mustMarshalRaw(mcp.CallToolParams{Name: "federated_search", Arguments: json.RawMessage(`{"query":"x"}`)}),
+			ID:      1,
+		})
+		fasthttpCtx := buildMCPFasthttpCtx(callBody, "")
+		fasthttpCtx.Request.Header.Set("X-MCP-Federation-Depth", "4")
+		req := wiredRequest(fasthttpCtx, env, nil)
+		defer appreq.Release(req)
+		_, err := (&mcp.Endpoint{}).Handle(req)
+		require.NoError(t, err)
+		var resp mcp.Response
+		require.NoError(t, json.Unmarshal(fasthttpCtx.Response.Body(), &resp))
+		require.NotNil(t, resp.Error)
+		require.Contains(t, resp.Error.Message, "max depth")
+		require.Equal(t, 0, calls, "backstop must stop the request before any fan-out")
+	})
+
+	t.Run("boundary maxDepth 1: 1 segment allowed, 2 rejected", func(t *testing.T) {
+		calls := 0
+		env := buildEnv(t, "philosophers", 1, &calls)
+		resp := callSearch(t, env, "philosophers")
+		require.Nil(t, resp.Error)
+		require.Equal(t, 1, calls)
+
+		calls = 0
+		env2 := buildEnv(t, "philosophers", 1, &calls)
+		resp2 := callSearch(t, env2, "philosophers/nietzsche")
+		require.NotNil(t, resp2.Error)
+		require.Equal(t, 0, calls)
+		require.Contains(t, resp2.Error.Message, "exceeds federation max depth")
 	})
 }
 

--- a/internal/case/mcp/federation_handlers.go
+++ b/internal/case/mcp/federation_handlers.go
@@ -3,6 +3,8 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	"trip2g/internal/model"
 )
@@ -14,6 +16,9 @@ func handleFederatedSearch(ctx context.Context, env Env, id any, argsRaw json.Ra
 	}
 	if args.Query == "" {
 		return errorResponse(id, ErrCodeInvalidParams, "query is required")
+	}
+	if depthErr := federationPathDepthExceeded(ctx, env, id, args.KBID); depthErr != nil {
+		return *depthErr
 	}
 
 	kbs, err := accessibleKBNotes(ctx, env)
@@ -87,6 +92,9 @@ func callFederatedSingleKB(
 	kbID string,
 	call func(client model.Federation, rest string) (model.FederationResult, error),
 ) Response {
+	if errResp := federationPathDepthExceeded(ctx, env, id, kbID); errResp != nil {
+		return *errResp
+	}
 	kbs, err := accessibleKBNotes(ctx, env)
 	if err != nil {
 		return errorResponse(id, ErrCodeInternal, err.Error())
@@ -208,6 +216,41 @@ func handleFederatedGraphQLRequest(ctx context.Context, env Env, id any, argsRaw
 	return callFederatedSingleKB(ctx, env, id, args.KBID, func(client model.Federation, rest string) (model.FederationResult, error) {
 		return client.GraphQLRequest(ctx, model.FederationGraphQLParams{KBID: rest, Query: args.Query, Variables: args.Variables})
 	})
+}
+
+// federationPathDepthExceeded rejects an explicit nested kb_id up front when the
+// path cannot fit under the federation depth limit, before any outbound hop fires.
+// The bound is invariant along the path: each hop consumes one segment and gains
+// one depth unit, so incomingDepth + segmentCount(kbID) is constant from the entry
+// node to the leaf. The entry node sees the full path and rejects here, so no
+// doomed hop runs and the caller gets a single clean error instead of a
+// triple-wrapped -32603. Fan-out and single-segment (segmentCount < 2) calls defer
+// to the runtime header-depth backstop in the endpoint: a single segment can only
+// exceed when max < 1, and any deeper path is already caught at the entry node.
+func federationPathDepthExceeded(ctx context.Context, env Env, id any, kbID string) *Response {
+	segs := segmentCount(kbID)
+	if segs < 2 {
+		return nil
+	}
+	total := FederationDepthFromContext(ctx) + segs
+	if limit := env.FederationMaxDepth(); total > limit {
+		resp := errorResponse(id, ErrCodeInternal,
+			fmt.Sprintf("kb_id path depth %d exceeds federation max depth %d", total, limit))
+		return &resp
+	}
+	return nil
+}
+
+// segmentCount counts the '/'-separated non-empty segments of a kb_id path
+// (empty kb_id = 0).
+func segmentCount(kbID string) int {
+	n := 0
+	for _, seg := range strings.Split(kbID, "/") {
+		if seg != "" {
+			n++
+		}
+	}
+	return n
 }
 
 func federationNotConfiguredResponse(id any, kbID string) Response {

--- a/internal/case/mcp/federation_handlers_test.go
+++ b/internal/case/mcp/federation_handlers_test.go
@@ -257,6 +257,7 @@ func TestFederatedSearchDelegatesNestedKBID(t *testing.T) {
 			require.Equal(t, "bob", kbID)
 			return federation, nil
 		},
+		FederationMaxDepthFunc: func() int { return 3 },
 	}
 
 	params := mcp.CallToolParams{

--- a/internal/case/mcp/federation_hoprewrite_test.go
+++ b/internal/case/mcp/federation_hoprewrite_test.go
@@ -29,6 +29,7 @@ func singlePeerEnv(kbID string, fed *federationMock) *EnvMock {
 		FederationClientFunc: func(context.Context, string) (appmodel.Federation, error) {
 			return fed, nil
 		},
+		FederationMaxDepthFunc: func() int { return 3 },
 	}
 }
 

--- a/internal/case/mcp/metrics_flow_test.go
+++ b/internal/case/mcp/metrics_flow_test.go
@@ -279,7 +279,7 @@ func TestMCPEndpointMetrics(t *testing.T) {
 		{
 			name:    "exceeded federation depth records rejected request",
 			body:    mcpInitBody,
-			headers: map[string]string{"X-MCP-Federation-Depth": "5"},
+			headers: map[string]string{"X-MCP-Federation-Depth": "6"},
 			setup: func(_ *testing.T, env *EnvMock) {
 				env.FederationMaxDepthFunc = func() int { return 5 }
 			},


### PR DESCRIPTION
## The off-by-one

Federation hop depth is a cumulative counter in the `X-MCP-Federation-Depth` header, +1 per outbound hop. `endpoint.go` rejected when `incomingDepth >= FederationMaxDepth()`. A `kb_id` path of N segments reaches depth N at the terminal peer (each KB note is itself a remote peer, so the last segment costs one more hop). With `MaxDepth=3`, `philosophers/nietzsche` (2 segments → depth 2) worked, but `philosophers/nietzsche/schopenhauer` (3 segments → depth 3) was **rejected** — only 2 nesting levels usable. Worse, the rejection was discovered only after the doomed outbound hops fired, producing a triple-wrapped `federation rpc error -32603: … -32603: … -32603: federation max depth exceeded`.

## Inclusive semantics (`>` instead of `>=`)

Reject only when depth would be **strictly greater** than `MaxDepth`, so depth == MaxDepth is allowed.

Depth trace verified in tests (`MaxDepth=3`): client depth 0 → each hop +1 → the terminal peer resolving the last of 3 segments receives depth 3; `3 > 3` is false ⇒ allowed. A 4th segment reaches depth 4, `4 > 3` ⇒ rejected.

## Early, clean reject by path length

Before firing any outbound hop, each node computes `incomingDepth + segmentCount(kb_id)` and rejects immediately with a single unwrapped message `kb_id path depth <total> exceeds federation max depth <max>` when it exceeds the limit. Because this sum is invariant along the path (each hop consumes one segment and gains one depth unit), the entry node — which sees the full path — rejects up front, so no doomed hops fire and there is no triple-wrapped `-32603`. Applied in `federation_handlers.go` (`handleFederatedSearch` + `callFederatedSingleKB`, covering similar/note_html/expand/graphql). Fan-out (`kb_id=""`, 0 segments) and single-segment paths defer to the backstop, since a deeper explicit path is already caught at the entry node.

## Loop-protection backstop retained

The cumulative header-depth check in `endpoint.go` is **kept** (with the same inclusive `>` comparison) as a backstop. Blind fan-out has 0 explicit segments but can still recurse via peers federating back (cycles); the counter still bounds that. Confirmed by a test: a fan-out request arriving with header depth 4 at `MaxDepth=3` is rejected by the backstop with **0** outbound calls.

## Tests (TDD)

- `TestMCPEndpointDepthEnforcement`: flipped — depth 3 at max 3 now passes; depth 4/10 rejected; `MaxDepth=1` allows depth 1.
- `TestFederationPathDepthEarlyReject`: 3-segment path allowed at max 3 (1 outbound hop); 4-segment rejected early with the single clean message and **0** outbound hops; fan-out cycle bounded by the backstop (0 outbound); boundary `MaxDepth=1` allows 1 segment, rejects 2.
- `metrics_flow_test.go` rejected-request case updated to the inclusive threshold (depth 6 at max 5).

Verify: `go build ./...`, `go vet`, `go test -race ./internal/case/mcp/... ./internal/federation/...`, golangci-lint (pinned) all clean.

Do not merge.