### PR TITLE
fix(embeddings): sub-batch chunk embedding requests to the server's max batch

### DIFF
--- a/internal/case/backjob/generatenoteversionembedding/resolve.go
+++ b/internal/case/backjob/generatenoteversionembedding/resolve.go
@@ -163,7 +163,7 @@ func generateChunkEmbeddings(ctx context.Context, env Env, versionID int64, titl
 			texts[i] = passagePrefix + mdchunk.TruncateToTokens(pe.chunk.Content, budget)
 		}
 
-		results, embErr := env.OpenAI().CreateEmbeddings(ctx, texts)
+		results, embErr := createEmbeddingsBatched(ctx, env, texts, vsConfig.ResolvedEmbedBatchSize())
 		if embErr != nil {
 			return fmt.Errorf("failed to create chunk embeddings: %w", embErr)
 		}
@@ -201,6 +201,25 @@ func generateChunkEmbeddings(ctx context.Context, env Env, versionID int64, titl
 	}
 
 	return nil
+}
+
+// createEmbeddingsBatched embeds texts in windows of at most maxBatch, since
+// the embedding server rejects a request above its own batch limit (e.g. TEI's
+// max-client-batch-size). Results are reassembled in the original order.
+func createEmbeddingsBatched(ctx context.Context, env Env, texts []string, maxBatch int) ([]openai.EmbeddingResult, error) {
+	if maxBatch <= 0 || len(texts) <= maxBatch {
+		return env.OpenAI().CreateEmbeddings(ctx, texts)
+	}
+	results := make([]openai.EmbeddingResult, 0, len(texts))
+	for start := 0; start < len(texts); start += maxBatch {
+		end := min(start+maxBatch, len(texts))
+		window, err := env.OpenAI().CreateEmbeddings(ctx, texts[start:end])
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, window...)
+	}
+	return results, nil
 }
 
 // NoteContentHash returns the content hash stored with a note's whole-note

--- a/internal/case/backjob/generatenoteversionembedding/resolve_test.go
+++ b/internal/case/backjob/generatenoteversionembedding/resolve_test.go
@@ -433,3 +433,234 @@ func TestResolve(t *testing.T) {
 		}
 	})
 }
