### PR TITLE
fix(telegram): request chat_member updates + correct sendContentMenu id-space

### DIFF
--- a/docs/dev/telegram_e2e.md
+++ b/docs/dev/telegram_e2e.md
@@ -203,3 +203,91 @@ delete from telegram_publish_sent_messages;
 delete from telegram_publish_sent_account_messages;
 update telegram_publish_notes set published_at = null, published_version_id = null, error_count = 0, last_error = null;
 ```
+
+## Live TG↔subgraph access e2e
+
+A separate, real end-to-end test drives an actual authenticated Telegram **user
+account** against a running trip2g bot and asserts the TG↔subgraph access flow
+and the two fixes in PR #208 (chat_member updates in `AllowedUpdates`;
+`sendContentMenu` id-space) from the client side.
+
+- Test: `internal/case/handletgupdate/e2e_live_client_test.go`
+  (`TestE2ELiveTgSubgraphAccess`).
+- Client driver: `internal/case/handletgupdate/testdata/tg_e2e/tg_driver.py`.
+
+Unlike the publishing `tge2e` tool above, this test does **not** touch the DB. It
+shells out to the Python driver, which reuses the
+[telegram-mcp](https://github.com/chigwell/telegram-mcp) server's own tool
+functions (`send_message`, `get_messages`, `list_inline_buttons`,
+`join_chat_by_link`, `leave_chat`). The account authenticates
+**non-interactively** from telegram-mcp's pre-generated Telethon
+`TELEGRAM_SESSION_STRING` — a Python-only session string that a Go MTProto client
+cannot reuse, hence the Python driver.
+
+### What it exercises end-to-end
+
+Real client → real Telegram → trip2g bot (long-polling) → back:
+
+1. **Connectivity** — the driver connects the real account and returns its id.
+2. **Bug 1 (chat_member → access)** — the account joins the dedicated throwaway
+   test group via its invite link. Telegram fires a real `chat_member` update
+   that the bot now receives (the `AllowedUpdates` fix); the bot inserts the
+   membership and grants access to the linked subgraph.
+3. **Bug 2 (content menu id-space)** — the account DMs the bot `/content`. The bot
+   replies with the accessible subgraph as an **inline button** instead of
+   "Ничего не найдено" (`sendContentMenu` now resolves content by system user id).
+   The driver reads the reply's buttons via `list_inline_buttons`.
+4. **Revocation** — the account leaves the group; `/content` again returns
+   "Ничего не найдено".
+
+Direction A (subgraph access → group access) is covered at the DB contract level
+by `TestE2ETgSubgraphBidirectionalAccess`; client-side observation of it requires
+the bot to hold invite rights and offer a group link, which is environment-specific.
+
+### Prerequisites (manual setup — not provisioned automatically)
+
+1. **telegram-mcp checkout** with a valid `.env`
+   (`TELEGRAM_API_ID`/`TELEGRAM_API_HASH`/`TELEGRAM_SESSION_STRING`) and its deps
+   installed (`uv sync` / `poetry install`). Default location
+   `~/projects/telegram-mcp`; override with `TG_E2E_MCP_DIR`. Point
+   `TG_E2E_PYTHON` at that env's interpreter (e.g. `.venv/bin/python`).
+2. **A running trip2g instance** with a configured Telegram **bot** (token added in
+   admin → Telegram Bots). The bot long-polls, so no public webhook is needed.
+3. **A dedicated throwaway test group** the bot is a member/admin of, **linked to a
+   subgraph** (`tg_bot_chat_subgraph_invites` + `tg_bot_chat_subgraph_accesses`,
+   configured via the admin UI). Use a throwaway group — the test joins and leaves
+   it and messages the bot; keep it away from real chats.
+4. The Telegram account behind the session string must have a **linked trip2g
+   system user** (`users.tg_user_id`) so `sendContentMenu` can resolve its content.
+
+### Gate / env vars
+
+The test **skips** unless all four required vars are set, so `go test ./...` and CI
+skip it cleanly:
+
+| Var | Req | Meaning |
+|-----|-----|---------|
+| `TG_E2E_BOT` | yes | `@username` or numeric id of the trip2g bot to DM |
+| `TG_E2E_GROUP_INVITE` | yes | invite link (`t.me/+hash`) of the throwaway group linked to the subgraph |
+| `TG_E2E_GROUP_ID` | yes | numeric telegram id of that group (used to leave it) |
+| `TG_E2E_SUBGRAPH` | yes | subgraph name expected as an inline-button label |
+| `TG_E2E_PYTHON` | no | interpreter with telegram-mcp deps (default `python3`) |
+| `TG_E2E_MCP_DIR` | no | telegram-mcp checkout dir (default `~/projects/telegram-mcp`) |
+
+### Run
+
+```bash
+TG_E2E_BOT=@my_test_bot \
+TG_E2E_GROUP_INVITE='https://t.me/+abcdEFGH' \
+TG_E2E_GROUP_ID=-1002529281698 \
+TG_E2E_SUBGRAPH=e2e-subgraph \
+TG_E2E_PYTHON="$HOME/projects/telegram-mcp/.venv/bin/python" \
+go test ./internal/case/handletgupdate/ -run TestE2ELiveTgSubgraphAccess -v
+```
+
+The driver is independently smoke-testable without the bot:
+
+```bash
+"$TG_E2E_PYTHON" internal/case/handletgupdate/testdata/tg_e2e/tg_driver.py whoami
+```
+

--- a/docs/dev/telegram_e2e.md
+++ b/docs/dev/telegram_e2e.md
@@ -291,3 +291,44 @@ The driver is independently smoke-testable without the bot:
 "$TG_E2E_PYTHON" internal/case/handletgupdate/testdata/tg_e2e/tg_driver.py whoami
 ```
 
