### PR TITLE
refactor(jobs): bounded telegram retries + consistent cron/back job shape

### DIFF
--- a/cmd/server/cronjobs.go
+++ b/cmd/server/cronjobs.go
@@ -20,55 +20,33 @@ import (
 )
 
 func getCronJobConfigs(app *app) []cronjobs.Job {
-	// Compile-time interface checks
-	var (
-		_ simplebackup.Env   = app
-		_ vacuumdatabase.Env = app
-
-		_ materializegitmirror.Env         = app
-		_ removeexpiredtgchatmembers.Env   = app
-		_ clearcronjobexecutionhistory.Env = app
-
-		_ sendscheduledtelegrampublishposts.Env = app
-		_ updatetelegrampublishposts.Env        = app
-		_ refreshtelegramaccounts.Env           = app
-		_ refreshtelegramchatusernames.Env      = app
-
-		_ regeneratenoteembeddings.Env = app
-
-		_ executecronwebhooks.Env = app
-
-		_ cleanupwebhookdeliverylogs.Env   = app
-		_ cleanupwebhookdeliveries.Env     = app
-		_ cleanupapikeylogs.Env            = app
-		_ expirestalewebhookdeliveries.Env = app
-	)
-
+	// Each New(app, ...) captures the typed env at wiring time — the constructor
+	// call is the compile-time proof that *app implements the job's Env.
 	jobs := []cronjobs.Job{
-		&materializegitmirror.Job{},
-		&removeexpiredtgchatmembers.Job{},
-		&clearcronjobexecutionhistory.Job{},
-		&sendscheduledtelegrampublishposts.Job{Cron: app.config.CronTelegramPublishSchedule},
-		&updatetelegrampublishposts.Job{},
-		&refreshtelegramaccounts.Job{},
-		&refreshtelegramchatusernames.Job{},
-		&regeneratenoteembeddings.Job{},
-		&executecronwebhooks.Job{Cron: app.config.CronExecuteWebhooksSchedule},
-		&cleanupwebhookdeliverylogs.Job{},
-		&cleanupwebhookdeliveries.Job{},
-		&cleanupapikeylogs.Job{Config: app.config.APIKeyLogs},
-		&expirestalewebhookdeliveries.Job{},
+		materializegitmirror.New(app),
+		removeexpiredtgchatmembers.New(app),
+		clearcronjobexecutionhistory.New(app),
+		sendscheduledtelegrampublishposts.New(app, app.config.CronTelegramPublishSchedule),
+		updatetelegrampublishposts.New(app),
+		refreshtelegramaccounts.New(app),
+		refreshtelegramchatusernames.New(app),
+		regeneratenoteembeddings.New(app),
+		executecronwebhooks.New(app, app.config.CronExecuteWebhooksSchedule),
+		cleanupwebhookdeliverylogs.New(app),
+		cleanupwebhookdeliveries.New(app),
+		cleanupapikeylogs.New(app, app.config.APIKeyLogs),
+		expirestalewebhookdeliveries.New(app),
 	}
 
 	// VACUUM/ANALYZE maintenance is opt-in (heavy full-DB rewrite; incompatible
 	// with Litestream, which owns WAL checkpointing).
 	if app.config.VacuumCron {
-		jobs = append(jobs, &vacuumdatabase.Job{})
+		jobs = append(jobs, vacuumdatabase.New(app))
 	}
 
 	// Conditionally add simple backup job if enabled
 	if app.simpleBackup != nil {
-		jobs = append(jobs, &simplebackup.Job{})
+		jobs = append(jobs, simplebackup.New(app))
 	}
 
 	return jobs

--- a/docs/dev/app_patterns.md
+++ b/docs/dev/app_patterns.md
@@ -118,12 +118,15 @@ Reference: `internal/case/cronjob/cleanupwebhookdeliveries/`
 
 ```go
 // job.go
-type Job struct{}
+type Job struct {
+    env Env
+}
+func New(env Env) *Job                    { return &Job{env: env} } // typed env captured at registration
 func (j *Job) Name() string              { return "cleanup_webhook_deliveries" }
 func (j *Job) Schedule() string           { return "0 0 3 * * *" } // 6-field cron (with seconds)
 func (j *Job) ExecuteAfterStart() bool    { return false }
-func (j *Job) Execute(ctx context.Context, env any) (any, error) {
-    return Resolve(ctx, env.(Env))
+func (j *Job) Execute(ctx context.Context) (any, error) {
+    return Resolve(ctx, j.env)
 }
 
 // resolve.go

--- a/internal/case/backjob/generatenoteversionembedding/resolve.go
+++ b/internal/case/backjob/generatenoteversionembedding/resolve.go
@@ -1,6 +1,6 @@
 package generatenoteversionembedding
 
-//go:generate go run github.com/matryer/moq -out mocks_test.go -pkg generatenoteversionembedding_test . Env
+//go:generate go tool github.com/matryer/moq -out mocks_test.go -pkg generatenoteversionembedding_test . Env
 
 import (
 	"bytes"

--- a/internal/case/backjob/sendtelegramaccountmessage/resolve.go
+++ b/internal/case/backjob/sendtelegramaccountmessage/resolve.go
@@ -13,7 +13,7 @@ import (
 	"trip2g/internal/tgtd"
 )
 
-//go:generate go run github.com/matryer/moq -out mocks_test.go -pkg sendtelegramaccountmessage_test . Env
+//go:generate go tool github.com/matryer/moq -out mocks_test.go -pkg sendtelegramaccountmessage_test . Env
 
 type Env interface {
 	InsertTelegramPublishSentAccountMessage(ctx context.Context, arg db.InsertTelegramPublishSentAccountMessageParams) error

--- a/internal/case/backjob/sendtelegramaccountmessage/resolve.go
+++ b/internal/case/backjob/sendtelegramaccountmessage/resolve.go
@@ -34,34 +34,44 @@ type Env interface {
 	UpdateTelegramPublishAccountInstantChatAccessHash(ctx context.Context, arg db.UpdateTelegramPublishAccountInstantChatAccessHashParams) error
 }
 
-func Resolve(ctx context.Context, env Env, params model.TelegramAccountSendPostParams) error {
-	// 10 minutes timeout for large file uploads (videos can be 300MB+)
-	jobTimeout := 10 * time.Minute
+// maxAttempts bounds the total telegram rate-limit retries (initial try + retries).
+const maxAttempts = 3
 
-	jobCtx, cancel := context.WithTimeout(context.Background(), jobTimeout)
+func Resolve(ctx context.Context, env Env, params model.TelegramAccountSendPostParams) error {
+	// 10 minutes timeout for large file uploads (videos can be 300MB+).
+	// Derive from the parent ctx so app shutdown cancels the job.
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 
-	err := resolve1(jobCtx, env, params)
-	if err != nil {
-		shouldRetry, delay := telegram.HandleRateLimit(err)
-		if shouldRetry {
-			env.Logger().Info("telegram rate limit hit, retrying after delay",
-				"delay", delay,
-				"job", JobID,
-			)
-			time.Sleep(delay)
-			err = Resolve(ctx, env, params)
+	var err error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		err = resolve(ctx, env, params)
+		if err == nil {
+			return nil
 		}
 
-		if err != nil {
+		shouldRetry, delay := telegram.HandleRateLimit(err)
+		if !shouldRetry || attempt == maxAttempts {
 			return err
+		}
+
+		env.Logger().Info("telegram rate limit hit, retrying after delay",
+			"delay", delay,
+			"attempt", attempt,
+			"job", JobID,
+		)
+
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 	}
 
-	return nil
+	return err
 }
 
-func resolve1(ctx context.Context, env Env, params model.TelegramAccountSendPostParams) error {
+func resolve(ctx context.Context, env Env, params model.TelegramAccountSendPostParams) error {
 	// Check if message already exists before sending to avoid duplicate messages
 	exists, err := env.CheckTelegramPublishSentAccountMessageExists(ctx, db.CheckTelegramPublishSentAccountMessageExistsParams{
 		NotePathID:     params.NotePathID,

--- a/internal/case/backjob/sendtelegramaccountmessage/resolve_test.go
+++ b/internal/case/backjob/sendtelegramaccountmessage/resolve_test.go
@@ -1,0 +1,120 @@
+package sendtelegramaccountmessage_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"trip2g/internal/case/backjob/sendtelegramaccountmessage"
+	"trip2g/internal/db"
+	"trip2g/internal/logger"
+	"trip2g/internal/model"
+)
+
+// rateLimitErr carries the "Too Many Requests" marker telegram.HandleRateLimit
+// looks for; "retry after 0" keeps the retry delay at the 1s floor for tests.
+var rateLimitErr = errors.New("Too Many Requests: retry after 0")
+
+func sendAccountRetryParams() model.TelegramAccountSendPostParams {
+	return model.TelegramAccountSendPostParams{
+		NotePathID:     123,
+		AccountID:      1,
+		TelegramChatID: 789,
+		Post: model.TelegramPost{
+			Content: "Test message",
+			Media:   []string{},
+		},
+	}
+}
+
+// sendAccountRetryEnv builds an EnvMock where GetTelegramAccountByID is the
+// rate-limit failure point; the CheckExists counter lets a later attempt skip
+// past sending entirely (already-sent) to reach a real success without ever
+// touching the real tgtd network client.
+func sendAccountRetryEnv(getAccountFn func(ctx context.Context, id int64) (db.TelegramAccount, error)) *EnvMock {
+	return &EnvMock{
+		LoggerFunc: func() logger.Logger { return &logger.DummyLogger{} },
+		CheckTelegramPublishSentAccountMessageExistsFunc: func(ctx context.Context, arg db.CheckTelegramPublishSentAccountMessageExistsParams) (int64, error) {
+			return 0, nil
+		},
+		GetTelegramAccountByIDFunc: getAccountFn,
+	}
+}
+
+func TestResolve_RateLimit_RetriedThenSucceeds(t *testing.T) {
+	checkCalls := 0
+	getAccountCalls := 0
+
+	env := sendAccountRetryEnv(func(ctx context.Context, id int64) (db.TelegramAccount, error) {
+		getAccountCalls++
+		return db.TelegramAccount{}, rateLimitErr
+	})
+	env.CheckTelegramPublishSentAccountMessageExistsFunc = func(ctx context.Context, arg db.CheckTelegramPublishSentAccountMessageExistsParams) (int64, error) {
+		checkCalls++
+		if checkCalls == 1 {
+			return 0, nil // not sent yet — proceed to send, which will rate-limit
+		}
+		return 999, nil // already sent by the time we retry — skip cleanly
+	}
+
+	err := sendtelegramaccountmessage.Resolve(context.Background(), env, sendAccountRetryParams())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if checkCalls != 2 {
+		t.Errorf("expected 2 resolve attempts (1 retry), got %d", checkCalls)
+	}
+	if getAccountCalls != 1 {
+		t.Errorf("expected GetTelegramAccountByID called once (rate-limited then skipped), got %d", getAccountCalls)
+	}
+}
+
+func TestResolve_RateLimit_RetriesExhausted(t *testing.T) {
+	calls := 0
+	env := sendAccountRetryEnv(func(ctx context.Context, id int64) (db.TelegramAccount, error) {
+		calls++
+		return db.TelegramAccount{}, rateLimitErr
+	})
+
+	err := sendtelegramaccountmessage.Resolve(context.Background(), env, sendAccountRetryParams())
+	if err == nil {
+		t.Fatal("expected error after retries exhausted, got nil")
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 attempts (max), got %d", calls)
+	}
+}
+
+func TestResolve_RateLimit_CtxCancelledDuringWait(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	env := sendAccountRetryEnv(func(ctx context.Context, id int64) (db.TelegramAccount, error) {
+		calls++
+		cancel() // cancel before the retry wait
+		return db.TelegramAccount{}, rateLimitErr
+	})
+
+	err := sendtelegramaccountmessage.Resolve(ctx, env, sendAccountRetryParams())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 attempt before ctx cancel, got %d", calls)
+	}
+}
+
+func TestResolve_NonRateLimit_NoRetry(t *testing.T) {
+	calls := 0
+	env := sendAccountRetryEnv(func(ctx context.Context, id int64) (db.TelegramAccount, error) {
+		calls++
+		return db.TelegramAccount{}, errors.New("some other telegram error")
+	})
+
+	err := sendtelegramaccountmessage.Resolve(context.Background(), env, sendAccountRetryParams())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 attempt (no retry), got %d", calls)
+	}
+}

--- a/internal/case/backjob/sendtelegrammessage/resolve.go
+++ b/internal/case/backjob/sendtelegrammessage/resolve.go
@@ -20,7 +20,7 @@ import (
 
 const parseMode = "HTML"
 
-//go:generate go run github.com/matryer/moq -out mocks_test.go -pkg sendtelegrammessage_test . Env
+//go:generate go tool github.com/matryer/moq -out mocks_test.go -pkg sendtelegrammessage_test . Env
 
 type Env interface {
 	SendTelegramMessage(ctx context.Context, chatID int64, msg tgbotapi.Chattable) (int64, error)
@@ -34,34 +34,44 @@ type Env interface {
 	Logger() logger.Logger
 }
 
-func Resolve(ctx context.Context, env Env, params model.TelegramSendPostParams) error {
-	// 10 minutes timeout for large file uploads (videos can be 300MB+)
-	jobTimeout := 10 * time.Minute
+// maxAttempts bounds the total telegram rate-limit retries (initial try + retries).
+const maxAttempts = 3
 
-	jobCtx, cancel := context.WithTimeout(context.Background(), jobTimeout)
+func Resolve(ctx context.Context, env Env, params model.TelegramSendPostParams) error {
+	// 10 minutes timeout for large file uploads (videos can be 300MB+).
+	// Derive from the parent ctx so app shutdown cancels the job.
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 
-	err := Resolve1(jobCtx, env, params)
-	if err != nil {
-		shouldRetry, delay := telegram.HandleRateLimit(err)
-		if shouldRetry {
-			env.Logger().Info("telegram rate limit hit, retrying after delay",
-				"delay", delay,
-				"job", JobID,
-			)
-			time.Sleep(delay)
-			err = Resolve(ctx, env, params)
+	var err error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		err = resolve(ctx, env, params)
+		if err == nil {
+			return nil
 		}
 
-		if err != nil {
+		shouldRetry, delay := telegram.HandleRateLimit(err)
+		if !shouldRetry || attempt == maxAttempts {
 			return err
+		}
+
+		env.Logger().Info("telegram rate limit hit, retrying after delay",
+			"delay", delay,
+			"attempt", attempt,
+			"job", JobID,
+		)
+
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 	}
 
-	return nil
+	return err
 }
 
-func Resolve1(ctx context.Context, env Env, params model.TelegramSendPostParams) error {
+func resolve(ctx context.Context, env Env, params model.TelegramSendPostParams) error {
 	// Check if message already exists before sending to avoid duplicate messages
 	exists, err := env.CheckTelegramPublishSentMessageExists(ctx, db.CheckTelegramPublishSentMessageExistsParams{
 		NotePathID: params.NotePathID,

--- a/internal/case/backjob/sendtelegrammessage/resolve_test.go
+++ b/internal/case/backjob/sendtelegrammessage/resolve_test.go
@@ -12,7 +12,7 @@ import (
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 )
 
-//go:generate go run github.com/matryer/moq -out mocks_test.go -pkg sendtelegrammessage_test . Env
+//go:generate go tool github.com/matryer/moq -out mocks_test.go -pkg sendtelegrammessage_test . Env
 
 type Env interface {
 	SendTelegramMessage(ctx context.Context, chatID int64, msg tgbotapi.Chattable) (int64, error)
@@ -325,6 +325,107 @@ func TestResolve_ContentHash_Consistency(t *testing.T) {
 
 	if firstHash != secondHash {
 		t.Errorf("expected consistent hash, got %s and %s", firstHash, secondHash)
+	}
+}
+
+// rateLimitErr carries the "Too Many Requests" marker telegram.HandleRateLimit
+// looks for; "retry after 0" keeps the retry delay at the 1s floor for tests.
+var rateLimitErr = errors.New("Too Many Requests: retry after 0")
+
+func sendRetryParams() model.TelegramSendPostParams {
+	return model.TelegramSendPostParams{
+		NotePathID:     123,
+		DBChatID:       456,
+		TelegramChatID: 789,
+		Post: model.TelegramPost{
+			Content: "Test message",
+			Media:   []string{},
+		},
+	}
+}
+
+func sendRetryEnv(sendFn func(ctx context.Context, chatID int64, msg tgbotapi.Chattable) (int64, error)) *EnvMock {
+	return &EnvMock{
+		LoggerFunc: func() logger.Logger { return &logger.DummyLogger{} },
+		CheckTelegramPublishSentMessageExistsFunc: func(ctx context.Context, arg db.CheckTelegramPublishSentMessageExistsParams) (int64, error) {
+			return 0, nil
+		},
+		SendTelegramMessageFunc: sendFn,
+		InsertTelegramPublishSentMessageFunc: func(ctx context.Context, arg db.InsertTelegramPublishSentMessageParams) error {
+			return nil
+		},
+		ClearTelegramPublishNoteLastErrorFunc: func(ctx context.Context, notePathID int64) error {
+			return nil
+		},
+		SetTelegramPublishNoteLastErrorFunc: func(ctx context.Context, arg db.SetTelegramPublishNoteLastErrorParams) error {
+			return nil
+		},
+	}
+}
+
+func TestResolve_RateLimit_RetriedThenSucceeds(t *testing.T) {
+	calls := 0
+	env := sendRetryEnv(func(ctx context.Context, chatID int64, msg tgbotapi.Chattable) (int64, error) {
+		calls++
+		if calls == 1 {
+			return 0, rateLimitErr
+		}
+		return 111, nil
+	})
+
+	err := sendtelegrammessage.Resolve(context.Background(), env, sendRetryParams())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 send attempts (1 retry), got %d", calls)
+	}
+	if len(env.InsertTelegramPublishSentMessageCalls()) != 1 {
+		t.Errorf("expected message inserted once after retry, got %d", len(env.InsertTelegramPublishSentMessageCalls()))
+	}
+}
+
+func TestResolve_RateLimit_RetriesExhausted(t *testing.T) {
+	env := sendRetryEnv(func(ctx context.Context, chatID int64, msg tgbotapi.Chattable) (int64, error) {
+		return 0, rateLimitErr
+	})
+
+	err := sendtelegrammessage.Resolve(context.Background(), env, sendRetryParams())
+	if err == nil {
+		t.Fatal("expected error after retries exhausted, got nil")
+	}
+	if got := len(env.SendTelegramMessageCalls()); got != 3 {
+		t.Errorf("expected 3 send attempts (max), got %d", got)
+	}
+}
+
+func TestResolve_RateLimit_CtxCancelledDuringWait(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	env := sendRetryEnv(func(ctx context.Context, chatID int64, msg tgbotapi.Chattable) (int64, error) {
+		cancel() // cancel before the retry wait
+		return 0, rateLimitErr
+	})
+
+	err := sendtelegrammessage.Resolve(ctx, env, sendRetryParams())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if got := len(env.SendTelegramMessageCalls()); got != 1 {
+		t.Errorf("expected 1 send attempt before ctx cancel, got %d", got)
+	}
+}
+
+func TestResolve_NonRateLimit_NoRetry(t *testing.T) {
+	env := sendRetryEnv(func(ctx context.Context, chatID int64, msg tgbotapi.Chattable) (int64, error) {
+		return 0, errors.New("some other telegram error")
+	})
+
+	err := sendtelegrammessage.Resolve(context.Background(), env, sendRetryParams())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if got := len(env.SendTelegramMessageCalls()); got != 1 {
+		t.Errorf("expected 1 send attempt (no retry), got %d", got)
 	}
 }
 

--- a/internal/case/backjob/updateallaccounttelegrampublishposts/resolve.go
+++ b/internal/case/backjob/updateallaccounttelegrampublishposts/resolve.go
@@ -8,7 +8,7 @@ import (
 	"trip2g/internal/logger"
 )
 
-//go:generate go run github.com/matryer/moq -out mocks_test.go -pkg updateallaccounttelegrampublishposts_test . Env
+//go:generate go tool github.com/matryer/moq -out mocks_test.go -pkg updateallaccounttelegrampublishposts_test . Env
 
 type Params struct {
 	AccountID int64

--- a/internal/case/backjob/updateallchattelegrampublishposts/resolve.go
+++ b/internal/case/backjob/updateallchattelegrampublishposts/resolve.go
@@ -8,7 +8,7 @@ import (
 	"trip2g/internal/logger"
 )
 
-//go:generate go run github.com/matryer/moq -out mocks_test.go -pkg updateallchattelegrampublishposts_test . Env
+//go:generate go tool github.com/matryer/moq -out mocks_test.go -pkg updateallchattelegrampublishposts_test . Env
 
 type Params struct {
 	ChatID int64

--- a/internal/case/backjob/updatetelegramaccountmessage/resolve.go
+++ b/internal/case/backjob/updatetelegramaccountmessage/resolve.go
@@ -14,7 +14,7 @@ import (
 	"trip2g/internal/tgtd"
 )
 
-//go:generate go run github.com/matryer/moq -out mocks_test.go -pkg updatetelegramaccountmessage_test . Env
+//go:generate go tool github.com/matryer/moq -out mocks_test.go -pkg updatetelegramaccountmessage_test . Env
 
 type Env interface {
 	Logger() logger.Logger

--- a/internal/case/backjob/updatetelegramaccountmessage/resolve.go
+++ b/internal/case/backjob/updatetelegramaccountmessage/resolve.go
@@ -32,35 +32,45 @@ type Env interface {
 	UpdateTelegramPublishAccountInstantChatAccessHash(ctx context.Context, arg db.UpdateTelegramPublishAccountInstantChatAccessHashParams) error
 }
 
-func Resolve(ctx context.Context, env Env, params model.TelegramAccountUpdatePostParams) error {
-	// 5 minutes timeout - updates mostly edit captions, but can replace photos
-	jobTimeout := 5 * time.Minute
+// maxAttempts bounds the total telegram rate-limit retries (initial try + retries).
+const maxAttempts = 3
 
-	jobCtx, cancel := context.WithTimeout(context.Background(), jobTimeout)
+func Resolve(ctx context.Context, env Env, params model.TelegramAccountUpdatePostParams) error {
+	// 5 minutes timeout - updates mostly edit captions, but can replace photos.
+	// Derive from the parent ctx so app shutdown cancels the job.
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
-	err := resolve1(jobCtx, env, params)
-	if err != nil {
-		shouldRetry, delay := telegram.HandleRateLimit(err)
-		if shouldRetry {
-			env.Logger().Info("telegram rate limit hit, retrying after delay",
-				"delay", delay,
-				"job", JobID,
-			)
-			time.Sleep(delay)
-			err = Resolve(ctx, env, params)
+	var err error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		err = resolve(ctx, env, params)
+		if err == nil {
+			return nil
 		}
 
-		if err != nil {
+		shouldRetry, delay := telegram.HandleRateLimit(err)
+		if !shouldRetry || attempt == maxAttempts {
 			return err
+		}
+
+		env.Logger().Info("telegram rate limit hit, retrying after delay",
+			"delay", delay,
+			"attempt", attempt,
+			"job", JobID,
+		)
+
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 	}
 
-	return nil
+	return err
 }
 
 //nolint:funlen,gocognit // complex edit logic with multiple post types
-func resolve1(ctx context.Context, env Env, params model.TelegramAccountUpdatePostParams) error {
+func resolve(ctx context.Context, env Env, params model.TelegramAccountUpdatePostParams) error {
 	logger := logger.WithPrefix(env.Logger(), "backjob/updatetelegramaccountmessage:")
 	post := params.Post
 

--- a/internal/case/backjob/updatetelegramaccountmessage/resolve_test.go
+++ b/internal/case/backjob/updatetelegramaccountmessage/resolve_test.go
@@ -1,0 +1,140 @@
+package updatetelegramaccountmessage_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"testing"
+
+	"trip2g/internal/case/backjob/updatetelegramaccountmessage"
+	"trip2g/internal/db"
+	"trip2g/internal/logger"
+	"trip2g/internal/model"
+)
+
+// rateLimitErr carries the "Too Many Requests" marker telegram.HandleRateLimit
+// looks for; "retry after 0" keeps the retry delay at the 1s floor for tests.
+var rateLimitErr = errors.New("Too Many Requests: retry after 0")
+
+func updateAccountRetryParams() model.TelegramAccountUpdatePostParams {
+	return model.TelegramAccountUpdatePostParams{
+		TelegramAccountSendPostParams: model.TelegramAccountSendPostParams{
+			NotePathID:     123,
+			AccountID:      1,
+			TelegramChatID: 789,
+			Post: model.TelegramPost{
+				Content: "Updated message",
+				Media:   []string{},
+			},
+		},
+		MessageID: 111,
+	}
+}
+
+func expectedTextContentHash(content string) string {
+	hash := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(hash[:])
+}
+
+// updateAccountRetryEnv builds an EnvMock where GetTelegramAccountByID is the
+// rate-limit failure point; the ContentHash counter lets a later attempt skip
+// past editing entirely (hash already matches) to reach a real success
+// without ever touching the real tgtd network client.
+func updateAccountRetryEnv(getAccountFn func(ctx context.Context, id int64) (db.TelegramAccount, error)) *EnvMock {
+	return &EnvMock{
+		LoggerFunc: func() logger.Logger { return &logger.DummyLogger{} },
+		GetTelegramPublishSentAccountMessagePostTypeFunc: func(ctx context.Context, arg db.GetTelegramPublishSentAccountMessagePostTypeParams) (string, error) {
+			return "text", nil
+		},
+		GetTelegramAccountByIDFunc: getAccountFn,
+	}
+}
+
+func TestResolve_RateLimit_RetriedThenSucceeds(t *testing.T) {
+	hashCalls := 0
+	getAccountCalls := 0
+	newHash := expectedTextContentHash("Updated message")
+
+	env := updateAccountRetryEnv(func(ctx context.Context, id int64) (db.TelegramAccount, error) {
+		getAccountCalls++
+		return db.TelegramAccount{}, rateLimitErr
+	})
+	env.GetTelegramPublishSentAccountMessageContentHashFunc = func(ctx context.Context, arg db.GetTelegramPublishSentAccountMessageContentHashParams) (string, error) {
+		hashCalls++
+		if hashCalls == 1 {
+			return "old_hash", nil // differs — proceed to edit, which will rate-limit
+		}
+		return newHash, nil // matches by the time we retry — skip cleanly
+	}
+
+	err := updatetelegramaccountmessage.Resolve(context.Background(), env, updateAccountRetryParams())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hashCalls != 2 {
+		t.Errorf("expected 2 resolve attempts (1 retry), got %d", hashCalls)
+	}
+	if getAccountCalls != 1 {
+		t.Errorf("expected GetTelegramAccountByID called once (rate-limited then skipped), got %d", getAccountCalls)
+	}
+}
+
+func TestResolve_RateLimit_RetriesExhausted(t *testing.T) {
+	calls := 0
+	env := updateAccountRetryEnv(func(ctx context.Context, id int64) (db.TelegramAccount, error) {
+		calls++
+		return db.TelegramAccount{}, rateLimitErr
+	})
+	env.GetTelegramPublishSentAccountMessageContentHashFunc = func(ctx context.Context, arg db.GetTelegramPublishSentAccountMessageContentHashParams) (string, error) {
+		return "old_hash", nil
+	}
+
+	err := updatetelegramaccountmessage.Resolve(context.Background(), env, updateAccountRetryParams())
+	if err == nil {
+		t.Fatal("expected error after retries exhausted, got nil")
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 attempts (max), got %d", calls)
+	}
+}
+
+func TestResolve_RateLimit_CtxCancelledDuringWait(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	env := updateAccountRetryEnv(func(ctx context.Context, id int64) (db.TelegramAccount, error) {
+		calls++
+		cancel() // cancel before the retry wait
+		return db.TelegramAccount{}, rateLimitErr
+	})
+	env.GetTelegramPublishSentAccountMessageContentHashFunc = func(ctx context.Context, arg db.GetTelegramPublishSentAccountMessageContentHashParams) (string, error) {
+		return "old_hash", nil
+	}
+
+	err := updatetelegramaccountmessage.Resolve(ctx, env, updateAccountRetryParams())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 attempt before ctx cancel, got %d", calls)
+	}
+}
+
+func TestResolve_NonRateLimit_NoRetry(t *testing.T) {
+	calls := 0
+	env := updateAccountRetryEnv(func(ctx context.Context, id int64) (db.TelegramAccount, error) {
+		calls++
+		return db.TelegramAccount{}, errors.New("some other telegram error")
+	})
+	env.GetTelegramPublishSentAccountMessageContentHashFunc = func(ctx context.Context, arg db.GetTelegramPublishSentAccountMessageContentHashParams) (string, error) {
+		return "old_hash", nil
+	}
+
+	err := updatetelegramaccountmessage.Resolve(context.Background(), env, updateAccountRetryParams())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 attempt (no retry), got %d", calls)
+	}
+}

--- a/internal/case/backjob/updatetelegrammessage/resolve.go
+++ b/internal/case/backjob/updatetelegrammessage/resolve.go
@@ -15,7 +15,7 @@ import (
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 )
 
-//go:generate go run github.com/matryer/moq -out mocks_test.go -pkg updatetelegrammessage_test . Env
+//go:generate go tool github.com/matryer/moq -out mocks_test.go -pkg updatetelegrammessage_test . Env
 
 type Env interface {
 	Logger() logger.Logger
@@ -26,34 +26,44 @@ type Env interface {
 	TelegramCaptionLengthLimit(ctx context.Context, accountID *int64) int
 }
 
-func Resolve(ctx context.Context, env Env, params model.TelegramUpdatePostParams) error {
-	// 5 minutes timeout - updates mostly edit captions, but can replace photos
-	jobTimeout := 5 * time.Minute
+// maxAttempts bounds the total telegram rate-limit retries (initial try + retries).
+const maxAttempts = 3
 
-	jobCtx, cancel := context.WithTimeout(context.Background(), jobTimeout)
+func Resolve(ctx context.Context, env Env, params model.TelegramUpdatePostParams) error {
+	// 5 minutes timeout - updates mostly edit captions, but can replace photos.
+	// Derive from the parent ctx so app shutdown cancels the job.
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
-	err := Resolve1(jobCtx, env, params)
-	if err != nil {
-		shouldRetry, delay := telegram.HandleRateLimit(err)
-		if shouldRetry {
-			env.Logger().Info("telegram rate limit hit, retrying after delay",
-				"delay", delay,
-				"job", JobID,
-			)
-			time.Sleep(delay)
-			err = Resolve(ctx, env, params)
+	var err error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		err = resolve(ctx, env, params)
+		if err == nil {
+			return nil
 		}
 
-		if err != nil {
+		shouldRetry, delay := telegram.HandleRateLimit(err)
+		if !shouldRetry || attempt == maxAttempts {
 			return err
+		}
+
+		env.Logger().Info("telegram rate limit hit, retrying after delay",
+			"delay", delay,
+			"attempt", attempt,
+			"job", JobID,
+		)
+
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 	}
 
-	return nil
+	return err
 }
 
-func Resolve1(ctx context.Context, env Env, params model.TelegramUpdatePostParams) error {
+func resolve(ctx context.Context, env Env, params model.TelegramUpdatePostParams) error {
 	logger := logger.WithPrefix(env.Logger(), "backjob/updatetelegrammessage:")
 	post := params.Post
 

--- a/internal/case/backjob/updatetelegrammessage/resolve_test.go
+++ b/internal/case/backjob/updatetelegrammessage/resolve_test.go
@@ -13,6 +13,104 @@ import (
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 )
 
+// rateLimitErr carries the "Too Many Requests" marker telegram.HandleRateLimit
+// looks for; "retry after 0" keeps the retry delay at the 1s floor for tests.
+var rateLimitErr = errors.New("Too Many Requests: retry after 0")
+
+func updateRetryParams() model.TelegramUpdatePostParams {
+	return model.TelegramUpdatePostParams{
+		TelegramSendPostParams: model.TelegramSendPostParams{
+			NotePathID:     123,
+			DBChatID:       456,
+			TelegramChatID: 789,
+			Post: model.TelegramPost{
+				Content: "Updated message",
+				Media:   []string{},
+			},
+		},
+		MessageID: 111,
+	}
+}
+
+func updateRetryEnv(sendFn func(ctx context.Context, chatID int64, msg tgbotapi.Chattable) error) *EnvMock {
+	return &EnvMock{
+		LoggerFunc: func() logger.Logger { return &logger.DummyLogger{} },
+		GetTelegramPublishSentMessagePostTypeFunc: func(ctx context.Context, arg db.GetTelegramPublishSentMessagePostTypeParams) (string, error) {
+			return "text", nil
+		},
+		GetTelegramPublishSentMessageContentHashFunc: func(ctx context.Context, arg db.GetTelegramPublishSentMessageContentHashParams) (string, error) {
+			return "old_hash", nil
+		},
+		SendTelegramRequestFunc: sendFn,
+		UpdateTelegramPublishSentMessageContentFunc: func(ctx context.Context, arg db.UpdateTelegramPublishSentMessageContentParams) error {
+			return nil
+		},
+	}
+}
+
+func TestResolve_RateLimit_RetriedThenSucceeds(t *testing.T) {
+	calls := 0
+	env := updateRetryEnv(func(ctx context.Context, chatID int64, msg tgbotapi.Chattable) error {
+		calls++
+		if calls == 1 {
+			return rateLimitErr
+		}
+		return nil
+	})
+
+	err := updatetelegrammessage.Resolve(context.Background(), env, updateRetryParams())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 send attempts (1 retry), got %d", calls)
+	}
+}
+
+func TestResolve_RateLimit_RetriesExhausted(t *testing.T) {
+	env := updateRetryEnv(func(ctx context.Context, chatID int64, msg tgbotapi.Chattable) error {
+		return rateLimitErr
+	})
+
+	err := updatetelegrammessage.Resolve(context.Background(), env, updateRetryParams())
+	if err == nil {
+		t.Fatal("expected error after retries exhausted, got nil")
+	}
+	if got := len(env.SendTelegramRequestCalls()); got != 3 {
+		t.Errorf("expected 3 send attempts (max), got %d", got)
+	}
+}
+
+func TestResolve_RateLimit_CtxCancelledDuringWait(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	env := updateRetryEnv(func(ctx context.Context, chatID int64, msg tgbotapi.Chattable) error {
+		cancel() // cancel before the retry wait
+		return rateLimitErr
+	})
+
+	err := updatetelegrammessage.Resolve(ctx, env, updateRetryParams())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if got := len(env.SendTelegramRequestCalls()); got != 1 {
+		t.Errorf("expected 1 send attempt before ctx cancel, got %d", got)
+	}
+}
+
+func TestResolve_NonRateLimit_NoRetry(t *testing.T) {
+	env := updateRetryEnv(func(ctx context.Context, chatID int64, msg tgbotapi.Chattable) error {
+		return errors.New("some other telegram error")
+	})
+
+	err := updatetelegrammessage.Resolve(context.Background(), env, updateRetryParams())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if got := len(env.SendTelegramRequestCalls()); got != 1 {
+		t.Errorf("expected 1 send attempt (no retry), got %d", got)
+	}
+}
+
 func TestResolve_Success_TextMessage(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/case/cronjob/cleanupapikeylogs/job.go
+++ b/internal/case/cronjob/cleanupapikeylogs/job.go
@@ -6,7 +6,12 @@ import (
 
 // Job implements the cronjobs.Job interface.
 type Job struct {
-	Config Config
+	env    Env
+	config Config
+}
+
+func New(env Env, config Config) *Job {
+	return &Job{env: env, config: config}
 }
 
 func (j *Job) Name() string {
@@ -22,6 +27,6 @@ func (j *Job) ExecuteAfterStart() bool {
 	return false
 }
 
-func (j *Job) Execute(ctx context.Context, env any) (any, error) {
-	return Resolve(ctx, env.(Env), j.Config) //nolint:errcheck // checked in cmd/server/cronjobs.go.
+func (j *Job) Execute(ctx context.Context) (any, error) {
+	return Resolve(ctx, j.env, j.config)
 }

--- a/internal/case/cronjob/cleanupwebhookdeliveries/job.go
+++ b/internal/case/cronjob/cleanupwebhookdeliveries/job.go
@@ -5,7 +5,13 @@ import (
 )
 
 // Job implements the cronjobs.Job interface.
-type Job struct{}
+type Job struct {
+	env Env
+}
+
+func New(env Env) *Job {
+	return &Job{env: env}
+}
 
 func (j *Job) Name() string {
 	return "cleanup_webhook_deliveries"
@@ -20,6 +26,6 @@ func (j *Job) ExecuteAfterStart() bool {
 	return false
 }
 
-func (j *Job) Execute(ctx context.Context, env any) (any, error) {
-	return Resolve(ctx, env.(Env)) //nolint:errcheck // checked in cmd/server/cronjobs.go.
+func (j *Job) Execute(ctx context.Context) (any, error) {
+	return Resolve(ctx, j.env)
 }

--- a/internal/case/cronjob/cleanupwebhookdeliverylogs/job.go
+++ b/internal/case/cronjob/cleanupwebhookdeliverylogs/job.go
@@ -5,7 +5,13 @@ import (
 )
 
 // Job implements the cronjobs.Job interface.
-type Job struct{}
+type Job struct {
+	env Env
+}
+
+func New(env Env) *Job {
+	return &Job{env: env}
+}
 
 func (j *Job) Name() string {
 	return "cleanup_webhook_delivery_logs"
@@ -22,6 +28,6 @@ func (j *Job) ExecuteAfterStart() bool {
 	return false
 }
 
-func (j *Job) Execute(ctx context.Context, env any) (any, error) {
-	return Resolve(ctx, env.(Env)) //nolint:errcheck // checked in cmd/server/cronjobs.go.
+func (j *Job) Execute(ctx context.Context) (any, error) {
+	return Resolve(ctx, j.env)
 }

--- a/internal/case/cronjob/clearcronjobexecutionhistory/job.go
+++ b/internal/case/cronjob/clearcronjobexecutionhistory/job.go
@@ -5,6 +5,11 @@ import (
 )
 
 type Job struct {
+	env Env
+}
+
+func New(env Env) *Job {
+	return &Job{env: env}
 }
 
 func (j *Job) Name() string {
@@ -19,6 +24,6 @@ func (j *Job) ExecuteAfterStart() bool {
 	return false // Don't run immediately on startup
 }
 
-func (j *Job) Execute(ctx context.Context, env any) (any, error) {
-	return Resolve(ctx, env.(Env), Filter{}) //nolint:errcheck // will checked in cmd/server/cronjobs.go
+func (j *Job) Execute(ctx context.Context) (any, error) {
+	return Resolve(ctx, j.env, Filter{})
 }

--- a/internal/case/cronjob/executecronwebhooks/job.go
+++ b/internal/case/cronjob/executecronwebhooks/job.go
@@ -6,8 +6,13 @@ import (
 
 // Job implements the cronjobs.Job interface.
 type Job struct {
-	// Cron is the schedule expression, injected from appconfig (env/flag).
-	Cron string
+	env Env
+	// cron is the schedule expression, injected from appconfig (env/flag).
+	cron string
+}
+
+func New(env Env, cron string) *Job {
+	return &Job{env: env, cron: cron}
 }
 
 func (j *Job) Name() string {
@@ -16,8 +21,8 @@ func (j *Job) Name() string {
 
 // Schedule returns the configured cron expression; defaults to every minute.
 func (j *Job) Schedule() string {
-	if j.Cron != "" {
-		return j.Cron
+	if j.cron != "" {
+		return j.cron
 	}
 	return "0 * * * * *"
 }
@@ -26,6 +31,6 @@ func (j *Job) ExecuteAfterStart() bool {
 	return false
 }
 
-func (j *Job) Execute(ctx context.Context, env any) (any, error) {
-	return Resolve(ctx, env.(Env)) //nolint:errcheck // checked in cmd/server/cronjobs.go.
+func (j *Job) Execute(ctx context.Context) (any, error) {
+	return Resolve(ctx, j.env)
 }

--- a/internal/case/cronjob/expirestalewebhookdeliveries/job.go
+++ b/internal/case/cronjob/expirestalewebhookdeliveries/job.go
@@ -3,7 +3,13 @@ package expirestalewebhookdeliveries
 import "context"
 
 // Job implements the cronjobs.Job interface.
-type Job struct{}
+type Job struct {
+	env Env
+}
+
+func New(env Env) *Job {
+	return &Job{env: env}
+}
 
 func (j *Job) Name() string { return "expire_stale_webhook_deliveries" }
 
@@ -12,6 +18,6 @@ func (j *Job) Schedule() string { return "0 * * * * *" }
 
 func (j *Job) ExecuteAfterStart() bool { return false }
 
-func (j *Job) Execute(ctx context.Context, env any) (any, error) {
-	return Resolve(ctx, env.(Env)) //nolint:errcheck // checked in cmd/server/cronjobs.go.
+func (j *Job) Execute(ctx context.Context) (any, error) {
+	return Resolve(ctx, j.env)
 }

--- a/internal/case/cronjob/materializegitmirror/job.go
+++ b/internal/case/cronjob/materializegitmirror/job.go
@@ -5,6 +5,11 @@ import (
 )
 
 type Job struct {
+	env Env
+}
+
+func New(env Env) *Job {
+	return &Job{env: env}
 }
 
 func (j *Job) Name() string {
@@ -19,6 +24,6 @@ func (j *Job) ExecuteAfterStart() bool {
 	return false // Don't run immediately on startup
 }
 
-func (j *Job) Execute(ctx context.Context, env any) (any, error) {
-	return Resolve(ctx, env.(Env)) //nolint:errcheck // will checked in cmd/server/cronjobs.go
+func (j *Job) Execute(ctx context.Context) (any, error) {
+	return Resolve(ctx, j.env)
 }

--- a/internal/case/cronjob/refreshtelegramaccounts/job.go
+++ b/internal/case/cronjob/refreshtelegramaccounts/job.go
@@ -4,7 +4,13 @@ import (
 	"context"
 )
 
-type Job struct{}
+type Job struct {
+	env Env
+}
+
+func New(env Env) *Job {
+	return &Job{env: env}
+}
 
 func (j *Job) Name() string {
 	return "refresh_telegram_accounts"
@@ -18,6 +24,6 @@ func (j *Job) ExecuteAfterStart() bool {
 	return false
 }
 
-func (j *Job) Execute(ctx context.Context, env any) (any, error) {
-	return Resolve(ctx, env.(Env)) //nolint:errcheck // error is returned
+func (j *Job) Execute(ctx context.Context) (any, error) {
+	return Resolve(ctx, j.env)
 }

--- a/internal/case/cronjob/refreshtelegramchatusernames/job.go
+++ b/internal/case/cronjob/refreshtelegramchatusernames/job.go
@@ -4,7 +4,19 @@ import "context"
 
 const refreshBatchSize = 100
 
-type Job struct{}
+type Env interface {
+	RefreshStaleTelegramChatUsernames(ctx context.Context, limit int) (int, error)
+}
+
+// Job delegates to a single app method; the logic stays in Execute rather than a
+// resolve.go — a thin wrapper would add ceremony without testable behavior.
+type Job struct {
+	env Env
+}
+
+func New(env Env) *Job {
+	return &Job{env: env}
+}
 
 func (j *Job) Name() string {
 	return "refresh_telegram_chat_usernames"
@@ -18,12 +30,8 @@ func (j *Job) ExecuteAfterStart() bool {
 	return false
 }
 
-type Env interface {
-	RefreshStaleTelegramChatUsernames(ctx context.Context, limit int) (int, error)
-}
-
-func (j *Job) Execute(ctx context.Context, env any) (any, error) {
-	n, err := env.(Env).RefreshStaleTelegramChatUsernames(ctx, refreshBatchSize) //nolint:errcheck // err is checked below
+func (j *Job) Execute(ctx context.Context) (any, error) {
+	n, err := j.env.RefreshStaleTelegramChatUsernames(ctx, refreshBatchSize)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/case/cronjob/regeneratenoteembeddings/job.go
+++ b/internal/case/cronjob/regeneratenoteembeddings/job.go
@@ -4,7 +4,13 @@ import (
 	"context"
 )
 
-type Job struct{}
+type Job struct {
+	env Env
+}
+
+func New(env Env) *Job {
+	return &Job{env: env}
+}
 
 func (j *Job) Name() string {
 	return "regenerate_note_embeddings"
@@ -18,6 +24,6 @@ func (j *Job) ExecuteAfterStart() bool {
 	return true // Run on startup to catch any missing embeddings
 }
 
-func (j *Job) Execute(ctx context.Context, env any) (any, error) {
-	return Resolve(ctx, env.(Env)) //nolint:errcheck // error is returned
+func (j *Job) Execute(ctx context.Context) (any, error) {
+	return Resolve(ctx, j.env)
 }

--- a/internal/case/cronjob/removeexpiredtgchatmembers/job.go
+++ b/internal/case/cronjob/removeexpiredtgchatmembers/job.go
@@ -5,6 +5,11 @@ import (
 )
 
 type Job struct {
+	env Env
+}
+
+func New(env Env) *Job {
+	return &Job{env: env}
 }
 
 func (j *Job) Name() string {
@@ -19,6 +24,6 @@ func (j *Job) ExecuteAfterStart() bool {
 	return true
 }
 
-func (j *Job) Execute(ctx context.Context, env any) (any, error) {
-	return Resolve(ctx, env.(Env), Filter{}) //nolint:errcheck // will checked in cmd/server/cronjobs.go
+func (j *Job) Execute(ctx context.Context) (any, error) {
+	return Resolve(ctx, j.env, Filter{})
 }

--- a/internal/case/cronjob/sendscheduledtelegrampublishposts/job.go
+++ b/internal/case/cronjob/sendscheduledtelegrampublishposts/job.go
@@ -5,8 +5,13 @@ import (
 )
 
 type Job struct {
-	// Cron is the schedule expression, injected from appconfig (env/flag).
-	Cron string
+	env Env
+	// cron is the schedule expression, injected from appconfig (env/flag).
+	cron string
+}
+
+func New(env Env, cron string) *Job {
+	return &Job{env: env, cron: cron}
 }
 
 func (j *Job) Name() string {
@@ -14,8 +19,8 @@ func (j *Job) Name() string {
 }
 
 func (j *Job) Schedule() string {
-	if j.Cron != "" {
-		return j.Cron
+	if j.cron != "" {
+		return j.cron
 	}
 	return "0 * * * * *" // default: every minute
 }
@@ -24,6 +29,6 @@ func (j *Job) ExecuteAfterStart() bool {
 	return true // Don't run immediately on startup
 }
 
-func (j *Job) Execute(ctx context.Context, env any) (any, error) {
-	return Resolve(ctx, env.(Env)) //nolint:errcheck // will checked in cmd/server/cronjobs.go
+func (j *Job) Execute(ctx context.Context) (any, error) {
+	return Resolve(ctx, j.env)
 }

--- a/internal/case/cronjob/sendscheduledtelegrampublishposts/resolve.go
+++ b/internal/case/cronjob/sendscheduledtelegrampublishposts/resolve.go
@@ -34,7 +34,7 @@ type Result struct {
 	AccountPosts []ResultPost `json:"account_posts"`
 }
 
-func Resolve(ctx context.Context, env Env) (any, error) {
+func Resolve(ctx context.Context, env Env) (*Result, error) {
 	res := Result{}
 
 	botPosts, err := enqueueBotJobs(ctx, env)
@@ -49,7 +49,7 @@ func Resolve(ctx context.Context, env Env) (any, error) {
 	}
 	res.AccountPosts = accountPosts
 
-	return res, nil
+	return &res, nil
 }
 
 type jobConfig struct {

--- a/internal/case/cronjob/simplebackup/job.go
+++ b/internal/case/cronjob/simplebackup/job.go
@@ -5,7 +5,13 @@ import (
 	"trip2g/internal/simplebackup"
 )
 
-type Job struct{}
+type Job struct {
+	env Env
+}
+
+func New(env Env) *Job {
+	return &Job{env: env}
+}
 
 func (j *Job) Name() string {
 	return "simple_backup"
@@ -19,18 +25,15 @@ func (j *Job) ExecuteAfterStart() bool {
 	return false
 }
 
-// Env interface that allows accessing the backup manager.
+// Env interface that allows accessing the backup manager. The job delegates to
+// internal/simplebackup.Manager; the logic stays in Execute rather than a
+// resolve.go — a thin wrapper would add ceremony without testable behavior.
 type Env interface {
 	BackupManager() *simplebackup.Manager
 }
 
-func (j *Job) Execute(ctx context.Context, env any) (any, error) {
-	e, ok := env.(Env)
-	if !ok {
-		return nil, nil // Config not enabled or invalid env
-	}
-
-	mgr := e.BackupManager()
+func (j *Job) Execute(ctx context.Context) (any, error) {
+	mgr := j.env.BackupManager()
 	if mgr == nil {
 		return nil, nil // Backup disabled
 	}

--- a/internal/case/cronjob/updatetelegrampublishposts/job.go
+++ b/internal/case/cronjob/updatetelegrampublishposts/job.go
@@ -5,6 +5,11 @@ import (
 )
 
 type Job struct {
+	env Env
+}
+
+func New(env Env) *Job {
+	return &Job{env: env}
 }
 
 func (j *Job) Name() string {
@@ -19,6 +24,6 @@ func (j *Job) ExecuteAfterStart() bool {
 	return false
 }
 
-func (j *Job) Execute(ctx context.Context, env any) (any, error) {
-	return Resolve(ctx, env.(Env)) //nolint:errcheck // will checked in cmd/server/cronjobs.go
+func (j *Job) Execute(ctx context.Context) (any, error) {
+	return Resolve(ctx, j.env)
 }

--- a/internal/case/cronjob/updatetelegrampublishposts/resolve.go
+++ b/internal/case/cronjob/updatetelegrampublishposts/resolve.go
@@ -6,7 +6,7 @@ import (
 	"trip2g/internal/logger"
 )
 
-//go:generate go run github.com/matryer/moq -out mocks_test.go -pkg updatetelegrampublishposts_test . Env
+//go:generate go tool github.com/matryer/moq -out mocks_test.go -pkg updatetelegrampublishposts_test . Env
 
 type Env interface {
 	Logger() logger.Logger
@@ -33,7 +33,7 @@ type Result struct {
 	Accounts []ResultAccount `json:"accounts"`
 }
 
-func Resolve(ctx context.Context, env Env) (any, error) {
+func Resolve(ctx context.Context, env Env) (*Result, error) {
 	logger := logger.WithPrefix(env.Logger(), "updatetelegrampublishposts:")
 
 	res := Result{}
@@ -81,5 +81,5 @@ func Resolve(ctx context.Context, env Env) (any, error) {
 	}
 
 	logger.Info("completed enqueueing updates", "total_chats", len(chatIDs), "total_accounts", len(accountIDs))
-	return res, nil
+	return &res, nil
 }

--- a/internal/case/cronjob/updatetelegrampublishposts/resolve_test.go
+++ b/internal/case/cronjob/updatetelegrampublishposts/resolve_test.go
@@ -105,7 +105,7 @@ func TestResolve(t *testing.T) { //nolint:gocognit // test complexity is accepta
 			}
 
 			if !tt.wantErr && result != nil {
-				res := result.(updatetelegrampublishposts.Result)
+				res := result
 				successCount := 0
 				failedCount := 0
 				for _, chat := range res.Chats {

--- a/internal/case/cronjob/vacuumdatabase/job.go
+++ b/internal/case/cronjob/vacuumdatabase/job.go
@@ -5,6 +5,11 @@ import (
 )
 
 type Job struct {
+	env Env
+}
+
+func New(env Env) *Job {
+	return &Job{env: env}
 }
 
 func (j *Job) Name() string {
@@ -20,7 +25,6 @@ func (j *Job) ExecuteAfterStart() bool {
 	return false // Don't run immediately on startup
 }
 
-func (j *Job) Execute(ctx context.Context, env any) (any, error) {
-	//nolint:errcheck // env is guaranteed to be of type vacuumdatabase.Env
-	return Resolve(ctx, env.(Env), Filter{})
+func (j *Job) Execute(ctx context.Context) (any, error) {
+	return Resolve(ctx, j.env, Filter{})
 }

--- a/internal/case/cronjob/vacuumdatabase/resolve_test.go
+++ b/internal/case/cronjob/vacuumdatabase/resolve_test.go
@@ -11,7 +11,7 @@ import (
 	"trip2g/internal/case/cronjob/vacuumdatabase"
 )
 
-//go:generate go run github.com/matryer/moq -out mocks_test.go -pkg vacuumdatabase_test . Env
+//go:generate go tool github.com/matryer/moq -out mocks_test.go -pkg vacuumdatabase_test . Env
 
 type Env interface {
 	VacuumDB(ctx context.Context) error

--- a/internal/cronjobs/jobs.go
+++ b/internal/cronjobs/jobs.go
@@ -31,7 +31,7 @@ type Job interface {
 	Name() string
 	Schedule() string
 	ExecuteAfterStart() bool
-	Execute(ctx context.Context, env interface{}) (interface{}, error)
+	Execute(ctx context.Context) (interface{}, error)
 }
 
 type Env interface {
@@ -272,7 +272,7 @@ func (cj *CronJobs) executeJob(jobID int64) (*db.CronJobExecution, error) {
 		}
 		return nil, fmt.Errorf("context done before execute for job %d: %w", jobID, ctxErr)
 	}
-	report, jobErr := job.job.Execute(cj.ctx, cj.env)
+	report, jobErr := job.job.Execute(cj.ctx)
 	cj.execMu.Unlock()
 
 	// Update execution status

--- a/internal/cronjobs/jobs_test.go
+++ b/internal/cronjobs/jobs_test.go
@@ -59,7 +59,7 @@ type noopJob struct{ name string }
 func (j *noopJob) Name() string                                                  { return j.name }
 func (j *noopJob) Schedule() string                                              { return "0 0 * * * *" }
 func (j *noopJob) ExecuteAfterStart() bool                                       { return false }
-func (j *noopJob) Execute(_ context.Context, _ interface{}) (interface{}, error) { return nil, nil }
+func (j *noopJob) Execute(_ context.Context) (interface{}, error)                { return nil, nil }
 
 // newTestCronJobs creates a CronJobs with pre-populated jobs map, bypassing New().
 func newTestCronJobs(env Env, jobIDs []int64) *CronJobs {
@@ -133,7 +133,7 @@ type gateJob struct {
 func (j *gateJob) Name() string            { return j.name }
 func (j *gateJob) Schedule() string        { return "0 0 * * * *" }
 func (j *gateJob) ExecuteAfterStart() bool { return false }
-func (j *gateJob) Execute(_ context.Context, _ interface{}) (interface{}, error) {
+func (j *gateJob) Execute(_ context.Context) (interface{}, error) {
 	j.execCount.Add(1)
 	return nil, nil
 }
@@ -269,7 +269,7 @@ type countingJob struct {
 func (j *countingJob) Name() string            { return j.name }
 func (j *countingJob) Schedule() string        { return "0 0 * * * *" }
 func (j *countingJob) ExecuteAfterStart() bool { return j.afterStart }
-func (j *countingJob) Execute(_ context.Context, _ interface{}) (interface{}, error) {
+func (j *countingJob) Execute(_ context.Context) (interface{}, error) {
 	j.execCount++
 	return nil, nil
 }

--- a/internal/cronjobs/serial_test.go
+++ b/internal/cronjobs/serial_test.go
@@ -21,7 +21,7 @@ type sleepJob struct {
 func (j *sleepJob) Name() string            { return j.name }
 func (j *sleepJob) Schedule() string        { return "0 0 * * * *" }
 func (j *sleepJob) ExecuteAfterStart() bool { return false }
-func (j *sleepJob) Execute(_ context.Context, _ interface{}) (interface{}, error) {
+func (j *sleepJob) Execute(_ context.Context) (interface{}, error) {
 	entry := time.Now()
 	j.mu.Lock()
 	j.entries = append(j.entries, entry)


### PR DESCRIPTION
Tidies the cron/back job implementation: one real bug-family fix plus consistency drifts. No scheduler redesign.

## 1. Bounded telegram retries (behavior change) — `sendtelegrammessage`, `updatetelegrammessage`, `sendtelegramaccountmessage`, `updatetelegramaccountmessage`

The `Resolve`/`Resolve1`(/`resolve1`) retry wrappers were broken in all four bot- and account-publishing send/update packages:

**Before**
- `jobCtx` built via `context.WithTimeout(context.Background(), 5/10m)` — **detached** from the parent ctx, so app shutdown/cancellation was ignored.
- On a telegram rate-limit, `Resolve` **recursively called itself with `context.Background()` again** → every retry got a **fresh 5/10-minute budget** and there was **no retry cap**: a persistent 429 = unbounded recursion.
- Waited with `time.Sleep(delay)`, blocking the queue worker and ignoring ctx.

**After**
- Timeout derived from the **parent ctx**: `context.WithTimeout(ctx, jobTimeout)`. Verified the parent is sane: the goqite runner (`cmd/server/queue.go` → `jobs.NewRunner`) hands each job `context.WithCancel(rootCtx)` where `rootCtx` is the app graceful-shutdown ctx (long-lived, no timeout) — so deriving from it respects shutdown. No documented detach needed.
- Bounded retry **loop**: `maxAttempts = 3` total, still using `telegram.HandleRateLimit(err)` for shouldRetry + delay.
- ctx-aware wait: `select { case <-time.After(delay): case <-ctx.Done(): return ctx.Err() }`.
- `Resolve1`/`resolve1` → unexported `resolve` (grep confirmed no external callers in any of the four packages).

Retry tests written first (TDD, red→green) for all four packages: rate-limit retried-then-succeeds; retries exhausted → error; ctx cancelled during wait → prompt ctx error; non-rate-limit error → no retry. The account packages (`sendtelegramaccountmessage`, `updatetelegramaccountmessage`) had no existing test files — the retry tests are new, and they avoid the real `tgtd` MTProto client by making `GetTelegramAccountByID` (send) / `GetTelegramPublishSentAccountMessageContentHash` (update) the controllable failure point, with a call-count-based mock that lets the "retried then succeeds" case resolve via the existing already-sent/unchanged-hash skip path rather than a live network send.

## 2. Unified cronjob `Resolve` return shapes

`sendscheduledtelegrampublishposts` and `updatetelegrampublishposts` returned `(any, error)`; both already built a real `Result` struct internally. Changed their `Resolve` signatures to `(*Result, error)` (return `&res`). Serialized shape is unchanged (the same `Result` is marshalled into the cron execution history). Updated the one type-asserting test.

## 3. resolve.go for the two outlier cronjobs — judgement call

`refreshtelegramchatusernames` and `simplebackup` have no resolve.go. Both are **thin delegations** — `refreshtelegramchatusernames` calls a single app method with a constant batch size; `simplebackup` calls `internal/simplebackup.Manager.PerformBackup`. Extracting a resolve.go + Env + moq test would be **ceremony without testable behavior**, so I left the logic in `Execute` (now using the typed env from the item-4 constructor) and added a short comment on each explaining why. No new resolve.go files.

## 4. Compile-time typed env — cron registration unified with the backjob idiom

Direction: mirror the backjob `jobs.Register[T,P]` + per-case `New(env)` idiom (typed constructor captures env at wiring time), **not** a generic adapter and **not** the minimal ok-assert version.

- `cronjobs.Job` interface: `Execute(ctx, env any) (any, error)` → `Execute(ctx) (any, error)`.
- Each of the 15 cronjob case packages got `New(env Env, <config…>) *Job` storing the typed env in the `Job` struct; `Execute` uses the stored env. Every `env.(Env)` assert and its `//nolint:errcheck "guaranteed"` comment is **gone**.
- `cmd/server/cronjobs.go`: `&pkg.Job{…}` literals → `pkg.New(app, …)` calls (config args preserved: `sendscheduled…`/`executecronwebhooks` cron strings, `cleanupapikeylogs` config). The redundant `var _ pkg.Env = app` pin block is **deleted** — each `New(app, …)` call is now the compile-time proof.
- `internal/cronjobs/jobs.go`: runner call site `Execute(cj.ctx)` (no env passed); `cj.env` still used for the DB bookkeeping. Job-interface mocks in `jobs_test.go` / `serial_test.go` updated.
- Grep confirmed no other `[]cronjobs.Job` / `Job` implementations outside these.

## 5. Unified moq directives

`//go:generate go run github.com/matryer/moq` → `go tool …` across `internal/case/cronjob` and `internal/case/backjob` (10 files). Regenerated `go generate` on the touched packages — **mocks regenerate byte-identically** (no diff).

## Verification
- `go build -tags dev ./internal/case/... ./internal/cronjobs/ ./internal/jobs/ ./cmd/server/` → OK
- `go vet -tags dev` (same set) → clean
- `go test ./internal/case/cronjob/... ./internal/case/backjob/... ./internal/cronjobs/... ./cmd/...` → all pass, including the new account-package retry suites:
  - `sendtelegramaccountmessage`: 4/4 new retry tests pass (3.01s)
  - `updatetelegramaccountmessage`: 4/4 new retry tests pass (3.01s)
- (full `go build ./...` without `-tags dev` fails only on pre-existing missing frontend/vault assets — unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

