### PR TITLE
feat(install): download progress bar

### DIFF
--- a/scripts/simple-install.sh
+++ b/scripts/simple-install.sh
@@ -188,9 +188,9 @@ else
 Pass TRIP2G_BINARY_URL=<url> or pre-place a binary at $BIN and re-run."
   ASSET="trip2g_${TAG}_linux_${GOARCH}.tar.gz"
   URL="https://github.com/$REPO/releases/download/$TAG/$ASSET"
-  say "Release $TAG → $ASSET"
+  say "Downloading $ASSET"
   TMPD=$(mktemp -d)
-  curl -fsSL -o "$TMPD/$ASSET" "$URL" \
+  curl -fL --progress-bar -o "$TMPD/$ASSET" "$URL" \
     || die "download failed: $URL
 Pass TRIP2G_BINARY_URL=<url> or pre-place a binary at $BIN and re-run."
   # checksum: the release ships <asset>.sha256 — verify when possible


### PR DESCRIPTION
The installer downloaded the ~36 MB release binary with `curl -fsSL` (silent), so a fresh install sat on a blank line for 10-15s with no feedback. Switch to `curl -fL --progress-bar` so the download shows a progress bar — real feedback for the operator (and it reads much better in the install demo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)