### PR TITLE
feat(gitapi): enforce can_pull/can_push token scopes

### DIFF
--- a/internal/gitapi/api.go
+++ b/internal/gitapi/api.go
@@ -25,6 +25,13 @@ import (
 
 var ErrNoAuth = errors.New("no auth provided")
 
+// Git smart-HTTP service / binary names, shared by the pack dispatch and the
+// info/refs service gate.
+const (
+	gitUploadPackService  = "git-upload-pack"
+	gitReceivePackService = "git-receive-pack"
+)
+
 // gitScope is the capability a request needs from a token.
 type gitScope int
 
@@ -104,8 +111,8 @@ func DefaultConfig() Config {
 func New(ctx context.Context, config Config, env Env) (*API, error) {
 	requiredBins := []string{
 		"git",
-		"git-upload-pack",
-		"git-receive-pack",
+		gitUploadPackService,
+		gitReceivePackService,
 		"tar",
 	}
 
@@ -384,9 +391,9 @@ func requiredScope(relPath, service string) gitScope {
 		return scopePush
 	case "/info/refs":
 		switch service {
-		case "git-upload-pack":
+		case gitUploadPackService:
 			return scopePull
-		case "git-receive-pack":
+		case gitReceivePackService:
 			return scopePush
 		}
 	}
@@ -397,6 +404,8 @@ func requiredScope(relPath, service string) gitScope {
 // column means the scope was never granted, so no scope = no access.
 func tokenHasScope(token db.GitToken, scope gitScope) bool {
 	switch scope {
+	case scopeNone:
+		return false
 	case scopePull:
 		return token.CanPull != nil && *token.CanPull
 	case scopePush:
@@ -409,7 +418,7 @@ func tokenHasScope(token db.GitToken, scope gitScope) bool {
 func (api *API) handleInfoRefs(ctx *fasthttp.RequestCtx) error {
 	service := string(ctx.QueryArgs().Peek("service"))
 
-	if service != "git-upload-pack" && service != "git-receive-pack" {
+	if service != gitUploadPackService && service != gitReceivePackService {
 		return fmt.Errorf("unsupported service: %s", service)
 	}
 
@@ -423,10 +432,10 @@ func (api *API) handleInfoRefs(ctx *fasthttp.RequestCtx) error {
 		api.config.RepoPath,
 	}
 
-	if service == "git-upload-pack" {
-		cmd = exec.Command("git-upload-pack", args...)
+	if service == gitUploadPackService {
+		cmd = exec.Command(gitUploadPackService, args...)
 	} else {
-		cmd = exec.Command("git-receive-pack", args...)
+		cmd = exec.Command(gitReceivePackService, args...)
 	}
 
 	cmd.Stderr = os.Stderr
@@ -447,7 +456,7 @@ func (api *API) handleInfoRefs(ctx *fasthttp.RequestCtx) error {
 }
 
 func (api *API) handleGitUploadPack(ctx *fasthttp.RequestCtx) error {
-	cmd := exec.Command("git-upload-pack", "--stateless-rpc", api.config.RepoPath)
+	cmd := exec.Command(gitUploadPackService, "--stateless-rpc", api.config.RepoPath)
 	cmd.Stdin = bytes.NewReader(ctx.PostBody())
 	cmd.Stdout = ctx
 
@@ -476,7 +485,7 @@ func (api *API) handleGitReceivePack(ctx *fasthttp.RequestCtx) error {
 		oldRev = strings.TrimSpace(mustGit(api, "rev-parse", api.config.MasterBranch))
 	}
 
-	cmd := exec.Command("git-receive-pack", "--stateless-rpc", api.config.RepoPath)
+	cmd := exec.Command(gitReceivePackService, "--stateless-rpc", api.config.RepoPath)
 	cmd.Stdin = bytes.NewReader(ctx.PostBody())
 	cmd.Stdout = ctx
 	cmd.Stderr = os.Stderr

--- a/internal/gitapi/api.go
+++ b/internal/gitapi/api.go
@@ -25,6 +25,15 @@ import (
 
 var ErrNoAuth = errors.New("no auth provided")
 
+// gitScope is the capability a request needs from a token.
+type gitScope int
+
+const (
+	scopeNone gitScope = iota
+	scopePull
+	scopePush
+)
+
 type NoteSource struct {
 	Path    string
 	Content []byte
@@ -245,7 +254,7 @@ func (api *API) HandleRequest(ctx *fasthttp.RequestCtx) bool {
 		return false
 	}
 
-	err := api.checkAuth(ctx)
+	token, err := api.checkAuth(ctx)
 	if err != nil {
 		api.logger.Warn("auth failed", "error", err)
 
@@ -262,11 +271,25 @@ func (api *API) HandleRequest(ctx *fasthttp.RequestCtx) bool {
 		return false
 	}
 
-	hdr, ok := handlers[path[len(api.config.BasePath):]]
+	relPath := path[len(api.config.BasePath):]
+
+	hdr, ok := handlers[relPath]
 	if !ok {
 		api.logger.Warn("unsupported path", "path", path)
 		ctx.SetStatusCode(fasthttp.StatusNotFound)
 		return true
+	}
+
+	// Enforce the token's scope: git-upload-pack (fetch/clone) requires can_pull,
+	// git-receive-pack (push) requires can_push. info/refs is gated on its
+	// ?service= so a scoped token can't advertise the other capability's refs.
+	if scope := requiredScope(relPath, string(ctx.QueryArgs().Peek("service"))); scope != scopeNone {
+		if !tokenHasScope(token, scope) {
+			api.logger.Warn("token scope denied", "path", path, "scope", scope)
+			ctx.SetStatusCode(fasthttp.StatusForbidden)
+			_, _ = ctx.WriteString("token lacks required git scope")
+			return true
+		}
 	}
 
 	api.mu.Lock()
@@ -299,7 +322,7 @@ func (api *API) HandleRequest(ctx *fasthttp.RequestCtx) bool {
 	return true
 }
 
-func (api *API) checkAuth(ctx *fasthttp.RequestCtx) error {
+func (api *API) checkAuth(ctx *fasthttp.RequestCtx) (db.GitToken, error) {
 	auth := strings.TrimSpace(string(ctx.Request.Header.Peek("Authorization")))
 	if auth == "" {
 		for k, v := range ctx.Request.Header.All() {
@@ -307,29 +330,29 @@ func (api *API) checkAuth(ctx *fasthttp.RequestCtx) error {
 		}
 
 		api.logger.Debug("no auth header")
-		return ErrNoAuth
+		return db.GitToken{}, ErrNoAuth
 	}
 
 	const prefix = "Basic "
 	if len(auth) <= len(prefix) || auth[:len(prefix)] != prefix {
 		api.logger.Debug("invalid auth header", "auth", auth)
-		return ErrNoAuth
+		return db.GitToken{}, ErrNoAuth
 	}
 
 	decoded, err := base64.StdEncoding.DecodeString(auth[len(prefix):])
 	if err != nil {
-		return fmt.Errorf("failed to decode auth: %w", err)
+		return db.GitToken{}, fmt.Errorf("failed to decode auth: %w", err)
 	}
 
 	parts := strings.SplitN(string(decoded), ":", 2)
 	if len(parts) != 2 {
 		api.logger.Debug("invalid auth format", "decoded", string(decoded))
-		return ErrNoAuth
+		return db.GitToken{}, ErrNoAuth
 	}
 
 	if parts[0] != "user" {
 		api.logger.Debug("invalid username", "username", parts[0])
-		return ErrNoAuth
+		return db.GitToken{}, ErrNoAuth
 	}
 
 	token := parts[1]
@@ -339,15 +362,48 @@ func (api *API) checkAuth(ctx *fasthttp.RequestCtx) error {
 	tokenHash := hex.EncodeToString(hash[:])
 
 	// Verify token exists in database
-	_, err = api.env.GitTokenByValueSha256(api.ctx, tokenHash)
+	gitToken, err := api.env.GitTokenByValueSha256(api.ctx, tokenHash)
 	if err != nil {
 		api.logger.Debug("invalid token", "error", err)
-		return ErrNoAuth
+		return db.GitToken{}, ErrNoAuth
 	}
 
 	api.logger.Info("auth success")
 
-	return nil
+	return gitToken, nil
+}
+
+// requiredScope maps a git endpoint (relative path + info/refs service) to the
+// capability a token must hold. scopeNone means the request is not a scoped git
+// operation and no scope check applies.
+func requiredScope(relPath, service string) gitScope {
+	switch relPath {
+	case "/git-upload-pack":
+		return scopePull
+	case "/git-receive-pack":
+		return scopePush
+	case "/info/refs":
+		switch service {
+		case "git-upload-pack":
+			return scopePull
+		case "git-receive-pack":
+			return scopePush
+		}
+	}
+	return scopeNone
+}
+
+// tokenHasScope reports whether the token carries the requested capability. A nil
+// column means the scope was never granted, so no scope = no access.
+func tokenHasScope(token db.GitToken, scope gitScope) bool {
+	switch scope {
+	case scopePull:
+		return token.CanPull != nil && *token.CanPull
+	case scopePush:
+		return token.CanPush != nil && *token.CanPush
+	default:
+		return false
+	}
 }
 
 func (api *API) handleInfoRefs(ctx *fasthttp.RequestCtx) error {

--- a/internal/gitapi/api_security_test.go
+++ b/internal/gitapi/api_security_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/base64"
 	"testing"
 
+	"trip2g/internal/db"
+
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
 )
@@ -36,4 +38,127 @@ func TestHandleRequestAuthenticatedUnknownPathReturnsClientError(t *testing.T) {
 	require.Nil(t, panicValue, "an authenticated unknown Git path must not call a nil handler")
 	require.True(t, handled)
 	require.Contains(t, []int{fasthttp.StatusNotFound, fasthttp.StatusMethodNotAllowed}, ctx.Response.StatusCode())
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// TestTokenScopeDecision is the decision matrix behind scope enforcement:
+// a token must hold can_pull for upload-pack (fetch/clone) and can_push for
+// receive-pack (push); info/refs inherits the scope of its ?service=.
+func TestTokenScopeDecision(t *testing.T) {
+	cases := []struct {
+		name    string
+		relPath string
+		service string
+		canPull *bool
+		canPush *bool
+		allowed bool
+	}{
+		// can_pull only
+		{"pull-only fetch ok", "/git-upload-pack", "", boolPtr(true), boolPtr(false), true},
+		{"pull-only push denied", "/git-receive-pack", "", boolPtr(true), boolPtr(false), false},
+		{"pull-only refs upload ok", "/info/refs", "git-upload-pack", boolPtr(true), boolPtr(false), true},
+		{"pull-only refs receive denied", "/info/refs", "git-receive-pack", boolPtr(true), boolPtr(false), false},
+
+		// can_push only
+		{"push-only push ok", "/git-receive-pack", "", boolPtr(false), boolPtr(true), true},
+		{"push-only fetch denied", "/git-upload-pack", "", boolPtr(false), boolPtr(true), false},
+		{"push-only refs receive ok", "/info/refs", "git-receive-pack", boolPtr(false), boolPtr(true), true},
+		{"push-only refs upload denied", "/info/refs", "git-upload-pack", boolPtr(false), boolPtr(true), false},
+
+		// both scopes
+		{"both fetch ok", "/git-upload-pack", "", boolPtr(true), boolPtr(true), true},
+		{"both push ok", "/git-receive-pack", "", boolPtr(true), boolPtr(true), true},
+
+		// neither scope (including nil columns = never granted)
+		{"neither fetch denied", "/git-upload-pack", "", boolPtr(false), boolPtr(false), false},
+		{"neither push denied", "/git-receive-pack", "", boolPtr(false), boolPtr(false), false},
+		{"nil-scopes fetch denied", "/git-upload-pack", "", nil, nil, false},
+		{"nil-scopes push denied", "/git-receive-pack", "", nil, nil, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			token := db.GitToken{CanPull: tc.canPull, CanPush: tc.canPush}
+			scope := requiredScope(tc.relPath, tc.service)
+			require.NotEqual(t, scopeNone, scope, "endpoint must resolve to a scope")
+			require.Equal(t, tc.allowed, tokenHasScope(token, scope))
+		})
+	}
+}
+
+// TestHandleRequestEnforcesTokenScope drives the full request path and asserts
+// the HTTP status: allowed operations advertise refs (200), scoped-out
+// operations are rejected with 403, and disabled/invalid tokens with 401.
+func TestHandleRequestEnforcesTokenScope(t *testing.T) {
+	cases := []struct {
+		name       string
+		service    string
+		canPull    *bool
+		canPush    *bool
+		tokenErr   bool
+		wantStatus int
+	}{
+		{"pull-only can fetch", "git-upload-pack", boolPtr(true), boolPtr(false), false, fasthttp.StatusOK},
+		{"pull-only cannot enumerate push", "git-receive-pack", boolPtr(true), boolPtr(false), false, fasthttp.StatusForbidden},
+		{"push-only can push", "git-receive-pack", boolPtr(false), boolPtr(true), false, fasthttp.StatusOK},
+		{"push-only cannot enumerate fetch", "git-upload-pack", boolPtr(false), boolPtr(true), false, fasthttp.StatusForbidden},
+		{"both fetch", "git-upload-pack", boolPtr(true), boolPtr(true), false, fasthttp.StatusOK},
+		{"both push", "git-receive-pack", boolPtr(true), boolPtr(true), false, fasthttp.StatusOK},
+		{"neither fetch", "git-upload-pack", boolPtr(false), boolPtr(false), false, fasthttp.StatusForbidden},
+		{"neither push", "git-receive-pack", boolPtr(false), boolPtr(false), false, fasthttp.StatusForbidden},
+		{"nil-scopes fetch", "git-upload-pack", nil, nil, false, fasthttp.StatusForbidden},
+		{"disabled token fetch", "git-upload-pack", boolPtr(true), boolPtr(true), true, fasthttp.StatusUnauthorized},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := &fakeEnv{gitToken: db.GitToken{CanPull: tc.canPull, CanPush: tc.canPush}}
+			if tc.tokenErr {
+				env.gitTokenErr = context.DeadlineExceeded
+			}
+			api := newTestAPI(t, env)
+
+			ctx := &fasthttp.RequestCtx{}
+			ctx.Request.SetRequestURI("/_system/git/info/refs?service=" + tc.service)
+			ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+			creds := base64.StdEncoding.EncodeToString([]byte("user:tok"))
+			ctx.Request.Header.Set("Authorization", "Basic "+creds)
+
+			require.True(t, api.HandleRequest(ctx))
+			require.Equal(t, tc.wantStatus, ctx.Response.StatusCode())
+		})
+	}
+}
+
+// TestHandleRequestScopeDeniedOnPackEndpoints covers the POST pack endpoints
+// directly (not just info/refs) for the denial directions.
+func TestHandleRequestScopeDeniedOnPackEndpoints(t *testing.T) {
+	cases := []struct {
+		name    string
+		path    string
+		canPull *bool
+		canPush *bool
+	}{
+		{"pull-only denied on receive-pack", "/git-receive-pack", boolPtr(true), boolPtr(false)},
+		{"push-only denied on upload-pack", "/git-upload-pack", boolPtr(false), boolPtr(true)},
+		{"neither denied on upload-pack", "/git-upload-pack", boolPtr(false), boolPtr(false)},
+		{"neither denied on receive-pack", "/git-receive-pack", boolPtr(false), boolPtr(false)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := &fakeEnv{gitToken: db.GitToken{CanPull: tc.canPull, CanPush: tc.canPush}}
+			api := newTestAPI(t, env)
+
+			ctx := &fasthttp.RequestCtx{}
+			ctx.Request.SetRequestURI("/_system/git" + tc.path)
+			ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+			creds := base64.StdEncoding.EncodeToString([]byte("user:tok"))
+			ctx.Request.Header.Set("Authorization", "Basic "+creds)
+
+			require.True(t, api.HandleRequest(ctx))
+			require.Equal(t, fasthttp.StatusForbidden, ctx.Response.StatusCode())
+		})
+	}
 }

--- a/internal/gitapi/testsupport_test.go
+++ b/internal/gitapi/testsupport_test.go
@@ -25,6 +25,10 @@ func newTestAPI(t *testing.T, env Env) *API {
 	}
 	cfg := Config{BasePath: "/_system/git", RepoPath: repo, MasterBranch: "master"}
 	api := &API{config: cfg, env: env, logger: &logger.DummyLogger{}, ctx: context.Background()}
+	api.handlers = map[string]map[string]handler{
+		"GET":  {"/info/refs": api.handleInfoRefs},
+		"POST": {"/git-upload-pack": api.handleGitUploadPack, "/git-receive-pack": api.handleGitReceivePack},
+	}
 	if err := api.ensureBareRepo(); err != nil {
 		t.Fatal(err)
 	}
@@ -54,6 +58,9 @@ type fakeEnv struct {
 	pushed   []string // paths passed to PushNotes
 	dbHashes map[string]string
 	pushErr  bool
+
+	gitToken    db.GitToken
+	gitTokenErr error
 }
 
 func (f *fakeEnv) Logger() logger.Logger { return &logger.DummyLogger{} }
@@ -94,7 +101,7 @@ func (f *fakeEnv) GetPrivateObject(context.Context, string) (io.ReadCloser, erro
 }
 func (f *fakeEnv) PrivateObjectExists(context.Context, string) (bool, error) { return false, nil }
 func (f *fakeEnv) GitTokenByValueSha256(context.Context, string) (db.GitToken, error) {
-	return db.GitToken{}, nil
+	return f.gitToken, f.gitTokenErr
 }
 
 func dbAsset(absPath string) db.NoteAsset {


### PR DESCRIPTION
## The gap

`git_tokens` rows carry `can_pull` and `can_push` scopes, and the admin UI lets
you set them — but gitapi's smart-HTTP auth (`internal/gitapi/api.go`) only
verified that the token *existed* (`GitTokenByValueSha256`) and never read those
columns. Result: any active (non-disabled) token granted **full pull + push**. A
token created as read-only (`can_pull=true, can_push=false`) could still push and
overwrite the vault.

## The enforcement

`checkAuth` now returns the authenticated `db.GitToken`, and `HandleRequest`
gates the request on its scope before dispatching:

- `git-upload-pack` / `info/refs?service=git-upload-pack` (fetch/clone) requires `can_pull`
- `git-receive-pack` / `info/refs?service=git-receive-pack` (push) requires `can_push`
- `info/refs` is gated on the requested **`?service=`**, not just the pack
  endpoints, so a scoped token can't advertise the other capability's refs.
- A missing/`nil` scope column = never granted = no access.
- Insufficient scope → **403 Forbidden** (clean git-client error); disabled/invalid
  tokens keep returning 401 (the read query already filters `disabled_at is null`).

## Test matrix (`internal/gitapi/api_security_test.go`)

`TestTokenScopeDecision` (pure decision) + `TestHandleRequestEnforcesTokenScope`
(full request path, HTTP status) + `TestHandleRequestScopeDeniedOnPackEndpoints`:

| token         | fetch (upload-pack) | push (receive-pack) |
|---------------|---------------------|---------------------|
| can_pull only | ok (200)            | denied (403)        |
| can_push only | denied (403)        | ok (200)            |
| both          | ok (200)            | ok (200)            |
| neither / nil | denied (403)        | denied (403)        |
| disabled      | 401 (auth fails)    | 401 (auth fails)    |

Verification: `go build ./internal/gitapi/...`, `go vet ./internal/gitapi/...`,
`go test ./internal/gitapi/...` all clean.

Out of scope (left untouched, per instructions): the sibling finding that
`UploadNoteAsset` in the gitapi Env is never called.
