### PR TITLE
feat(metrics): embedding pipeline + job-queue depth metrics

### DIFF
--- a/cmd/server/debug_embedding.go
+++ b/cmd/server/debug_embedding.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"trip2g/internal/mdchunk"
+	"trip2g/internal/openai"
 )
 
 // debugEmbeddingEnabled gates /debug/embedding registration: vector search
@@ -90,7 +91,7 @@ func (a *app) handleDebugEmbedding(w http.ResponseWriter, r *http.Request) {
 			texts[i] = passagePrefix + c.Content
 		}
 		embedStart := time.Now()
-		embeddings, err := a.openaiClient.CreateEmbeddings(r.Context(), texts)
+		embeddings, err := a.openaiClient.CreateEmbeddings(r.Context(), texts, openai.KindDebug)
 		embedMs = time.Since(embedStart).Milliseconds()
 		if err != nil {
 			embedErrStr = err.Error()

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -196,7 +196,8 @@ type appState struct {
 
 	notFoundTracker *notfoundtracker.Tracker
 
-	mcpMetrics *metrics.MCPMetrics
+	mcpMetrics       *metrics.MCPMetrics
+	embeddingMetrics *metrics.EmbeddingMetrics
 
 	redirectManager *redirectmanager.Manager
 
@@ -345,7 +346,8 @@ func main() {
 
 			oidcKeys: oidcauth.NewKeyCache(),
 
-			mcpMetrics: metrics.NewMCPMetrics(prometheus.DefaultRegisterer),
+			mcpMetrics:       metrics.NewMCPMetrics(prometheus.DefaultRegisterer),
+			embeddingMetrics: metrics.NewEmbeddingMetrics(prometheus.DefaultRegisterer),
 
 			purchaseTokenManager: purchasetoken.NewManager(config.PurchaseToken),
 
@@ -397,6 +399,12 @@ func main() {
 	a.constructPatreon()
 	a.constructBoosty()
 
+	// Carry embedding metrics on the root context so job/cron code (no HTTP
+	// request to thread metrics through) can record embedding pipeline
+	// observations. Must happen before queues and the cron scheduler are built
+	// from ctx below, so every derived context inherits the value.
+	ctx = metrics.ContextWithEmbeddingMetrics(ctx, a.embeddingMetrics)
+
 	a.globalQueue = a.createQueue(ctx, "global_jobs", QueueOpts{
 		Limit:        10,
 		PollInterval: a.config.GlobalQueuePollInterval,
@@ -414,6 +422,7 @@ func main() {
 			a.config.Features.VectorSearch.ResolvedModelName(),
 			a.config.Features.VectorSearch.BaseURL,
 		)
+		a.openaiClient.SetMetrics(a.embeddingMetrics)
 	}
 
 	// Start the internal health server early so /livez answers 200 throughout

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -17,6 +17,7 @@ import (
 	"trip2g/internal/metrics"
 	"trip2g/internal/router"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/valyala/fasthttp"
 	"github.com/valyala/fasthttp/fasthttpadaptor"
 	"golang.org/x/crypto/acme"
@@ -329,7 +330,7 @@ func (a *app) startInternalServer() {
 	debugHandler := fasthttpadaptor.NewFastHTTPHandler(debugMux)
 
 	// Start metrics updater
-	metricsUpdater := metrics.NewUpdater(a, a.config.Metrics.UpdateInterval)
+	metricsUpdater := metrics.NewUpdater(a, a.config.Metrics.UpdateInterval, prometheus.DefaultRegisterer)
 	go func() {
 		err := metricsUpdater.Run(a.ctx)
 		if err != nil && !errors.Is(err, context.Canceled) {

--- a/internal/case/backjob/generatenoteversionembedding/resolve.go
+++ b/internal/case/backjob/generatenoteversionembedding/resolve.go
@@ -15,6 +15,7 @@ import (
 	"trip2g/internal/features"
 	"trip2g/internal/logger"
 	"trip2g/internal/mdchunk"
+	"trip2g/internal/metrics"
 	"trip2g/internal/model"
 	"trip2g/internal/openai"
 )
@@ -36,6 +37,18 @@ type Env interface {
 }
 
 func Resolve(ctx context.Context, env Env, params Params) error {
+	err := resolve(ctx, env, params)
+
+	jobResult := "succeeded"
+	if err != nil {
+		jobResult = "failed"
+	}
+	metrics.EmbeddingMetricsFromContext(ctx).RecordJob(jobResult)
+
+	return err
+}
+
+func resolve(ctx context.Context, env Env, params Params) error {
 	if !env.Features().VectorSearch.Enabled {
 		env.Logger().Debug("vector search disabled, skipping embedding generation")
 		return nil
@@ -81,7 +94,7 @@ func Resolve(ctx context.Context, env Env, params Params) error {
 	text := passagePrefix + mdchunk.TruncateToTokens(noteView.Title+"\n\n"+mdchunk.StripFrontmatter(string(noteView.Content)), budget)
 
 	// Generate embedding
-	result, err := env.OpenAI().CreateEmbedding(ctx, text)
+	result, err := env.OpenAI().CreateEmbedding(ctx, text, openai.KindWholeNote)
 	if err != nil {
 		return fmt.Errorf("failed to create embedding: %w", err)
 	}
@@ -163,7 +176,7 @@ func generateChunkEmbeddings(ctx context.Context, env Env, versionID int64, titl
 			texts[i] = passagePrefix + mdchunk.TruncateToTokens(pe.chunk.Content, budget)
 		}
 
-		results, embErr := env.OpenAI().CreateEmbeddings(ctx, texts)
+		results, embErr := env.OpenAI().CreateEmbeddings(ctx, texts, openai.KindChunk)
 		if embErr != nil {
 			return fmt.Errorf("failed to create chunk embeddings: %w", embErr)
 		}

--- a/internal/case/cronjob/regeneratenoteembeddings/resolve.go
+++ b/internal/case/cronjob/regeneratenoteembeddings/resolve.go
@@ -11,6 +11,7 @@ import (
 	"trip2g/internal/db"
 	"trip2g/internal/features"
 	"trip2g/internal/logger"
+	"trip2g/internal/metrics"
 	"trip2g/internal/model"
 )
 
@@ -30,6 +31,14 @@ type Result struct {
 }
 
 func Resolve(ctx context.Context, env Env) (*Result, error) {
+	result, err := resolve(ctx, env)
+	if result != nil {
+		metrics.EmbeddingMetricsFromContext(ctx).RecordRegen(result.EnqueuedCount, result.UpToDateCount, len(result.Errors))
+	}
+	return result, err
+}
+
+func resolve(ctx context.Context, env Env) (*Result, error) {
 	result := &Result{}
 
 	if !env.Features().VectorSearch.Enabled {

--- a/internal/case/sitesearch/retrieve.go
+++ b/internal/case/sitesearch/retrieve.go
@@ -95,7 +95,7 @@ func Retrieve(
 
 func vectorSearch(ctx context.Context, env RetrieveEnv, query string, useLatest bool) ([]appmodel.SearchResult, map[string]string, error) {
 	queryPrefix := env.Features().VectorSearch.ResolvedQueryPrefix()
-	embedding, err := env.OpenAI().CreateEmbedding(ctx, queryPrefix+query)
+	embedding, err := env.OpenAI().CreateEmbedding(ctx, queryPrefix+query, openai.KindQuery)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create query embedding: %w", err)
 	}

--- a/internal/metrics/embedding.go
+++ b/internal/metrics/embedding.go
@@ -1,0 +1,111 @@
+package metrics
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// EmbeddingMetrics collects Prometheus metrics for the embedding pipeline:
+// embedding API requests (whole-note, chunk, query), embed job outcomes, and
+// the regeneration cron sweep. All record methods are nil-safe so callers
+// without wired metrics (tests, partial app setups) can call them
+// unconditionally.
+type EmbeddingMetrics struct {
+	requests      *prometheus.CounterVec
+	duration      *prometheus.HistogramVec
+	jobs          *prometheus.CounterVec
+	regenEnqueued prometheus.Counter
+	regenUpToDate prometheus.Counter
+	regenErrors   prometheus.Counter
+}
+
+// NewEmbeddingMetrics creates and registers all embedding Prometheus metrics on reg.
+func NewEmbeddingMetrics(reg prometheus.Registerer) *EmbeddingMetrics {
+	m := &EmbeddingMetrics{
+		requests: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "trip2g_embedding_requests_total",
+			Help: "Total number of embedding API requests by result, kind and error reason",
+		}, []string{"result", "kind", "reason"}),
+		duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "trip2g_embedding_request_duration_seconds",
+			Help:    "Embedding API request duration in seconds, per kind",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"kind"}),
+		jobs: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "trip2g_embedding_jobs_total",
+			Help: "Total number of generate-note-version-embedding job executions by result",
+		}, []string{"result"}),
+		regenEnqueued: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "trip2g_embedding_regen_enqueued_total",
+			Help: "Total number of notes enqueued for re-embedding by the regeneration cron",
+		}),
+		regenUpToDate: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "trip2g_embedding_regen_up_to_date_total",
+			Help: "Total number of notes found already up to date by the regeneration cron",
+		}),
+		regenErrors: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "trip2g_embedding_regen_errors_total",
+			Help: "Total number of enqueue errors reported by the regeneration cron",
+		}),
+	}
+
+	reg.MustRegister(m.requests, m.duration, m.jobs, m.regenEnqueued, m.regenUpToDate, m.regenErrors)
+	return m
+}
+
+// RecordEmbeddingRequest records one embedding API call: requests_total
+// (labeled by kind, result and — on error — a bounded failure reason) and the
+// duration histogram (labeled by kind). reason is ignored (empty) on success.
+func (m *EmbeddingMetrics) RecordEmbeddingRequest(kind, result, reason string, seconds float64) {
+	if m == nil {
+		return
+	}
+	m.requests.WithLabelValues(result, kind, reason).Inc()
+	m.duration.WithLabelValues(kind).Observe(seconds)
+}
+
+// RecordJob counts one generate-note-version-embedding job execution by result
+// ("succeeded" or "failed").
+func (m *EmbeddingMetrics) RecordJob(result string) {
+	if m == nil {
+		return
+	}
+	m.jobs.WithLabelValues(result).Inc()
+}
+
+// RecordRegen adds one regeneration cron sweep's counts to the running totals.
+func (m *EmbeddingMetrics) RecordRegen(enqueued, upToDate, errs int) {
+	if m == nil {
+		return
+	}
+	m.regenEnqueued.Add(float64(enqueued))
+	m.regenUpToDate.Add(float64(upToDate))
+	m.regenErrors.Add(float64(errs))
+}
+
+// Bounded failure reasons for the requests_total "reason" label — the
+// embedding client classifies API errors into this fixed set so the label
+// never grows unbounded.
+const (
+	EmbeddingErrorBatchTooLarge = "batch_too_large"
+	EmbeddingErrorOverloaded    = "overloaded"
+	EmbeddingErrorOther         = "other"
+)
+
+type embeddingMetricsContextKey struct{}
+
+// ContextWithEmbeddingMetrics stores m in ctx so background job/cron code
+// (which has no HTTP request to carry metrics through) can record embedding
+// pipeline observations. Wired once, at the root context queues and the cron
+// scheduler are built from.
+func ContextWithEmbeddingMetrics(ctx context.Context, m *EmbeddingMetrics) context.Context {
+	return context.WithValue(ctx, embeddingMetricsContextKey{}, m)
+}
+
+// EmbeddingMetricsFromContext returns the embedding metrics stored in ctx, or
+// nil (all record methods are nil-safe).
+func EmbeddingMetricsFromContext(ctx context.Context) *EmbeddingMetrics {
+	m, _ := ctx.Value(embeddingMetricsContextKey{}).(*EmbeddingMetrics)
+	return m
+}

--- a/internal/metrics/embedding_test.go
+++ b/internal/metrics/embedding_test.go
@@ -1,0 +1,118 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewEmbeddingMetrics_Records(t *testing.T) {
+	f := func(v float64) *float64 { return &v }
+	u := func(v uint64) *uint64 { return &v }
+
+	cases := []struct {
+		name   string
+		record func(m *EmbeddingMetrics)
+		metric string
+		labels map[string]string
+
+		wantCounter   *float64
+		wantHistCount *uint64
+		wantHistSum   *float64
+	}{
+		{
+			name:        "requests_total counts ok by kind",
+			record:      func(m *EmbeddingMetrics) { m.RecordEmbeddingRequest("whole_note", "ok", "", 0.1) },
+			metric:      "trip2g_embedding_requests_total",
+			labels:      map[string]string{"result": "ok", "kind": "whole_note", "reason": ""},
+			wantCounter: f(1),
+		},
+		{
+			name: "requests_total counts errors with bounded reason",
+			record: func(m *EmbeddingMetrics) {
+				m.RecordEmbeddingRequest("chunk", "error", EmbeddingErrorBatchTooLarge, 0.2)
+			},
+			metric:      "trip2g_embedding_requests_total",
+			labels:      map[string]string{"result": "error", "kind": "chunk", "reason": EmbeddingErrorBatchTooLarge},
+			wantCounter: f(1),
+		},
+		{
+			name:          "request_duration observes per kind",
+			record:        func(m *EmbeddingMetrics) { m.RecordEmbeddingRequest("query", "ok", "", 0.5) },
+			metric:        "trip2g_embedding_request_duration_seconds",
+			labels:        map[string]string{"kind": "query"},
+			wantHistCount: u(1),
+			wantHistSum:   f(0.5),
+		},
+		{
+			name:        "jobs_total counts by result",
+			record:      func(m *EmbeddingMetrics) { m.RecordJob("succeeded") },
+			metric:      "trip2g_embedding_jobs_total",
+			labels:      map[string]string{"result": "succeeded"},
+			wantCounter: f(1),
+		},
+		{
+			name:        "regen_enqueued_total accumulates",
+			record:      func(m *EmbeddingMetrics) { m.RecordRegen(3, 5, 1) },
+			metric:      "trip2g_embedding_regen_enqueued_total",
+			labels:      map[string]string{},
+			wantCounter: f(3),
+		},
+		{
+			name:        "regen_up_to_date_total accumulates",
+			record:      func(m *EmbeddingMetrics) { m.RecordRegen(3, 5, 1) },
+			metric:      "trip2g_embedding_regen_up_to_date_total",
+			labels:      map[string]string{},
+			wantCounter: f(5),
+		},
+		{
+			name:        "regen_errors_total accumulates",
+			record:      func(m *EmbeddingMetrics) { m.RecordRegen(3, 5, 1) },
+			metric:      "trip2g_embedding_regen_errors_total",
+			labels:      map[string]string{},
+			wantCounter: f(1),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := prometheus.NewRegistry()
+			m := NewEmbeddingMetrics(reg)
+			tc.record(m)
+
+			metric := findMetric(t, reg, tc.metric, tc.labels)
+			if tc.wantCounter != nil {
+				require.InDelta(t, *tc.wantCounter, metric.GetCounter().GetValue(), 1e-9)
+			}
+			if tc.wantHistCount != nil {
+				require.Equal(t, *tc.wantHistCount, metric.GetHistogram().GetSampleCount())
+			}
+			if tc.wantHistSum != nil {
+				require.InDelta(t, *tc.wantHistSum, metric.GetHistogram().GetSampleSum(), 1e-9)
+			}
+		})
+	}
+}
+
+func TestEmbeddingMetrics_NilSafe(t *testing.T) {
+	var m *EmbeddingMetrics
+	require.NotPanics(t, func() {
+		m.RecordEmbeddingRequest("whole_note", "ok", "", 0.1)
+		m.RecordJob("succeeded")
+		m.RecordRegen(1, 2, 3)
+	})
+}
+
+func TestEmbeddingMetricsContext_RoundTrips(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewEmbeddingMetrics(reg)
+
+	ctx := ContextWithEmbeddingMetrics(context.Background(), m)
+	require.Same(t, m, EmbeddingMetricsFromContext(ctx))
+}
+
+func TestEmbeddingMetricsFromContext_MissingReturnsNil(t *testing.T) {
+	require.Nil(t, EmbeddingMetricsFromContext(context.Background()))
+}

--- a/internal/metrics/test.go
+++ b/internal/metrics/test.go
@@ -6,6 +6,7 @@ package metrics
 import (
 	"context"
 	"sync"
+	"trip2g/internal/db"
 )
 
 // Ensure, that EnvMock does implement Env.
@@ -30,6 +31,9 @@ var _ Env = &EnvMock{}
 //			CountVisibleNotePathsFunc: func(ctx context.Context) (int64, error) {
 //				panic("mock out the CountVisibleNotePaths method")
 //			},
+//			ListGoqiteAllQueueStatsFunc: func(ctx context.Context) ([]db.ListGoqiteAllQueueStatsRow, error) {
+//				panic("mock out the ListGoqiteAllQueueStats method")
+//			},
 //			SumNoteAssetsSizesFunc: func(ctx context.Context) (int64, error) {
 //				panic("mock out the SumNoteAssetsSizes method")
 //			},
@@ -51,6 +55,9 @@ type EnvMock struct {
 
 	// CountVisibleNotePathsFunc mocks the CountVisibleNotePaths method.
 	CountVisibleNotePathsFunc func(ctx context.Context) (int64, error)
+
+	// ListGoqiteAllQueueStatsFunc mocks the ListGoqiteAllQueueStats method.
+	ListGoqiteAllQueueStatsFunc func(ctx context.Context) ([]db.ListGoqiteAllQueueStatsRow, error)
 
 	// SumNoteAssetsSizesFunc mocks the SumNoteAssetsSizes method.
 	SumNoteAssetsSizesFunc func(ctx context.Context) (int64, error)
@@ -77,17 +84,23 @@ type EnvMock struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 		}
+		// ListGoqiteAllQueueStats holds details about calls to the ListGoqiteAllQueueStats method.
+		ListGoqiteAllQueueStats []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+		}
 		// SumNoteAssetsSizes holds details about calls to the SumNoteAssetsSizes method.
 		SumNoteAssetsSizes []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 		}
 	}
