### PR TITLE
refactor(markdownv2): simplify html_converter + fix converter bugs

### DIFF
--- a/internal/markdownv2/html_converter.go
+++ b/internal/markdownv2/html_converter.go
@@ -384,8 +384,11 @@ func (c *HTMLConverter) Process(nv *model.NoteView) ConverterResult {
 					}
 
 					if list.IsOrdered() {
-						// For ordered lists, calculate item number based on child index
-						itemNum := 1
+						// For ordered lists, calculate item number based on start + child index
+						itemNum := list.Start
+						if itemNum == 0 {
+							itemNum = 1
+						}
 						for prev := node.PreviousSibling(); prev != nil; prev = prev.PreviousSibling() {
 							itemNum++
 						}

--- a/internal/markdownv2/html_converter.go
+++ b/internal/markdownv2/html_converter.go
@@ -124,14 +124,11 @@ func (c *HTMLConverter) Process(nv *model.NoteView) ConverterResult {
 	res := ConverterResult{}
 	src := nv.Content
 
-	c.state = lineStart
 	c.skipClosingTag = make(map[ast.Node]bool)
 	c.isUnpublishedLink = make(map[ast.Node]bool)
 	c.unpublishedLinks = nil
 	c.bufStack = nil
 	c.pushBuffer() // Initialize with root buffer
-
-	var lines []string
 
 	_ = ast.Walk(nv.Ast(), func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		switch node := n.(type) {
@@ -140,33 +137,15 @@ func (c *HTMLConverter) Process(nv *model.NoteView) ConverterResult {
 
 		case *ast.Paragraph:
 			if n.HasBlankPreviousLines() && entering {
-				lines = append(lines, "\n\n")
-			}
-
-			if !entering && len(c.bufStack) == 1 {
-				// End of paragraph in root buffer, add current line to lines slice
-				current := c.bufStack[0]
-				if current.Len() > 0 {
-					lines = append(lines, current.String())
-					current.Reset()
-				}
+				c.Write("\n\n")
 			}
 
 		case *ast.Text:
 			if entering {
 				text := string(node.Segment.Value(src))
-				escapedText := html.EscapeString(text)
-
-				c.Write(escapedText)
+				c.Write(html.EscapeString(text))
 				if node.SoftLineBreak() {
-					if len(c.bufStack) == 1 {
-						// In root buffer: add current line to lines and start new line
-						lines = append(lines, c.bufStack[0].String(), "\n")
-						c.bufStack[0].Reset()
-					} else {
-						// In nested buffer (blockquote): just add newline
-						c.Write("\n")
-					}
+					c.Write("\n")
 				}
 			}
 
@@ -214,17 +193,19 @@ func (c *HTMLConverter) Process(nv *model.NoteView) ConverterResult {
 
 		case *ast.Blockquote:
 			if entering {
+				if n.HasBlankPreviousLines() {
+					c.Write("\n\n")
+				}
 				c.pushBuffer()
 			} else {
-				content := c.popBuffer()
+				content := strings.TrimSpace(c.popBuffer())
 
-				// Check if blockquote ends with spoiler (||)
-				isExpandable := strings.HasSuffix(content, "||")
-				if isExpandable {
+				// Blockquote ending with || means Telegram expandable quote
+				if strings.HasSuffix(content, "||") {
 					content = strings.TrimSuffix(content, "||")
-					lines = append(lines, fmt.Sprintf(`<blockquote expandable>%s</blockquote>`, content))
+					c.Write(fmt.Sprintf(`<blockquote expandable>%s</blockquote>`, content))
 				} else {
-					lines = append(lines, fmt.Sprintf(`<blockquote>%s</blockquote>`, content))
+					c.Write(fmt.Sprintf(`<blockquote>%s</blockquote>`, content))
 				}
 			}
 
@@ -306,22 +287,17 @@ func (c *HTMLConverter) Process(nv *model.NoteView) ConverterResult {
 
 		case *ast.FencedCodeBlock:
 			if entering {
-				lines = append(lines, "\n")
+				c.Write("\n")
 
 				language := string(node.Language(src))
-				code := string(node.Lines().Value(src))
+				code := html.EscapeString(strings.TrimSuffix(string(node.Lines().Value(src)), "\n"))
 
-				var codeHTML string
 				if language != "" {
-					codeHTML = fmt.Sprintf(`<pre><code class="language-%s">%s</code></pre>`,
-						html.EscapeString(language),
-						html.EscapeString(strings.TrimSuffix(code, "\n")))
+					c.Write(fmt.Sprintf(`<pre><code class="language-%s">%s</code></pre>`,
+						html.EscapeString(language), code))
 				} else {
-					codeHTML = fmt.Sprintf("<pre>%s</pre>",
-						html.EscapeString(strings.TrimSuffix(code, "\n")))
+					c.Write(fmt.Sprintf("<pre>%s</pre>", code))
 				}
-
-				lines = append(lines, codeHTML)
 			}
 
 		case *wikilink.Node:
@@ -393,25 +369,17 @@ func (c *HTMLConverter) Process(nv *model.NoteView) ConverterResult {
 
 		case *ast.List:
 			if entering && n.HasBlankPreviousLines() {
-				lines = append(lines, "\n")
+				c.Write("\n")
 			}
 
 		case *ast.ListItem:
 			if entering {
-				// Get the parent list
-				parent := node.Parent()
-				if list, ok := parent.(*ast.List); ok {
-					// Add newline before first list item if previous content exists
-					// This handles the case when list follows a paragraph without blank line
+				if list, ok := node.Parent().(*ast.List); ok {
+					// Start list on a new line when it follows a paragraph without blank line
 					if node.PreviousSibling() == nil {
-						// Flush buffer if not empty
-						if len(c.bufStack) == 1 && c.bufStack[0].Len() > 0 {
-							lines = append(lines, c.bufStack[0].String())
-							c.bufStack[0].Reset()
-						}
-						// Add newline if lines exist and last element is not already a newline
-						if len(lines) > 0 && lines[len(lines)-1] != "\n" && lines[len(lines)-1] != "\n\n" {
-							lines = append(lines, "\n")
+						cur := c.bufStack[len(c.bufStack)-1].String()
+						if cur != "" && !strings.HasSuffix(cur, "\n") {
+							c.Write("\n")
 						}
 					}
 
@@ -427,17 +395,8 @@ func (c *HTMLConverter) Process(nv *model.NoteView) ConverterResult {
 						c.Write("- ")
 					}
 				}
-			} else if len(c.bufStack) == 1 {
-				// End of list item - flush to lines
-				current := c.bufStack[0]
-				if current.Len() > 0 {
-					lines = append(lines, current.String())
-					current.Reset()
-					// Add newline if not the last item
-					if node.NextSibling() != nil {
-						lines = append(lines, "\n")
-					}
-				}
+			} else if node.NextSibling() != nil {
+				c.Write("\n")
 			}
 
 		case *ast.TextBlock:
@@ -461,23 +420,17 @@ func (c *HTMLConverter) Process(nv *model.NoteView) ConverterResult {
 		return ast.WalkContinue, nil
 	})
 
-	// Add any remaining content in root buffer
-	if len(c.bufStack) > 0 && c.bufStack[0].Len() > 0 {
-		lines = append(lines, c.bufStack[0].String())
-	}
-
 	// Add unpublished links footer if any
 	if len(c.unpublishedLinks) > 0 {
-		lines = append(lines, "\n\n—————————\n🔜 Скоро выйдут:")
+		c.Write("\n\n—————————\n🔜 Скоро выйдут:")
 		for _, link := range c.unpublishedLinks {
-			// Format date: "5 ноября, 14:30"
 			publishStr := formatPublishDate(link.publishAt)
-			lines = append(lines, fmt.Sprintf("\n• <u>%s</u> — %s", html.EscapeString(link.label), publishStr))
+			c.Write(fmt.Sprintf("\n• <u>%s</u> — %s", html.EscapeString(link.label), publishStr))
 		}
-		lines = append(lines, "\n\n📬 Подпишитесь, чтобы не пропустить")
+		c.Write("\n\n📬 Подпишитесь, чтобы не пропустить")
 	}
 
-	content := strings.Join(lines, "")
+	content := c.bufStack[0].String()
 
 	// Remove excessive blank lines (more than 2 newlines in a row)
 	// This happens when media files are removed from paragraphs

--- a/internal/markdownv2/html_converter.go
+++ b/internal/markdownv2/html_converter.go
@@ -259,8 +259,12 @@ func (c *HTMLConverter) Process(nv *model.NoteView) ConverterResult {
 					return ast.WalkSkipChildren, nil
 				}
 			} else {
-				msg := fmt.Sprintf("unsupported image source: %s", dest)
-				res.Warnings = append(res.Warnings, msg)
+				// ast.Walk visits the node again with entering=false even after
+				// WalkSkipChildren, so warn only once.
+				if entering {
+					msg := fmt.Sprintf("unsupported image source: %s", dest)
+					res.Warnings = append(res.Warnings, msg)
+				}
 				return ast.WalkSkipChildren, nil
 			}
 
@@ -282,8 +286,10 @@ func (c *HTMLConverter) Process(nv *model.NoteView) ConverterResult {
 					return ast.WalkSkipChildren, nil
 				}
 			} else {
-				msg := fmt.Sprintf("unsupported image source: %s", dest)
-				res.Warnings = append(res.Warnings, msg)
+				if entering {
+					msg := fmt.Sprintf("unsupported image source: %s", dest)
+					res.Warnings = append(res.Warnings, msg)
+				}
 				return ast.WalkSkipChildren, nil
 			}
 

--- a/internal/markdownv2/html_converter.go
+++ b/internal/markdownv2/html_converter.go
@@ -34,15 +34,16 @@ func extractImageAltText(node *ast.Image, src []byte) string {
 	return sb.String()
 }
 
-// extractCustomEmojiID extracts emoji ID from ce.trip2g.com URL or local tg_ce_*.webp path.
-// Returns empty string if path doesn't match any pattern.
+// extractCustomEmojiID extracts emoji ID from tg://emoji URL, ce.trip2g.com URL,
+// or local tg_ce_*.webp path. Returns empty string if path doesn't match any pattern.
 func extractCustomEmojiID(path string) string {
-	// Try ce.trip2g.com URL pattern
+	if id, ok := strings.CutPrefix(path, "tg://emoji?id="); ok {
+		return id
+	}
 	matches := ceEmojiURLPattern.FindStringSubmatch(path)
 	if len(matches) == 2 {
 		return matches[1]
 	}
-	// Try local tg_ce_*.webp pattern
 	matches = localCustomEmojiPattern.FindStringSubmatch(path)
 	if len(matches) == 2 {
 		return matches[1]
@@ -85,7 +86,6 @@ type unpublishedLink struct {
 type NodeHandlerFunc func(c *HTMLConverter, n ast.Node, src []byte, entering bool) (ast.WalkStatus, bool)
 
 type HTMLConverter struct {
-	CommonConverter
 	bufStack           []*strings.Builder
 	linkResolver       LinkResolver
 	skipClosingTag     map[ast.Node]bool
@@ -105,6 +105,15 @@ func (c *HTMLConverter) Write(s string) {
 	}
 }
 
+// writePair writes the opening tag on entering and the closing tag on exit.
+func (c *HTMLConverter) writePair(entering bool, open, closing string) {
+	if entering {
+		c.Write(open)
+	} else {
+		c.Write(closing)
+	}
+}
+
 func (c *HTMLConverter) pushBuffer() {
 	c.bufStack = append(c.bufStack, &strings.Builder{})
 }
@@ -119,9 +128,16 @@ func (c *HTMLConverter) popBuffer() string {
 	return result
 }
 
-//nolint:nestif,gocognit,gocyclo,cyclop,funlen // ast traversal always looks like this
+// currentBuffer returns the accumulated content of the buffer being written to.
+func (c *HTMLConverter) currentBuffer() string {
+	if len(c.bufStack) == 0 {
+		return ""
+	}
+	return c.bufStack[len(c.bufStack)-1].String()
+}
+
 func (c *HTMLConverter) Process(nv *model.NoteView) ConverterResult {
-	res := ConverterResult{}
+	res := &ConverterResult{}
 	src := nv.Content
 
 	c.skipClosingTag = make(map[ast.Node]bool)
@@ -131,307 +147,10 @@ func (c *HTMLConverter) Process(nv *model.NoteView) ConverterResult {
 	c.pushBuffer() // Initialize with root buffer
 
 	_ = ast.Walk(nv.Ast(), func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		switch node := n.(type) {
-		case *ast.Document:
-			// Nothing to do
-
-		case *ast.Paragraph:
-			if n.HasBlankPreviousLines() && entering {
-				c.Write("\n\n")
-			}
-
-		case *ast.Text:
-			if entering {
-				text := string(node.Segment.Value(src))
-				c.Write(html.EscapeString(text))
-				if node.SoftLineBreak() {
-					c.Write("\n")
-				}
-			}
-
-		case *ast.Emphasis:
-			var tag string
-			if node.Level == 1 {
-				if entering {
-					tag = "<i>"
-				} else {
-					tag = "</i>"
-				}
-			} else {
-				if entering {
-					tag = "<b>"
-				} else {
-					tag = "</b>"
-				}
-			}
-			c.Write(tag)
-
-		case *extast.Strikethrough:
-			var tag string
-			if entering {
-				tag = "<s>"
-			} else {
-				tag = "</s>"
-			}
-			c.Write(tag)
-
-		case *ast.CodeSpan:
-			var tag string
-			if entering {
-				tag = "<code>"
-			} else {
-				tag = "</code>"
-			}
-			c.Write(tag)
-
-		case *highlight.HighlightAST:
-			if entering {
-				c.Write(`<span class="tg-spoiler">`)
-			} else {
-				c.Write("</span>")
-			}
-
-		case *ast.Blockquote:
-			if entering {
-				if n.HasBlankPreviousLines() {
-					c.Write("\n\n")
-				}
-				c.pushBuffer()
-			} else {
-				content := strings.TrimSpace(c.popBuffer())
-
-				// Blockquote ending with || means Telegram expandable quote
-				if strings.HasSuffix(content, "||") {
-					content = strings.TrimSuffix(content, "||")
-					c.Write(fmt.Sprintf(`<blockquote expandable>%s</blockquote>`, content))
-				} else {
-					c.Write(fmt.Sprintf(`<blockquote>%s</blockquote>`, content))
-				}
-			}
-
-		case *ast.Link:
-			if entering {
-				c.Write(fmt.Sprintf(`<a href="%s">`, html.EscapeString(string(node.Destination))))
-			} else {
-				c.Write("</a>")
-			}
-
-		case *ast.AutoLink:
-			if entering {
-				url := string(node.URL(src))
-				c.Write(fmt.Sprintf(`<a href="%s">%s</a>`, html.EscapeString(url), html.EscapeString(url)))
-			}
-
-		case *enclavecore.Enclave:
-			dest := string(node.Destination)
-			var emojiID string
-
-			if strings.HasPrefix(dest, "tg://emoji?id=") {
-				emojiID = strings.TrimPrefix(dest, "tg://emoji?id=")
-			} else if id := extractCustomEmojiID(dest); id != "" {
-				emojiID = id
-			}
-
-			if emojiID != "" {
-				if entering {
-					alt := stripSizeSuffix(node.Alt)
-					c.Write(fmt.Sprintf(`<tg-emoji emoji-id="%s">%s</tg-emoji>`,
-						html.EscapeString(emojiID), html.EscapeString(alt)))
-					return ast.WalkSkipChildren, nil
-				}
-			} else {
-				// ast.Walk visits the node again with entering=false even after
-				// WalkSkipChildren, so warn only once.
-				if entering {
-					msg := fmt.Sprintf("unsupported image source: %s", dest)
-					res.Warnings = append(res.Warnings, msg)
-				}
-				return ast.WalkSkipChildren, nil
-			}
-
-		case *ast.Image:
-			dest := string(node.Destination)
-			var emojiID string
-
-			if strings.HasPrefix(dest, "tg://emoji?id=") {
-				emojiID = strings.TrimPrefix(dest, "tg://emoji?id=")
-			} else if id := extractCustomEmojiID(dest); id != "" {
-				emojiID = id
-			}
-
-			if emojiID != "" {
-				if entering {
-					alt := stripSizeSuffix(extractImageAltText(node, src))
-					c.Write(fmt.Sprintf(`<tg-emoji emoji-id="%s">%s</tg-emoji>`,
-						html.EscapeString(emojiID), html.EscapeString(alt)))
-					return ast.WalkSkipChildren, nil
-				}
-			} else {
-				if entering {
-					msg := fmt.Sprintf("unsupported image source: %s", dest)
-					res.Warnings = append(res.Warnings, msg)
-				}
-				return ast.WalkSkipChildren, nil
-			}
-
-		case *ast.RawHTML:
-			if entering {
-				tag := string(node.Segments.Value(src))
-				if tag == "<u>" || tag == "</u>" {
-					c.Write(tag)
-				} else {
-					msg := fmt.Sprintf("raw html tag is not supported: %s", tag)
-					res.Warnings = append(res.Warnings, msg)
-				}
-			}
-
-		case *ast.FencedCodeBlock:
-			if entering {
-				c.Write("\n")
-
-				language := string(node.Language(src))
-				code := html.EscapeString(strings.TrimSuffix(string(node.Lines().Value(src)), "\n"))
-
-				if language != "" {
-					c.Write(fmt.Sprintf(`<pre><code class="language-%s">%s</code></pre>`,
-						html.EscapeString(language), code))
-				} else {
-					c.Write(fmt.Sprintf("<pre>%s</pre>", code))
-				}
-			}
-
-		case *wikilink.Node:
-			if c.linkResolver != nil && !node.Embed {
-				if entering {
-					dest := string(node.Target)
-					link, err := c.linkResolver(dest)
-					if err != nil {
-						res.Warnings = append(res.Warnings, err.Error())
-						c.skipClosingTag[n] = true
-						return ast.WalkSkipChildren, nil
-					}
-
-					// Handle different link types
-					switch {
-					case link.URL != "":
-						// Regular link with URL
-						c.Write(fmt.Sprintf(`<a href="%s">`, html.EscapeString(link.URL)))
-
-						// If Label is provided, use it instead of node children
-						if link.Label != "" {
-							c.Write(html.EscapeString(link.Label))
-							c.Write("</a>")
-							c.skipClosingTag[n] = true
-							return ast.WalkSkipChildren, nil
-						}
-					case link.Label != "":
-						// Unpublished link with label (with or without PublishAt)
-						label := link.Label
-
-						// If has PublishAt, add to footer list
-						if link.PublishAt != nil {
-							c.unpublishedLinks = append(c.unpublishedLinks, unpublishedLink{
-								label:     label,
-								publishAt: *link.PublishAt,
-							})
-						}
-
-						// Mark this node as unpublished link
-						c.isUnpublishedLink[n] = true
-
-						// Write underlined text with label instead of link
-						c.Write(fmt.Sprintf("<u>%s</u>", html.EscapeString(label)))
-
-						// Skip children since we already wrote the label
-						c.skipClosingTag[n] = true
-						return ast.WalkSkipChildren, nil
-					default:
-						// No URL and no Label - skip
-						c.skipClosingTag[n] = true
-						return ast.WalkSkipChildren, nil
-					}
-				} else {
-					if !c.skipClosingTag[n] {
-						// Check if this was an unpublished link (underlined text)
-						if c.isUnpublishedLink[n] {
-							c.Write("</u>")
-						} else {
-							c.Write("</a>")
-						}
-					}
-					delete(c.skipClosingTag, n)
-					delete(c.isUnpublishedLink, n)
-				}
-			} else {
-				// No link resolver or embed - skip this node
-				return ast.WalkSkipChildren, nil
-			}
-
-		case *ast.List:
-			if entering && n.HasBlankPreviousLines() {
-				c.Write("\n")
-			}
-
-		case *ast.ListItem:
-			if entering {
-				if list, ok := node.Parent().(*ast.List); ok {
-					// Start list on a new line when it follows a paragraph without blank line
-					if node.PreviousSibling() == nil {
-						cur := c.bufStack[len(c.bufStack)-1].String()
-						if cur != "" && !strings.HasSuffix(cur, "\n") {
-							c.Write("\n")
-						}
-					}
-
-					if list.IsOrdered() {
-						// For ordered lists, calculate item number based on start + child index
-						itemNum := list.Start
-						if itemNum == 0 {
-							itemNum = 1
-						}
-						for prev := node.PreviousSibling(); prev != nil; prev = prev.PreviousSibling() {
-							itemNum++
-						}
-						c.Write(fmt.Sprintf("%d. ", itemNum))
-					} else {
-						// For unordered lists, use dash
-						c.Write("- ")
-					}
-				}
-			} else if node.NextSibling() != nil {
-				c.Write("\n")
-			}
-
-		case *ast.TextBlock:
-			// TextBlock is a container for text within list items - just pass through
-
-		default:
-			if c.UnknownNodeHandler != nil {
-				status, handled := c.UnknownNodeHandler(c, n, src, entering)
-				if handled {
-					return status, nil
-				}
-			}
-			if entering {
-				msg := fmt.Sprintf("unexpected markdown node: %s", n.Kind())
-				res.Warnings = append(res.Warnings, msg)
-			}
-
-			return ast.WalkSkipChildren, nil
-		}
-
-		return ast.WalkContinue, nil
+		return c.renderNode(n, src, entering, res), nil
 	})
 
-	// Add unpublished links footer if any
-	if len(c.unpublishedLinks) > 0 {
-		c.Write("\n\n—————————\n🔜 Скоро выйдут:")
-		for _, link := range c.unpublishedLinks {
-			publishStr := formatPublishDate(link.publishAt)
-			c.Write(fmt.Sprintf("\n• <u>%s</u> — %s", html.EscapeString(link.label), publishStr))
-		}
-		c.Write("\n\n📬 Подпишитесь, чтобы не пропустить")
-	}
+	c.writeUnpublishedFooter()
 
 	content := c.bufStack[0].String()
 
@@ -442,11 +161,267 @@ func (c *HTMLConverter) Process(nv *model.NoteView) ConverterResult {
 	}
 
 	// Trim leading/trailing whitespace (e.g., when cover image is removed)
-	content = strings.TrimSpace(content)
+	res.Content = strings.TrimSpace(content)
 
-	res.Content = content
+	return *res
+}
 
-	return res
+//nolint:gocyclo,cyclop,gocognit // flat per-node dispatch
+func (c *HTMLConverter) renderNode(n ast.Node, src []byte, entering bool, res *ConverterResult) ast.WalkStatus {
+	switch node := n.(type) {
+	case *ast.Document:
+		// Nothing to do
+
+	case *ast.Paragraph:
+		if entering && n.HasBlankPreviousLines() {
+			c.Write("\n\n")
+		}
+
+	case *ast.Text:
+		if entering {
+			c.Write(html.EscapeString(string(node.Segment.Value(src))))
+			if node.SoftLineBreak() {
+				c.Write("\n")
+			}
+		}
+
+	case *ast.Emphasis:
+		if node.Level == 1 {
+			c.writePair(entering, "<i>", "</i>")
+		} else {
+			c.writePair(entering, "<b>", "</b>")
+		}
+
+	case *extast.Strikethrough:
+		c.writePair(entering, "<s>", "</s>")
+
+	case *ast.CodeSpan:
+		c.writePair(entering, "<code>", "</code>")
+
+	case *highlight.HighlightAST:
+		c.writePair(entering, `<span class="tg-spoiler">`, "</span>")
+
+	case *ast.Blockquote:
+		c.renderBlockquote(n, entering)
+
+	case *ast.Link:
+		if entering {
+			c.Write(fmt.Sprintf(`<a href="%s">`, html.EscapeString(string(node.Destination))))
+		} else {
+			c.Write("</a>")
+		}
+
+	case *ast.AutoLink:
+		if entering {
+			url := string(node.URL(src))
+			c.Write(fmt.Sprintf(`<a href="%s">%s</a>`, html.EscapeString(url), html.EscapeString(url)))
+		}
+
+	case *enclavecore.Enclave:
+		return c.renderCustomEmoji(string(node.Destination), node.Alt, entering, res)
+
+	case *ast.Image:
+		return c.renderCustomEmoji(string(node.Destination), extractImageAltText(node, src), entering, res)
+
+	case *ast.RawHTML:
+		if entering {
+			tag := string(node.Segments.Value(src))
+			if tag == "<u>" || tag == "</u>" {
+				c.Write(tag)
+			} else {
+				res.Warnings = append(res.Warnings, fmt.Sprintf("raw html tag is not supported: %s", tag))
+			}
+		}
+
+	case *ast.FencedCodeBlock:
+		if entering {
+			c.renderFencedCodeBlock(node, src)
+		}
+
+	case *wikilink.Node:
+		return c.renderWikilink(node, entering, res)
+
+	case *ast.List:
+		if entering && n.HasBlankPreviousLines() {
+			c.Write("\n")
+		}
+
+	case *ast.ListItem:
+		c.renderListItem(node, entering)
+
+	case *ast.TextBlock:
+		// TextBlock is a container for text within list items - just pass through
+
+	default:
+		if c.UnknownNodeHandler != nil {
+			status, handled := c.UnknownNodeHandler(c, n, src, entering)
+			if handled {
+				return status
+			}
+		}
+		if entering {
+			res.Warnings = append(res.Warnings, fmt.Sprintf("unexpected markdown node: %s", n.Kind()))
+		}
+
+		return ast.WalkSkipChildren
+	}
+
+	return ast.WalkContinue
+}
+
+// renderBlockquote collects the quote content in its own buffer and wraps it
+// into <blockquote> in the parent buffer on exit.
+func (c *HTMLConverter) renderBlockquote(n ast.Node, entering bool) {
+	if entering {
+		if n.HasBlankPreviousLines() {
+			c.Write("\n\n")
+		}
+		c.pushBuffer()
+		return
+	}
+
+	content := strings.TrimSpace(c.popBuffer())
+
+	// Blockquote ending with || means Telegram expandable quote
+	if inner, ok := strings.CutSuffix(content, "||"); ok {
+		c.Write(fmt.Sprintf(`<blockquote expandable>%s</blockquote>`, inner))
+	} else {
+		c.Write(fmt.Sprintf(`<blockquote>%s</blockquote>`, content))
+	}
+}
+
+// renderCustomEmoji renders a Telegram custom emoji, or warns on an unsupported
+// image source. Warns only on entering: ast.Walk visits the node again with
+// entering=false even after WalkSkipChildren.
+func (c *HTMLConverter) renderCustomEmoji(dest, alt string, entering bool, res *ConverterResult) ast.WalkStatus {
+	emojiID := extractCustomEmojiID(dest)
+	if !entering {
+		return ast.WalkSkipChildren
+	}
+
+	if emojiID == "" {
+		res.Warnings = append(res.Warnings, fmt.Sprintf("unsupported image source: %s", dest))
+		return ast.WalkSkipChildren
+	}
+
+	c.Write(fmt.Sprintf(`<tg-emoji emoji-id="%s">%s</tg-emoji>`,
+		html.EscapeString(emojiID), html.EscapeString(stripSizeSuffix(alt))))
+	return ast.WalkSkipChildren
+}
+
+func (c *HTMLConverter) renderFencedCodeBlock(node *ast.FencedCodeBlock, src []byte) {
+	c.Write("\n")
+
+	language := string(node.Language(src))
+	code := html.EscapeString(strings.TrimSuffix(string(node.Lines().Value(src)), "\n"))
+
+	if language != "" {
+		c.Write(fmt.Sprintf(`<pre><code class="language-%s">%s</code></pre>`,
+			html.EscapeString(language), code))
+	} else {
+		c.Write(fmt.Sprintf("<pre>%s</pre>", code))
+	}
+}
+
+func (c *HTMLConverter) renderWikilink(node *wikilink.Node, entering bool, res *ConverterResult) ast.WalkStatus {
+	if c.linkResolver == nil || node.Embed {
+		return ast.WalkSkipChildren
+	}
+
+	if !entering {
+		if !c.skipClosingTag[node] {
+			if c.isUnpublishedLink[node] {
+				c.Write("</u>")
+			} else {
+				c.Write("</a>")
+			}
+		}
+		delete(c.skipClosingTag, node)
+		delete(c.isUnpublishedLink, node)
+		return ast.WalkContinue
+	}
+
+	link, err := c.linkResolver(string(node.Target))
+	if err != nil {
+		res.Warnings = append(res.Warnings, err.Error())
+		c.skipClosingTag[node] = true
+		return ast.WalkSkipChildren
+	}
+
+	switch {
+	case link.URL != "":
+		c.Write(fmt.Sprintf(`<a href="%s">`, html.EscapeString(link.URL)))
+
+		// If Label is provided, use it instead of node children
+		if link.Label != "" {
+			c.Write(html.EscapeString(link.Label))
+			c.Write("</a>")
+			c.skipClosingTag[node] = true
+			return ast.WalkSkipChildren
+		}
+		return ast.WalkContinue
+
+	case link.Label != "":
+		// Unpublished link: render as underlined label, list in the footer if it has a date
+		if link.PublishAt != nil {
+			c.unpublishedLinks = append(c.unpublishedLinks, unpublishedLink{
+				label:     link.Label,
+				publishAt: *link.PublishAt,
+			})
+		}
+
+		c.isUnpublishedLink[node] = true
+		c.Write(fmt.Sprintf("<u>%s</u>", html.EscapeString(link.Label)))
+		c.skipClosingTag[node] = true
+		return ast.WalkSkipChildren
+
+	default:
+		// No URL and no Label - skip
+		c.skipClosingTag[node] = true
+		return ast.WalkSkipChildren
+	}
+}
+
+func (c *HTMLConverter) renderListItem(node *ast.ListItem, entering bool) {
+	if !entering {
+		if node.NextSibling() != nil {
+			c.Write("\n")
+		}
+		return
+	}
+
+	list, ok := node.Parent().(*ast.List)
+	if !ok {
+		return
+	}
+
+	// Start list on a new line when it follows a paragraph without blank line
+	if node.PreviousSibling() == nil {
+		if cur := c.currentBuffer(); cur != "" && !strings.HasSuffix(cur, "\n") {
+			c.Write("\n")
+		}
+	}
+
+	if list.IsOrdered() {
+		itemNum := max(list.Start, 1)
+		for prev := node.PreviousSibling(); prev != nil; prev = prev.PreviousSibling() {
+			itemNum++
+		}
+		c.Write(fmt.Sprintf("%d. ", itemNum))
+	} else {
+		c.Write("- ")
+	}
+}
+
+func (c *HTMLConverter) writeUnpublishedFooter() {
+	if len(c.unpublishedLinks) == 0 {
+		return
+	}
+	c.Write("\n\n—————————\n🔜 Скоро выйдут:")
+	for _, link := range c.unpublishedLinks {
+		c.Write(fmt.Sprintf("\n• <u>%s</u> — %s", html.EscapeString(link.label), formatPublishDate(link.publishAt)))
+	}
+	c.Write("\n\n📬 Подпишитесь, чтобы не пропустить")
 }
 
 func formatPublishDate(t time.Time) string {

--- a/internal/markdownv2/html_converter.go
+++ b/internal/markdownv2/html_converter.go
@@ -347,6 +347,11 @@ func (c *HTMLConverter) renderWikilink(node *wikilink.Node, entering bool, res *
 		c.skipClosingTag[node] = true
 		return ast.WalkSkipChildren
 	}
+	if link == nil {
+		// Resolver returned nothing - drop the link like the no-URL/no-Label case
+		c.skipClosingTag[node] = true
+		return ast.WalkSkipChildren
+	}
 
 	switch {
 	case link.URL != "":

--- a/internal/markdownv2/html_converter_test.go
+++ b/internal/markdownv2/html_converter_test.go
@@ -504,19 +504,19 @@ func TestHTMLCustomEmoji(t *testing.T) {
 			name:     "unsupported image source",
 			markdown: "![](https://example.com/image.png)",
 			expected: ``,
-			warnings: 2, // Both Enclave and Image nodes are created
+			warnings: 1, // warned once per unsupported image (regression: was double-counted on exit visit)
 		},
 		{
 			name:     "ce.trip2g.com wrong extension",
 			markdown: "![](https://ce.trip2g.com/123.png)",
 			expected: ``,
-			warnings: 2, // Both Enclave and Image nodes are created
+			warnings: 1, // warned once per unsupported image (regression: was double-counted on exit visit)
 		},
 		{
 			name:     "ce.trip2g.com non-numeric id",
 			markdown: "![](https://ce.trip2g.com/abc.webp)",
 			expected: ``,
-			warnings: 2, // Both Enclave and Image nodes are created
+			warnings: 1, // warned once per unsupported image (regression: was double-counted on exit visit)
 		},
 		// Local asset tg_ce_*.webp format tests
 		{
@@ -547,13 +547,13 @@ func TestHTMLCustomEmoji(t *testing.T) {
 			name:     "local asset tg_ce non-numeric id",
 			markdown: "![](assets/tg_ce_abc.webp)",
 			expected: ``,
-			warnings: 2,
+			warnings: 1,
 		},
 		{
 			name:     "local asset tg_ce wrong extension",
 			markdown: "![](assets/tg_ce_123.png)",
 			expected: ``,
-			warnings: 2,
+			warnings: 1,
 		},
 	}
 

--- a/internal/markdownv2/html_converter_test.go
+++ b/internal/markdownv2/html_converter_test.go
@@ -379,6 +379,15 @@ func TestHTMLWikilinks(t *testing.T) {
 			warnings: 0,
 		},
 		{
+			name:     "resolver returns nil result (regression: used to panic)",
+			markdown: "See [[unknown]] here",
+			linkResolver: func(target string) (*markdownv2.LinkResolverResult, error) {
+				return nil, nil
+			},
+			expected: `See  here`,
+			warnings: 0,
+		},
+		{
 			name:     "wikilink with resolver error",
 			markdown: "See [[missing-note]] here",
 			linkResolver: func(target string) (*markdownv2.LinkResolverResult, error) {

--- a/internal/markdownv2/html_converter_test.go
+++ b/internal/markdownv2/html_converter_test.go
@@ -205,6 +205,13 @@ func TestHTMLList(t *testing.T) {
 3. third item`,
 		},
 		{
+			name: "ordered list starting from 3",
+			markdown: `3. third item
+4. fourth item`,
+			expected: `3. third item
+4. fourth item`,
+		},
+		{
 			name: "paragraph followed by unordered list",
 			markdown: `Unordered list:
 - First item

--- a/internal/markdownv2/html_converter_test.go
+++ b/internal/markdownv2/html_converter_test.go
@@ -275,6 +275,67 @@ title: "Test"
 	}
 }
 
+// Block-level elements inside a blockquote must stay inside it
+// (regression: they used to leak out of the <blockquote> tag).
+func TestHTMLBlockquoteNestedBlocks(t *testing.T) {
+	tests := []struct {
+		name     string
+		markdown string
+		expected string
+	}{
+		{
+			name:     "multiple paragraphs in blockquote",
+			markdown: "> first para\n>\n> second para",
+			expected: "<blockquote>first para\n\nsecond para</blockquote>",
+		},
+		{
+			name:     "code block in blockquote",
+			markdown: "> quote with code\n> ```\n> x\n> ```",
+			expected: "<blockquote>quote with code\n<pre>x</pre></blockquote>",
+		},
+		{
+			name:     "list in blockquote",
+			markdown: "> a list:\n> - one\n> - two",
+			expected: "<blockquote>a list:\n- one\n- two</blockquote>",
+		},
+		{
+			name:     "nested blockquote stays inside outer",
+			markdown: "before\n\n> outer\n> > inner",
+			expected: "before\n\n<blockquote>outer<blockquote>inner</blockquote></blockquote>",
+		},
+		{
+			name:     "paragraph then blockquote keeps blank line separator",
+			markdown: "before\n\n> quoted",
+			expected: "before\n\n<blockquote>quoted</blockquote>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mdOptions := mdloader.Options{
+				Sources: []mdloader.SourceFile{{
+					Content: []byte(`---
+free: true
+title: "Test"
+---
+` + tt.markdown),
+				}},
+				Log:     &logger.TestLogger{},
+				Version: "latest",
+			}
+
+			nvs, err := mdloader.Load(mdOptions)
+			require.NoError(t, err)
+
+			convertor := markdownv2.HTMLConverter{}
+			res := convertor.Process(nvs.List[0])
+
+			require.Empty(t, res.Warnings)
+			require.Equal(t, tt.expected, res.Content)
+		})
+	}
+}
+
 func TestHTMLWikilinks(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
Analysis + cleanup of `internal/markdownv2/html_converter.go` (goldmark AST → Telegram HTML). 4 real bugs found and fixed (each pinned by a new/updated test), then a behavior-preserving refactor. All commits keep `go test ./internal/markdownv2/` green; dependent packages (`convertnoteviewtotgpost`, `handletgnavigationupdate`, `handletgcanvasupdate`) also pass.

## Bugs found (all fixed)

1. **Duplicate "unsupported image source" warning** — `html_converter.go:262` / `:285` (old): the warning branch ran on both the entering and exiting visit, because `ast.Walk` visits a node again with `entering=false` even after `WalkSkipChildren`. Every unsupported image produced the same warning twice. The old test comments `// Both Enclave and Image nodes are created` were wrong — the AST dump shows a single `Image` node; the count of 2 was the duplicate. Test expectations updated 2 → 1.

2. **Block elements inside a blockquote leaked out of it** — the converter kept two parallel output sinks: a `lines []string` slice and the buffer stack. Everything block-level (`Paragraph` separators, `FencedCodeBlock`, `ListItem` flushes, closed `Blockquote`s) appended straight to `lines`, ignoring an open blockquote buffer. Confirmed broken outputs on old code:
   - `> first\n>\n> second` → `<blockquote>first parasecond para</blockquote>` (paragraphs fused)
   - code block in quote → `<pre>x</pre><blockquote>quote with code</blockquote>` (code rendered *before and outside* the quote)
   - list in quote → `<blockquote>a list:- one- two</blockquote>` (items fused)
   - nested quote → `<blockquote>inner</blockquote><blockquote>outer</blockquote>` (inner ejected before outer, wrong order)

   Fix: `lines` is gone; everything writes to the current buffer of the stack, and `Blockquote` handles its own `\n\n` separator (previously that separator worked at top level only by accident — the *inner* paragraph's blank-line flag leaked it into `lines`). New `TestHTMLBlockquoteNestedBlocks` pins all four cases. Note: Telegram doesn't render nested `<blockquote>` tags, but content now at least stays in-order and inside the quote.

3. **Ordered list start number ignored** — `3. three\n4. four` rendered as `1. three\n2. four`. Now uses `list.Start`. Pinned in `TestHTMLList`.

4. **Panic on `LinkResolver` returning `(nil, nil)`** — `renderWikilink` deref'd the result without a nil check (`link.URL`). The very first resolver in the existing test suite returns `nil, nil` for unknown targets, so this is a realistic contract. Now treated like the empty-result case (link dropped, no warning). Pinned by regression test (confirmed panic before fix).

Flagged, not fixed (same-family, out of scope): `converter.go:110-116` (`CommonConverter`, the markdown flavor) has the same duplicate-warning-on-exit pattern for `Enclave` nodes.

## Simplifications (behavior-preserving)

Before: `Process` was one ~360-line walk closure (file 499 lines) juggling `lines` + `bufStack` with special root-vs-nested branches everywhere. After (file 441 lines):

- `Process` is ~30 lines: init → walk → footer → normalize.
- `renderNode` is a flat dispatch switch; fat cases moved to `renderBlockquote`, `renderCustomEmoji`, `renderFencedCodeBlock`, `renderWikilink`, `renderListItem`, `writeUnpublishedFooter`.
- `Enclave` and `Image` cases were near-identical 22-line blocks → one shared `renderCustomEmoji` (the `tg://emoji?id=` prefix moved into `extractCustomEmojiID`).
- Symmetric tags (`<i>`, `<b>`, `<s>`, `<code>`, spoiler span) via a tiny `writePair`.
- Removed dead code: the unused `CommonConverter` embed and `c.state = lineStart` (state was never read in the HTML path).
- Dropped the `//nolint:nestif,gocognit,gocyclo,cyclop,funlen` pile down to the dispatch-switch nolint; golangci-lint clean.

## Test coverage gaps closed

- Block-level content inside blockquotes (none existed — this is why bug 2 survived)
- Ordered list with non-1 start
- nil resolver result
- Duplicate-warning counts corrected with accurate comments

## Verification

- `go test ./internal/markdownv2/` green after every commit
- `go test` on the three dependent case packages: green
- `go vet`, `golangci-lint run ./internal/markdownv2/...`: 0 issues
- `go build ./...` fails only on pre-existing fresh-worktree embed assets (`ui/admin/-/web.js`, `vault.zip`), unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
