### PR TITLE
feat(mcp): federated_instructions — fetch a route's own instructions, with a route cache

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -43,6 +43,7 @@ import (
 	"trip2g/internal/dataencryption"
 	"trip2g/internal/db"
 	"trip2g/internal/defaulttemplate"
+	"trip2g/internal/fedinstr"
 	"trip2g/internal/frontmatterpatch"
 	"trip2g/internal/gitapi"
 	"trip2g/internal/hotauthtoken"
@@ -235,6 +236,8 @@ type appState struct {
 
 	*chartdata.ChartData // server-side data for url/internal datachart sources (promotes ChartRows, SaveChartData)
 
+	*fedinstr.Cache // caches federated instructions per kb_id (promotes CachedFederatedInstructions, StoreFederatedInstructions)
+
 	patreonClientManager *patreon.ClientManager
 	boostyClientManager  *boosty.ClientManager
 
@@ -375,6 +378,7 @@ func main() {
 	a.ctx = ctx
 	a.SiteConfigBuilder = configregistry.NewSiteConfigBuilder(a)
 	a.pageCache = pagecache.New()
+	a.Cache = fedinstr.New()
 	a.sigChan = make(chan os.Signal, 1)
 	signal.Notify(a.sigChan, syscall.SIGINT, syscall.SIGTERM)
 

--- a/internal/case/mcp/federated_graphql_test.go
+++ b/internal/case/mcp/federated_graphql_test.go
@@ -72,6 +72,12 @@ func (e *fedGQLEnv) FederatedFanoutLimit() int            { panic("unexpected") 
 func (e *fedGQLEnv) FederatedFanoutTimeout() time.Duration {
 	panic("unexpected")
 }
+func (e *fedGQLEnv) CachedFederatedInstructions(_ string) (model.FederationResult, bool) {
+	panic("unexpected")
+}
+func (e *fedGQLEnv) StoreFederatedInstructions(_ string, _ model.FederationResult) {
+	panic("unexpected")
+}
 func (e *fedGQLEnv) ResolveAPIKey(_ context.Context, _, _ string) (*db.ApiKey, error) {
 	panic("unexpected")
 }

--- a/internal/case/mcp/federated_instructions_test.go
+++ b/internal/case/mcp/federated_instructions_test.go
@@ -1,0 +1,200 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"trip2g/internal/case/mcp"
+	"trip2g/internal/fedinstr"
+	appmodel "trip2g/internal/model"
+
+	"github.com/stretchr/testify/require"
+)
+
+func fedInstrNoteViews() *appmodel.NoteViews {
+	kbNote := &appmodel.NoteView{
+		PathID:             17,
+		MCPFederationKBURL: "https://bob.example/_system/mcp",
+		MCPFederationKBID:  "bob",
+	}
+	nvs := appmodel.NewNoteViews()
+	nvs.MCPFederationNotes = []*appmodel.MCPFederationNote{appmodel.NewMCPFederationNote(kbNote)}
+	return nvs
+}
+
+func callFederatedInstructions(env mcp.Env, args string) mcp.Response {
+	params := mcp.CallToolParams{Name: "federated_instructions", Arguments: json.RawMessage(args)}
+	paramsJSON, _ := json.Marshal(params)
+	return mcp.Resolve(context.Background(), env, mcp.Request{
+		JSONRPC: "2.0",
+		Method:  "tools/call",
+		Params:  paramsJSON,
+		ID:      1,
+	})
+}
+
+func TestFederatedInstructionsDirectPeer(t *testing.T) {
+	nvs := fedInstrNoteViews()
+	cache := fedinstr.New()
+	federation := &federationMock{
+		instructionsFunc: func(_ context.Context) (appmodel.FederationResult, error) {
+			return appmodel.FederationResult{
+				Content: []appmodel.FederationContent{{Type: "text", Text: "bob's guidance"}},
+			}, nil
+		},
+	}
+	env := &EnvMock{
+		LatestNoteViewsFunc: func() *appmodel.NoteViews { return nvs },
+		CanReadNoteFunc:     func(context.Context, *appmodel.NoteView) (bool, error) { return true, nil },
+		FederationClientFunc: func(_ context.Context, kbID string) (appmodel.Federation, error) {
+			require.Equal(t, "bob", kbID)
+			return federation, nil
+		},
+		CachedFederatedInstructionsFunc: cache.CachedFederatedInstructions,
+		StoreFederatedInstructionsFunc:  cache.StoreFederatedInstructions,
+	}
+
+	resp := callFederatedInstructions(env, `{"kb_id":"bob"}`)
+	require.Nil(t, resp.Error)
+	result := resp.Result.(mcp.CallToolResult)
+	require.Equal(t, "bob's guidance", result.Content[0].Text)
+}
+
+func TestFederatedInstructionsNestedForwards(t *testing.T) {
+	nvs := fedInstrNoteViews()
+	cache := fedinstr.New()
+	var gotKBID string
+	federation := &federationMock{
+		federatedInstructionsFunc: func(_ context.Context, params appmodel.FederationInstructionsParams) (appmodel.FederationResult, error) {
+			gotKBID = params.KBID
+			return appmodel.FederationResult{
+				Content: []appmodel.FederationContent{{Type: "text", Text: "nietzsche's guidance"}},
+			}, nil
+		},
+	}
+	env := &EnvMock{
+		LatestNoteViewsFunc: func() *appmodel.NoteViews { return nvs },
+		CanReadNoteFunc:     func(context.Context, *appmodel.NoteView) (bool, error) { return true, nil },
+		FederationClientFunc: func(_ context.Context, kbID string) (appmodel.Federation, error) {
+			require.Equal(t, "bob", kbID)
+			return federation, nil
+		},
+		FederationMaxDepthFunc:          func() int { return 5 },
+		CachedFederatedInstructionsFunc: cache.CachedFederatedInstructions,
+		StoreFederatedInstructionsFunc:  cache.StoreFederatedInstructions,
+	}
+
+	resp := callFederatedInstructions(env, `{"kb_id":"bob/nietzsche"}`)
+	require.Nil(t, resp.Error)
+	require.Equal(t, "nietzsche", gotKBID, "rest of the path must forward to the next hop")
+	result := resp.Result.(mcp.CallToolResult)
+	require.Equal(t, "nietzsche's guidance", result.Content[0].Text)
+}
+
+func TestFederatedInstructionsRespectsMaxDepth(t *testing.T) {
+	nvs := fedInstrNoteViews()
+	cache := fedinstr.New()
+	federation := &federationMock{} // must never be called: depth is rejected up front
+	env := &EnvMock{
+		LatestNoteViewsFunc:             func() *appmodel.NoteViews { return nvs },
+		CanReadNoteFunc:                 func(context.Context, *appmodel.NoteView) (bool, error) { return true, nil },
+		FederationClientFunc:            func(context.Context, string) (appmodel.Federation, error) { return federation, nil },
+		FederationMaxDepthFunc:          func() int { return 2 },
+		CachedFederatedInstructionsFunc: cache.CachedFederatedInstructions,
+		StoreFederatedInstructionsFunc:  cache.StoreFederatedInstructions,
+	}
+
+	// bob/nietzsche/deep = 3 segments > max depth 2.
+	resp := callFederatedInstructions(env, `{"kb_id":"bob/nietzsche/deep"}`)
+	require.NotNil(t, resp.Error)
+	require.Equal(t, mcp.ErrCodeInternal, resp.Error.Code)
+}
+
+func TestFederatedInstructionsCacheHitSkipsForward(t *testing.T) {
+	nvs := fedInstrNoteViews()
+	cache := fedinstr.New()
+	var calls int32
+	federation := &federationMock{
+		instructionsFunc: func(_ context.Context) (appmodel.FederationResult, error) {
+			atomic.AddInt32(&calls, 1)
+			return appmodel.FederationResult{
+				Content: []appmodel.FederationContent{{Type: "text", Text: "guidance once"}},
+			}, nil
+		},
+	}
+	env := &EnvMock{
+		LatestNoteViewsFunc:             func() *appmodel.NoteViews { return nvs },
+		CanReadNoteFunc:                 func(context.Context, *appmodel.NoteView) (bool, error) { return true, nil },
+		FederationClientFunc:            func(context.Context, string) (appmodel.Federation, error) { return federation, nil },
+		CachedFederatedInstructionsFunc: cache.CachedFederatedInstructions,
+		StoreFederatedInstructionsFunc:  cache.StoreFederatedInstructions,
+	}
+
+	first := callFederatedInstructions(env, `{"kb_id":"bob"}`)
+	require.Nil(t, first.Error)
+	second := callFederatedInstructions(env, `{"kb_id":"bob"}`)
+	require.Nil(t, second.Error)
+
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls), "second call must be served from cache")
+	require.Equal(t, "guidance once", second.Result.(mcp.CallToolResult).Content[0].Text)
+}
+
+func TestFederatedInstructionsCacheConcurrent(t *testing.T) {
+	nvs := fedInstrNoteViews()
+	cache := fedinstr.New()
+	federation := &federationMock{
+		instructionsFunc: func(_ context.Context) (appmodel.FederationResult, error) {
+			return appmodel.FederationResult{
+				Content: []appmodel.FederationContent{{Type: "text", Text: "guidance"}},
+			}, nil
+		},
+	}
+	env := &EnvMock{
+		LatestNoteViewsFunc:             func() *appmodel.NoteViews { return nvs },
+		CanReadNoteFunc:                 func(context.Context, *appmodel.NoteView) (bool, error) { return true, nil },
+		FederationClientFunc:            func(context.Context, string) (appmodel.Federation, error) { return federation, nil },
+		CachedFederatedInstructionsFunc: cache.CachedFederatedInstructions,
+		StoreFederatedInstructionsFunc:  cache.StoreFederatedInstructions,
+	}
+
+	var wg sync.WaitGroup
+	var failures int32
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if callFederatedInstructions(env, `{"kb_id":"bob"}`).Error != nil {
+				atomic.AddInt32(&failures, 1)
+			}
+		}()
+	}
+	wg.Wait()
+	require.Zero(t, atomic.LoadInt32(&failures), "no concurrent call should error")
+}
+
+func TestFederatedInstructionsUnknownKBID(t *testing.T) {
+	nvs := fedInstrNoteViews()
+	cache := fedinstr.New()
+	env := &EnvMock{
+		LatestNoteViewsFunc:             func() *appmodel.NoteViews { return nvs },
+		CanReadNoteFunc:                 func(context.Context, *appmodel.NoteView) (bool, error) { return true, nil },
+		CachedFederatedInstructionsFunc: cache.CachedFederatedInstructions,
+		StoreFederatedInstructionsFunc:  cache.StoreFederatedInstructions,
+	}
+
+	resp := callFederatedInstructions(env, `{"kb_id":"ghost"}`)
+	require.Nil(t, resp.Error)
+	result := resp.Result.(mcp.CallToolResult)
+	payload := result.StructuredContent.(mcp.FederationStatusPayload)
+	require.Equal(t, "federation_not_configured", payload.Status)
+}
+
+func TestFederatedInstructionsRequiresKBID(t *testing.T) {
+	env := &EnvMock{}
+	resp := callFederatedInstructions(env, `{}`)
+	require.NotNil(t, resp.Error)
+	require.Equal(t, mcp.ErrCodeInvalidParams, resp.Error.Code)
+}

