### PR TITLE
feat(defaulttemplate): parse widget keywords in content: list

### DIFF
--- a/internal/defaulttemplate/widgets.go
+++ b/internal/defaulttemplate/widgets.go
@@ -41,7 +41,10 @@ type WidgetRef struct {
 }
 
 // parseContentRef parses a content string into a ContentRef.
-// Recognized values: "selfcontent", "magazine", "[[Title]]", "path.md", false.
+// Recognized values: "selfcontent", "magazine", "toc", "inlinks"/"backlinks",
+// "outlinks", "similar", "[[Title]]", "path.md", false.
+// The widget keywords mirror parseWidgetRef so a content: list can render the
+// same blocks (backlinks, similar, TOC, ...) inline under the note body.
 func parseContentRef(raw interface{}) ContentRef {
 	s, ok := raw.(string)
 	if !ok {
@@ -60,6 +63,14 @@ func parseContentRef(raw interface{}) ContentRef {
 		return ContentRef{Kind: ContentRefSelfContent}
 	case "magazine":
 		return ContentRef{Kind: ContentRefMagazine}
+	case "toc":
+		return ContentRef{Kind: ContentRefTOC}
+	case "inlinks", "backlinks":
+		return ContentRef{Kind: ContentRefInLinks}
+	case "outlinks":
+		return ContentRef{Kind: ContentRefOutLinks}
+	case "similar":
+		return ContentRef{Kind: ContentRefSimilar}
 	case "false", "none":
 		return ContentRef{Kind: ContentRefNone}
 	}

--- a/internal/defaulttemplate/widgets_test.go
+++ b/internal/defaulttemplate/widgets_test.go
@@ -1,0 +1,29 @@
+package defaulttemplate
+
+import "testing"
+
+func TestParseContentRefWidgetKeywords(t *testing.T) {
+	cases := []struct {
+		in   string
+		want ContentRefKind
+	}{
+		{"self", ContentRefSelfContent},
+		{"selfcontent", ContentRefSelfContent},
+		{"magazine", ContentRefMagazine},
+		{"toc", ContentRefTOC},
+		{"TOC", ContentRefTOC},
+		{"inlinks", ContentRefInLinks},
+		{"backlinks", ContentRefInLinks},
+		{"outlinks", ContentRefOutLinks},
+		{"similar", ContentRefSimilar},
+		{"false", ContentRefNone},
+		{"[[Some Note]]", ContentRefWikiLink},
+		{"docs/page.md", ContentRefFile},
+	}
+	for _, c := range cases {
+		got := parseContentRef(c.in)
+		if got.Kind != c.want {
+			t.Errorf("parseContentRef(%q).Kind = %v, want %v", c.in, got.Kind, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## What
`parseContentRef` now recognizes the same widget keywords as the sidebar parser (`parseWidgetRef`): `toc`, `inlinks`/`backlinks`, `outlinks`, `similar`. So a note's `content:` list can render these blocks inline under the body, e.g.:

```yaml
content: [self, backlinks, similar]
```

## Why
The render switch (`views.html` / `views.html.go`) and `template.go`/`jsonld.go` already handle `ContentRefSimilar`, `ContentRefInLinks`, `ContentRefOutLinks`, `ContentRefTOC` in the main content column — but nothing ever produced those kinds, because `parseContentRef` only handled `self`/`magazine`/wikilink/file. So `content: [self, backlinks, similar]` silently fell through to `ContentRefFile` and tried (and failed) to resolve notes literally named "backlinks"/"similar". This completes the intended-but-unwired feature.

This unblocks a docs frontmatter-patch that puts a backlinks + related section under every thoughts/user article without editing each note.

## Test
Added `TestParseContentRefWidgetKeywords`. `go test ./internal/defaulttemplate/` passes; no `go generate` needed (only `.go` changed, the template already switches on these kinds).