### PR TITLE
refactor(case): compile-time cross-case Env contracts

### DIFF
--- a/cmd/server/case_methods.go
+++ b/cmd/server/case_methods.go
@@ -4,12 +4,17 @@ import (
 	"context"
 	"trip2g/internal/case/convertnoteviewtotgpost"
 	"trip2g/internal/case/gettelegramchatname"
+	"trip2g/internal/case/handlenotewebhooks"
 	"trip2g/internal/case/sendtelegramaccountpublishpost"
 	"trip2g/internal/case/sendtelegrampublishpost"
 	"trip2g/internal/case/updatetelegramaccountpublishpost"
 	"trip2g/internal/case/updatetelegrampublishpost"
 	"trip2g/internal/model"
 )
+
+func (a *app) HandleNoteWebhooks(ctx context.Context, changes []handlenotewebhooks.NoteChange, depth int) error {
+	return handlenotewebhooks.Resolve(ctx, a, changes, depth)
+}
 
 func (a *app) UpdateTelegramPublishPost(ctx context.Context, notePathID int64) error {
 	return updatetelegrampublishpost.Resolve(ctx, a, notePathID)

--- a/internal/case/admin/renderpreview/endpoint.go
+++ b/internal/case/admin/renderpreview/endpoint.go
@@ -21,13 +21,26 @@ type httpErrorBody struct {
 	Error string `json:"error"`
 }
 
+// endpointEnv composes this endpoint's own Env with checkapikey.Env, needed
+// only for the API-key auth fallback below. Kept local to the endpoint (not
+// added to Env) because Resolve's auth is the caller's responsibility.
+type endpointEnv interface {
+	Env
+	checkapikey.Env
+}
+
 func (e *Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 	ctx := req.Req
+
+	env, ok := req.Env.(endpointEnv)
+	if !ok {
+		return nil, appreq.ErrInvalidEnv
+	}
 
 	// Auth: admin session OR API key.
 	token, _ := req.UserToken()
 	if !token.IsAdmin() {
-		_, err := checkapikey.Resolve(ctx, req.Env.(checkapikey.Env), "render_preview")
+		_, err := checkapikey.Resolve(ctx, env, "render_preview")
 		if err != nil {
 			return writeErr(ctx, http.StatusUnauthorized, "unauthorized: "+err.Error())
 		}
@@ -40,7 +53,7 @@ func (e *Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 		return writeErr(ctx, http.StatusBadRequest, "invalid JSON: "+err.Error())
 	}
 
-	resp, err := Resolve(ctx, req.Env.(Env), input)
+	resp, err := Resolve(ctx, env, input)
 	if err != nil {
 		return writeErr(ctx, http.StatusBadRequest, err.Error())
 	}
@@ -57,7 +70,12 @@ type GetEndpoint struct{}
 func (e *GetEndpoint) Handle(req *appreq.Request) (interface{}, error) {
 	ctx := req.Req
 	args := ctx.QueryArgs()
-	buf := req.Env.(Env).PreviewBuffer()
+
+	env, ok := req.Env.(endpointEnv)
+	if !ok {
+		return nil, appreq.ErrInvalidEnv
+	}
+	buf := env.PreviewBuffer()
 
 	// ?longpolling&since=N — no auth, returns {action, version} after ≤30 s.
 	if args.Has("longpolling") {
@@ -90,7 +108,7 @@ func (e *GetEndpoint) Handle(req *appreq.Request) (interface{}, error) {
 	// Default and ?live — require admin auth or API key.
 	token, _ := req.UserToken()
 	if !token.IsAdmin() {
-		_, err := checkapikey.Resolve(ctx, req.Env.(checkapikey.Env), "render_preview")
+		_, err := checkapikey.Resolve(ctx, env, "render_preview")
 		if err != nil {
 			ctx.SetStatusCode(http.StatusUnauthorized)
 			ctx.SetBodyString("unauthorized")

--- a/internal/case/hidenotes/mocks_test.go
+++ b/internal/case/hidenotes/mocks_test.go
@@ -6,6 +6,7 @@ package hidenotes
 import (
 	"context"
 	"sync"
+	"trip2g/internal/case/handlenotewebhooks"
 	"trip2g/internal/db"
 	"trip2g/internal/logger"
 	internalmodel "trip2g/internal/model"
@@ -22,6 +23,9 @@ var _ Env = &EnvMock{}
 //
 //		// make and configure a mocked Env
 //		mockedEnv := &EnvMock{
+//			HandleNoteWebhooksFunc: func(ctx context.Context, changes []handlenotewebhooks.NoteChange, depth int) error {
+//				panic("mock out the HandleNoteWebhooks method")
+//			},
 //			HideNotePathFunc: func(ctx context.Context, params db.HideNotePathParams) error {
 //				panic("mock out the HideNotePath method")
 //			},
@@ -44,6 +48,9 @@ var _ Env = &EnvMock{}
 //
 //	}
 type EnvMock struct {
+	// HandleNoteWebhooksFunc mocks the HandleNoteWebhooks method.
+	HandleNoteWebhooksFunc func(ctx context.Context, changes []handlenotewebhooks.NoteChange, depth int) error
+
 	// HideNotePathFunc mocks the HideNotePath method.
 	HideNotePathFunc func(ctx context.Context, params db.HideNotePathParams) error
 
@@ -61,6 +68,15 @@ type EnvMock struct {
 
 	// calls tracks calls to the methods.
 	calls struct {
+		// HandleNoteWebhooks holds details about calls to the HandleNoteWebhooks method.
+		HandleNoteWebhooks []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Changes is the changes argument value.
+			Changes []handlenotewebhooks.NoteChange
+			// Depth is the depth argument value.
+			Depth int
+		}
 		// HideNotePath holds details about calls to the HideNotePath method.
 		HideNotePath []struct {
 			// Ctx is the ctx argument value.
@@ -87,11 +103,52 @@ type EnvMock struct {
 			Batch notebus.Batch
 		}
 	}
+	lockHandleNoteWebhooks sync.RWMutex
 	lockHideNotePath       sync.RWMutex
 	lockLatestNoteViews    sync.RWMutex
 	lockLogger             sync.RWMutex
 	lockPrepareLatestNotes sync.RWMutex
 	lockPublishNoteChanges sync.RWMutex
+}
+
+// HandleNoteWebhooks calls HandleNoteWebhooksFunc.
+func (mock *EnvMock) HandleNoteWebhooks(ctx context.Context, changes []handlenotewebhooks.NoteChange, depth int) error {
+	if mock.HandleNoteWebhooksFunc == nil {
+		panic("EnvMock.HandleNoteWebhooksFunc: method is nil but Env.HandleNoteWebhooks was just called")
+	}
+	callInfo := struct {
+		Ctx     context.Context
+		Changes []handlenotewebhooks.NoteChange
+		Depth   int
+	}{
+		Ctx:     ctx,
+		Changes: changes,
+		Depth:   depth,
+	}
+	mock.lockHandleNoteWebhooks.Lock()
+	mock.calls.HandleNoteWebhooks = append(mock.calls.HandleNoteWebhooks, callInfo)
+	mock.lockHandleNoteWebhooks.Unlock()
+	return mock.HandleNoteWebhooksFunc(ctx, changes, depth)
+}
+
+// HandleNoteWebhooksCalls gets all the calls that were made to HandleNoteWebhooks.
+// Check the length with:
+//
+//	len(mockedEnv.HandleNoteWebhooksCalls())
+func (mock *EnvMock) HandleNoteWebhooksCalls() []struct {
+	Ctx     context.Context
+	Changes []handlenotewebhooks.NoteChange
+	Depth   int
+} {
+	var calls []struct {
+		Ctx     context.Context
+		Changes []handlenotewebhooks.NoteChange
+		Depth   int
+	}
+	mock.lockHandleNoteWebhooks.RLock()
+	calls = mock.calls.HandleNoteWebhooks
+	mock.lockHandleNoteWebhooks.RUnlock()
+	return calls
 }
 
 // HideNotePath calls HideNotePathFunc.

--- a/internal/case/hidenotes/resolve.go
+++ b/internal/case/hidenotes/resolve.go
@@ -18,6 +18,7 @@ type Env interface {
 	PrepareLatestNotes(ctx context.Context, partial bool) (*internalmodel.NoteViews, error)
 	Logger() logger.Logger
 	PublishNoteChanges(batch notebus.Batch)
+	HandleNoteWebhooks(ctx context.Context, changes []handlenotewebhooks.NoteChange, depth int) error
 }
 
 type Input = model.HideNotesInput
@@ -99,13 +100,7 @@ func triggerWebhooks(ctx context.Context, env Env, changes []handlenotewebhooks.
 		return
 	}
 
-	webhookEnv, ok := req.Env.(handlenotewebhooks.Env)
-	if !ok {
-		env.Logger().Error("failed to cast env to handlenotewebhooks.Env for hide webhooks")
-		return
-	}
-
-	webhookErr := handlenotewebhooks.Resolve(ctx, webhookEnv, changes, req.WebhookDepth)
+	webhookErr := env.HandleNoteWebhooks(ctx, changes, req.WebhookDepth)
 	if webhookErr != nil {
 		env.Logger().Error("failed to handle note webhooks for hide", "error", webhookErr)
 	}

--- a/internal/case/render404/render.go
+++ b/internal/case/render404/render.go
@@ -1,7 +1,6 @@
 package render404
 
 import (
-	"context"
 	"net/http"
 	"trip2g/internal/appreq"
 	"trip2g/internal/case/renderlayout"
@@ -18,6 +17,8 @@ type Params struct {
 }
 
 type Env interface {
+	renderlayout.Env
+
 	TrackNotFound(path string, ip string)
 }
 
@@ -38,22 +39,17 @@ func Handle(req *appreq.Request) (interface{}, error) {
 		return nil, err
 	}
 
-	var jsURLs, cssURLs []string
-	var localeHashes map[string]string
+	jsURLs := env.UserJSURLs()
+	cssURLs := env.UserCSSURLs()
+	localeHashes := env.UserLocaleHashes()
 	devMode := "false"
+	if env.IsDevMode() {
+		devMode = "true"
+	}
 	injections := map[string][]db.HtmlInjection{}
-
-	if rlEnv, rlOk := req.Env.(renderlayout.Env); rlOk {
-		jsURLs = rlEnv.UserJSURLs()
-		cssURLs = rlEnv.UserCSSURLs()
-		localeHashes = rlEnv.UserLocaleHashes()
-		if rlEnv.IsDevMode() {
-			devMode = "true"
-		}
-		if active, injErr := rlEnv.ActiveHTMLInjections(context.Background()); injErr == nil {
-			for _, inj := range active {
-				injections[inj.Placement] = append(injections[inj.Placement], inj)
-			}
+	if active, injErr := env.ActiveHTMLInjections(ctx); injErr == nil {
+		for _, inj := range active {
+			injections[inj.Placement] = append(injections[inj.Placement], inj)
 		}
 	}
 

--- a/internal/case/rendernotepage/endpoint.go
+++ b/internal/case/rendernotepage/endpoint.go
@@ -588,24 +588,19 @@ func buildDefaultTemplateCtx( //nolint:gocognit // template context assembly req
 	// render the version author for normal notes (gated on admin in the template).
 	injectLastEditedByResolver(env, resp)
 
-	// Fetch JS/CSS URLs and dev mode from the renderlayout.Env interface.
-	rlEnv, ok := req.Env.(renderlayout.Env)
-
 	jsURLs := layoutParams.JSURLs
 	cssURLs := layoutParams.CSSURLs
 	inlineCSS := ""
 	devMode := "false"
 
-	if ok {
-		if len(jsURLs) == 0 {
-			jsURLs = rlEnv.UserJSURLs()
-		}
-		if len(cssURLs) == 0 {
-			inlineCSS = rlEnv.UserInlineCSS()
-		}
-		if rlEnv.IsDevMode() {
-			devMode = "true"
-		}
+	if len(jsURLs) == 0 {
+		jsURLs = env.UserJSURLs()
+	}
+	if len(cssURLs) == 0 {
+		inlineCSS = env.UserInlineCSS()
+	}
+	if env.IsDevMode() {
+		devMode = "true"
 	}
 
 	// toc.js handles both TOC scrollspy and sidebar active-link highlighting;
@@ -629,15 +624,13 @@ func buildDefaultTemplateCtx( //nolint:gocognit // template context assembly req
 
 	// Build HTML injections map.
 	injections := map[string][]db.HtmlInjection{}
-	if ok {
-		active, err := rlEnv.ActiveHTMLInjections(context.Background())
-		if err == nil {
-			for _, inj := range active {
-				injections[inj.Placement] = append(injections[inj.Placement], inj)
-			}
-		} else {
-			env.Logger().Error("failed to get active HTML injections", "error", err)
+	active, err := env.ActiveHTMLInjections(req.Req)
+	if err == nil {
+		for _, inj := range active {
+			injections[inj.Placement] = append(injections[inj.Placement], inj)
 		}
+	} else {
+		env.Logger().Error("failed to get active HTML injections", "error", err)
 	}
 
 	// Convert hreflang slice.
@@ -650,16 +643,11 @@ func buildDefaultTemplateCtx( //nolint:gocognit // template context assembly req
 	}
 
 	dtCtx := &defaulttemplate.Ctx{
-		Note:   resp.NoteView,
-		Notes:  templateviews.NewNVS(resp.Notes, resp.DefaultVersion),
-		Title:  layoutParams.Title,
-		JSURLs: jsURLs,
-		LocaleHashes: func() map[string]string {
-			if ok {
-				return rlEnv.UserLocaleHashes()
-			}
-			return nil
-		}(),
+		Note:            resp.NoteView,
+		Notes:           templateviews.NewNVS(resp.Notes, resp.DefaultVersion),
+		Title:           layoutParams.Title,
+		JSURLs:          jsURLs,
+		LocaleHashes:    env.UserLocaleHashes(),
 		CSSURLs:         cssURLs,
 		InlineCSS:       inlineCSS,
 		DevMode:         devMode,

--- a/internal/case/rendernotepage/endpoint_cache_test.go
+++ b/internal/case/rendernotepage/endpoint_cache_test.go
@@ -92,6 +92,11 @@ func cacheTestEnv(views *model.NoteViews, layouts *model.Layouts) (*EnvMock, *pa
 		NoteVersionEditorFunc: func(ctx context.Context, versionID int64) (*templateviews.NoteEditor, error) {
 			return nil, nil
 		},
+		UserJSURLsFunc:       func() []string { return nil },
+		UserCSSURLsFunc:      func() []string { return nil },
+		UserInlineCSSFunc:    func() string { return "" },
+		UserLocaleHashesFunc: func() map[string]string { return nil },
+		IsDevModeFunc:        func() bool { return false },
 		// Authenticated-viewer path (handleUserToken) — only exercised by the
 		// authenticated-bypass test; harmless stubs otherwise.
 		ListActiveUserSubgraphsFunc: func(ctx context.Context, userID int64) ([]string, error) {

--- a/internal/case/rendernotepage/mocks_test.go
+++ b/internal/case/rendernotepage/mocks_test.go
@@ -55,6 +55,9 @@ var _ rendernotepage.Env = &EnvMock{}
 //			InsertUserNoteViewFunc: func(ctx context.Context, params db.InsertUserNoteViewParams) error {
 //				panic("mock out the InsertUserNoteView method")
 //			},
+//			IsDevModeFunc: func() bool {
+//				panic("mock out the IsDevMode method")
+//			},
 //			LastUserNoteViewFunc: func(ctx context.Context, arg db.LastUserNoteViewParams) (db.LastUserNoteViewRow, error) {
 //				panic("mock out the LastUserNoteView method")
 //			},
@@ -97,6 +100,18 @@ var _ rendernotepage.Env = &EnvMock{}
 //			UpsertUserNoteDailyViewFunc: func(ctx context.Context, params db.UpsertUserNoteDailyViewParams) (int64, error) {
 //				panic("mock out the UpsertUserNoteDailyView method")
 //			},
+//			UserCSSURLsFunc: func() []string {
+//				panic("mock out the UserCSSURLs method")
+//			},
+//			UserInlineCSSFunc: func() string {
+//				panic("mock out the UserInlineCSS method")
+//			},
+//			UserJSURLsFunc: func() []string {
+//				panic("mock out the UserJSURLs method")
+//			},
+//			UserLocaleHashesFunc: func() map[string]string {
+//				panic("mock out the UserLocaleHashes method")
+//			},
 //		}
 //
 //		// use mockedEnv in code that requires rendernotepage.Env
@@ -133,6 +148,9 @@ type EnvMock struct {
 
 	// InsertUserNoteViewFunc mocks the InsertUserNoteView method.
 	InsertUserNoteViewFunc func(ctx context.Context, params db.InsertUserNoteViewParams) error
+
+	// IsDevModeFunc mocks the IsDevMode method.
+	IsDevModeFunc func() bool
 
 	// LastUserNoteViewFunc mocks the LastUserNoteView method.
 	LastUserNoteViewFunc func(ctx context.Context, arg db.LastUserNoteViewParams) (db.LastUserNoteViewRow, error)
@@ -175,6 +193,18 @@ type EnvMock struct {
 
 	// UpsertUserNoteDailyViewFunc mocks the UpsertUserNoteDailyView method.
 	UpsertUserNoteDailyViewFunc func(ctx context.Context, params db.UpsertUserNoteDailyViewParams) (int64, error)
+
+	// UserCSSURLsFunc mocks the UserCSSURLs method.
+	UserCSSURLsFunc func() []string
+
+	// UserInlineCSSFunc mocks the UserInlineCSS method.
+	UserInlineCSSFunc func() string
+
+	// UserJSURLsFunc mocks the UserJSURLs method.
+	UserJSURLsFunc func() []string
+
+	// UserLocaleHashesFunc mocks the UserLocaleHashes method.
+	UserLocaleHashesFunc func() map[string]string
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -233,6 +263,9 @@ type EnvMock struct {
 			Ctx context.Context
 			// Params is the params argument value.
 			Params db.InsertUserNoteViewParams
+		}
+		// IsDevMode holds details about calls to the IsDevMode method.
+		IsDevMode []struct {
 		}
 		// LastUserNoteView holds details about calls to the LastUserNoteView method.
 		LastUserNoteView []struct {
@@ -306,6 +339,18 @@ type EnvMock struct {
 			// Params is the params argument value.
 			Params db.UpsertUserNoteDailyViewParams
 		}
+		// UserCSSURLs holds details about calls to the UserCSSURLs method.
+		UserCSSURLs []struct {
+		}
+		// UserInlineCSS holds details about calls to the UserInlineCSS method.
+		UserInlineCSS []struct {
+		}
+		// UserJSURLs holds details about calls to the UserJSURLs method.
+		UserJSURLs []struct {
+		}
+		// UserLocaleHashes holds details about calls to the UserLocaleHashes method.
+		UserLocaleHashes []struct {
+		}
 	}
 	lockActiveHTMLInjections                sync.RWMutex
 	lockAssetURL                            sync.RWMutex
@@ -317,6 +362,7 @@ type EnvMock struct {
 	lockGetTelegramPostLinksByNoteVersionID sync.RWMutex
 	lockIncreaseUserNoteViewCount           sync.RWMutex
 	lockInsertUserNoteView                  sync.RWMutex
+	lockIsDevMode                           sync.RWMutex
 	lockLastUserNoteView                    sync.RWMutex
 	lockLatestNoteChunks                    sync.RWMutex
 	lockLatestNoteViews                     sync.RWMutex
@@ -331,6 +377,10 @@ type EnvMock struct {
 	lockSiteTitleTemplate                   sync.RWMutex
 	lockStoreCachedPage                     sync.RWMutex
 	lockUpsertUserNoteDailyView             sync.RWMutex
+	lockUserCSSURLs                         sync.RWMutex
+	lockUserInlineCSS                       sync.RWMutex
+	lockUserJSURLs                          sync.RWMutex
+	lockUserLocaleHashes                    sync.RWMutex
 }
 
 // ActiveHTMLInjections calls ActiveHTMLInjectionsFunc.
@@ -660,6 +710,33 @@ func (mock *EnvMock) InsertUserNoteViewCalls() []struct {
 	mock.lockInsertUserNoteView.RLock()
 	calls = mock.calls.InsertUserNoteView
 	mock.lockInsertUserNoteView.RUnlock()
+	return calls
+}
+
+// IsDevMode calls IsDevModeFunc.
+func (mock *EnvMock) IsDevMode() bool {
+	if mock.IsDevModeFunc == nil {
+		panic("EnvMock.IsDevModeFunc: method is nil but Env.IsDevMode was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockIsDevMode.Lock()
+	mock.calls.IsDevMode = append(mock.calls.IsDevMode, callInfo)
+	mock.lockIsDevMode.Unlock()
+	return mock.IsDevModeFunc()
+}
+
+// IsDevModeCalls gets all the calls that were made to IsDevMode.
+// Check the length with:
+//
+//	len(mockedEnv.IsDevModeCalls())
+func (mock *EnvMock) IsDevModeCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockIsDevMode.RLock()
+	calls = mock.calls.IsDevMode
+	mock.lockIsDevMode.RUnlock()
 	return calls
 }
 
@@ -1105,5 +1182,113 @@ func (mock *EnvMock) UpsertUserNoteDailyViewCalls() []struct {
 	mock.lockUpsertUserNoteDailyView.RLock()
 	calls = mock.calls.UpsertUserNoteDailyView
 	mock.lockUpsertUserNoteDailyView.RUnlock()
+	return calls
+}
+
+// UserCSSURLs calls UserCSSURLsFunc.
+func (mock *EnvMock) UserCSSURLs() []string {
+	if mock.UserCSSURLsFunc == nil {
+		panic("EnvMock.UserCSSURLsFunc: method is nil but Env.UserCSSURLs was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockUserCSSURLs.Lock()
+	mock.calls.UserCSSURLs = append(mock.calls.UserCSSURLs, callInfo)
+	mock.lockUserCSSURLs.Unlock()
+	return mock.UserCSSURLsFunc()
+}
+
+// UserCSSURLsCalls gets all the calls that were made to UserCSSURLs.
+// Check the length with:
+//
+//	len(mockedEnv.UserCSSURLsCalls())
+func (mock *EnvMock) UserCSSURLsCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockUserCSSURLs.RLock()
+	calls = mock.calls.UserCSSURLs
+	mock.lockUserCSSURLs.RUnlock()
+	return calls
+}
+
+// UserInlineCSS calls UserInlineCSSFunc.
+func (mock *EnvMock) UserInlineCSS() string {
+	if mock.UserInlineCSSFunc == nil {
+		panic("EnvMock.UserInlineCSSFunc: method is nil but Env.UserInlineCSS was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockUserInlineCSS.Lock()
+	mock.calls.UserInlineCSS = append(mock.calls.UserInlineCSS, callInfo)
+	mock.lockUserInlineCSS.Unlock()
+	return mock.UserInlineCSSFunc()
+}
+
+// UserInlineCSSCalls gets all the calls that were made to UserInlineCSS.
+// Check the length with:
+//
+//	len(mockedEnv.UserInlineCSSCalls())
+func (mock *EnvMock) UserInlineCSSCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockUserInlineCSS.RLock()
+	calls = mock.calls.UserInlineCSS
+	mock.lockUserInlineCSS.RUnlock()
+	return calls
+}
+
+// UserJSURLs calls UserJSURLsFunc.
+func (mock *EnvMock) UserJSURLs() []string {
+	if mock.UserJSURLsFunc == nil {
+		panic("EnvMock.UserJSURLsFunc: method is nil but Env.UserJSURLs was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockUserJSURLs.Lock()
+	mock.calls.UserJSURLs = append(mock.calls.UserJSURLs, callInfo)
+	mock.lockUserJSURLs.Unlock()
+	return mock.UserJSURLsFunc()
+}
+
+// UserJSURLsCalls gets all the calls that were made to UserJSURLs.
+// Check the length with:
+//
+//	len(mockedEnv.UserJSURLsCalls())
+func (mock *EnvMock) UserJSURLsCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockUserJSURLs.RLock()
+	calls = mock.calls.UserJSURLs
+	mock.lockUserJSURLs.RUnlock()
+	return calls
+}
+
+// UserLocaleHashes calls UserLocaleHashesFunc.
+func (mock *EnvMock) UserLocaleHashes() map[string]string {
+	if mock.UserLocaleHashesFunc == nil {
+		panic("EnvMock.UserLocaleHashesFunc: method is nil but Env.UserLocaleHashes was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockUserLocaleHashes.Lock()
+	mock.calls.UserLocaleHashes = append(mock.calls.UserLocaleHashes, callInfo)
+	mock.lockUserLocaleHashes.Unlock()
+	return mock.UserLocaleHashesFunc()
+}
+
+// UserLocaleHashesCalls gets all the calls that were made to UserLocaleHashes.
+// Check the length with:
+//
+//	len(mockedEnv.UserLocaleHashesCalls())
+func (mock *EnvMock) UserLocaleHashesCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockUserLocaleHashes.RLock()
+	calls = mock.calls.UserLocaleHashes
+	mock.lockUserLocaleHashes.RUnlock()
 	return calls
 }

--- a/internal/case/rendernotepage/resolve.go
+++ b/internal/case/rendernotepage/resolve.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"trip2g/internal/case/renderlayout"
 	"trip2g/internal/db"
 	"trip2g/internal/features"
 	"trip2g/internal/logger"
@@ -21,6 +22,8 @@ import (
 )
 
 type Env interface {
+	renderlayout.Env
+
 	Layouts() *model.Layouts
 
 	Features() features.Features
@@ -54,7 +57,6 @@ type Env interface {
 		ctx context.Context,
 		arg db.GetTelegramPostLinksByNoteVersionIDParams,
 	) ([]db.GetTelegramPostLinksByNoteVersionIDRow, error)
-	ActiveHTMLInjections(ctx context.Context) ([]db.HtmlInjection, error)
 	// AssetURL returns the cache-busting URL for an embedded asset path, used to
 	// build conditional per-note widget script tags (chart.js, mermaid.js).
 	AssetURL(path string) string

--- a/internal/case/rendernotepage/userspace.go
+++ b/internal/case/rendernotepage/userspace.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"trip2g/internal/case/renderlayout"
 	"trip2g/internal/defaulttemplate"
 	"trip2g/internal/langdetect"
 	"trip2g/internal/model"
@@ -211,19 +210,10 @@ func buildUserSpaceHelper(
 	env Env,
 	resp *Response,
 ) *userSpaceHelper {
-	var (
-		jsURLs       []string
-		cssURLs      []string
-		localeHashes map[string]string
-		devMode      bool
-	)
-
-	if rlEnv, ok := env.(renderlayout.Env); ok {
-		jsURLs = rlEnv.UserJSURLs()
-		cssURLs = rlEnv.UserCSSURLs()
-		localeHashes = rlEnv.UserLocaleHashes()
-		devMode = rlEnv.IsDevMode()
-	}
+	jsURLs := env.UserJSURLs()
+	cssURLs := env.UserCSSURLs()
+	localeHashes := env.UserLocaleHashes()
+	devMode := env.IsDevMode()
 
 	uiLang := langdetect.DetectPreferred(
 		string(ctx.Request.Header.Cookie(langCookieName)),


### PR DESCRIPTION
Eliminates all 5 runtime `req.Env.(othercase.Env)` type-assertions across use cases, replacing each with a compile-time-checked Env contract.

## Change 1: hidenotes → handlenotewebhooks
`hidenotes.Env` now declares `HandleNoteWebhooks(ctx, changes, depth) error` directly instead of asserting to `handlenotewebhooks.Env` and silently skipping on failure. Added `(*app) HandleNoteWebhooks` wrapper in `cmd/server/case_methods.go` that calls `handlenotewebhooks.Resolve`.

## Change 2: rendernotepage + render404 → renderlayout
- `rendernotepage.Env` and `render404.Env` now embed `renderlayout.Env` (interface embedding) instead of doing optional runtime asserts. Both assert sites in rendernotepage are gone: `endpoint.go` (`buildDefaultTemplateCtx`) and `userspace.go` (`buildUserSpaceHelper`).
- `rendernotepage`'s `Env` already declared `ActiveHTMLInjections` with the identical signature as `renderlayout.Env`, so the duplicate declaration was removed in favor of the embedded one (Go 1.14+ allows this since signatures match).
- `render404`'s `context.Background()` call for `ActiveHTMLInjections` was replaced with the request's real context — `req.Req` (`*fasthttp.RequestCtx`) implements `context.Context` directly, so it's threaded through as `ctx` instead of a detached background context.
- Same fix applied in `rendernotepage/endpoint.go`'s `buildDefaultTemplateCtx`, which now passes `req.Req` instead of `context.Background()`.

## Change 3: admin/renderpreview → checkapikey
`renderpreview`'s own `Env` interface stays minimal (auth is documented as the caller's responsibility in `resolve.go`). Instead, `endpoint.go` declares a private composite `endpointEnv` (`Env` + `checkapikey.Env`) and does a single runtime assert per handler (`Endpoint.Handle`, `GetEndpoint.Handle`) at the top, reused for both the API-key check and the `Resolve` call — replacing three separate asserts (two to `checkapikey.Env`, one to `Env`) with one.

## Change 4: router regeneration
Ran `go generate ./internal/router/...` (via `gencmd`) after all Env shape changes — `internal/router/env.go` / `endpoints_gen.go` produced **no diff**. The generator composes each endpoint package's exported `Env` type by name, not its expanded method set, so widening `rendernotepage.Env`/`render404.Env` via embedding doesn't change what it emits. `renderpreview`'s new `endpointEnv` is unexported and local to that endpoint, so it's correctly invisible to the generator — no deviation needed.

## Verification
- `go build -tags dev ./...` — pass (see note below)
- `go vet -tags dev ./...` — pass
- `go test -tags dev ./internal/case/... ./internal/router/... ./internal/graph/...` — all pass (136 packages with tests, 0 failures)

Note: this worktree lacks a built frontend bundle (`npm run build` output) and `onboarding-vault/vault.zip`, so plain `go build ./...`/`go vet ./...` fail on `assets/embed.go` (missing `ui/admin/-/web.js` etc.) — confirmed pre-existing by stashing this branch's changes and reproducing the identical failure on `main`. `-tags dev` uses the dev embed variant and builds/vets clean, proving this refactor itself is sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)