### PR TITLE
chore(codeql): ignore generated CLI bundles

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,3 +3,9 @@ name: "CodeQL Config"
 paths-ignore:
   - "assets/milkdown/milkdown.js"
   - "assets/tiptap/tiptap.js"
+  # Generated CLI bundles: large esbuild output (readable, not minified) that
+  # otherwise trips CodeQL's "changes too large" heuristic and mis-attributes
+  # pre-existing alerts to any PR that rebuilds them.
+  - "cli/memcli/dist/**"
+  - "onboarding-vault/.obsidian/plugins/trip2g/memcli.js"
+  - "onboarding-vault/.obsidian/plugins/trip2g/trip2g-sync.mjs"


### PR DESCRIPTION
The readable (unminified) memcli/trip2g-sync bundles are large generated files. When a PR rebuilds them, CodeQL's diff analysis exceeds its size threshold and falls back to attributing pre-existing repo alerts to the PR ("changes too large") — as happened on #190 (3 phantom high alerts, 0 in changed files).

Adds the three committed bundle copies to `paths-ignore` so CodeQL skips them. They are third-party/generated code, not hand-written source, so excluding them from analysis loses nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)