+
+// TestResolveChunkBatching is split from TestResolve to keep gocognit under the limit.
+func TestResolveChunkBatching(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("sub-batches chunk embeddings to the server's max batch size", func(t *testing.T) {
+		// A note with more changed chunks than the server's max batch must be
+		// split into multiple CreateEmbeddings requests, each within the limit,
+		// with results reassembled onto the right chunk index. Otherwise the
+		// server rejects the oversized batch, the note never finishes embedding,
+		// and it gets re-enqueued forever (the production incident this fixes).
+		var requestSizes []int
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var req struct {
+				Input []string `json:"input"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			requestSizes = append(requestSizes, len(req.Input))
+			data := make([]map[string]any, len(req.Input))
+			for i, in := range req.Input {
+				// Vector value encodes which input text produced it, so the test can
+				// verify each chunk lands on its own vector after reassembly.
+				data[i] = map[string]any{"object": "embedding", "index": i, "embedding": []float32{float32(len(in))}}
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"object": "list",
+				"data":   data,
+				"usage":  map[string]any{"total_tokens": len(req.Input)},
+			})
+		}))
+		defer srv.Close()
+
+		// 16 short paragraphs so mdchunk splits into >8 chunks, each a distinct
+		// length so the returned vector (encoding input length) is distinguishable.
+		var paras []string
+		for i := 1; i <= 16; i++ {
+			// Each paragraph is a distinct length (so the mock vector, which
+			// encodes input length, is distinguishable per chunk) and big enough
+			// on its own to exceed chunkTargetTokens, forcing one chunk per paragraph.
+			paras = append(paras, strings.Repeat("word ", 500+i))
+		}
+		content := []byte(strings.Join(paras, "\n\n"))
+		noteView := &model.NoteView{
+			VersionID: 1,
+			Title:     "Test Note",
+			Content:   content,
+			Permalink: "/test-note",
+		}
+		cfg := features.VectorSearchConfig{Enabled: true, Model: features.EmbeddingModelSmall, EmbedBatchSize: 8}
+		chunks := mdchunk.Split(noteView.Title, content)
+		require.Greater(t, len(chunks), 8, "test setup: note must split into more chunks than the batch size")
+
+		var upserted []db.UpsertNoteVersionChunkParams
+		env := &EnvMock{
+			FeaturesFunc: func() features.Features { return features.Features{VectorSearch: cfg} },
+			LoggerFunc:   func() logger.Logger { return &logger.TestLogger{} },
+			LatestNoteViewsFunc: func() *model.NoteViews {
+				return &model.NoteViews{Map: map[string]*model.NoteView{noteView.Permalink: noteView}}
+			},
+			GetNoteVersionEmbeddingFunc: func(ctx context.Context, versionID int64) (db.NoteVersionEmbedding, error) {
+				return db.NoteVersionEmbedding{}, sql.ErrNoRows
+			},
+			GetNoteVersionChunksFunc: func(ctx context.Context, versionID int64) ([]db.NoteVersionChunk, error) {
+				return nil, nil
+			},
+			OpenAIFunc: func() *openai.Client {
+				return openai.New("test-key", "text-embedding-3-small", srv.URL+"/v1")
+			},
+			UpsertNoteVersionEmbeddingFunc: func(ctx context.Context, arg db.UpsertNoteVersionEmbeddingParams) error {
+				return nil
+			},
+			UpsertNoteVersionChunkFunc: func(ctx context.Context, arg db.UpsertNoteVersionChunkParams) error {
+				upserted = append(upserted, arg)
+				return nil
+			},
+			DeleteNoteVersionChunksBeyondFunc: func(ctx context.Context, arg db.DeleteNoteVersionChunksBeyondParams) error {
+				return nil
+			},
+		}
+
+		err := generatenoteversionembedding.Resolve(ctx, env, generatenoteversionembedding.Params{VersionID: 1})
+		require.NoError(t, err)
+
+		// requestSizes[0] is the whole-note embedding (1 text); the rest are the
+		// chunk sub-batches.
+		require.Greater(t, len(requestSizes), 1)
+		for _, size := range requestSizes[1:] {
+			require.LessOrEqual(t, size, 8, "each chunk sub-batch must stay within the configured max batch size")
+		}
+
+		require.Len(t, upserted, len(chunks), "every chunk must be embedded and upserted")
+		budget := cfg.ResolvedMaxInputTokens() * 9 / 10
+		for _, u := range upserted {
+			want := mdchunk.TruncateToTokens(chunks[u.ChunkIndex].Content, budget)
+			wantVector := model.Float32SliceToBytes([]float32{float32(len(want))})
+			require.Equal(t, wantVector, u.Embedding, "chunk %d must carry the vector for its own text, not another chunk's", u.ChunkIndex)
+		}
+	})
+
+	t.Run("stays a single request when chunk count is within the max batch size", func(t *testing.T) {
+		// No regression: a note within the batch limit must still embed in one
+		// CreateEmbeddings call for the chunk phase.
+		var requestSizes []int
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var req struct {
+				Input []string `json:"input"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			requestSizes = append(requestSizes, len(req.Input))
+			data := make([]map[string]any, len(req.Input))
+			for i := range req.Input {
+				data[i] = map[string]any{"object": "embedding", "index": i, "embedding": []float32{0.1, 0.2, 0.3}}
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"object": "list",
+				"data":   data,
+				"usage":  map[string]any{"total_tokens": len(req.Input)},
+			})
+		}))
+		defer srv.Close()
+
+		content := []byte("A short note with just one paragraph of content.")
+		noteView := &model.NoteView{
+			VersionID: 1,
+			Title:     "Test Note",
+			Content:   content,
+			Permalink: "/test-note",
+		}
+		cfg := features.VectorSearchConfig{Enabled: true, Model: features.EmbeddingModelSmall, EmbedBatchSize: 8}
+		chunks := mdchunk.Split(noteView.Title, content)
+		require.LessOrEqual(t, len(chunks), 8, "test setup: note must fit within the batch size")
+
+		env := &EnvMock{
+			FeaturesFunc: func() features.Features { return features.Features{VectorSearch: cfg} },
+			LoggerFunc:   func() logger.Logger { return &logger.TestLogger{} },
+			LatestNoteViewsFunc: func() *model.NoteViews {
+				return &model.NoteViews{Map: map[string]*model.NoteView{noteView.Permalink: noteView}}
+			},
+			GetNoteVersionEmbeddingFunc: func(ctx context.Context, versionID int64) (db.NoteVersionEmbedding, error) {
+				return db.NoteVersionEmbedding{}, sql.ErrNoRows
+			},
+			GetNoteVersionChunksFunc: func(ctx context.Context, versionID int64) ([]db.NoteVersionChunk, error) {
+				return nil, nil
+			},
+			OpenAIFunc: func() *openai.Client {
+				return openai.New("test-key", "text-embedding-3-small", srv.URL+"/v1")
+			},
+			UpsertNoteVersionEmbeddingFunc: func(ctx context.Context, arg db.UpsertNoteVersionEmbeddingParams) error {
+				return nil
+			},
+			UpsertNoteVersionChunkFunc: func(ctx context.Context, arg db.UpsertNoteVersionChunkParams) error {
+				return nil
+			},
+			DeleteNoteVersionChunksBeyondFunc: func(ctx context.Context, arg db.DeleteNoteVersionChunksBeyondParams) error {
+				return nil
+			},
+		}
+
+		err := generatenoteversionembedding.Resolve(ctx, env, generatenoteversionembedding.Params{VersionID: 1})
+		require.NoError(t, err)
+		require.Len(t, requestSizes, 2, "whole-note request + a single chunk-phase request, no sub-batching needed")
+	})
+
+	t.Run("honors a configured max batch size smaller than the default", func(t *testing.T) {
+		var requestSizes []int
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var req struct {
+				Input []string `json:"input"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			requestSizes = append(requestSizes, len(req.Input))
+			data := make([]map[string]any, len(req.Input))
+			for i := range req.Input {
+				data[i] = map[string]any{"object": "embedding", "index": i, "embedding": []float32{0.1, 0.2, 0.3}}
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"object": "list",
+				"data":   data,
+				"usage":  map[string]any{"total_tokens": len(req.Input)},
+			})
+		}))
+		defer srv.Close()
+
+		var paras []string
+		for i := 1; i <= 6; i++ {
+			paras = append(paras, strings.Repeat("word ", 500+i))
+		}
+		content := []byte(strings.Join(paras, "\n\n"))
+		noteView := &model.NoteView{
+			VersionID: 1,
+			Title:     "Test Note",
+			Content:   content,
+			Permalink: "/test-note",
+		}
+		cfg := features.VectorSearchConfig{Enabled: true, Model: features.EmbeddingModelSmall, EmbedBatchSize: 4}
+		chunks := mdchunk.Split(noteView.Title, content)
+		require.Greater(t, len(chunks), 4, "test setup: note must exceed the configured batch size")
+
+		env := &EnvMock{
+			FeaturesFunc: func() features.Features { return features.Features{VectorSearch: cfg} },
+			LoggerFunc:   func() logger.Logger { return &logger.TestLogger{} },
+			LatestNoteViewsFunc: func() *model.NoteViews {
+				return &model.NoteViews{Map: map[string]*model.NoteView{noteView.Permalink: noteView}}
+			},
+			GetNoteVersionEmbeddingFunc: func(ctx context.Context, versionID int64) (db.NoteVersionEmbedding, error) {
+				return db.NoteVersionEmbedding{}, sql.ErrNoRows
+			},
+			GetNoteVersionChunksFunc: func(ctx context.Context, versionID int64) ([]db.NoteVersionChunk, error) {
+				return nil, nil
+			},
+			OpenAIFunc: func() *openai.Client {
+				return openai.New("test-key", "text-embedding-3-small", srv.URL+"/v1")
+			},
+			UpsertNoteVersionEmbeddingFunc: func(ctx context.Context, arg db.UpsertNoteVersionEmbeddingParams) error {
+				return nil
+			},
+			UpsertNoteVersionChunkFunc: func(ctx context.Context, arg db.UpsertNoteVersionChunkParams) error {
+				return nil
+			},
+			DeleteNoteVersionChunksBeyondFunc: func(ctx context.Context, arg db.DeleteNoteVersionChunksBeyondParams) error {
+				return nil
+			},
+		}
+
+		err := generatenoteversionembedding.Resolve(ctx, env, generatenoteversionembedding.Params{VersionID: 1})
+		require.NoError(t, err)
+		for _, size := range requestSizes[1:] {
+			require.LessOrEqual(t, size, 4, "chunk sub-batches must respect the configured (smaller) max batch size")
+		}
+	})
+}

--- a/internal/features/vector_search.go
+++ b/internal/features/vector_search.go
@@ -184,6 +184,12 @@ type VectorSearchConfig struct {
 	QueryPfx   string `json:"query_prefix"`
 	PassagePfx string `json:"passage_prefix"`
 
+	// EmbedBatchSize caps how many texts go into a single CreateEmbeddings
+	// request. The embedding server enforces its own hard limit (TEI's
+	// max-client-batch-size defaults to 8); a batch above it gets rejected
+	// outright, and the caller must sub-batch to stay under it.
+	EmbedBatchSize int `json:"embed_batch_size"`
+
 	Reranker RerankerConfig `json:"reranker"` // optional second-stage cross-encoder reranker (blend mode)
 }
 
@@ -219,6 +225,19 @@ func (c VectorSearchConfig) ResolvedMaxInputTokens() int {
 		return c.MaxTokens
 	}
 	return c.Model.defaultMaxInputTokens()
+}
+
+// defaultEmbedBatchSize is TEI's default max-client-batch-size. It is not
+// model-specific — it's a limit of the serving backend, not the model.
+const defaultEmbedBatchSize = 8
+
+// ResolvedEmbedBatchSize returns the max texts per CreateEmbeddings request:
+// explicit override if set, otherwise defaultEmbedBatchSize.
+func (c VectorSearchConfig) ResolvedEmbedBatchSize() int {
+	if c.EmbedBatchSize > 0 {
+		return c.EmbedBatchSize
+	}
+	return defaultEmbedBatchSize
 }
 
 // ResolvedQueryPrefix returns the query prefix string: explicit override if


### PR DESCRIPTION
## Incident

The fleet's embedding server (TEI, `max-client-batch-size` 8) had its queue saturated (~52 min) by a permanent retry loop:

- `generateChunkEmbeddings` (internal/case/backjob/generatenoteversionembedding/resolve.go) batched **all** of a note's changed chunks into a single `CreateEmbeddings` call.
- Long notes produce 11-16 chunks. Any batch above 8 gets rejected by TEI ("batch size 11-16 > maximum allowed batch size 8").
- The rejected request means chunks are never saved, so the note stays "not up to date" and `regenerate_note_embeddings` re-enqueues it on every run.
- Permanent retry loop, hammering the single-CPU embedding server fleet-wide.

The whole-note embedding path (1 text per request) was unaffected — only the chunk-batching path sent variable-length batches. The code already capped chunk *token* size but not chunk *count*.

## Fix

- `generateChunkEmbeddings` now sub-batches `CreateEmbeddings` calls into windows of at most `EmbedBatchSize` texts (new helper `createEmbeddingsBatched`), reassembling results back into the original chunk order across windows. Any sub-batch error still fails the whole call, same as before — nothing is silently dropped.
- Added `VectorSearchConfig.EmbedBatchSize` (JSON: `embed_batch_size`) with a `ResolvedEmbedBatchSize()` accessor mirroring the existing `ResolvedMaxInputTokens`/`ResolvedDimensions` pattern, defaulting to **8** (TEI's default `max-client-batch-size`). This is a serving-backend limit, not a model property, so it's not keyed off `EmbeddingModel` like the other resolved fields. Lets the bundled arm64 retriever (or any other backend) raise the limit without a code change.

## Other call sites audit

Grepped all `CreateEmbeddings` call sites in `internal/`. Only `generateChunkEmbeddings` sends a variable-length batch. The whole-note path (`internal/case/backjob/generatenoteversionembedding/resolve.go:84`) and `CreateEmbedding` (singular, in `internal/openai/client.go`) always send exactly 1 text — no risk there.

## Tests (TDD, red-first)

`TestResolveChunkBatching` (split out from `TestResolve` to stay under the gocognit limit):
- 16-chunk note, `EmbedBatchSize: 8` → asserts multiple `CreateEmbeddings` calls, each ≤ 8 texts, and every chunk lands on its own vector at the right index after reassembly (mock server encodes the vector from input length so misalignment would be caught).
- ≤8-chunk note → still a single chunk-phase request (no regression).
- `EmbedBatchSize: 4` on a 6-chunk note → windowing honors the configured (smaller) size.

## Verification

- `go build ./internal/...` — clean (unrelated pre-existing `vault.zip`/`web.js` asset-embed errors only, not touched by this change)
- `go vet ./internal/...` — clean
- `go test ./internal/case/backjob/... ./internal/features/...` — all pass
- `golangci-lint run ./internal/case/backjob/generatenoteversionembedding/... ./internal/features/...` — 0 issues