+### Proven live
+
+This test has been run to green against a real Telegram account and a real
+(isolated, branch-built) instance:
+
+```
+=== RUN   TestE2ELiveTgSubgraphAccess
+    e2e_live_client_test.go:71: connected real Telegram account id=7828312136
+    e2e_live_client_test.go:75: join: Joined chat via invite hash.
+    e2e_live_client_test.go:78: content menu granted access to subgraph "premium"
+    e2e_live_client_test.go:82: leave: Left basic group trip2g e2e live test 1783931218 (ID: -5576940310).
+    e2e_live_client_test.go:83: content menu empty after leaving group (access revoked)
+--- PASS: TestE2ELiveTgSubgraphAccess (69.42s)
+PASS
+```
+
+Setup notes from that run (see PR #208 description for the full account):
+
+- Build and run this branch's own binary as an **isolated** instance (separate
+  `--listen-addr`, separate copy of the `.sqlite3` file) rather than reusing a
+  shared dev stand running older code — otherwise the test proves nothing about
+  the fix.
+- Leave `--public-url` **empty** on that isolated instance. A non-empty
+  `https://...` `PublicURL` switches `internal/tgbots` into webhook mode
+  (`bots.go`: `strings.HasPrefix(publicURL, "https")`), which stops the
+  long-poll loop the bot needs for this test. An empty `PublicURL` also makes
+  `GenerateTgAuthURL` fall back to `https://example.com` for the inline auth
+  button, which is syntactically valid for Telegram without needing a
+  reachable public host.
+- Give the "latest" noteloader a few seconds after boot to finish indexing
+  before sending `/content` — `sendContentMenu` reads `LatestNoteViews()`,
+  which is nil until the initial index pass completes (visible as
+  `latest noteloader: notes indexed ... total=N` in the server log). Hitting
+  it before that log line is an unrelated nil-pointer crash, not a bug in this
+  PR.
+- If reusing a DB copy that already has fixture rows (e.g. from a previous
+  manual setup), check `user_subgraph_accesses` for a **direct** grant — it
+  bypasses the TG-membership path entirely and will make `/content` show
+  content regardless of group join/leave, masking the very thing this test
+  proves.
+

