### PR TITLE
fix(instareel): escape slide title before innerHTML

### DIFF
--- a/docs/_layouts/trip2g/instareel.html
+++ b/docs/_layouts/trip2g/instareel.html
@@ -309,7 +309,8 @@
     const promptCounter = document.getElementById('promptCounter');
 
     function renderHighlights(text) {
-      return text.replace(/\[([^\]]+)\]/g, '<span class="hl">$1</span>');
+      const esc = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      return esc.replace(/\[([^\]]+)\]/g, '<span class="hl">$1</span>');
     }
 
     function showSlide(i) {
@@ -943,7 +944,8 @@
     let syncIgnoreUntil = 0; // ignore polls briefly after own send
 
     function renderHighlightsSync(text) {
-      return text.replace(/\[([^\]]+)\]/g, '<span class="hl">$1</span>');
+      const esc = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      return esc.replace(/\[([^\]]+)\]/g, '<span class="hl">$1</span>');
     }
 
     function syncSend(slideIdx) {


### PR DESCRIPTION
Fixes the two `js/xss-through-dom` alerts CodeQL surfaced on #190 (instareel.html:318 and :963).

`renderHighlights`/`renderHighlightsSync` took the slide title — plain text read from `.slide-title`.textContent (instareel.html:288) — and injected it into `innerHTML` after only wrapping `[WORD]` in a span. HTML meta-characters in a title (e.g. a slide titled with `<img onerror=…>`) were reinterpreted as HTML. Now the title is HTML-escaped before the highlight substitution, so only the intended `<span class="hl">` markup is injected.

Low real-world severity (the title is the note author's own markdown), but these templates ship to users' sites and vaults can be multi-author, so escaping is the correct hardening.

Not addressed here: alert #67 (`clear-text-storage` of the Cleanvoice API key in localStorage) — that's the user's own key in their own browser; decision pending (dismiss vs session-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)