### PR TITLE
fix(auth): return an error when requesting an email code with no SMTP configured

### DIFF
--- a/cmd/server/email.go
+++ b/cmd/server/email.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"trip2g/internal/case/backjob/sendformsubmit"
 	"trip2g/internal/case/backjob/sendsignincode"
+	"trip2g/internal/case/requestemailsignin"
 	"trip2g/internal/db"
 	"trip2g/internal/model"
 )
@@ -83,6 +84,10 @@ func (a *app) LogSignInCodes() bool {
 	return a.config.LogSignInCodes
 }
 
+func (a *app) SMTPHost() string {
+	return a.config.SMTPHost
+}
+
 func (a *app) EnqueueSendFormSubmitEmail(ctx context.Context, submitID int64) error {
 	return a.SendFormSubmitEmailJob.EnqueueSendFormSubmit(ctx, submitID)
 }
@@ -137,3 +142,4 @@ func (a *app) GetFormSubmitForEmail(ctx context.Context, submitID int64) (*sendf
 
 var _ sendformsubmit.Env = (*app)(nil)
 var _ sendsignincode.Env = (*app)(nil)
+var _ requestemailsignin.Env = (*app)(nil)

--- a/internal/case/createpaymentlink/mocks_test.go
+++ b/internal/case/createpaymentlink/mocks_test.go
@@ -53,11 +53,17 @@ var _ createpaymentlink.Env = &EnvMock{}
 //			InsertPurchaseFunc: func(ctx context.Context, arg db.InsertPurchaseParams) error {
 //				panic("mock out the InsertPurchase method")
 //			},
+//			LogSignInCodesFunc: func() bool {
+//				panic("mock out the LogSignInCodes method")
+//			},
 //			MaxActiveSignInCodesFunc: func() int64 {
 //				panic("mock out the MaxActiveSignInCodes method")
 //			},
 //			PublicURLFunc: func() string {
 //				panic("mock out the PublicURL method")
+//			},
+//			SMTPHostFunc: func() string {
+//				panic("mock out the SMTPHost method")
 //			},
 //			StorePurchaseTokenFunc: func(ctx context.Context, data appmodel.PurchaseToken) (string, error) {
 //				panic("mock out the StorePurchaseToken method")
@@ -117,11 +123,17 @@ type EnvMock struct {
 	// InsertPurchaseFunc mocks the InsertPurchase method.
 	InsertPurchaseFunc func(ctx context.Context, arg db.InsertPurchaseParams) error
 
+	// LogSignInCodesFunc mocks the LogSignInCodes method.
+	LogSignInCodesFunc func() bool
+
 	// MaxActiveSignInCodesFunc mocks the MaxActiveSignInCodes method.
 	MaxActiveSignInCodesFunc func() int64
 
 	// PublicURLFunc mocks the PublicURL method.
 	PublicURLFunc func() string
+
+	// SMTPHostFunc mocks the SMTPHost method.
+	SMTPHostFunc func() string
 
 	// StorePurchaseTokenFunc mocks the StorePurchaseToken method.
 	StorePurchaseTokenFunc func(ctx context.Context, data appmodel.PurchaseToken) (string, error)
@@ -206,11 +218,17 @@ type EnvMock struct {
 			// Arg is the arg argument value.
 			Arg db.InsertPurchaseParams
 		}
+		// LogSignInCodes holds details about calls to the LogSignInCodes method.
+		LogSignInCodes []struct {
+		}
 		// MaxActiveSignInCodes holds details about calls to the MaxActiveSignInCodes method.
 		MaxActiveSignInCodes []struct {
 		}
 		// PublicURL holds details about calls to the PublicURL method.
 		PublicURL []struct {
+		}
+		// SMTPHost holds details about calls to the SMTPHost method.
+		SMTPHost []struct {
 		}
 		// StorePurchaseToken holds details about calls to the StorePurchaseToken method.
 		StorePurchaseToken []struct {
@@ -270,8 +288,10 @@ type EnvMock struct {
 	lockGeneratePurchaseID             sync.RWMutex
 	lockIncrementAndCheckSigninCounter sync.RWMutex
 	lockInsertPurchase                 sync.RWMutex
+	lockLogSignInCodes                 sync.RWMutex
 	lockMaxActiveSignInCodes           sync.RWMutex
 	lockPublicURL                      sync.RWMutex
+	lockSMTPHost                       sync.RWMutex
 	lockStorePurchaseToken             sync.RWMutex
 	lockTryToAutoRegisterUser          sync.RWMutex
 	lockTurnstileSiteKey               sync.RWMutex
@@ -619,6 +639,33 @@ func (mock *EnvMock) InsertPurchaseCalls() []struct {
 	return calls
 }
 
+// LogSignInCodes calls LogSignInCodesFunc.
+func (mock *EnvMock) LogSignInCodes() bool {
+	if mock.LogSignInCodesFunc == nil {
+		panic("EnvMock.LogSignInCodesFunc: method is nil but Env.LogSignInCodes was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockLogSignInCodes.Lock()
+	mock.calls.LogSignInCodes = append(mock.calls.LogSignInCodes, callInfo)
+	mock.lockLogSignInCodes.Unlock()
+	return mock.LogSignInCodesFunc()
+}
+
+// LogSignInCodesCalls gets all the calls that were made to LogSignInCodes.
+// Check the length with:
+//
+//	len(mockedEnv.LogSignInCodesCalls())
+func (mock *EnvMock) LogSignInCodesCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockLogSignInCodes.RLock()
+	calls = mock.calls.LogSignInCodes
+	mock.lockLogSignInCodes.RUnlock()
+	return calls
+}
+
 // MaxActiveSignInCodes calls MaxActiveSignInCodesFunc.
 func (mock *EnvMock) MaxActiveSignInCodes() int64 {
 	if mock.MaxActiveSignInCodesFunc == nil {
@@ -670,6 +717,33 @@ func (mock *EnvMock) PublicURLCalls() []struct {
 	mock.lockPublicURL.RLock()
 	calls = mock.calls.PublicURL
 	mock.lockPublicURL.RUnlock()
+	return calls
+}
+
+// SMTPHost calls SMTPHostFunc.
+func (mock *EnvMock) SMTPHost() string {
+	if mock.SMTPHostFunc == nil {
+		panic("EnvMock.SMTPHostFunc: method is nil but Env.SMTPHost was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockSMTPHost.Lock()
+	mock.calls.SMTPHost = append(mock.calls.SMTPHost, callInfo)
+	mock.lockSMTPHost.Unlock()
+	return mock.SMTPHostFunc()
+}
+
+// SMTPHostCalls gets all the calls that were made to SMTPHost.
+// Check the length with:
+//
+//	len(mockedEnv.SMTPHostCalls())
+func (mock *EnvMock) SMTPHostCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockSMTPHost.RLock()
+	calls = mock.calls.SMTPHost
+	mock.lockSMTPHost.RUnlock()
 	return calls
 }
 

--- a/internal/case/requestemailsignin/mocks_test.go
+++ b/internal/case/requestemailsignin/mocks_test.go
@@ -31,8 +31,14 @@ var _ Env = &EnvMock{}
 //			IncrementAndCheckSigninCounterFunc: func() bool {
 //				panic("mock out the IncrementAndCheckSigninCounter method")
 //			},
+//			LogSignInCodesFunc: func() bool {
+//				panic("mock out the LogSignInCodes method")
+//			},
 //			MaxActiveSignInCodesFunc: func() int64 {
 //				panic("mock out the MaxActiveSignInCodes method")
+//			},
+//			SMTPHostFunc: func() string {
+//				panic("mock out the SMTPHost method")
 //			},
 //			TryToAutoRegisterUserFunc: func(ctx context.Context, email string) (*db.User, error) {
 //				panic("mock out the TryToAutoRegisterUser method")
@@ -68,8 +74,14 @@ type EnvMock struct {
 	// IncrementAndCheckSigninCounterFunc mocks the IncrementAndCheckSigninCounter method.
 	IncrementAndCheckSigninCounterFunc func() bool
 
+	// LogSignInCodesFunc mocks the LogSignInCodes method.
+	LogSignInCodesFunc func() bool
+
 	// MaxActiveSignInCodesFunc mocks the MaxActiveSignInCodes method.
 	MaxActiveSignInCodesFunc func() int64
+
+	// SMTPHostFunc mocks the SMTPHost method.
+	SMTPHostFunc func() string
 
 	// TryToAutoRegisterUserFunc mocks the TryToAutoRegisterUser method.
 	TryToAutoRegisterUserFunc func(ctx context.Context, email string) (*db.User, error)
@@ -114,8 +126,14 @@ type EnvMock struct {
 		// IncrementAndCheckSigninCounter holds details about calls to the IncrementAndCheckSigninCounter method.
 		IncrementAndCheckSigninCounter []struct {
 		}
+		// LogSignInCodes holds details about calls to the LogSignInCodes method.
+		LogSignInCodes []struct {
+		}
 		// MaxActiveSignInCodes holds details about calls to the MaxActiveSignInCodes method.
 		MaxActiveSignInCodes []struct {
+		}
+		// SMTPHost holds details about calls to the SMTPHost method.
+		SMTPHost []struct {
 		}
 		// TryToAutoRegisterUser holds details about calls to the TryToAutoRegisterUser method.
 		TryToAutoRegisterUser []struct {
@@ -155,7 +173,9 @@ type EnvMock struct {
 	lockCreateSignInCode               sync.RWMutex
 	lockEnqueueRequestSignInEmail      sync.RWMutex
 	lockIncrementAndCheckSigninCounter sync.RWMutex
+	lockLogSignInCodes                 sync.RWMutex
 	lockMaxActiveSignInCodes           sync.RWMutex
+	lockSMTPHost                       sync.RWMutex
 	lockTryToAutoRegisterUser          sync.RWMutex
 	lockTurnstileSiteKey               sync.RWMutex
 	lockUserBanByUserID                sync.RWMutex
@@ -302,6 +322,33 @@ func (mock *EnvMock) IncrementAndCheckSigninCounterCalls() []struct {
 	return calls
 }
 
+// LogSignInCodes calls LogSignInCodesFunc.
+func (mock *EnvMock) LogSignInCodes() bool {
+	if mock.LogSignInCodesFunc == nil {
+		panic("EnvMock.LogSignInCodesFunc: method is nil but Env.LogSignInCodes was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockLogSignInCodes.Lock()
+	mock.calls.LogSignInCodes = append(mock.calls.LogSignInCodes, callInfo)
+	mock.lockLogSignInCodes.Unlock()
+	return mock.LogSignInCodesFunc()
+}
+
+// LogSignInCodesCalls gets all the calls that were made to LogSignInCodes.
+// Check the length with:
+//
+//	len(mockedEnv.LogSignInCodesCalls())
+func (mock *EnvMock) LogSignInCodesCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockLogSignInCodes.RLock()
+	calls = mock.calls.LogSignInCodes
+	mock.lockLogSignInCodes.RUnlock()
+	return calls
+}
+
 // MaxActiveSignInCodes calls MaxActiveSignInCodesFunc.
 func (mock *EnvMock) MaxActiveSignInCodes() int64 {
 	if mock.MaxActiveSignInCodesFunc == nil {
@@ -326,6 +373,33 @@ func (mock *EnvMock) MaxActiveSignInCodesCalls() []struct {
 	mock.lockMaxActiveSignInCodes.RLock()
 	calls = mock.calls.MaxActiveSignInCodes
 	mock.lockMaxActiveSignInCodes.RUnlock()
+	return calls
+}
+
+// SMTPHost calls SMTPHostFunc.
+func (mock *EnvMock) SMTPHost() string {
+	if mock.SMTPHostFunc == nil {
+		panic("EnvMock.SMTPHostFunc: method is nil but Env.SMTPHost was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockSMTPHost.Lock()
+	mock.calls.SMTPHost = append(mock.calls.SMTPHost, callInfo)
+	mock.lockSMTPHost.Unlock()
+	return mock.SMTPHostFunc()
+}
+
+// SMTPHostCalls gets all the calls that were made to SMTPHost.
+// Check the length with:
+//
+//	len(mockedEnv.SMTPHostCalls())
+func (mock *EnvMock) SMTPHostCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockSMTPHost.RLock()
+	calls = mock.calls.SMTPHost
+	mock.lockSMTPHost.RUnlock()
 	return calls
 }
 

--- a/internal/case/requestemailsignin/resolve.go
+++ b/internal/case/requestemailsignin/resolve.go
@@ -20,6 +20,8 @@ type Env interface {
 	CreateSignInCode(ctx context.Context, userID int64) (string, error)
 	UserBanByUserID(ctx context.Context, userID int64) (*db.UserBan, error)
 	MaxActiveSignInCodes() int64
+	SMTPHost() string
+	LogSignInCodes() bool
 
 	// patreon, boosty, etc
 	TryToAutoRegisterUser(ctx context.Context, email string) (*db.User, error)
@@ -63,6 +65,10 @@ func Resolve(ctx context.Context, env Env, input Input, remoteIP string) (model.
 		if env.IncrementAndCheckSigninCounter() {
 			return &model.RequestCaptchaPayload{SiteKey: siteKey}, nil
 		}
+	}
+
+	if env.SMTPHost() == "" && !env.LogSignInCodes() {
+		return &model.ErrorPayload{Message: "Email delivery isn't configured on this server, so no code can be sent. Sign in with Google or GitHub instead, or ask the site admin."}, nil
 	}
 
 	user, err := env.UserByEmail(ctx, input.Email)

--- a/internal/case/requestemailsignin/resolve.go
+++ b/internal/case/requestemailsignin/resolve.go
@@ -68,7 +68,9 @@ func Resolve(ctx context.Context, env Env, input Input, remoteIP string) (model.
 	}
 
 	if env.SMTPHost() == "" && !env.LogSignInCodes() {
-		return &model.ErrorPayload{Message: "Email delivery isn't configured on this server, so no code can be sent. Sign in with Google or GitHub instead, or ask the site admin."}, nil
+		return &model.ErrorPayload{
+			Message: "Email delivery isn't configured on this server, so no code can be sent. Sign in with Google or GitHub instead, or ask the site admin.",
+		}, nil
 	}
 
 	user, err := env.UserByEmail(ctx, input.Email)

--- a/internal/case/requestemailsignin/resolve_test.go
+++ b/internal/case/requestemailsignin/resolve_test.go
@@ -177,7 +177,11 @@ func TestNoSMTP_LogSignInCodesDisabled_ReturnsError(t *testing.T) {
 
 	errPayload, ok := result.(*model.ErrorPayload)
 	require.True(t, ok, "expected ErrorPayload, got %T", result)
-	require.Equal(t, "Email delivery isn't configured on this server, so no code can be sent. Sign in with Google or GitHub instead, or ask the site admin.", errPayload.Message)
+	require.Equal(
+		t,
+		"Email delivery isn't configured on this server, so no code can be sent. Sign in with Google or GitHub instead, or ask the site admin.",
+		errPayload.Message,
+	)
 	require.Empty(t, env.EnqueueRequestSignInEmailCalls(), "must not queue a code that can't be delivered")
 }
 

--- a/internal/case/requestemailsignin/resolve_test.go
+++ b/internal/case/requestemailsignin/resolve_test.go
@@ -29,6 +29,8 @@ func fullFlowEnv(siteKey string) *EnvMock {
 			return 0, nil
 		},
 		MaxActiveSignInCodesFunc: func() int64 { return 3 },
+		SMTPHostFunc:             func() string { return "smtp.example.com" },
+		LogSignInCodesFunc:       func() bool { return false },
 		CreateSignInCodeFunc: func(_ context.Context, _ int64) (string, error) {
 			return "ABC123", nil
 		},
@@ -160,4 +162,52 @@ func TestMaxActiveSignInCodes_AtLimitRejected(t *testing.T) {
 	require.True(t, ok, "count == limit must return ErrorPayload, got %T", result)
 	require.Equal(t, "too_many_sign_in_codes", errPayload.Message)
 	require.Empty(t, env.CreateSignInCodeCalls(), "must not create a code once the limit is reached")
+}
+
+// TestNoSMTP_LogSignInCodesDisabled_ReturnsError verifies that when no SMTP is
+// configured and code logging is disabled, no code can ever be delivered, so
+// Resolve returns an ErrorPayload without creating or queueing a code.
+func TestNoSMTP_LogSignInCodesDisabled_ReturnsError(t *testing.T) {
+	env := fullFlowEnv("")
+	env.SMTPHostFunc = func() string { return "" }
+	env.LogSignInCodesFunc = func() bool { return false }
+
+	result, err := Resolve(context.Background(), env, Input{Email: "user@example.com"}, "")
+	require.NoError(t, err)
+
+	errPayload, ok := result.(*model.ErrorPayload)
+	require.True(t, ok, "expected ErrorPayload, got %T", result)
+	require.Equal(t, "Email delivery isn't configured on this server, so no code can be sent. Sign in with Google or GitHub instead, or ask the site admin.", errPayload.Message)
+	require.Empty(t, env.EnqueueRequestSignInEmailCalls(), "must not queue a code that can't be delivered")
+}
+
+// TestNoSMTP_LogSignInCodesEnabled_ProceedsNormally verifies that when SMTP is
+// not configured but code logging is enabled, the code is still logged
+// server-side, so Resolve proceeds to the normal success path.
+func TestNoSMTP_LogSignInCodesEnabled_ProceedsNormally(t *testing.T) {
+	env := fullFlowEnv("")
+	env.SMTPHostFunc = func() string { return "" }
+	env.LogSignInCodesFunc = func() bool { return true }
+
+	result, err := Resolve(context.Background(), env, Input{Email: "user@example.com"}, "")
+	require.NoError(t, err)
+
+	payload, ok := result.(*model.RequestEmailSignInCodePayload)
+	require.True(t, ok, "expected RequestEmailSignInCodePayload, got %T", result)
+	require.True(t, payload.Success)
+}
+
+// TestSMTPConfigured_ProceedsNormally verifies that when SMTP is configured,
+// the normal success path is unaffected regardless of LogSignInCodes.
+func TestSMTPConfigured_ProceedsNormally(t *testing.T) {
+	env := fullFlowEnv("")
+	env.SMTPHostFunc = func() string { return "smtp.example.com" }
+	env.LogSignInCodesFunc = func() bool { return false }
+
+	result, err := Resolve(context.Background(), env, Input{Email: "user@example.com"}, "")
+	require.NoError(t, err)
+
+	payload, ok := result.(*model.RequestEmailSignInCodePayload)
+	require.True(t, ok, "expected RequestEmailSignInCodePayload, got %T", result)
+	require.True(t, payload.Success)
 }


### PR DESCRIPTION
## Bug

Requesting an email sign-in code with no SMTP configured returned success and the frontend showed "We sent a code to your email" + an "Open email" button — but `SendMail` silently no-ops when `SMTPHost` is empty (`cmd/server/email.go`), so nothing was ever sent. Users got stuck waiting for a code that never arrives.

## Fix

`internal/case/requestemailsignin/resolve.go`: `Resolve` now returns an `ErrorPayload` (not a fake success) when both `SMTPHost` is empty and `LogSignInCodes` is disabled — before any sign-in code is created or queued.

Three states:
- No SMTP + `LogSignInCodes=false` → `ErrorPayload` with an actionable message ("sign in with Google/GitHub instead, or ask the site admin")
- No SMTP + `LogSignInCodes=true` → unchanged: proceeds normally, code is generated and logged (bootstrap path added in #197)
- SMTP configured → unchanged: normal email delivery

`ErrorPayload` is already a member of the `RequestEmailSignInCodeOrErrorPayload` union, so no GraphQL schema change was needed.

## Frontend

No change needed — `assets/ui/auth/auth.view.ts`'s `submit()` already handles the `ErrorPayload` case generically for this mutation: it sets `request_error` and returns without advancing to the "code sent" screen.

## Testing

Added to `internal/case/requestemailsignin/resolve_test.go`:
- no SMTP + no logging → `ErrorPayload`, no code created/queued
- no SMTP + logging enabled → proceeds to success
- SMTP configured → proceeds to success (existing behavior, kept green)

`go test ./internal/case/requestemailsignin/...` passes (13/13).