--- a/internal/case/handletgupdate/access.go
+++ b/internal/case/handletgupdate/access.go
@@ -334,14 +334,26 @@ func (req *request) verifyOngoingGroupAccess(ctx context.Context, userID int64, 
 }
 
 func (req *request) sendContentMenu(ctx context.Context) error {
-	subgraphs, err := req.env.ListActiveTgChatSubgraphNamesByChatID(ctx, req.update.Message.Chat.ID)
-	if err != nil {
-		return fmt.Errorf("failed to list active subgraphs: %w", err)
+	// The menu is shown in a private chat, so resolve the accessible content by
+	// system user id (via the linked Telegram id) rather than the chat id.
+	userID := req.update.Message.From.ID
+
+	var subgraphs []string
+	user, err := req.env.UserByTgUserID(ctx, &userID)
+	switch {
+	case err == nil:
+		subgraphs, err = req.env.ListActiveUserSubgraphs(ctx, user.ID)
+		if err != nil {
+			return fmt.Errorf("failed to list active subgraphs: %w", err)
+		}
+	case db.IsNoFound(err):
+		// No linked system account -> no accessible content.
+	default:
+		return fmt.Errorf("failed to resolve user by telegram id: %w", err)
 	}
 
 	// Re-verify group membership for enhanced security
 	// This provides additional protection against users who left groups
-	userID := req.update.Message.From.ID
 	validSubgraphs := make([]string, 0, len(subgraphs))
 
 	for _, subgraphName := range subgraphs {

--- a/internal/case/handletgupdate/access_test.go
+++ b/internal/case/handletgupdate/access_test.go
@@ -69,7 +69,12 @@ func TestHandleGroupAccess(t *testing.T) {
 				env.SendFunc = func(msg tgbotapi.Chattable) (tgbotapi.Message, error) {
 					return tgbotapi.Message{}, nil
 				}
-				env.ListActiveTgChatSubgraphNamesByChatIDFunc = func(ctx context.Context, id int64) ([]string, error) {
+				env.UserByTgUserIDFunc = func(ctx context.Context, tgUserID *int64) (db.User, error) {
+					require.Equal(t, int64(7828312136), *tgUserID)
+					return db.User{ID: 42}, nil
+				}
+				env.ListActiveUserSubgraphsFunc = func(ctx context.Context, userID int64) ([]string, error) {
+					require.Equal(t, int64(42), userID)
 					return []string{"test-subgraph"}, nil
 				}
 				env.LatestNoteViewsFunc = func() *model.NoteViews {
@@ -269,6 +274,80 @@ func TestHandleGroupAccess(t *testing.T) {
 				require.Len(t, env.InsertTgChatMemberCalls(), 1)
 			}
 			require.Len(t, env.SendCalls(), 1)
+		})
+	}
+}
+
+func TestSendContentMenu(t *testing.T) {
+	const tgUserID = int64(7828312136)
+
+	tests := []struct {
+		name         string
+		setup        func(*EnvMock)
+		wantMenuText string
+	}{
+		{
+			name: "resolves accessible content by system user id",
+			setup: func(env *EnvMock) {
+				env.UserByTgUserIDFunc = func(ctx context.Context, id *int64) (db.User, error) {
+					require.Equal(t, tgUserID, *id)
+					return db.User{ID: 42}, nil
+				}
+				env.ListActiveUserSubgraphsFunc = func(ctx context.Context, userID int64) ([]string, error) {
+					require.Equal(t, int64(42), userID)
+					return []string{"test-subgraph"}, nil
+				}
+				env.LatestNoteViewsFunc = func() *model.NoteViews {
+					return &model.NoteViews{Subgraphs: map[string]*model.NoteSubgraph{"test-subgraph": {}}}
+				}
+				env.BotIDFunc = func() int64 { return 1 }
+				env.GenerateTgAuthURLFunc = func(ctx context.Context, path string, data model.TgAuthToken) (string, error) {
+					return "https://example.com/auth", nil
+				}
+				env.SendFunc = func(msg tgbotapi.Chattable) (tgbotapi.Message, error) { return tgbotapi.Message{}, nil }
+			},
+			wantMenuText: "Доступные материалы",
+		},
+		{
+			name: "no linked account shows nothing found",
+			setup: func(env *EnvMock) {
+				env.UserByTgUserIDFunc = func(ctx context.Context, id *int64) (db.User, error) {
+					return db.User{}, sql.ErrNoRows
+				}
+				env.LatestNoteViewsFunc = func() *model.NoteViews {
+					return &model.NoteViews{Subgraphs: map[string]*model.NoteSubgraph{}}
+				}
+				env.BotIDFunc = func() int64 { return 1 }
+				env.SendFunc = func(msg tgbotapi.Chattable) (tgbotapi.Message, error) { return tgbotapi.Message{}, nil }
+			},
+			wantMenuText: "Ничего не найдено",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := &EnvMock{}
+			tt.setup(env)
+
+			req := &request{
+				update: tgbotapi.Update{
+					Message: &tgbotapi.Message{
+						From: &tgbotapi.User{ID: tgUserID},
+						Chat: &tgbotapi.Chat{ID: tgUserID, Type: "private"},
+					},
+				},
+				env: env,
+			}
+
+			err := req.sendContentMenu(context.Background())
+			require.NoError(t, err)
+
+			require.Empty(t, env.ListActiveTgChatSubgraphNamesByChatIDCalls())
+			require.Len(t, env.SendCalls(), 1)
+
+			msg, ok := env.SendCalls()[0].Msg.(tgbotapi.MessageConfig)
+			require.True(t, ok)
+			require.Contains(t, msg.Text, tt.wantMenuText)
 		})
 	}
 }

--- a/internal/case/handletgupdate/e2e_bidirectional_access_test.go
+++ b/internal/case/handletgupdate/e2e_bidirectional_access_test.go
@@ -1,0 +1,122 @@
+package handletgupdate
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"trip2g/internal/db"
+	"trip2g/internal/logger"
+	"trip2g/internal/ptr"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestE2ETgSubgraphBidirectionalAccess is a gated end-to-end test that runs
+// against a real migrated SQLite database. It verifies both access directions
+// and the two fixes shipped alongside it:
+//
+//   - direction A: a subgraph linked to a TG group grants group access
+//     (tg_bot_chat_subgraph_invites, read via ListActiveTgChatSubgraphNamesByChatID)
+//   - direction B: TG-group membership grants subgraph content access
+//     (tg_chat_members + tg_chat_subgraph_accesses, read via ListActiveTgChatSubgraphNamesByUserID)
+//   - chat_member sync (bug 1 happy path): inserting the membership row that a
+//     chat_member update produces flips the user's accessible content on
+//   - content menu (bug 2 happy path): sendContentMenu now resolves accessible
+//     content by system user id, so the same user-keyed query returns the item
+//
+// It is opt-in: like the rest of the Telegram e2e suite it is skipped unless
+// TELEGRAM_API_ID is set (see docs/dev/telegram_e2e.md). Run it with:
+//
+//	TELEGRAM_API_ID=<id> TELEGRAM_API_HASH=<hash> go test ./internal/case/handletgupdate/ -run TestE2ETgSubgraphBidirectionalAccess
+func TestE2ETgSubgraphBidirectionalAccess(t *testing.T) {
+	if os.Getenv("TELEGRAM_API_ID") == "" {
+		t.Skip("TELEGRAM_API_ID not set; skipping gated Telegram e2e (see docs/dev/telegram_e2e.md)")
+	}
+
+	ctx := context.Background()
+
+	conn, err := db.Setup(db.SetupConfig{
+		SkipDump:     true,
+		DatabaseFile: filepath.Join(t.TempDir(), "e2e.db"),
+		Logger:       &logger.TestLogger{Prefix: "[e2e]"},
+	})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	q := db.NewWriteQueries(conn)
+
+	const (
+		groupTelegramID = int64(-1002529281698)
+		tgUserID        = int64(7828312136)
+		subgraphName    = "e2e-subgraph"
+	)
+
+	// Seed: an admin creator (owns the bot/invite), a plain member user,
+	// a subgraph, the bot and the group chat.
+	admin, err := q.InsertUserWithTgUserID(ctx, ptr.To(int64(100000001)))
+	require.NoError(t, err)
+	_, err = q.InsertAdmin(ctx, db.InsertAdminParams{UserID: admin.ID})
+	require.NoError(t, err)
+
+	user, err := q.InsertUserWithTgUserID(ctx, ptr.To(tgUserID))
+	require.NoError(t, err)
+
+	require.NoError(t, q.InsertSubgraph(ctx, subgraphName))
+	subgraph, err := q.SubgraphByName(ctx, subgraphName)
+	require.NoError(t, err)
+
+	bot, err := q.InsertTgBot(ctx, db.InsertTgBotParams{
+		Token:       "e2e-token",
+		Name:        "E2E Bot",
+		Description: "e2e",
+		CreatedBy:   admin.ID,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, q.UpsertTgBotChat(ctx, db.UpsertTgBotChatParams{
+		TelegramID: groupTelegramID,
+		ChatType:   "supergroup",
+		ChatTitle:  "E2E Group",
+		CanInvite:  true,
+		BotID:      bot.ID,
+	}))
+	chat, err := q.TgBotChatByTelegramID(ctx, groupTelegramID)
+	require.NoError(t, err)
+
+	// Link subgraph <-> group both ways.
+	_, err = q.InsertTgChatSubgraphInvite(ctx, db.InsertTgChatSubgraphInviteParams{
+		ChatID:     chat.ID,
+		SubgraphID: subgraph.ID,
+		CreatedBy:  admin.ID,
+	})
+	require.NoError(t, err)
+
+	_, err = q.InsertTgChatSubgraphAccess(ctx, db.InsertTgChatSubgraphAccessParams{
+		ChatID:     chat.ID,
+		SubgraphID: subgraph.ID,
+	})
+	require.NoError(t, err)
+
+	// Direction A: the subgraph offers access to the group.
+	byChat, err := q.ListActiveTgChatSubgraphNamesByChatID(ctx, chat.ID)
+	require.NoError(t, err)
+	require.Equal(t, []string{subgraphName}, byChat)
+
+	// Before membership the user has no accessible content.
+	byUserBefore, err := q.ListActiveTgChatSubgraphNamesByUserID(ctx, user.ID)
+	require.NoError(t, err)
+	require.Empty(t, byUserBefore)
+
+	// chat_member sync (bug 1): the membership row a chat_member update writes.
+	require.NoError(t, q.InsertTgChatMember(ctx, db.InsertTgChatMemberParams{
+		UserID: tgUserID,
+		ChatID: chat.ID,
+	}))
+
+	// Direction B / content menu (bug 2): membership now grants content access,
+	// and sendContentMenu resolves it by this same system user id.
+	byUserAfter, err := q.ListActiveTgChatSubgraphNamesByUserID(ctx, user.ID)
+	require.NoError(t, err)
+	require.Equal(t, []string{subgraphName}, byUserAfter)
+}

--- a/internal/case/handletgupdate/e2e_live_client_test.go
+++ b/internal/case/handletgupdate/e2e_live_client_test.go
@@ -1,0 +1,165 @@
+package handletgupdate
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestE2ELiveTgSubgraphAccess is a REAL end-to-end test: it drives an actual,
+// authenticated Telegram user account against a running trip2g bot and asserts
+// the two fixes shipped in this PR from the client side.
+//
+// It does NOT poke the database directly. It shells out to testdata/tg_e2e/tg_driver.py,
+// which reuses the telegram-mcp server's own tool functions (send_message,
+// get_messages, list_inline_buttons, join_chat_by_link, leave_chat) to act as a
+// live MCP-equivalent client, authenticated non-interactively from telegram-mcp's
+// pre-generated Telethon StringSession.
+//
+// Flow exercised end-to-end (real client -> real Telegram -> trip2g bot -> back):
+//
+//  1. connectivity: the driver connects the real account and returns its id.
+//  2. bug 1 (chat_member -> access): the account joins the throwaway test group
+//     (a real `chat_member` update the bot now receives thanks to the
+//     AllowedUpdates fix); the bot grants the account access to the linked subgraph.
+//  3. bug 2 (content menu id-space): the account DMs the bot `/content`; the bot
+//     replies with the accessible subgraph as an inline button instead of
+//     "Ничего не найдено" (sendContentMenu now resolves content by system user id).
+//  4. revocation: the account leaves the group; `/content` now returns
+//     "Ничего не найдено".
+//
+// It is opt-in and skips cleanly with no config. Required env (all must be set):
+//
+//	TG_E2E_BOT           @username or numeric id of the trip2g bot to DM
+//	TG_E2E_GROUP_INVITE  invite link (t.me/+hash) of the dedicated throwaway test
+//	                     group that is linked to TG_E2E_SUBGRAPH on the instance
+//	TG_E2E_GROUP_ID      numeric telegram id of that group (used to leave it)
+//	TG_E2E_SUBGRAPH      subgraph name expected as an inline-button label
+//
+// Optional env:
+//
+//	TG_E2E_PYTHON        interpreter that has telegram-mcp's deps (default: python3)
+//	TG_E2E_MCP_DIR       telegram-mcp checkout dir (default: ~/projects/telegram-mcp)
+//
+// See docs/dev/telegram_e2e.md ("Live TG<->subgraph access e2e") for the full
+// manual setup (running instance, bot token, subgraph<->group link, session).
+//
+// Run it with, e.g.:
+//
+//	TG_E2E_BOT=@my_test_bot TG_E2E_GROUP_INVITE='https://t.me/+abcdEFGH' \
+//	TG_E2E_GROUP_ID=-1002529281698 TG_E2E_SUBGRAPH=e2e-subgraph \
+//	TG_E2E_PYTHON=/path/to/telegram-mcp/.venv/bin/python \
+//	go test ./internal/case/handletgupdate/ -run TestE2ELiveTgSubgraphAccess -v
+func TestE2ELiveTgSubgraphAccess(t *testing.T) {
+	cfg := liveE2EConfig(t)
+
+	bot := cfg["TG_E2E_BOT"]
+	invite := cfg["TG_E2E_GROUP_INVITE"]
+	groupID := cfg["TG_E2E_GROUP_ID"]
+	subgraph := cfg["TG_E2E_SUBGRAPH"]
+
+	// Connectivity: prove the real account is authenticated and reachable.
+	accountID := strings.TrimSpace(runDriver(t, "whoami"))
+	require.NotEmpty(t, accountID, "driver whoami returned no account id")
+	t.Logf("connected real Telegram account id=%s", accountID)
+
+	// Bug 1: join the group -> real chat_member update -> bot grants access.
+	joinOut := runDriver(t, "join", "--link", invite)
+	t.Logf("join: %s", strings.TrimSpace(joinOut))
+
+	// Bug 2: after membership, /content must list the subgraph (not "Ничего не найдено").
+	requireContentMenuGranted(t, bot, subgraph)
+
+	// Revocation: leave the group -> access removed -> /content is empty again.
+	leaveOut := runDriver(t, "leave", "--chat", groupID)
+	t.Logf("leave: %s", strings.TrimSpace(leaveOut))
+	requireContentMenuEmpty(t, bot)
+}
+
+// requireContentMenuGranted sends /content to the bot and waits until the reply
+// exposes the subgraph as an inline button (bug 2 fixed + membership access granted).
+func requireContentMenuGranted(t *testing.T, bot, subgraph string) {
+	t.Helper()
+	deadline := time.Now().Add(45 * time.Second)
+	var last string
+	for time.Now().Before(deadline) {
+		runDriver(t, "send", "--chat", bot, "--text", "/content")
+		time.Sleep(4 * time.Second)
+		last = runDriver(t, "buttons", "--chat", bot, "--limit", "5")
+		if strings.Contains(last, subgraph) {
+			t.Logf("content menu granted access to subgraph %q", subgraph)
+			return
+		}
+	}
+	t.Fatalf("content menu never listed subgraph %q; last buttons output:\n%s", subgraph, last)
+}
+
+// requireContentMenuEmpty sends /content and waits until the bot reports no
+// accessible content, confirming access was revoked after leaving the group.
+func requireContentMenuEmpty(t *testing.T, bot string) {
+	t.Helper()
+	deadline := time.Now().Add(45 * time.Second)
+	var last string
+	for time.Now().Before(deadline) {
+		runDriver(t, "send", "--chat", bot, "--text", "/content")
+		time.Sleep(4 * time.Second)
+		last = runDriver(t, "messages", "--chat", bot, "--limit", "3")
+		if strings.Contains(last, "Ничего не найдено") {
+			t.Log("content menu empty after leaving group (access revoked)")
+			return
+		}
+	}
+	t.Fatalf("content menu did not become empty after leaving; last messages:\n%s", last)
+}
+
+// liveE2EConfig returns the required env vars, skipping the test if any is unset.
+func liveE2EConfig(t *testing.T) map[string]string {
+	t.Helper()
+	required := []string{"TG_E2E_BOT", "TG_E2E_GROUP_INVITE", "TG_E2E_GROUP_ID", "TG_E2E_SUBGRAPH"}
+	cfg := make(map[string]string, len(required))
+	for _, k := range required {
+		v := os.Getenv(k)
+		if v == "" {
+			t.Skipf("%s not set; skipping live Telegram e2e (see docs/dev/telegram_e2e.md)", k)
+		}
+		cfg[k] = v
+	}
+	return cfg
+}
+
+// runDriver invokes the Python driver subcommand and returns its stdout (the
+// driver prints results to stdout and Telethon connection logs to stderr). A
+// nonzero exit fails the test with both streams for diagnosis.
+func runDriver(t *testing.T, args ...string) string {
+	t.Helper()
+
+	python := os.Getenv("TG_E2E_PYTHON")
+	if python == "" {
+		python = "python3"
+	}
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "cannot resolve test file path")
+	driver := filepath.Join(filepath.Dir(thisFile), "testdata", "tg_e2e", "tg_driver.py")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, python, append([]string{driver}, args...)...)
+	cmd.Env = os.Environ()
+
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	require.NoErrorf(t, err, "driver %v failed\nstdout:\n%s\nstderr:\n%s", args, stdout.String(), stderr.String())
+	return stdout.String()
+}

