### PR TITLE
fix(admin): correct onboarding doc link + honest storage unit label

### DIFF
--- a/assets/ui/admin/dashboard/buildinfo/buildinfo.view.tree
+++ b/assets/ui/admin/dashboard/buildinfo/buildinfo.view.tree
@@ -7,6 +7,6 @@ $trip2g_admin_dashboard_buildinfo $mol_view
 				padding \.5rem .75rem
 			sub / <= build_git_commit @ \Software Version
 		<= OnboardingLink $mol_link
-			uri \https://trip2g.com/docs/onbording
+			uri \https://trip2g.com/docs/onboarding-vault
 			external true
 			title @ \Onboarding Documentation

--- a/assets/ui/admin/dashboard/storageusage/storageusage.view.ts
+++ b/assets/ui/admin/dashboard/storageusage/storageusage.view.ts
@@ -24,7 +24,7 @@ namespace $.$$ {
 
 		override db_label(): string {
 			const d = this.data().db
-			return `${super.db_label()}: ${d.current.toFixed(2)} MB / ${d.limit.toFixed(2)} MB`
+			return `${super.db_label()}: ${d.current.toFixed(2)} MiB / ${d.limit.toFixed(2)} MiB`
 		}
 
 		override db_portion(): number {
@@ -35,7 +35,7 @@ namespace $.$$ {
 
 		override assets_label(): string {
 			const d = this.data().assets
-			return `${super.assets_label()}: ${d.current.toFixed(2)} MB / ${d.limit.toFixed(2)} MB`
+			return `${super.assets_label()}: ${d.current.toFixed(2)} MiB / ${d.limit.toFixed(2)} MiB`
 		}
 
 		override assets_portion(): number {


### PR DESCRIPTION
## Summary

- **Onboarding doc link typo**: `buildinfo.view.tree` linked to `/docs/onbording` (typo). The correct public slug is `/docs/onboarding-vault`, confirmed against `docs/en/user/onboarding-vault.md` (no `route`/`slug` frontmatter override present, so the permalink derives from the vault path itself).
- **Storage usage unit label**: `storageusage.view.ts` labeled quota numbers as "MB", but the GraphQL query requests `format: MB`, and the resolver (`internal/graph/storage_helpers.go:15-16`, case `StorageSizeFormatMb`) divides bytes by `1024*1024` — i.e. true MiB, not decimal MB. Changed frontend labels from "MB" to "MiB" (math untouched). No locale file changes needed — the "MB"/"MiB" strings only live in `view.ts`, not in the `.view.tree.locale=ru.json` files for either component.

## Storage-unit finding

Confirmed via `internal/graph/storage_helpers.go:5-20` (`convertStorageSize`): the `MB` enum case (`internal/graph/schema.graphqls:1148`, wired at `internal/graph/schema.resolvers.go:2171-2178`) computes `bytes / (1024*1024)` — binary MiB math under a "MB" label. This matches the observed 100 MB limit displaying as "95.37" (100/95.37 ≈ 2^20/10^6). Backend left untouched; only the frontend label text was corrected.

## Test plan

- [x] Visual diff review: both edits are single-line string changes, syntax verified by inspection (no `node_modules` available in this worktree for `tsc --noEmit`)
- [x] Checked `.view.tree.locale=ru.json` for buildinfo and storageusage — no unit-label strings present, no changes needed