-	lockCountAllNotePaths     sync.RWMutex
-	lockCountNoteAssets       sync.RWMutex
-	lockCountNoteVersions     sync.RWMutex
-	lockCountVisibleNotePaths sync.RWMutex
-	lockSumNoteAssetsSizes    sync.RWMutex
+	lockCountAllNotePaths       sync.RWMutex
+	lockCountNoteAssets         sync.RWMutex
+	lockCountNoteVersions       sync.RWMutex
+	lockCountVisibleNotePaths   sync.RWMutex
+	lockListGoqiteAllQueueStats sync.RWMutex
+	lockSumNoteAssetsSizes      sync.RWMutex
 }
 
 // CountAllNotePaths calls CountAllNotePathsFunc.
@@ -215,6 +228,38 @@ func (mock *EnvMock) CountVisibleNotePathsCalls() []struct {
 	mock.lockCountVisibleNotePaths.RLock()
 	calls = mock.calls.CountVisibleNotePaths
 	mock.lockCountVisibleNotePaths.RUnlock()
+	return calls
+}
+
+// ListGoqiteAllQueueStats calls ListGoqiteAllQueueStatsFunc.
+func (mock *EnvMock) ListGoqiteAllQueueStats(ctx context.Context) ([]db.ListGoqiteAllQueueStatsRow, error) {
+	if mock.ListGoqiteAllQueueStatsFunc == nil {
+		panic("EnvMock.ListGoqiteAllQueueStatsFunc: method is nil but Env.ListGoqiteAllQueueStats was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+	}{
+		Ctx: ctx,
+	}
+	mock.lockListGoqiteAllQueueStats.Lock()
+	mock.calls.ListGoqiteAllQueueStats = append(mock.calls.ListGoqiteAllQueueStats, callInfo)
+	mock.lockListGoqiteAllQueueStats.Unlock()
+	return mock.ListGoqiteAllQueueStatsFunc(ctx)
+}
+
+// ListGoqiteAllQueueStatsCalls gets all the calls that were made to ListGoqiteAllQueueStats.
+// Check the length with:
+//
+//	len(mockedEnv.ListGoqiteAllQueueStatsCalls())
+func (mock *EnvMock) ListGoqiteAllQueueStatsCalls() []struct {
+	Ctx context.Context
+} {
+	var calls []struct {
+		Ctx context.Context
+	}
+	mock.lockListGoqiteAllQueueStats.RLock()
+	calls = mock.calls.ListGoqiteAllQueueStats
+	mock.lockListGoqiteAllQueueStats.RUnlock()
 	return calls
 }
 

--- a/internal/metrics/updater.go
+++ b/internal/metrics/updater.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+
+	"trip2g/internal/db"
 )
 
 //go:generate go tool github.com/matryer/moq -out test.go -pkg metrics . Env
