### PR TITLE
fix(admin): show "unlimited" storage label when the quota is 0

### DIFF
--- a/assets/ui/admin/dashboard/storageusage/storageusage.view.ts
+++ b/assets/ui/admin/dashboard/storageusage/storageusage.view.ts
@@ -24,6 +24,7 @@ namespace $.$$ {
 
 		override db_label(): string {
 			const d = this.data().db
+			if (d.limit === 0) return `${super.db_label()}: ${d.current.toFixed(2)} MiB used (unlimited)`
 			return `${super.db_label()}: ${d.current.toFixed(2)} MiB / ${d.limit.toFixed(2)} MiB`
 		}
 
@@ -35,6 +36,7 @@ namespace $.$$ {
 
 		override assets_label(): string {
 			const d = this.data().assets
+			if (d.limit === 0) return `${super.assets_label()}: ${d.current.toFixed(2)} MiB used (unlimited)`
 			return `${super.assets_label()}: ${d.current.toFixed(2)} MiB / ${d.limit.toFixed(2)} MiB`
 		}
 


### PR DESCRIPTION
## Summary
- `db_label()` and `assets_label()` in the admin storage-usage dashboard rendered `X.XX MiB / 0.00 MiB` when a quota is unlimited (limit === 0)
- Now renders `X.XX MiB used (unlimited)` in that case; unchanged when limit > 0

## Test plan
- [x] Reviewed diff for syntax correctness (no local tsc runnable from this fresh worktree — no `src` dir under project tsconfig)
- [ ] Visual check in admin dashboard with an unlimited storage plan