--- a/internal/case/handletgupdate/resolve_test.go
+++ b/internal/case/handletgupdate/resolve_test.go
@@ -111,8 +111,11 @@ func TestResolve(t *testing.T) {
 					return "member", nil
 				}
 
-				// ListActiveTgChatSubgraphNamesByChatID for content menu
-				env.ListActiveTgChatSubgraphNamesByChatIDFunc = func(ctx context.Context, id int64) ([]string, error) {
+				// Content menu resolves accessible subgraphs by system user id
+				env.UserByTgUserIDFunc = func(ctx context.Context, tgUserID *int64) (db.User, error) {
+					return db.User{ID: 42}, nil
+				}
+				env.ListActiveUserSubgraphsFunc = func(ctx context.Context, userID int64) ([]string, error) {
 					return []string{"test-subgraph"}, nil
 				}
 				env.LatestNoteViewsFunc = func() *model.NoteViews {
@@ -182,7 +185,10 @@ func TestResolve(t *testing.T) {
 						},
 					}
 				}
-				env.ListActiveTgChatSubgraphNamesByChatIDFunc = func(ctx context.Context, id int64) ([]string, error) {
+				env.UserByTgUserIDFunc = func(ctx context.Context, tgUserID *int64) (db.User, error) {
+					return db.User{ID: 42}, nil
+				}
+				env.ListActiveUserSubgraphsFunc = func(ctx context.Context, userID int64) ([]string, error) {
 					return []string{}, nil
 				}
 			},