@@ -16,6 +18,7 @@ type Env interface {
 	CountNoteVersions(ctx context.Context) (int64, error)
 	SumNoteAssetsSizes(ctx context.Context) (int64, error)
 	CountNoteAssets(ctx context.Context) (int64, error)
+	ListGoqiteAllQueueStats(ctx context.Context) ([]db.ListGoqiteAllQueueStatsRow, error)
 }
 
 // Updater periodically updates Prometheus metrics.
@@ -26,40 +29,53 @@ type Updater struct {
 	noteVersions     prometheus.Gauge
 	noteAssetsSize   prometheus.Gauge
 	noteAssetsCount  prometheus.Gauge
+	queueDepth       *prometheus.GaugeVec
 	interval         time.Duration
 }
 
-// NewUpdater creates a metrics updater with Prometheus gauges.
-func NewUpdater(env Env, interval time.Duration) *Updater {
+// NewUpdater creates a metrics updater with Prometheus gauges, registered on reg.
+func NewUpdater(env Env, interval time.Duration, reg prometheus.Registerer) *Updater {
 	allNotePaths := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "trip2g_note_paths_all",
 		Help: "Total number of note paths (including hidden)",
 	})
-	prometheus.MustRegister(allNotePaths)
+	reg.MustRegister(allNotePaths)
 
 	visibleNotePaths := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "trip2g_note_paths_visible",
 		Help: "Number of visible note paths (excluding hidden)",
 	})
