### PR TITLE
fix(email): honor SMTP_STARTTLS=false

### DIFF
--- a/cmd/server/email.go
+++ b/cmd/server/email.go
@@ -70,13 +70,44 @@ func (a *app) SendMail(_ context.Context, data model.Mail) error {
 		return wc.Close()
 	}
 
-	// No TLS (e.g. MailHog on port 1025).
-	err := smtp.SendMail(addr, auth, a.config.MailFrom, []string{data.To}, []byte(body))
+	// Plaintext SMTP: sends an explicit conversation and never issues STARTTLS,
+	// even if the server advertises it (smtp.SendMail does opportunistic
+	// STARTTLS regardless of this flag, which breaks e.g. a local Postfix relay
+	// presenting a self-signed cert for its own hostname).
+	c, err := smtp.Dial(addr)
 	if err != nil {
-		return fmt.Errorf("smtp send: %w", err)
+		return fmt.Errorf("smtp dial: %w", err)
+	}
+	defer c.Close()
+
+	if auth != nil {
+		err = c.Auth(auth)
+		if err != nil {
+			return fmt.Errorf("smtp auth: %w", err)
+		}
 	}
 
-	return nil
+	err = c.Mail(a.config.MailFrom)
+	if err != nil {
+		return fmt.Errorf("smtp mail from: %w", err)
+	}
+
+	err = c.Rcpt(data.To)
+	if err != nil {
+		return fmt.Errorf("smtp rcpt: %w", err)
+	}
+
+	wc, err := c.Data()
+	if err != nil {
+		return fmt.Errorf("smtp data: %w", err)
+	}
+
+	_, err = fmt.Fprint(wc, body)
+	if err != nil {
+		return fmt.Errorf("smtp write: %w", err)
+	}
+
+	return wc.Close()
 }
 
 func (a *app) LogSignInCodes() bool {

--- a/cmd/server/email_test.go
+++ b/cmd/server/email_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+
+	"trip2g/internal/appconfig"
+	"trip2g/internal/logger"
+	"trip2g/internal/model"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSMTPServer is a minimal in-process SMTP server that advertises
+// STARTTLS in its EHLO response (mirroring a real Postfix relay), but never
+// actually performs the TLS handshake. It records whether the connecting
+// client issued a STARTTLS command, so tests can assert the client never
+// attempted opportunistic TLS when it shouldn't.
+type fakeSMTPServer struct {
+	ln net.Listener
+	mu sync.Mutex
+
+	starttlsIssued bool
+}
+
+func newFakeSMTPServer(t *testing.T) *fakeSMTPServer {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	s := &fakeSMTPServer{ln: ln}
+	go s.serve()
+	t.Cleanup(func() { ln.Close() })
+	return s
+}
+
+func (s *fakeSMTPServer) addr() string {
+	return s.ln.Addr().String()
+}
+
+func (s *fakeSMTPServer) sawSTARTTLS() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.starttlsIssued
+}
+
+func (s *fakeSMTPServer) serve() {
+	for {
+		conn, err := s.ln.Accept()
+		if err != nil {
+			return
+		}
+		go s.handle(conn)
+	}
+}
+
+func (s *fakeSMTPServer) handle(conn net.Conn) {
+	defer conn.Close()
+
+	r := bufio.NewReader(conn)
+	w := conn
+
+	fmt.Fprintf(w, "220 fake.smtp.local ESMTP\r\n")
+
+	inData := false
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return
+		}
+		line = strings.TrimRight(line, "\r\n")
+
+		if inData {
+			if line == "." {
+				inData = false
+				fmt.Fprintf(w, "250 OK\r\n")
+			}
+			continue
+		}
+
+		upper := strings.ToUpper(line)
+		switch {
+		case strings.HasPrefix(upper, "EHLO"):
+			fmt.Fprintf(w, "250-fake.smtp.local\r\n")
+			fmt.Fprintf(w, "250 STARTTLS\r\n")
+		case strings.HasPrefix(upper, "HELO"):
+			fmt.Fprintf(w, "250 fake.smtp.local\r\n")
+		case strings.HasPrefix(upper, "STARTTLS"):
+			s.mu.Lock()
+			s.starttlsIssued = true
+			s.mu.Unlock()
+			fmt.Fprintf(w, "220 ready to start TLS\r\n")
+		case strings.HasPrefix(upper, "MAIL FROM"):
+			fmt.Fprintf(w, "250 OK\r\n")
+		case strings.HasPrefix(upper, "RCPT TO"):
+			fmt.Fprintf(w, "250 OK\r\n")
+		case upper == "DATA":
+			inData = true
+			fmt.Fprintf(w, "354 End data with <CR><LF>.<CR><LF>\r\n")
+		case upper == "QUIT":
+			fmt.Fprintf(w, "221 Bye\r\n")
+			return
+		default:
+			fmt.Fprintf(w, "250 OK\r\n")
+		}
+	}
+}
+
+// TestSendMail_StartTLSFalse_NeverIssuesSTARTTLS reproduces the field bug:
+// a server advertising STARTTLS in EHLO (like a real Postfix relay with a
+// self-signed cert) must not trigger opportunistic TLS when
+// SMTPStartTLS=false, or the send fails with a cert-verification error.
+func TestSendMail_StartTLSFalse_NeverIssuesSTARTTLS(t *testing.T) {
+	server := newFakeSMTPServer(t)
+	host, port := splitHostPort(t, server.addr())
+
+	a := &app{appState: &appState{
+		log: &logger.TestLogger{},
+		config: &appconfig.Config{
+			SMTPHost:     host,
+			SMTPPort:     port,
+			SMTPStartTLS: false,
+			MailFrom:     "no-reply@example.com",
+		},
+	}}
+
+	err := a.SendMail(context.Background(), model.Mail{
+		To:      "user@example.com",
+		Subject: "Test",
+		Plain:   []byte("hello"),
+	})
+	require.NoError(t, err)
+	require.False(t, server.sawSTARTTLS(), "plaintext path must never issue STARTTLS")
+}
+
+func splitHostPort(t *testing.T, addr string) (string, int) {
+	t.Helper()
+	host, portStr, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	var port int
+	_, err = fmt.Sscanf(portStr, "%d", &port)
+	require.NoError(t, err)
+	return host, port
+}