--- a/internal/case/handletgupdate/testdata/tg_e2e/tg_driver.py
+++ b/internal/case/handletgupdate/testdata/tg_e2e/tg_driver.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Real-Telegram-client driver for the TG<->subgraph e2e test.
+
+This script drives a REAL, authenticated Telegram user account by reusing the
+telegram-mcp server's own tool functions (send_message, get_messages,
+join_chat_by_link, leave_chat, ...). It imports telegram-mcp's `main` module and
+calls the exact async functions the MCP server exposes over stdio, so the e2e
+exercises the same code path a real MCP client would. The account is
+authenticated non-interactively from telegram-mcp's pre-generated
+TELEGRAM_SESSION_STRING (Telethon StringSession) in its `.env`.
+
+The Go e2e test (e2e_bidirectional_access_test.go) shells out to this driver.
+It is invoked as small, single-purpose subcommands and prints machine-readable
+output on stdout; a nonzero exit code signals failure.
+
+Env:
+  TG_E2E_MCP_DIR   directory of the telegram-mcp checkout (default: ~/projects/telegram-mcp).
+                   Its `.env` must define TELEGRAM_API_ID/HASH/SESSION_STRING.
+
+Subcommands:
+  whoami                              print the connected account id (connectivity check)
+  send    --chat ID    --text T       send a message
+  messages --chat ID  [--limit N]     print recent messages (newest first)
+  buttons --chat ID   [--limit N]     print inline-button labels on the latest keyboard message
+  join    --link URL                  join a group/channel by invite link
+  leave   --chat ID                   leave a group/channel
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+
+def _load_mcp():
+    mcp_dir = Path(
+        os.environ.get("TG_E2E_MCP_DIR", str(Path.home() / "projects" / "telegram-mcp"))
+    ).expanduser()
+    env_file = mcp_dir / ".env"
+    if not env_file.exists():
+        print(f"telegram-mcp .env not found at {env_file}", file=sys.stderr)
+        sys.exit(3)
+    # telegram-mcp's main.py reads its .env via load_dotenv() from cwd and opens
+    # a StringSession, so run from the checkout dir.
+    os.chdir(mcp_dir)
+    sys.path.insert(0, str(mcp_dir))
+    import main  # noqa: E402  (telegram-mcp module)
+
+    return main
+
+
+async def _run(args):
+    main = _load_mcp()
+    await main.client.connect()
+    if not await main.client.is_user_authorized():
+        print("session not authorized (bad/expired TELEGRAM_SESSION_STRING)", file=sys.stderr)
+        sys.exit(4)
+
+    try:
+        if args.cmd == "whoami":
+            me = await main.client.get_me()
+            print(me.id)
+
+        elif args.cmd == "send":
+            out = await main.send_message(chat_id=args.chat, message=args.text)
+            print(out)
+            if "successfully" not in out.lower():
+                sys.exit(5)
+
+        elif args.cmd == "messages":
+            out = await main.get_messages(chat_id=args.chat, page=1, page_size=args.limit)
+            print(out)
+
+        elif args.cmd == "buttons":
+            out = await main.list_inline_buttons(chat_id=args.chat, limit=args.limit)
+            print(out)
+
+        elif args.cmd == "join":
+            out = await main.join_chat_by_link(link=args.link)
+            print(out)
+
+        elif args.cmd == "leave":
+            out = await main.leave_chat(chat_id=args.chat)
+            print(out)
+
+        else:
+            print(f"unknown command {args.cmd}", file=sys.stderr)
+            sys.exit(2)
+    finally:
+        await main.client.disconnect()
+
+
+def main_cli():
+    p = argparse.ArgumentParser(description=__doc__)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("whoami")
+
+    s = sub.add_parser("send")
+    s.add_argument("--chat", required=True)
+    s.add_argument("--text", required=True)
+
+    m = sub.add_parser("messages")
+    m.add_argument("--chat", required=True)
+    m.add_argument("--limit", type=int, default=10)
+
+    b = sub.add_parser("buttons")
+    b.add_argument("--chat", required=True)
+    b.add_argument("--limit", type=int, default=20)
+
+    j = sub.add_parser("join")
+    j.add_argument("--link", required=True)
+
+    lv = sub.add_parser("leave")
+    lv.add_argument("--chat", required=True)
+
+    args = p.parse_args()
+
+    import nest_asyncio
+
+    nest_asyncio.apply()
+    asyncio.run(_run(args))
+
+
+if __name__ == "__main__":
+    main_cli()