-	prometheus.MustRegister(visibleNotePaths)
+	reg.MustRegister(visibleNotePaths)
 
 	noteVersions := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "trip2g_note_versions",
 		Help: "Total number of note versions",
 	})
-	prometheus.MustRegister(noteVersions)
+	reg.MustRegister(noteVersions)
 
 	noteAssetsSize := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "trip2g_note_assets_bytes",
 		Help: "Total size of note assets in bytes",
 	})
-	prometheus.MustRegister(noteAssetsSize)
+	reg.MustRegister(noteAssetsSize)
 
 	noteAssetsCount := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "trip2g_note_assets",
 		Help: "Number of note assets",
 	})
-	prometheus.MustRegister(noteAssetsCount)
+	reg.MustRegister(noteAssetsCount)
+
+	// state="pending" is never-received jobs; state="retrying" is jobs redelivered
+	// at least once (received > 1). goqite's per-queue MaxReceive lives only in
+	// process memory (appQueue), not the DB, so a job that finally exceeds it and
+	// becomes undeliverable still shows up here as "retrying" rather than a
+	// separate "dead" state — a sustained climb in either state is the signal
+	// worth alerting on.
+	queueDepth := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "trip2g_job_queue_depth",
+		Help: "Number of goqite job-queue rows by queue and state (pending, retrying)",
+	}, []string{"queue", "state"})
+	reg.MustRegister(queueDepth)
 
 	return &Updater{
 		env:              env,
@@ -68,6 +84,7 @@ func NewUpdater(env Env, interval time.Duration) *Updater {
 		noteVersions:     noteVersions,
 		noteAssetsSize:   noteAssetsSize,
 		noteAssetsCount:  noteAssetsCount,
+		queueDepth:       queueDepth,
 		interval:         interval,
 	}
 }