### PR DESCRIPTION
## Bug

`cmd/server/email.go` `SendMail`, `SMTPStartTLS == false` branch called Go's `smtp.SendMail(addr, auth, ...)`. That helper does **opportunistic STARTTLS** internally: if the target server advertises STARTTLS in its EHLO response, it upgrades the connection and verifies the server cert against the hostname — regardless of `SMTPStartTLS` config.

Field-tested against a real local Postfix relay (which advertises STARTTLS with a self-signed cert for its own hostname). With `SMTP_STARTTLS=false` set, the send still failed:

```
smtp send: tls: failed to verify certificate: x509: certificate is valid for <host>, not localhost
```

The old comment ("No TLS (e.g. MailHog on port 1025)") was misleading — that path only actually skipped TLS when the server didn't advertise STARTTLS at all.

## Fix

Replaced the `smtp.SendMail(...)` call in the `SMTPStartTLS == false` branch with an explicit plaintext SMTP conversation (`Dial` → `Auth` → `Mail` → `Rcpt` → `Data` → write → close) that never calls `StartTLS`, mirroring the structure of the existing `SMTPStartTLS == true` branch. That branch is untouched. `smtp.PlainAuth`'s built-in refusal to send credentials over unencrypted non-localhost connections is preserved as-is (correct behavior, not worked around).

## Testing

Added `cmd/server/email_test.go` with a fake in-process SMTP server (`net.Listener` on `127.0.0.1:0`) that:
- Advertises `STARTTLS` in its EHLO response (reproducing the real Postfix behavior)
- Records whether the client ever issued a `STARTTLS` command

`TestSendMail_StartTLSFalse_NeverIssuesSTARTTLS` asserts that with `SMTPStartTLS=false`, `SendMail` completes successfully against this fake server and the server never saw a `STARTTLS` command from the client.

Confirmed red→green: ran the new test against the old `smtp.SendMail`-based code first — it failed with `tls: first record does not look like a TLS handshake` (the fake server's plaintext response confusing the opportunistic-TLS handshake), reproducing the bug class. After the fix, the test passes.

```
go test -tags dev ./cmd/server/...
ok  	trip2g/cmd/server	1.223s
```

`go vet -tags dev ./cmd/server/...` and `gofmt -l cmd/server/email.go cmd/server/email_test.go` are both clean.

`go build ./...` in a fresh worktree fails only on pre-existing missing gitignored frontend assets (`assets/embed.go:8: pattern ui/admin/-/web.js: no matching files found`), unrelated to this change.