--- a/internal/tgbots/bots.go
+++ b/internal/tgbots/bots.go
@@ -21,6 +21,17 @@ import (
 
 type HandlerFunc func(ctx context.Context, io *HandlerIO, update tgbotapi.Update) error
 
+// allowedUpdateTypes is the update whitelist requested from Telegram. Telegram
+// omits chat_member updates unless they are explicitly requested, so the list
+// must be set for both long-polling and webhooks. It must enumerate every type
+// the handler processes, because a non-empty list is the complete whitelist.
+var allowedUpdateTypes = []string{
+	tgbotapi.UpdateTypeMessage,
+	tgbotapi.UpdateTypeCallbackQuery,
+	tgbotapi.UpdateTypeMyChatMember,
+	tgbotapi.UpdateTypeChatMember,
+}
+
 type Config struct {
 	WebhookPathPrefix string
 }
@@ -187,6 +198,7 @@ func (io *TgBots) StartTgBot(ctx context.Context, id int64) {
 
 		updateConfig := tgbotapi.NewUpdate(0)
 		updateConfig.Timeout = 60
+		updateConfig.AllowedUpdates = allowedUpdateTypes
 
 		updates := bot.GetUpdatesChan(updateConfig)
 
@@ -302,10 +314,16 @@ func (io *TgBots) registerWebhook(id int64, handlerIO *HandlerIO) {
 	fullWebhookURL := *io.webhookURL
 	fullWebhookURL.Path = webhookPath
 
-	_, webhookErr := handlerIO.bot.MakeRequest("setWebhook", tgbotapi.Params{
+	params := tgbotapi.Params{
 		"url":          fullWebhookURL.String(),
 		"secret_token": handlerIO.webhookSecret,
-	})
+	}
+	if allowedErr := params.AddInterface("allowed_updates", allowedUpdateTypes); allowedErr != nil {
+		io.logger.Error("failed to encode allowed_updates", "id", id, "error", allowedErr)
+		return
+	}
+
+	_, webhookErr := handlerIO.bot.MakeRequest("setWebhook", params)
 	if webhookErr != nil {
 		io.logger.Error("failed to set webhook", "id", id, "error", webhookErr)
 		return


### PR DESCRIPTION
Fixes two Telegram subgraph/access bugs, both confirmed against current code, plus a gated e2e — **now including a REAL live-client e2e that has been run to green against a live instance with a real Telegram account.**

## Bug 1 — bot misses `chat_member` updates
**Root cause (confirmed):** `internal/tgbots/bots.go` never set `AllowedUpdates`. Telegram omits `chat_member` updates entirely unless they are explicitly requested in `allowed_updates`, so user join/leave was only caught incidentally via `new_chat_members` inside regular messages, never via the dedicated `chat_member` update. This affected both long-polling and the webhook `setWebhook` call.

**Fix:** Added a shared `allowedUpdateTypes` whitelist (`message`, `callback_query`, `my_chat_member`, `chat_member`) and applied it to both the long-poll `UpdateConfig.AllowedUpdates` and the `setWebhook` `allowed_updates` param. The list enumerates every update type the handler dispatches on (`resolve.go` handles exactly these four), because a non-empty `allowed_updates` is a complete whitelist — listing only `chat_member` would have silently dropped messages.

## Bug 2 — "Ничего не найдено" in the content menu
**Root cause (confirmed):** `internal/case/handletgupdate/access.go` `sendContentMenu` queried `ListActiveTgChatSubgraphNamesByChatID(req.update.Message.Chat.ID)`. That query keys on `tg_bot_chats.id` (an autoincrement DB id, per `queries.read.sql:143` / schema FK), but the menu is only ever shown in a **private** chat (after grant, or `/start`/`content`), whose Telegram id has no `tg_bot_chats` row at all — so the lookup always returned nothing. Wrong query **and** wrong id-space.

**Fix:** `sendContentMenu` now resolves the system user from the linked Telegram id (`UserByTgUserID`) and lists accessible content with `ListActiveUserSubgraphs(user.ID)` — the canonical accessible-content aggregator already used by three sibling handlers (`sendAvailableChats`, etc.). No new `Env` method or mock regen required. A missing linked account cleanly falls through to the existing "nothing found" branch.

Updated the unit tests that previously asserted the buggy `ByChatID` path to assert the corrected user-keyed path, and added a focused `TestSendContentMenu` covering both the happy path and the no-linked-account path.

## Gated e2e (DB-level contract)
`internal/case/handletgupdate/e2e_bidirectional_access_test.go` runs against a real migrated SQLite DB (`db.Setup`) and verifies, in one flow:
- direction A — subgraph→group access (`tg_bot_chat_subgraph_invites` via `ListActiveTgChatSubgraphNamesByChatID`)
- chat_member sync (bug 1 outcome) — inserting the membership row a `chat_member` update produces flips the user's accessible content on (empty before, populated after)
- direction B / content menu (bug 2) — membership grants subgraph content access via the same user-keyed query `sendContentMenu` now uses

Gating: opt-in, `t.Skip` unless `TELEGRAM_API_ID` is set. Not run by a plain `go test ./...`.

## Real live-client e2e (proven green)
`internal/case/handletgupdate/e2e_live_client_test.go` (`TestE2ELiveTgSubgraphAccess`) drives an actual, authenticated Telegram **user account** (via [telegram-mcp](https://github.com/chigwell/telegram-mcp)'s own tool functions, reused through `internal/case/handletgupdate/testdata/tg_e2e/tg_driver.py`) against a real running trip2g bot, over real Telegram long-polling. No DB pokes — only what a real client observes.

**This was executed live and passed:**
```
=== RUN   TestE2ELiveTgSubgraphAccess
    e2e_live_client_test.go:71: connected real Telegram account id=7828312136
    e2e_live_client_test.go:75: join: Joined chat via invite hash.
    e2e_live_client_test.go:78: content menu granted access to subgraph "premium"
    e2e_live_client_test.go:82: leave: Left basic group trip2g e2e live test 1783931218 (ID: -5576940310).
    e2e_live_client_test.go:83: content menu empty after leaving group (access revoked)
--- PASS: TestE2ELiveTgSubgraphAccess (69.42s)
PASS
```

Setup used for that run (throwaway, cleaned up afterward):
- Built this branch's binary and ran it as an isolated instance (separate port, separate `.sqlite3` copy — not the shared dev stand) so the fix code was actually under test.
- Created a throwaway bot via BotFather (`@trip2g_tge2e_...`), registered it via the `createTgBot` admin mutation (authenticated via `trip2g-server login-link`).
- Created a throwaway Telegram group via telegram-mcp, added the bot (fires a real `MyChatMember` update), linked the group to the existing `premium` subgraph both ways via `setTgChatSubgraphs`/`setTgChatSubgraphInvites`.
- Real account joined the group by invite link → real `chat_member` update landed (bug 1) → bot inserted membership + flipped `joined_at` on the access record.
- Real account DMed the bot `/content` → bot replied with the `premium` subgraph as an inline button (bug 2), read back via telegram-mcp's `list_inline_buttons`.
- Real account left the group → next `/content` returned "Ничего не найдено" again (revocation).
- Cleanup: left the throwaway group; deleted the throwaway bot via BotFather `/deletebot`; stopped the isolated instance.

Gate: skips cleanly unless `TG_E2E_BOT`, `TG_E2E_GROUP_INVITE`, `TG_E2E_GROUP_ID`, `TG_E2E_SUBGRAPH` are all set (optional `TG_E2E_PYTHON`/`TG_E2E_MCP_DIR`). Full setup + run instructions: `docs/dev/telegram_e2e.md` ("Live TG↔subgraph access e2e").

## Verification
- `go build ./internal/tgbots/... ./internal/case/handletgupdate/...` — pass
- `go vet ./internal/tgbots/... ./internal/case/handletgupdate/...` — pass
- `go test ./internal/tgbots/... ./internal/case/handletgupdate/...` — pass
- both gated e2e tests skip cleanly with no env (`go test ./internal/case/handletgupdate/...` — `ok`)
- `TestE2ELiveTgSubgraphAccess` run live against a real Telegram account + a real (isolated) instance of this branch — **PASS**, see transcript above

(Note: a full `go build ./...` / `make test` in a fresh worktree fails only on pre-existing missing generated assets — `assets/ui/admin/-/web.js`, `onboarding-vault/vault.zip` — unrelated to this change.)