@@ -122,5 +139,16 @@ func (u *Updater) updateMetrics(ctx context.Context) {
 	assetsCount, err := u.env.CountNoteAssets(ctx)
 	if err == nil {
 		u.noteAssetsCount.Set(float64(assetsCount))
+	}
+
+	// Job queue depth, per queue. Reset first so a queue that drains to zero
+	// (and drops out of the grouped query) doesn't leave a stale nonzero value.
+	stats, err := u.env.ListGoqiteAllQueueStats(ctx)
+	if err == nil {
+		u.queueDepth.Reset()
+		for _, s := range stats {
+			u.queueDepth.WithLabelValues(s.Queue, "pending").Set(float64(s.PendingCount))
+			u.queueDepth.WithLabelValues(s.Queue, "retrying").Set(float64(s.RetryCount))
+		}
 	}
 }

--- a/internal/metrics/updater_test.go
+++ b/internal/metrics/updater_test.go
@@ -1,0 +1,70 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"trip2g/internal/db"
+)
+
+func TestUpdater_QueueDepth(t *testing.T) {
+	reg := prometheus.NewRegistry()
+
+	env := &EnvMock{
+		CountAllNotePathsFunc:     func(ctx context.Context) (int64, error) { return 0, nil },
+		CountVisibleNotePathsFunc: func(ctx context.Context) (int64, error) { return 0, nil },
+		CountNoteVersionsFunc:     func(ctx context.Context) (int64, error) { return 0, nil },
+		SumNoteAssetsSizesFunc:    func(ctx context.Context) (int64, error) { return 0, nil },
+		CountNoteAssetsFunc:       func(ctx context.Context) (int64, error) { return 0, nil },
+		ListGoqiteAllQueueStatsFunc: func(ctx context.Context) ([]db.ListGoqiteAllQueueStatsRow, error) {
+			return []db.ListGoqiteAllQueueStatsRow{
+				{Queue: "global_jobs", TotalJobs: 12, PendingCount: 5, RetryCount: 2},
+			}, nil
+		},
+	}
+
+	u := NewUpdater(env, 0, reg)
+	u.updateMetrics(context.Background())
+
+	pending := findMetric(t, reg, "trip2g_job_queue_depth", map[string]string{"queue": "global_jobs", "state": "pending"})
+	require.InDelta(t, 5, pending.GetGauge().GetValue(), 1e-9)
+
+	retrying := findMetric(t, reg, "trip2g_job_queue_depth", map[string]string{"queue": "global_jobs", "state": "retrying"})
+	require.InDelta(t, 2, retrying.GetGauge().GetValue(), 1e-9)
+}
+
+func TestUpdater_QueueDepth_ResetsDrainedQueues(t *testing.T) {
+	reg := prometheus.NewRegistry()
+
+	calls := 0
+	env := &EnvMock{
+		CountAllNotePathsFunc:     func(ctx context.Context) (int64, error) { return 0, nil },
+		CountVisibleNotePathsFunc: func(ctx context.Context) (int64, error) { return 0, nil },
+		CountNoteVersionsFunc:     func(ctx context.Context) (int64, error) { return 0, nil },
+		SumNoteAssetsSizesFunc:    func(ctx context.Context) (int64, error) { return 0, nil },
+		CountNoteAssetsFunc:       func(ctx context.Context) (int64, error) { return 0, nil },
+		ListGoqiteAllQueueStatsFunc: func(ctx context.Context) ([]db.ListGoqiteAllQueueStatsRow, error) {
+			calls++
+			if calls == 1 {
+				return []db.ListGoqiteAllQueueStatsRow{{Queue: "global_jobs", TotalJobs: 3, PendingCount: 3}}, nil
+			}
+			// Queue fully drained: absent from the grouped query results.
+			return nil, nil
+		},
+	}
+
+	u := NewUpdater(env, 0, reg)
+	u.updateMetrics(context.Background())
+	u.updateMetrics(context.Background())
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, mf := range families {
+		if mf.GetName() == "trip2g_job_queue_depth" {
+			require.Empty(t, mf.GetMetric(), "stale queue depth series must be reset after the queue drains")
+		}
+	}
+}

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -2,15 +2,22 @@ package openai
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
+	"strings"
+	"time"
 
 	"github.com/sashabaranov/go-openai"
