### PR TITLE
fix(magazine): keep leading tables out of magazine card excerpts

### DIFF
--- a/docs/dev/default_template.md
+++ b/docs/dev/default_template.md
@@ -202,6 +202,29 @@ Each magazine card displays an image from `note.FirstImageURL()`:
 
 The featured card shows images at 280px height; grid cards at 200px.
 
+### Card Excerpt
+
+Each card shows a short preview built by `PartialRenderer.Introduce()` — the note body **up to the first heading or the first thematic break (`---`)**, whichever comes first.
+
+To control the preview, put a `---` right after a short intro:
+
+```markdown
+---
+title: "My Post"
+---
+
+One or two sentences that make a good card preview.
+
+---
+
+## The rest of the article
+Everything below the `---` stays off the card.
+```
+
+Notes:
+- The excerpt **drops tables** — a leading table would blow out the fixed-size card, so `Introduce()` skips `*extast.Table` nodes and keeps the surrounding prose. Still, prefer a `---` cut after a short intro rather than relying on this fallback.
+- Frontmatter must be well-formed YAML between two `---` fences. If the YAML fails to parse (for example an **unquoted `title:` that contains a colon**, like `title: Env pattern: one spine`), goldmark-meta leaves the whole block in the body and it renders as visible text. Quote such values: `title: "Env pattern: one spine"`. A body thematic break (`---`) never collides with this because only a `---` on line 1 opens frontmatter.
+
 ## Footer
 
 The site footer is rendered from a note specified in frontmatter via `footer: [[Footer]]`.

--- a/internal/mdloader/partial_renderer.go
+++ b/internal/mdloader/partial_renderer.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
+	extast "github.com/yuin/goldmark/extension/ast"
 )
 
 type PartialRenderer struct {
@@ -250,15 +251,41 @@ func (pr *PartialRenderer) Introduce() model.NoteViewSection {
 	if firstHeadingIndex == -1 {
 		return model.NoteViewSection{
 			TitleHTML:   "",
-			ContentHTML: pr.renderNodeRange(allNodes, 0, len(allNodes)),
+			ContentHTML: pr.renderExcerptRange(allNodes, 0, len(allNodes)),
 		}
 	}
 
 	// Return content before the first heading
 	return model.NoteViewSection{
 		TitleHTML:   "",
-		ContentHTML: pr.renderNodeRange(allNodes, 0, firstHeadingIndex),
+		ContentHTML: pr.renderExcerptRange(allNodes, 0, firstHeadingIndex),
 	}
+}
+
+// renderExcerptRange renders nodes [start,end) like renderNodeRange, but drops
+// tables. A leading table would blow out the fixed-size magazine card, so the
+// excerpt keeps the surrounding prose and skips the table. Authors control the
+// cut point with a `---` after a short intro.
+func (pr *PartialRenderer) renderExcerptRange(allNodes []ast.Node, start, end int) string {
+	if start < 0 || start >= len(allNodes) || end <= start {
+		return ""
+	}
+
+	var buf bytes.Buffer
+
+	pr.withCurrentPage(func() {
+		for i := start; i < end && i < len(allNodes); i++ {
+			node := allNodes[i]
+			if _, ok := node.(*extast.Table); ok {
+				continue // skip wide tables in the excerpt
+			}
+			if err := pr.md.Renderer().Render(&buf, pr.content, node); err != nil {
+				continue // Skip nodes that can't be rendered.
+			}
+		}
+	})
+
+	return buf.String()
 }
 
 // extractLinkText builds the text content of a link node.

--- a/internal/mdloader/partial_renderer_test.go
+++ b/internal/mdloader/partial_renderer_test.go
@@ -225,3 +225,28 @@ func TestPartialRendererImageAssetReplace(t *testing.T) {
 	require.NotContains(t, sections[0].ContentHTML, "./assets/photo.jpg")
 	require.NotContains(t, slides[0].ContentHTML, "./assets/slide1.png")
 }
+
+func introduceHTML(t *testing.T, body string) string {
+	t.Helper()
+	pages, err := mdloader.Load(mdloader.Options{
+		Sources: []mdloader.SourceFile{{Path: "index.md", Content: []byte(body)}},
+		Log:     &logger.TestLogger{},
+	})
+	require.NoError(t, err)
+	require.Len(t, pages.List, 1)
+	return pages.List[0].PartialRenderer.Introduce().ContentHTML
+}
+
+func TestIntroduceCutsAtThematicBreak(t *testing.T) {
+	html := introduceHTML(t, "Short intro.\n\n---\n\n## Body\n\nrest\n")
+	require.Contains(t, html, "Short intro.")
+	require.NotContains(t, html, "rest")
+}
+
+func TestIntroduceSkipsLeadingTable(t *testing.T) {
+	body := "Results first.\n\n| A | B |\n|---|---|\n| 1 | 2 |\n\n---\n\n## Story\n\ntail\n"
+	html := introduceHTML(t, body)
+	require.Contains(t, html, "Results first.")
+	require.NotContains(t, html, "<table")
+	require.NotContains(t, html, "tail")
+}


### PR DESCRIPTION
## Problem
On `/ru/thoughts`, a magazine card breaks when an article's intro (the body before the first heading / `---`) contains a wide table. `PartialRenderer.Introduce()` renders every node before the cut, including tables, which blows out the fixed-size card. `search-benchmark.md` (intro = two wide results tables) and `sync-benchmark.md` (mermaid + table) are affected.

## Fix
`Introduce()` now renders the excerpt via `renderExcerptRange`, which skips `*extast.Table` nodes while keeping the surrounding prose. The existing `---` / heading cut is unchanged — authors still control the preview by putting `---` after a short intro.

## Tests
- `TestIntroduceCutsAtThematicBreak` — excerpt stops at the first `---`.
- `TestIntroduceSkipsLeadingTable` — a table in the intro is not rendered in the excerpt.

## Docs
`docs/dev/default_template.md` gains a **Card Excerpt** section explaining the `---` cut, the table-skip fallback, and the frontmatter YAML-quoting requirement (an unquoted `title:` with a colon makes goldmark-meta leak the raw frontmatter as body text).

## Related (not in this PR)
Two RU articles have unquoted colon titles that leak frontmatter (`env-pattern.md`, `anatomy-15-months.md`) — content fix handled separately for owner review.