### PR TITLE
feat(tge2e): add interactive login subcommand

### DIFF
--- a/cmd/tge2e/login.go
+++ b/cmd/tge2e/login.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	_ "modernc.org/sqlite"
+	"trip2g/internal/dataencryption"
+)
+
+func runLogin() error {
+	apiID, apiHash, err := LoadAPICredentials()
+	if err != nil {
+		return err
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		return fmt.Errorf("failed to open database: %w", err)
+	}
+	defer db.Close()
+
+	var exists int
+	err = db.QueryRow(`select 1 from telegram_accounts where id = 1`).Scan(&exists)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return fmt.Errorf("telegram_accounts: not found (id=1) - seed the DB first: sqlite3 %s < testdata/e2e_seed.sql", dbPath)
+		}
+		return fmt.Errorf("failed to query telegram_accounts: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	result, sessionData, err := AuthenticateAccount(ctx, apiID, apiHash)
+	if err != nil {
+		return fmt.Errorf("authentication failed: %w", err)
+	}
+
+	encryptor, err := dataencryption.NewManager(dataencryption.DefaultConfig())
+	if err != nil {
+		return fmt.Errorf("failed to create encryptor: %w", err)
+	}
+
+	encryptedSession, err := encryptor.EncryptData(sessionData)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt session: %w", err)
+	}
+
+	res, err := db.Exec(`
+		update telegram_accounts
+		set phone = ?, session_data = ?, display_name = ?
+		where id = 1
+	`, result.Phone, encryptedSession, result.DisplayName)
+	if err != nil {
+		return fmt.Errorf("failed to update telegram_accounts: %w", err)
+	}
+	rows, _ := res.RowsAffected()
+	fmt.Printf("telegram_accounts: updated %d row(s)\n", rows)
+	fmt.Printf("Logged in as: %s (%s)\n", result.DisplayName, result.Phone)
+
+	fmt.Println("\nNext step: run ./tge2e -db " + dbPath + " extract to discover channels and write .tg_e2e_session")
+	fmt.Println("(the account must be a member/admin of the 4 test channels for discovery to succeed)")
+
+	return nil
+}

--- a/cmd/tge2e/main.go
+++ b/cmd/tge2e/main.go
@@ -48,6 +48,8 @@ func main() {
 		err = runExtract()
 	case "patch-db":
 		err = runPatchDB()
+	case "login":
+		err = runLogin()
 	case "verify":
 		err = runVerify()
 	case "cleanup":
@@ -82,6 +84,8 @@ Commands:
 
   patch-db  Update database with credentials from .tg_e2e_session
             (reverse of extract)
+
+  login     Interactive account login (phone + SMS code); saves session to telegram_accounts id=1
 
   verify    Check that database credentials are valid
             Returns exit code 0 if ready, 1 if not


### PR DESCRIPTION
## Summary
- Add `login` subcommand to `cmd/tge2e` that runs the existing interactive `AuthenticateAccount` flow (phone + SMS code + optional 2FA)
- On success, encrypts the session and writes it into `telegram_accounts` id=1, same pattern as `patch-db`
- Verifies the `telegram_accounts` row exists before starting the interactive flow, with a clear "seed the DB first" error otherwise

## Test plan
- [x] `go build ./cmd/tge2e` succeeds
- [x] `go vet ./cmd/tge2e/...` clean
- [x] `gofmt -l` clean on changed files
- [x] `tge2e -db x help` lists the new `login` command
- [x] Dispatch verified against a non-seeded DB: correct "seed the DB first" error, no panic
- [x] Dispatch verified into `AuthenticateAccount` against a seeded DB with piped empty stdin: reaches the interactive prompt and returns a clean "phone number is required" error, no panic