+
+	"trip2g/internal/metrics"
 )
 
 // Client wraps an OpenAI-compatible API for embedding generation.
 type Client struct {
 	client    *openai.Client
 	modelName string
+	metrics   *metrics.EmbeddingMetrics
 }
 
 // EmbeddingResult holds the embedding vector and token usage.
@@ -18,6 +25,14 @@ type EmbeddingResult struct {
 	Vector []float32
 	Tokens int
 }
+
+// Bounded kind labels for embedding requests — what the text being embedded is.
+const (
+	KindWholeNote = "whole_note"
+	KindChunk     = "chunk"
+	KindQuery     = "query"
+	KindDebug     = "debug"
+)
 
 // New creates a new OpenAI-compatible embedding client.
 // modelName is the model identifier sent in API requests (e.g. "text-embedding-3-small"
@@ -35,14 +50,21 @@ func New(apiKey string, modelName string, baseURL string) *Client {
 	}
 }
 
+// SetMetrics wires the embedding request/duration metrics. Optional — a
+// client without metrics set (e.g. in tests) records nothing.
+func (c *Client) SetMetrics(m *metrics.EmbeddingMetrics) {
+	c.metrics = m
+}
+
 // ModelName returns the configured embedding model name.
 func (c *Client) ModelName() string {
 	return c.modelName
 }
 