--- a/internal/case/mcp/federation_handlers.go
+++ b/internal/case/mcp/federation_handlers.go
@@ -92,32 +92,85 @@ func callFederatedSingleKB(
 	kbID string,
 	call func(client model.Federation, rest string) (model.FederationResult, error),
 ) Response {
-	if errResp := federationPathDepthExceeded(ctx, env, id, kbID); errResp != nil {
+	result, errResp := federatedSingleKBResult(ctx, env, id, kbID, call)
+	if errResp != nil {
 		return *errResp
+	}
+	return successResponse(id, federationResultToToolResult(result))
+}
+
+// federatedSingleKBResult is the shared core of callFederatedSingleKB that hands
+// back the raw result so callers can post-process it (e.g. cache it) before
+// building the tool response. On any failure it returns the error Response.
+func federatedSingleKBResult(
+	ctx context.Context,
+	env Env,
+	id any,
+	kbID string,
+	call func(client model.Federation, rest string) (model.FederationResult, error),
+) (model.FederationResult, *Response) {
+	if errResp := federationPathDepthExceeded(ctx, env, id, kbID); errResp != nil {
+		return model.FederationResult{}, errResp
 	}
 	kbs, err := accessibleKBNotes(ctx, env)
 	if err != nil {
-		return errorResponse(id, ErrCodeInternal, err.Error())
+		resp := errorResponse(id, ErrCodeInternal, err.Error())
+		return model.FederationResult{}, &resp
 	}
 	if len(kbs) == 0 {
-		return federationNotConfiguredResponse(id, kbID)
+		resp := federationNotConfiguredResponse(id, kbID)
+		return model.FederationResult{}, &resp
 	}
 	kb, rest := findFederationKB(kbs, kbID)
 	if kb == nil {
-		return federationNotConfiguredResponse(id, kbID)
+		resp := federationNotConfiguredResponse(id, kbID)
+		return model.FederationResult{}, &resp
 	}
 	client, err := env.FederationClient(ctx, kb.ID)
 	if err != nil {
 		// A client that can't be built is still a failed outbound attempt,
 		// same as on the fan-out path.
 		metricsFromContext(ctx).RecordFederatedRequest(federatedStatus(err))
-		return errorResponse(id, ErrCodeInternal, err.Error())
+		resp := errorResponse(id, ErrCodeInternal, err.Error())
+		return model.FederationResult{}, &resp
 	}
 	result, err := call(client, rest)
 	metricsFromContext(ctx).RecordFederatedRequest(federatedStatus(err))
 	if err != nil {
-		return errorResponse(id, ErrCodeInternal, err.Error())
+		resp := errorResponse(id, ErrCodeInternal, err.Error())
+		return model.FederationResult{}, &resp
 	}
+	return result, nil
+}
+
+// handleFederatedInstructions fetches a federated base's own instructions by
+// kb_id, forwarding through the federation hop chain like the other federated
+// tools. Results are cached per full kb_id path so repeat calls (and
+// already-visited routes) are served without re-forwarding.
+func handleFederatedInstructions(ctx context.Context, env Env, id any, argsRaw json.RawMessage) Response {
+	args, errResp := unmarshalArgs[FederatedInstructionsArguments](argsRaw, id, "federated_instructions")
+	if errResp != nil {
+		return *errResp
+	}
+	if args.KBID == "" {
+		return errorResponse(id, ErrCodeInvalidParams, "kb_id is required")
+	}
+
+	if cached, ok := env.CachedFederatedInstructions(args.KBID); ok {
+		return successResponse(id, federationResultToToolResult(cached))
+	}
+
+	result, errResp := federatedSingleKBResult(ctx, env, id, args.KBID,
+		func(client model.Federation, rest string) (model.FederationResult, error) {
+			if rest == "" {
+				return client.Instructions(ctx)
+			}
+			return client.FederatedInstructions(ctx, model.FederationInstructionsParams{KBID: rest})
+		})
+	if errResp != nil {
+		return *errResp
+	}
+	env.StoreFederatedInstructions(args.KBID, result)
 	return successResponse(id, federationResultToToolResult(result))
 }
 

--- a/internal/case/mcp/federation_handlers_test.go
+++ b/internal/case/mcp/federation_handlers_test.go
@@ -17,6 +17,9 @@ type federationMock struct {
 	noteHTMLFunc        func(ctx context.Context, params appmodel.FederationNoteHTMLParams) (appmodel.FederationResult, error)
 	expandFunc          func(ctx context.Context, params appmodel.FederationExpandParams) (appmodel.FederationResult, error)
 	federatedExpandFunc func(ctx context.Context, params appmodel.FederationExpandParams) (appmodel.FederationResult, error)
+
+	instructionsFunc          func(ctx context.Context) (appmodel.FederationResult, error)
+	federatedInstructionsFunc func(ctx context.Context, params appmodel.FederationInstructionsParams) (appmodel.FederationResult, error)
 }
 
 func (m *federationMock) Search(ctx context.Context, params appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
@@ -68,6 +71,20 @@ func (m *federationMock) FederatedExpand(ctx context.Context, params appmodel.Fe
 		panic("unexpected FederatedExpand call")
 	}
 	return m.federatedExpandFunc(ctx, params)
+}
+
+func (m *federationMock) Instructions(ctx context.Context) (appmodel.FederationResult, error) {
+	if m.instructionsFunc == nil {
+		panic("unexpected Instructions call")
+	}
+	return m.instructionsFunc(ctx)
+}
+
+func (m *federationMock) FederatedInstructions(ctx context.Context, params appmodel.FederationInstructionsParams) (appmodel.FederationResult, error) {
+	if m.federatedInstructionsFunc == nil {
+		panic("unexpected FederatedInstructions call")
+	}
+	return m.federatedInstructionsFunc(ctx, params)
 }
 
 func TestFederatedSearchUsesMockedFederationClient(t *testing.T) {

--- a/internal/case/mcp/graphql_tools_test.go
+++ b/internal/case/mcp/graphql_tools_test.go
@@ -65,6 +65,12 @@ func (e *gqlRequestEnv) FederatedFanoutLimit() int            { panic("unexpecte
 func (e *gqlRequestEnv) FederatedFanoutTimeout() time.Duration {
 	panic("unexpected")
 }
+func (e *gqlRequestEnv) CachedFederatedInstructions(_ string) (model.FederationResult, bool) {
+	panic("unexpected")
+}
+func (e *gqlRequestEnv) StoreFederatedInstructions(_ string, _ model.FederationResult) {
+	panic("unexpected")
+}
 func (e *gqlRequestEnv) ResolveAPIKey(_ context.Context, _, _ string) (*db.ApiKey, error) {
 	panic("unexpected")
 }

--- a/internal/case/mcp/mocks_test.go
+++ b/internal/case/mcp/mocks_test.go
@@ -26,6 +26,9 @@ var _ mcp.Env = &EnvMock{}
 //
 //		// make and configure a mocked mcp.Env
 //		mockedEnv := &EnvMock{
+//			CachedFederatedInstructionsFunc: func(kbID string) (model.FederationResult, bool) {
+//				panic("mock out the CachedFederatedInstructions method")
+//			},
 //			CanReadNoteFunc: func(ctx context.Context, note *model.NoteView) (bool, error) {
 //				panic("mock out the CanReadNote method")
 //			},
@@ -107,6 +110,9 @@ var _ mcp.Env = &EnvMock{}
 //			SiteConfigFunc: func(ctx context.Context) model.SiteConfig {
 //				panic("mock out the SiteConfig method")
 //			},
+//			StoreFederatedInstructionsFunc: func(kbID string, result model.FederationResult)  {
+//				panic("mock out the StoreFederatedInstructions method")
+//			},
 //		}
 //
 //		// use mockedEnv in code that requires mcp.Env
@@ -114,6 +120,9 @@ var _ mcp.Env = &EnvMock{}
 //
 //	}
 type EnvMock struct {
+	// CachedFederatedInstructionsFunc mocks the CachedFederatedInstructions method.
+	CachedFederatedInstructionsFunc func(kbID string) (model.FederationResult, bool)
+
 	// CanReadNoteFunc mocks the CanReadNote method.
 	CanReadNoteFunc func(ctx context.Context, note *model.NoteView) (bool, error)
 
@@ -195,8 +204,16 @@ type EnvMock struct {
 	// SiteConfigFunc mocks the SiteConfig method.
 	SiteConfigFunc func(ctx context.Context) model.SiteConfig
 
+	// StoreFederatedInstructionsFunc mocks the StoreFederatedInstructions method.
+	StoreFederatedInstructionsFunc func(kbID string, result model.FederationResult)
+
 	// calls tracks calls to the methods.
 	calls struct {
+		// CachedFederatedInstructions holds details about calls to the CachedFederatedInstructions method.
+		CachedFederatedInstructions []struct {
+			// KbID is the kbID argument value.
+			KbID string
+		}
 		// CanReadNote holds details about calls to the CanReadNote method.
 		CanReadNote []struct {
 			// Ctx is the ctx argument value.
@@ -328,7 +345,15 @@ type EnvMock struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 		}
+		// StoreFederatedInstructions holds details about calls to the StoreFederatedInstructions method.
+		StoreFederatedInstructions []struct {
+			// KbID is the kbID argument value.
+			KbID string
+			// Result is the result argument value.
+			Result model.FederationResult
+		}
 	}
+	lockCachedFederatedInstructions        sync.RWMutex
 	lockCanReadNote                        sync.RWMutex
 	lockDecryptData                        sync.RWMutex
 	lockFeatures                           sync.RWMutex
@@ -356,6 +381,39 @@ type EnvMock struct {
 	lockSearchLatestNotes                  sync.RWMutex
 	lockSearchLiveNotes                    sync.RWMutex
 	lockSiteConfig                         sync.RWMutex
+	lockStoreFederatedInstructions         sync.RWMutex
+}
+
+// CachedFederatedInstructions calls CachedFederatedInstructionsFunc.
+func (mock *EnvMock) CachedFederatedInstructions(kbID string) (model.FederationResult, bool) {
+	if mock.CachedFederatedInstructionsFunc == nil {
+		panic("EnvMock.CachedFederatedInstructionsFunc: method is nil but Env.CachedFederatedInstructions was just called")
+	}
+	callInfo := struct {
+		KbID string
+	}{
+		KbID: kbID,
+	}
+	mock.lockCachedFederatedInstructions.Lock()
+	mock.calls.CachedFederatedInstructions = append(mock.calls.CachedFederatedInstructions, callInfo)
+	mock.lockCachedFederatedInstructions.Unlock()
+	return mock.CachedFederatedInstructionsFunc(kbID)
+}
+
+// CachedFederatedInstructionsCalls gets all the calls that were made to CachedFederatedInstructions.
+// Check the length with:
+//
+//	len(mockedEnv.CachedFederatedInstructionsCalls())
+func (mock *EnvMock) CachedFederatedInstructionsCalls() []struct {
+	KbID string
+} {
+	var calls []struct {
+		KbID string
+	}
+	mock.lockCachedFederatedInstructions.RLock()
+	calls = mock.calls.CachedFederatedInstructions
+	mock.lockCachedFederatedInstructions.RUnlock()
+	return calls
 }
 
 // CanReadNote calls CanReadNoteFunc.
@@ -1197,5 +1255,41 @@ func (mock *EnvMock) SiteConfigCalls() []struct {
 	mock.lockSiteConfig.RLock()
 	calls = mock.calls.SiteConfig
 	mock.lockSiteConfig.RUnlock()
+	return calls
+}
+
+// StoreFederatedInstructions calls StoreFederatedInstructionsFunc.
+func (mock *EnvMock) StoreFederatedInstructions(kbID string, result model.FederationResult) {
+	if mock.StoreFederatedInstructionsFunc == nil {
+		panic("EnvMock.StoreFederatedInstructionsFunc: method is nil but Env.StoreFederatedInstructions was just called")
+	}
+	callInfo := struct {
+		KbID   string
+		Result model.FederationResult
+	}{
+		KbID:   kbID,
+		Result: result,
+	}
+	mock.lockStoreFederatedInstructions.Lock()
+	mock.calls.StoreFederatedInstructions = append(mock.calls.StoreFederatedInstructions, callInfo)
+	mock.lockStoreFederatedInstructions.Unlock()
+	mock.StoreFederatedInstructionsFunc(kbID, result)
+}
+
+// StoreFederatedInstructionsCalls gets all the calls that were made to StoreFederatedInstructions.
+// Check the length with:
+//
+//	len(mockedEnv.StoreFederatedInstructionsCalls())
+func (mock *EnvMock) StoreFederatedInstructionsCalls() []struct {
+	KbID   string
+	Result model.FederationResult
+} {
+	var calls []struct {
+		KbID   string
+		Result model.FederationResult
+	}
+	mock.lockStoreFederatedInstructions.RLock()
+	calls = mock.calls.StoreFederatedInstructions
+	mock.lockStoreFederatedInstructions.RUnlock()
 	return calls
 }

--- a/internal/case/mcp/resolve.go
+++ b/internal/case/mcp/resolve.go
@@ -59,6 +59,9 @@ type Env interface {
 	FederatedFanoutConcurrency() int
 	FederatedFanoutLimit() int
 	FederatedFanoutTimeout() time.Duration
+	// Federated instructions cache (per kb_id path)
+	CachedFederatedInstructions(kbID string) (model.FederationResult, bool)
+	StoreFederatedInstructions(kbID string, result model.FederationResult)
 	// API key auth
 	ResolveAPIKey(ctx context.Context, value, action string) (*db.ApiKey, error)
 	// Admin GraphQL tools
@@ -179,6 +182,7 @@ var reservedMCPTools = map[string]bool{ //nolint:gochecknoglobals // immutable s
 	"federated_similar":         true,
 	"federated_note_html":       true,
 	"federated_expand":          true,
+	"federated_instructions":    true,
 	"graphql_introspection":     true,
 	"graphql_request":           true,
 	"federated_graphql_request": true,
@@ -425,13 +429,42 @@ func handleToolsList(ctx context.Context, env Env, id any) Response { //nolint:f
 				Required: []string{"kb_id"},
 			},
 		},
+		{
+			Name: "federated_instructions",
+			Description: "Fetch the instructions/guidance for a federated knowledge base by kb_id " +
+				`(e.g. "philosophers/nietzsche") — read a base's own conventions before searching it. ` +
+				"Nested bases are addressed with '/' and the call routes through each peer recursively.",
+			InputSchema: &InputSchema{
+				Type: "object",
+				Properties: map[string]Property{
+					"kb_id": {
+						Type: "string",
+						Description: "Target knowledge base id; nested bases use '/' " +
+							`(e.g. "philosophers/nietzsche" routes through the 'philosophers' peer, recursively)`,
+					},
+				},
+				Required: []string{"kb_id"},
+			},
+		},
 	}
 
-	// Append dynamic tools from notes with mcp_method (excluding reserved names)
+	// Append dynamic tools from notes with mcp_method (excluding reserved names).
+	// Several notes can share an mcp_method (e.g. localized en/ru instruction
+	// notes) — the call side (handleDynamicMethod) resolves to the first note in
+	// path-sorted order, so tools/list must list each method once, keeping that
+	// same first note. Otherwise tools/list returns duplicate tool names.
+	seenMCPMethods := make(map[string]bool)
 	for _, note := range env.LatestNoteViews().List {
 		if note.MCPMethod == "" || reservedMCPTools[note.MCPMethod] {
 			continue
 		}
+		if seenMCPMethods[note.MCPMethod] {
+			continue
+		}
+		// Claim the method for this note before the read check so the first note
+		// in path-sorted order always owns it — matching handleDynamicMethod,
+		// which stops at that same first note whether or not it is readable.
+		seenMCPMethods[note.MCPMethod] = true
 		ok, err := canReadMCPNote(ctx, env, note)
 		if err != nil || !ok {
 			continue
@@ -518,6 +551,8 @@ func handleToolsCall(ctx context.Context, env Env, req Request) Response {
 		return handleFederatedNoteHTML(ctx, env, req.ID, params.Arguments)
 	case "federated_expand":
 		return handleFederatedExpand(ctx, env, req.ID, params.Arguments)
+	case "federated_instructions":
+		return handleFederatedInstructions(ctx, env, req.ID, params.Arguments)
 	case "graphql_introspection":
 		if !mcpAdminToolsEnabled(ctx) {
 			return errorResponse(req.ID, ErrCodeMethodNotFound, "Method not found: graphql_introspection")

--- a/internal/case/mcp/resolve_test.go
+++ b/internal/case/mcp/resolve_test.go
@@ -161,7 +161,7 @@ soul_profile:
 		require.Nil(t, resp.Error)
 
 		result := resp.Result.(mcp.ListToolsResult)
-		require.Len(t, result.Tools, 8)
+		require.Len(t, result.Tools, 9)
 
 		var toolNames []string
 		for _, tool := range result.Tools {
@@ -176,6 +176,7 @@ soul_profile:
 			"federated_similar",
 			"federated_note_html",
 			"federated_expand",
+			"federated_instructions",
 		}, toolNames)
 	})
 
@@ -215,13 +216,54 @@ soul_profile:
 		for _, tool := range result.Tools {
 			toolNames = append(toolNames, tool.Name)
 		}
-		require.Len(t, toolNames, 9)
+		require.Len(t, toolNames, 10)
 		require.Contains(t, toolNames, "code-review")
 
 		// Dynamic tool carries description and empty schema
-		dynTool := result.Tools[8]
+		dynTool := result.Tools[9]
 		require.Equal(t, "code-review", dynTool.Name)
 		require.Equal(t, "Detailed code review", dynTool.Description)
+	})
+
+	t.Run("tools/list dedupes notes sharing an mcp_method", func(t *testing.T) {
+		// Localized en/ru notes both declaring mcp_method: instructions must not
+		// produce two tools with the same name. The first note in path-sorted
+		// order wins, matching handleDynamicMethod's resolution.
+		en := &appmodel.NoteView{
+			Path:           "_mcp_instructions.md",
+			MCPMethod:      "instructions",
+			MCPDescription: "Full tool reference (EN)",
+			Content:        []byte("EN instructions"),
+		}
+		ru := &appmodel.NoteView{
+			Path:           "ru/_mcp_instructions.md",
+			MCPMethod:      "instructions",
+			MCPDescription: "MCP Инструкции (RU)",
+			Content:        []byte("RU instructions"),
+		}
+		env := &EnvMock{
+			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+			LatestNoteViewsFunc: func() *appmodel.NoteViews {
+				return &appmodel.NoteViews{List: []*appmodel.NoteView{en, ru}, PathMap: map[string]*appmodel.NoteView{}}
+			},
+			CanReadNoteFunc:             func(context.Context, *appmodel.NoteView) (bool, error) { return true, nil },
+			FederatedGraphQLEnabledFunc: func() bool { return false },
+			FederationMaxDepthFunc:      func() int { return 3 },
+		}
+
+		resp := mcp.Resolve(ctx, env, mcp.Request{JSONRPC: "2.0", Method: "tools/list", ID: 6})
+		result := resp.Result.(mcp.ListToolsResult)
+
+		count := 0
+		var desc string
+		for _, tool := range result.Tools {
+			if tool.Name == "instructions" {
+				count++
+				desc = tool.Description
+			}
+		}
+		require.Equal(t, 1, count, "instructions must appear exactly once")
+		require.Equal(t, "Full tool reference (EN)", desc, "first note in path order wins")
 	})
 
 	t.Run("method not found returns error", func(t *testing.T) {

--- a/internal/case/mcp/types.go
+++ b/internal/case/mcp/types.go
@@ -138,6 +138,10 @@ type FederatedNoteHTMLArguments struct {
 	MatchID string `json:"match_id,omitempty"`
 }
 
+type FederatedInstructionsArguments struct {
+	KBID string `json:"kb_id"`
+}
+
 type FederatedExpandArguments struct {
 	KBID    string   `json:"kb_id"`
 	PID     int64    `json:"pid,omitempty"`

--- a/internal/federation/client.go
+++ b/internal/federation/client.go
@@ -82,6 +82,14 @@ func (c *Client) GraphQLRequest(ctx context.Context, params model.FederationGrap
 	return c.callTool(ctx, "graphql_request", params)
 }
 
+func (c *Client) Instructions(ctx context.Context) (model.FederationResult, error) {
+	return c.callTool(ctx, "instructions", nil)
+}
+
+func (c *Client) FederatedInstructions(ctx context.Context, params model.FederationInstructionsParams) (model.FederationResult, error) {
+	return c.callTool(ctx, "federated_instructions", params)
+}
+
 func (c *Client) callTool(ctx context.Context, name string, args any) (model.FederationResult, error) {
 	if c == nil {
 		return model.FederationResult{}, errors.New("federation client is nil")

--- a/internal/fedinstr/cache.go
+++ b/internal/fedinstr/cache.go
@@ -1,0 +1,78 @@
+// Package fedinstr caches federated knowledge-base instructions per kb_id path.
+// A federated instructions lookup forwards through the federation hop chain, so
+// repeat calls (and already-visited routes) are served from here instead of
+// re-forwarding to the peer.
+package fedinstr
+
+import (
+	"sync"
+	"time"
+
+	"trip2g/internal/model"
+)
+
+const (
+	DefaultMaxEntries = 256
+	DefaultTTL        = 10 * time.Minute
+)
+
+type entry struct {
+	result   model.FederationResult
+	storedAt time.Time
+}
+
+// Cache is a bounded, TTL'd, concurrency-safe store of federated instructions
+// keyed by the full kb_id path (e.g. "philosophers/nietzsche").
+type Cache struct {
+	mu         sync.RWMutex
+	entries    map[string]entry
+	ttl        time.Duration
+	maxEntries int
+	now        func() time.Time
+}
+
+func New() *Cache {
+	return &Cache{
+		entries:    make(map[string]entry),
+		ttl:        DefaultTTL,
+		maxEntries: DefaultMaxEntries,
+		now:        time.Now,
+	}
+}
+
+// CachedFederatedInstructions returns a fresh cached result for kbID, or ok=false
+// when absent or stale.
+func (c *Cache) CachedFederatedInstructions(kbID string) (model.FederationResult, bool) {
+	c.mu.RLock()
+	e, ok := c.entries[kbID]
+	c.mu.RUnlock()
+	if !ok || c.now().Sub(e.storedAt) >= c.ttl {
+		return model.FederationResult{}, false
+	}
+	return e.result, true
+}
+
+// StoreFederatedInstructions caches result under kbID, evicting the oldest entry
+// when the cache is full.
+func (c *Cache) StoreFederatedInstructions(kbID string, result model.FederationResult) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, exists := c.entries[kbID]; !exists && len(c.entries) >= c.maxEntries {
+		c.evictOldestLocked()
+	}
+	c.entries[kbID] = entry{result: result, storedAt: c.now()}
+}
+
+func (c *Cache) evictOldestLocked() {
+	var oldestKey string
+	var oldestAt time.Time
+	for k, e := range c.entries {
+		if oldestKey == "" || e.storedAt.Before(oldestAt) {
+			oldestKey = k
+			oldestAt = e.storedAt
+		}
+	}
+	if oldestKey != "" {
+		delete(c.entries, oldestKey)
+	}
+}

--- a/internal/fedinstr/cache_test.go
+++ b/internal/fedinstr/cache_test.go
@@ -1,0 +1,77 @@
+package fedinstr
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"trip2g/internal/model"
+
+	"github.com/stretchr/testify/require"
+)
+
+func resultWithText(text string) model.FederationResult {
+	return model.FederationResult{Content: []model.FederationContent{{Type: "text", Text: text}}}
+}
+
+func TestCacheStoreAndHit(t *testing.T) {
+	c := New()
+	_, ok := c.CachedFederatedInstructions("a/b")
+	require.False(t, ok)
+
+	c.StoreFederatedInstructions("a/b", resultWithText("guidance"))
+	got, ok := c.CachedFederatedInstructions("a/b")
+	require.True(t, ok)
+	require.Equal(t, "guidance", got.Content[0].Text)
+}
+
+func TestCacheTTLExpiry(t *testing.T) {
+	c := New()
+	now := time.Now()
+	c.now = func() time.Time { return now }
+
+	c.StoreFederatedInstructions("a", resultWithText("x"))
+	_, ok := c.CachedFederatedInstructions("a")
+	require.True(t, ok)
+
+	now = now.Add(DefaultTTL + time.Second)
+	_, ok = c.CachedFederatedInstructions("a")
+	require.False(t, ok, "entry past TTL must miss")
+}
+
+func TestCacheEvictsOldestWhenFull(t *testing.T) {
+	c := New()
+	base := time.Now()
+	tick := 0
+	c.now = func() time.Time { tick++; return base.Add(time.Duration(tick) * time.Millisecond) }
+	c.maxEntries = 3
+
+	c.StoreFederatedInstructions("k0", resultWithText("0")) // oldest
+	c.StoreFederatedInstructions("k1", resultWithText("1"))
+	c.StoreFederatedInstructions("k2", resultWithText("2"))
+	c.StoreFederatedInstructions("k3", resultWithText("3")) // evicts k0
+
+	_, ok := c.CachedFederatedInstructions("k0")
+	require.False(t, ok, "oldest entry must be evicted")
+	for _, k := range []string{"k1", "k2", "k3"} {
+		_, survived := c.CachedFederatedInstructions(k)
+		require.True(t, survived, "recent entry %s must survive", k)
+	}
+	require.Len(t, c.entries, 3)
+}
+
+func TestCacheConcurrent(t *testing.T) {
+	c := New()
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key := fmt.Sprintf("kb/%d", i%8)
+			c.StoreFederatedInstructions(key, resultWithText(key))
+			c.CachedFederatedInstructions(key)
+		}(i)
+	}
+	wg.Wait()
+}

--- a/internal/model/federation.go
+++ b/internal/model/federation.go
@@ -17,6 +17,8 @@ type Federation interface {
 	Expand(ctx context.Context, params FederationExpandParams) (FederationResult, error)
 	FederatedExpand(ctx context.Context, params FederationExpandParams) (FederationResult, error)
 	GraphQLRequest(ctx context.Context, params FederationGraphQLParams) (FederationResult, error)
+	Instructions(ctx context.Context) (FederationResult, error)
+	FederatedInstructions(ctx context.Context, params FederationInstructionsParams) (FederationResult, error)
 }
 
 type FederationClientFactory interface {
@@ -45,6 +47,10 @@ type FederationSimilarParams struct {
 	Path   string `json:"path,omitempty"`
 	Href   string `json:"href,omitempty"`
 	Limit  int    `json:"limit,omitempty"`
+}
+
+type FederationInstructionsParams struct {
+	KBID string `json:"kb_id,omitempty"`
 }
 
 type FederationGraphQLParams struct {

--- a/internal/model/federation_easyjson.go
+++ b/internal/model/federation_easyjson.go
@@ -613,7 +613,74 @@ func (v *FederationNoteHTMLParams) UnmarshalJSON(data []byte) error {
 func (v *FederationNoteHTMLParams) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson7b3c8c57DecodeTrip2gInternalModel4(l, v)
 }
-func easyjson7b3c8c57DecodeTrip2gInternalModel5(in *jlexer.Lexer, out *FederationGraphQLParams) {
+func easyjson7b3c8c57DecodeTrip2gInternalModel5(in *jlexer.Lexer, out *FederationInstructionsParams) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "kb_id":
+			out.KBID = string(in.String())
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjson7b3c8c57EncodeTrip2gInternalModel5(out *jwriter.Writer, in FederationInstructionsParams) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.KBID != "" {
+		const prefix string = ",\"kb_id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.String(string(in.KBID))
+	}
+	out.RawByte('}')
+}
+
+// MarshalJSON supports json.Marshaler interface
+func (v FederationInstructionsParams) MarshalJSON() ([]byte, error) {
+	w := jwriter.Writer{}
+	easyjson7b3c8c57EncodeTrip2gInternalModel5(&w, v)
+	return w.Buffer.BuildBytes(), w.Error
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v FederationInstructionsParams) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjson7b3c8c57EncodeTrip2gInternalModel5(w, v)
+}
+
+// UnmarshalJSON supports json.Unmarshaler interface
+func (v *FederationInstructionsParams) UnmarshalJSON(data []byte) error {
+	r := jlexer.Lexer{Data: data}
+	easyjson7b3c8c57DecodeTrip2gInternalModel5(&r, v)
+	return r.Error()
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *FederationInstructionsParams) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjson7b3c8c57DecodeTrip2gInternalModel5(l, v)
+}
+func easyjson7b3c8c57DecodeTrip2gInternalModel6(in *jlexer.Lexer, out *FederationGraphQLParams) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -672,7 +739,7 @@ func easyjson7b3c8c57DecodeTrip2gInternalModel5(in *jlexer.Lexer, out *Federatio
 		in.Consumed()
 	}
 }
-func easyjson7b3c8c57EncodeTrip2gInternalModel5(out *jwriter.Writer, in FederationGraphQLParams) {
+func easyjson7b3c8c57EncodeTrip2gInternalModel6(out *jwriter.Writer, in FederationGraphQLParams) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -723,27 +790,27 @@ func easyjson7b3c8c57EncodeTrip2gInternalModel5(out *jwriter.Writer, in Federati
 // MarshalJSON supports json.Marshaler interface
 func (v FederationGraphQLParams) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson7b3c8c57EncodeTrip2gInternalModel5(&w, v)
+	easyjson7b3c8c57EncodeTrip2gInternalModel6(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v FederationGraphQLParams) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson7b3c8c57EncodeTrip2gInternalModel5(w, v)
+	easyjson7b3c8c57EncodeTrip2gInternalModel6(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *FederationGraphQLParams) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson7b3c8c57DecodeTrip2gInternalModel5(&r, v)
+	easyjson7b3c8c57DecodeTrip2gInternalModel6(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *FederationGraphQLParams) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson7b3c8c57DecodeTrip2gInternalModel5(l, v)
+	easyjson7b3c8c57DecodeTrip2gInternalModel6(l, v)
 }
-func easyjson7b3c8c57DecodeTrip2gInternalModel6(in *jlexer.Lexer, out *FederationExpandParams) {
+func easyjson7b3c8c57DecodeTrip2gInternalModel7(in *jlexer.Lexer, out *FederationExpandParams) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -805,7 +872,7 @@ func easyjson7b3c8c57DecodeTrip2gInternalModel6(in *jlexer.Lexer, out *Federatio
 		in.Consumed()
 	}
 }
-func easyjson7b3c8c57EncodeTrip2gInternalModel6(out *jwriter.Writer, in FederationExpandParams) {
+func easyjson7b3c8c57EncodeTrip2gInternalModel7(out *jwriter.Writer, in FederationExpandParams) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -880,27 +947,27 @@ func easyjson7b3c8c57EncodeTrip2gInternalModel6(out *jwriter.Writer, in Federati
 // MarshalJSON supports json.Marshaler interface
 func (v FederationExpandParams) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson7b3c8c57EncodeTrip2gInternalModel6(&w, v)
+	easyjson7b3c8c57EncodeTrip2gInternalModel7(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v FederationExpandParams) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson7b3c8c57EncodeTrip2gInternalModel6(w, v)
+	easyjson7b3c8c57EncodeTrip2gInternalModel7(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *FederationExpandParams) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson7b3c8c57DecodeTrip2gInternalModel6(&r, v)
+	easyjson7b3c8c57DecodeTrip2gInternalModel7(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *FederationExpandParams) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson7b3c8c57DecodeTrip2gInternalModel6(l, v)
+	easyjson7b3c8c57DecodeTrip2gInternalModel7(l, v)
 }
-func easyjson7b3c8c57DecodeTrip2gInternalModel7(in *jlexer.Lexer, out *FederationContent) {
+func easyjson7b3c8c57DecodeTrip2gInternalModel8(in *jlexer.Lexer, out *FederationContent) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -933,7 +1000,7 @@ func easyjson7b3c8c57DecodeTrip2gInternalModel7(in *jlexer.Lexer, out *Federatio
 		in.Consumed()
 	}
 }
-func easyjson7b3c8c57EncodeTrip2gInternalModel7(out *jwriter.Writer, in FederationContent) {
+func easyjson7b3c8c57EncodeTrip2gInternalModel8(out *jwriter.Writer, in FederationContent) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -953,23 +1020,23 @@ func easyjson7b3c8c57EncodeTrip2gInternalModel7(out *jwriter.Writer, in Federati
 // MarshalJSON supports json.Marshaler interface
 func (v FederationContent) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson7b3c8c57EncodeTrip2gInternalModel7(&w, v)
+	easyjson7b3c8c57EncodeTrip2gInternalModel8(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v FederationContent) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson7b3c8c57EncodeTrip2gInternalModel7(w, v)
+	easyjson7b3c8c57EncodeTrip2gInternalModel8(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *FederationContent) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson7b3c8c57DecodeTrip2gInternalModel7(&r, v)
+	easyjson7b3c8c57DecodeTrip2gInternalModel8(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *FederationContent) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson7b3c8c57DecodeTrip2gInternalModel7(l, v)
+	easyjson7b3c8c57DecodeTrip2gInternalModel8(l, v)
 }


### PR DESCRIPTION
## The gap (verified live)

trip2g claims agent behavior can be customized per-KB via instructions, but this promise broke across federation:

- The existing `instructions` tool is **root-only** — no `kb_id` param — so it returns only the directly-connected base's guidance.
- `federated_instructions` did not exist (`Method not found`).
- `initialize` ignores a `kb_id`.

So when an agent descends into e.g. `philosophers/nietzsche` via federation, it had **no way** to read nietzsche's own conventions before searching it — which is the whole point of per-KB instructions.

## What this adds

**New MCP tool `federated_instructions(kb_id)`.** Nested `kb_id` uses the same `'/'`-separated addressing as `federated_search` (e.g. `philosophers/nietzsche`). It forwards through the federation hop chain, mirroring `federated_search` / `callFederatedSingleKB`:

- resolve `kb_id` via `findFederationKB` → get the `FederationClient`;
- if the remaining path is empty, call the target peer's `instructions` tool (`Federation.Instructions`);
- otherwise forward `federated_instructions` with the rest to the next hop (`Federation.FederatedInstructions`, recursive);
- same federation max-depth early-reject as the other federated tools (`federationPathDepthExceeded`).

Two methods were added to the `model.Federation` interface (`Instructions`, `FederatedInstructions`) plus their HTTP client impls in `internal/federation`; the remote `instructions`/`federated_instructions` tools are called via the existing `callTool` transport.

## Route cache

New `internal/fedinstr` package (service-package pattern): a bounded (256 entries), TTL'd (10 min), `sync.RWMutex`-guarded cache keyed by the **full kb_id path**, embedded anonymously on `app` so `CachedFederatedInstructions` / `StoreFederatedInstructions` promote onto it. On a call: cache hit + fresh → return without forwarding; else fetch → store → return. Verified concurrency-safe under `-race`.

## Duplicate `instructions` tool bug — FIXED

`tools/list` returned **two** tools both named `instructions` (localized en/ru instruction notes both declaring `mcp_method: instructions`). The dynamic-tool loop appended every matching note, while the call side (`handleDynamicMethod`) resolves only the first note in path-sorted order. Fixed by deduping `tools/list` on `mcp_method` — the first note in path order wins, matching the call side. This was a contained fix, done here.

## Tests (TDD, `-race`)

- direct-peer `kb_id` returns that peer's instructions;
- nested `kb_id` (`bob/nietzsche`) forwards `nietzsche` to the next hop;
- deep path rejected by max-depth;
- cache hit returns without a second forward (mock called once across two calls);
- concurrent calls, no race;
- unknown `kb_id` → `federation_not_configured`; missing `kb_id` → invalid params;
- cache unit tests: store/hit, TTL expiry, oldest-eviction when full, concurrent access;
- `tools/list` dedupe test (en/ru instruction notes → one tool, first wins).

## Verify

`go build`, `go vet`, `go test -race ./internal/case/mcp/... ./internal/federation/... ./internal/fedinstr/... ./internal/model/...`, `golangci-lint` — all clean.

Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)