-// CreateEmbedding generates an embedding for the given text.
-func (c *Client) CreateEmbedding(ctx context.Context, text string) (*EmbeddingResult, error) {
-	results, err := c.CreateEmbeddings(ctx, []string{text})
+// CreateEmbedding generates an embedding for the given text. kind labels the
+// request in metrics (see the Kind* constants).
+func (c *Client) CreateEmbedding(ctx context.Context, text string, kind string) (*EmbeddingResult, error) {
+	results, err := c.CreateEmbeddings(ctx, []string{text}, kind)
 	if err != nil {
 		return nil, err
 	}
@@ -50,20 +72,27 @@ func (c *Client) CreateEmbedding(ctx context.Context, text string) (*EmbeddingRe
 }
 
 // CreateEmbeddings generates embeddings for multiple texts in a single API call.
-func (c *Client) CreateEmbeddings(ctx context.Context, texts []string) ([]EmbeddingResult, error) {
+// kind labels the request in metrics (see the Kind* constants).
+func (c *Client) CreateEmbeddings(ctx context.Context, texts []string, kind string) ([]EmbeddingResult, error) {
 	if len(texts) == 0 {
 		return nil, nil
 	}
+	start := time.Now()
 	resp, err := c.client.CreateEmbeddings(ctx, openai.EmbeddingRequest{
 		Model: openai.EmbeddingModel(c.modelName),
 		Input: texts,
 	})
+	seconds := time.Since(start).Seconds()
 	if err != nil {
+		c.metrics.RecordEmbeddingRequest(kind, "error", classifyError(err), seconds)
 		return nil, err
 	}
 	if len(resp.Data) != len(texts) {
+		c.metrics.RecordEmbeddingRequest(kind, "error", metrics.EmbeddingErrorOther, seconds)
 		return nil, fmt.Errorf("expected %d embeddings, got %d", len(texts), len(resp.Data))
 	}
+	c.metrics.RecordEmbeddingRequest(kind, "ok", "", seconds)
+
 	results := make([]EmbeddingResult, len(texts))
 	for i, d := range resp.Data {
 		results[i] = EmbeddingResult{
@@ -72,4 +101,32 @@ func (c *Client) CreateEmbeddings(ctx context.Context, texts []string) ([]Embedd
 		}
 	}
 	return results, nil
+}
+
+// classifyError maps an embedding API error to a bounded reason label. The
+// batch-too-large and rate-limit (overloaded) cases are the ones that caused
+// the queue-saturation incident this metric exists to catch early.
+func classifyError(err error) string {
+	var apiErr *openai.APIError
+	if errors.As(err, &apiErr) {
+		if apiErr.HTTPStatusCode == http.StatusTooManyRequests {
+			return metrics.EmbeddingErrorOverloaded
+		}
+		if apiErr.HTTPStatusCode == http.StatusBadRequest && looksLikeBatchTooLarge(apiErr.Message) {
+			return metrics.EmbeddingErrorBatchTooLarge
+		}
+		return metrics.EmbeddingErrorOther
+	}
+	var reqErr *openai.RequestError
+	if errors.As(err, &reqErr) {
+		if reqErr.HTTPStatusCode == http.StatusTooManyRequests {
+			return metrics.EmbeddingErrorOverloaded
+		}
+	}
+	return metrics.EmbeddingErrorOther
+}
+
+func looksLikeBatchTooLarge(message string) bool {
+	msg := strings.ToLower(message)
+	return strings.Contains(msg, "batch") || strings.Contains(msg, "too many") || strings.Contains(msg, "too large")
 }


### PR DESCRIPTION
## What was blind

`internal/case/backjob/generatenoteversionembedding/`, `internal/openai/`, and the goqite job queues emitted zero metrics. The queue-saturated-embedding-server incident (fleet search timing out) was only diagnosable by SSHing into TEI logs — nothing showed on graphs, nothing could page.

## Metrics added

**Embedding API requests** (`internal/openai/client.go`, via `EmbeddingMetrics` threaded into `openai.Client`):
- `trip2g_embedding_requests_total{result="ok|error", kind="whole_note|chunk|query|debug", reason=""|"batch_too_large"|"overloaded"|"other"}` — `reason` classifies the failure from the OpenAI-compatible API's `APIError`/`RequestError` (HTTP 429 → `overloaded`, HTTP 400 with a batch/too-large message → `batch_too_large`) — these two were the smoking gun in the incident.
- `trip2g_embedding_request_duration_seconds{kind}` — histogram, default buckets.

**Embed job outcomes** (`internal/case/backjob/generatenoteversionembedding/resolve.go`):
- `trip2g_embedding_jobs_total{result="succeeded|failed"}` — every `Resolve` execution.
- Deviation from the ask: no `"retried"` state. goqite job handlers (`internal/jobs.Register`) only get `(ctx, params)`, not the message's receive count, so a retry attempt is indistinguishable from a first attempt at the `Resolve` call site without deeper goqite plumbing. The queue-depth `retrying` state (below) covers "stuck/retrying" visibility at the queue level instead.

**Regeneration cron** (`internal/case/cronjob/regeneratenoteembeddings/resolve.go`):
- `trip2g_embedding_regen_enqueued_total`, `trip2g_embedding_regen_up_to_date_total`, `trip2g_embedding_regen_errors_total` — counters, incremented by each sweep's `Result`.

**Job queue depth** (`internal/metrics/updater.go`, the existing periodic `Updater` loop):
- `trip2g_job_queue_depth{queue, state="pending|retrying"}` — sampled every `Updater` tick via the already-existing `ListGoqiteAllQueueStats` sqlc query (same one the admin panel/debug endpoint uses), reset before each write so a drained queue doesn't leave a stale nonzero series.
- Deviation from the ask: no separate `"dead"` state. goqite's per-queue `MaxReceive` lives only in process memory (`appQueue.maxReceive`), not in the DB, so "permanently undeliverable" isn't queryable from the `goqite` table alone without extra plumbing. A job that exceeds `MaxReceive` still shows up under `state="retrying"` — a sustained climb in either `pending` or `retrying` is the signal worth alerting on, which is what would have caught this incident.

## Wiring

- `EmbeddingMetrics` registered once in `cmd/server/main.go` (`prometheus.DefaultRegisterer`, same pattern as `MCPMetrics`), then:
  - passed into `openaiClient.SetMetrics(...)` for the request-level counter/histogram.
  - carried on the root `ctx` via `metrics.ContextWithEmbeddingMetrics` *before* the job queues and cron scheduler are constructed from that `ctx`, so job/cron code (no HTTP request to thread metrics through) can pull it back out with `metrics.EmbeddingMetricsFromContext` — nil-safe, so no `Env` interface / mock changes needed in the job/cron packages and all existing tests pass unmodified.
- `openai.Client.CreateEmbedding`/`CreateEmbeddings` gained a `kind` parameter (bounded: `KindWholeNote`/`KindChunk`/`KindQuery`/`KindDebug`); the 4 production call sites were updated. `openai.New(...)` signature is unchanged (11 existing test call sites untouched).
- `metrics.NewUpdater` now takes a `prometheus.Registerer` param (was implicitly using the global registerer) — needed so tests can assert against an isolated registry instead of mutating `prometheus.DefaultRegisterer`/`DefaultGatherer` globals (which `golangci-lint`'s `reassign` linter flags). Production call site passes `prometheus.DefaultRegisterer`, matching `NewMCPMetrics`/`NewEmbeddingMetrics`.

## Alert PromQL

```promql
# Queue backing up — early warning before it climbs into the thousands
trip2g_job_queue_depth{state="pending"} > 500

# Sustained embedding failures (rate limited / batch too large / other)
rate(trip2g_embedding_requests_total{result="error"}[5m]) > 0.1

# Root-cause breakdown by failure reason once the above fires
sum by (reason) (rate(trip2g_embedding_requests_total{result="error"}[5m]))

# Regeneration cron reporting errors
increase(trip2g_embedding_regen_errors_total[1h]) > 0
```

## Testing

- TDD: `internal/metrics/embedding_test.go` (new `EmbeddingMetrics` Observe* methods, nil-safety, context round-trip) and `internal/metrics/updater_test.go` (queue-depth gauge set + reset-on-drain) written alongside the implementation.
- `go build ./...`, `go vet ./...`, `golangci-lint run` (0 issues on touched packages) all clean.
- `go test ./internal/metrics/... ./internal/case/backjob/generatenoteversionembedding/... ./internal/case/cronjob/regeneratenoteembeddings/... ./internal/case/sitesearch/... ./internal/case/mcp/... ./cmd/server/...` — all pass, including every pre-existing test in the two resolve.go packages, unmodified.

Not merged — for review.