### PR TITLE
refactor(jobs): drop fake type param from Register, closure-captured env

### DIFF
--- a/docs/dev/queues.md
+++ b/docs/dev/queues.md
@@ -68,9 +68,17 @@ type JobStruct struct {
     enqueue jobs.EnqueueFunc
 }
 
-func New(env jobs.Env) *JobStruct {
+type JobEnv interface {
+    jobs.Env
+    Env
+}
+
+func New(env JobEnv) *JobStruct {
     return &JobStruct{
-        enqueue: jobs.Register(env, QueueID, JobID, Priority, Resolve),
+        enqueue: jobs.Register(env, QueueID, JobID, Priority,
+            func(ctx context.Context, params Params) error {
+                return Resolve(ctx, env, params)
+            }),
     }
 }
 

--- a/internal/case/backjob/deliverchangewebhook/job.go
+++ b/internal/case/backjob/deliverchangewebhook/job.go
@@ -22,7 +22,10 @@ type DeliverChangeWebhookEnv interface {
 
 func New(env DeliverChangeWebhookEnv) *DeliverChangeWebhookJob {
 	return &DeliverChangeWebhookJob{
-		enqueue: jobs.Register(env, QueueID, JobID, Priority, Resolve),
+		enqueue: jobs.Register(env, QueueID, JobID, Priority,
+			func(ctx context.Context, params handlenotewebhooks.DeliverChangeWebhookParams) error {
+				return Resolve(ctx, env, params)
+			}),
 	}
 }
 

--- a/internal/case/backjob/delivercronwebhook/job.go
+++ b/internal/case/backjob/delivercronwebhook/job.go
@@ -29,7 +29,10 @@ type DeliverCronWebhookEnv interface {
 
 func New(env DeliverCronWebhookEnv) *DeliverCronWebhookJob {
 	return &DeliverCronWebhookJob{
-		enqueue: jobs.Register(env, QueueID, JobID, Priority, Resolve),
+		enqueue: jobs.Register(env, QueueID, JobID, Priority,
+			func(ctx context.Context, params DeliverCronParams) error {
+				return Resolve(ctx, env, params)
+			}),
 	}
 }
 

--- a/internal/case/backjob/generatenoteversionembedding/job.go
+++ b/internal/case/backjob/generatenoteversionembedding/job.go
@@ -22,7 +22,10 @@ type JobEnv interface {
 
 func New(env JobEnv) *Job {
 	return &Job{
-		enqueue: jobs.Register(env, QueueID, JobID, Priority, Resolve),
+		enqueue: jobs.Register(env, QueueID, JobID, Priority,
+			func(ctx context.Context, params Params) error {
+				return Resolve(ctx, env, params)
+			}),
 	}
 }
 

--- a/internal/case/backjob/importtelegramchannel/job.go
+++ b/internal/case/backjob/importtelegramchannel/job.go
@@ -21,7 +21,10 @@ type ImportTelegramChannelEnv interface {
 
 func New(env ImportTelegramChannelEnv) *ImportTelegramChannelJob {
 	return &ImportTelegramChannelJob{
-		enqueue: jobs.Register(env, QueueID, JobID, Priority, Resolve),
+		enqueue: jobs.Register(env, QueueID, JobID, Priority,
+			func(ctx context.Context, params model.ImportTelegramChannelParams) error {
+				return Resolve(ctx, env, params)
+			}),
 	}
 }
 

--- a/internal/case/backjob/refreshchartdata/job.go
+++ b/internal/case/backjob/refreshchartdata/job.go
@@ -22,7 +22,10 @@ type JobEnv interface {
 
 func New(env JobEnv) *Job {
 	return &Job{
-		enqueue: jobs.Register(env, QueueID, JobID, Priority, Resolve),
+		enqueue: jobs.Register(env, QueueID, JobID, Priority,
+			func(ctx context.Context, p Params) error {
+				return Resolve(ctx, env, p)
+			}),
 	}
 }
 

--- a/internal/case/backjob/sendformsubmit/job.go
+++ b/internal/case/backjob/sendformsubmit/job.go
@@ -21,7 +21,10 @@ type SendFormSubmitEmailEnv interface {
 
 func New(env SendFormSubmitEmailEnv) *SendFormSubmitEmailJob {
 	return &SendFormSubmitEmailJob{
-		enqueue: jobs.Register(env, QueueID, JobID, Priority, Resolve),
+		enqueue: jobs.Register(env, QueueID, JobID, Priority,
+			func(ctx context.Context, params Params) error {
+				return Resolve(ctx, env, params)
+			}),
 	}
 }
 

--- a/internal/case/backjob/sendsignincode/job.go
+++ b/internal/case/backjob/sendsignincode/job.go
@@ -21,7 +21,10 @@ type SendSignInCodeEnv interface {
 
 func New(env SendSignInCodeEnv) *SendSignInCodeJob {
 	return &SendSignInCodeJob{
-		enqueue: jobs.Register(env, QueueID, JobID, Priority, Resolve),
+		enqueue: jobs.Register(env, QueueID, JobID, Priority,
+			func(ctx context.Context, params Params) error {
+				return Resolve(ctx, env, params)
+			}),
 	}
 }
 

--- a/internal/case/backjob/sendtelegramaccountmessage/job.go
+++ b/internal/case/backjob/sendtelegramaccountmessage/job.go
@@ -22,7 +22,10 @@ type SendTelegramAccountMessageEnv interface {
 
 func New(env SendTelegramAccountMessageEnv) *SendTelegramAccountMessageJob {
 	return &SendTelegramAccountMessageJob{
-		enqueue: jobs.Register(env, QueueID, JobID, Priority, Resolve),
+		enqueue: jobs.Register(env, QueueID, JobID, Priority,
+			func(ctx context.Context, params model.TelegramAccountSendPostParams) error {
+				return Resolve(ctx, env, params)
+			}),
 	}
 }
 

--- a/internal/case/backjob/sendtelegramaccountpost/job.go
+++ b/internal/case/backjob/sendtelegramaccountpost/job.go
@@ -21,7 +21,10 @@ type SendTelegramAccountPostEnv interface {
 
 func New(env SendTelegramAccountPostEnv) *SendTelegramAccountPostJob {
 	return &SendTelegramAccountPostJob{
-		enqueue: jobs.Register(env, QueueID, JobID, Priority, Resolve),
+		enqueue: jobs.Register(env, QueueID, JobID, Priority,
+			func(ctx context.Context, params model.SendTelegramPublishPostParams) error {
+				return Resolve(ctx, env, params)
+			}),
 	}
 }
 

--- a/internal/case/backjob/sendtelegrammessage/job.go
+++ b/internal/case/backjob/sendtelegrammessage/job.go
@@ -22,7 +22,10 @@ type SendTelegramMessageEnv interface {
 
 func New(env SendTelegramMessageEnv) *SendTelegramMessageJob {
 	return &SendTelegramMessageJob{
-		enqueue: jobs.Register(env, QueueID, JobID, Priority, Resolve),
+		enqueue: jobs.Register(env, QueueID, JobID, Priority,
+			func(ctx context.Context, params model.TelegramSendPostParams) error {
+				return Resolve(ctx, env, params)
+			}),
 	}
 }
 

--- a/internal/case/backjob/sendtelegrampost/job.go
+++ b/internal/case/backjob/sendtelegrampost/job.go
@@ -21,7 +21,10 @@ type SendTelegramPostEnv interface {
 
 func New(env SendTelegramPostEnv) *SendTelegramPostJob {
 	return &SendTelegramPostJob{
-		enqueue: jobs.Register(env, QueueID, JobID, Priority, Resolve),
+		enqueue: jobs.Register(env, QueueID, JobID, Priority,
+			func(ctx context.Context, params model.SendTelegramPublishPostParams) error {
+				return Resolve(ctx, env, params)
+			}),
 	}
 }
 

--- a/internal/case/backjob/updateallaccounttelegrampublishposts/job.go
+++ b/internal/case/backjob/updateallaccounttelegrampublishposts/job.go
@@ -21,7 +21,10 @@ type UpdateAllAccountTelegramPublishPostsEnv interface {
 
 func New(env UpdateAllAccountTelegramPublishPostsEnv) *UpdateAllAccountTelegramPublishPostsJob {
 	return &UpdateAllAccountTelegramPublishPostsJob{
-		enqueue: jobs.Register(env, QueueID, JobID, Priority, Resolve),
+		enqueue: jobs.Register(env, QueueID, JobID, Priority,
+			func(ctx context.Context, params Params) error {
+				return Resolve(ctx, env, params)
+			}),
 	}
 }
 

--- a/internal/case/backjob/updateallchattelegrampublishposts/job.go
+++ b/internal/case/backjob/updateallchattelegrampublishposts/job.go
@@ -21,7 +21,10 @@ type UpdateAllChatTelegramPublishPostsEnv interface {
 
 func New(env UpdateAllChatTelegramPublishPostsEnv) *UpdateAllChatTelegramPublishPostsJob {
 	return &UpdateAllChatTelegramPublishPostsJob{
-		enqueue: jobs.Register(env, QueueID, JobID, Priority, Resolve),
+		enqueue: jobs.Register(env, QueueID, JobID, Priority,
+			func(ctx context.Context, params Params) error {
+				return Resolve(ctx, env, params)
+			}),
 	}
 }
 

--- a/internal/case/backjob/updatetelegramaccountmessage/job.go
+++ b/internal/case/backjob/updatetelegramaccountmessage/job.go
@@ -22,7 +22,10 @@ type UpdateTelegramAccountMessageEnv interface {
 
 func New(env UpdateTelegramAccountMessageEnv) *UpdateTelegramAccountMessageJob {
 	return &UpdateTelegramAccountMessageJob{
-		enqueue: jobs.Register(env, QueueID, JobID, Priority, Resolve),
+		enqueue: jobs.Register(env, QueueID, JobID, Priority,
+			func(ctx context.Context, params model.TelegramAccountUpdatePostParams) error {
+				return Resolve(ctx, env, params)
+			}),
 	}
 }
 

--- a/internal/case/backjob/updatetelegramaccountpost/job.go
+++ b/internal/case/backjob/updatetelegramaccountpost/job.go
@@ -21,7 +21,10 @@ type UpdateTelegramAccountPostEnv interface {
 
 func New(env UpdateTelegramAccountPostEnv) *UpdateTelegramAccountPostJob {
 	return &UpdateTelegramAccountPostJob{
-		enqueue: jobs.Register(env, QueueID, JobID, Priority, Resolve),
+		enqueue: jobs.Register(env, QueueID, JobID, Priority,
+			func(ctx context.Context, notePathID int64) error {
+				return Resolve(ctx, env, notePathID)
+			}),
 	}
 }
 

--- a/internal/case/backjob/updatetelegrammessage/job.go
+++ b/internal/case/backjob/updatetelegrammessage/job.go
@@ -22,7 +22,10 @@ type UpdateTelegramMessageEnv interface {
 
 func New(env UpdateTelegramMessageEnv) *UpdateTelegramMessageJob {
 	return &UpdateTelegramMessageJob{
-		enqueue: jobs.Register(env, QueueID, JobID, Priority, Resolve),
+		enqueue: jobs.Register(env, QueueID, JobID, Priority,
+			func(ctx context.Context, params model.TelegramUpdatePostParams) error {
+				return Resolve(ctx, env, params)
+			}),
 	}
 }
 

--- a/internal/case/backjob/updatetelegrampost/job.go
+++ b/internal/case/backjob/updatetelegrampost/job.go
@@ -21,7 +21,10 @@ type UpdateTelegramPostEnv interface {
 
 func New(env UpdateTelegramPostEnv) *UpdateTelegramPostJob {
 	return &UpdateTelegramPostJob{
-		enqueue: jobs.Register(env, QueueID, JobID, Priority, Resolve),
+		enqueue: jobs.Register(env, QueueID, JobID, Priority,
+			func(ctx context.Context, notePathID int64) error {
+				return Resolve(ctx, env, notePathID)
+			}),
 	}
 }
 

--- a/internal/jobs/env.go
+++ b/internal/jobs/env.go
@@ -14,18 +14,13 @@ type Env interface {
 
 type EnqueueFunc func(ctx context.Context, data any) error
 
-func Register[T any, P any](
+func Register[P any](
 	env Env,
 	qID model.BackgroundQueueID,
 	jobID string,
 	priority int,
-	resolveFunc func(context.Context, T, P) error,
+	handler func(context.Context, P) error,
 ) EnqueueFunc {
-	_, ok := env.(T)
-	if !ok {
-		panic(fmt.Sprintf("the provided env does not implement the required interface: %T", new(T)))
-	}
-
 	env.RegisterJob(qID, jobID, func(ctx context.Context, m []byte) error {
 		var params P
 
@@ -34,7 +29,7 @@ func Register[T any, P any](
 			return fmt.Errorf("failed to unmarshal %s params: %w", jobID, err)
 		}
 
-		err = resolveFunc(ctx, env.(T), params) //nolint:errcheck // backjobs.Env should embeded all env interfaces
+		err = handler(ctx, params)
 		if err != nil {
 			return fmt.Errorf("failed to run %s job: %w", jobID, err)
 		}

--- a/internal/jobs/env_test.go
+++ b/internal/jobs/env_test.go
@@ -1,0 +1,92 @@
+package jobs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trip2g/internal/model"
+)
+
+type registerTestParams struct {
+	Value string `json:"value"`
+}
+
+type registerTestEnv struct {
+	registeredID     string
+	registeredQueue  model.BackgroundQueueID
+	handler          func(ctx context.Context, m []byte) error
+	enqueuedTask     model.BackgroundTask
+	enqueueCallCount int
+}
+
+func (e *registerTestEnv) RegisterJob(qID model.BackgroundQueueID, id string, handler func(ctx context.Context, m []byte) error) {
+	e.registeredQueue = qID
+	e.registeredID = id
+	e.handler = handler
+}
+
+func (e *registerTestEnv) EnqueueJob(_ context.Context, job model.BackgroundTask) error {
+	e.enqueueCallCount++
+	e.enqueuedTask = job
+	return nil
+}
+
+func TestRegisterHandlerUnmarshalsAndCallsThrough(t *testing.T) {
+	env := &registerTestEnv{}
+	var calledCtx context.Context
+	var calledParams registerTestParams
+
+	Register(env, model.BackgroundDefaultQueue, "test_job", 5,
+		func(ctx context.Context, params registerTestParams) error {
+			calledCtx = ctx
+			calledParams = params
+			return nil
+		})
+
+	require.Equal(t, model.BackgroundDefaultQueue, env.registeredQueue)
+	require.Equal(t, "test_job", env.registeredID)
+	require.NotNil(t, env.handler)
+
+	ctx := context.Background()
+	err := env.handler(ctx, []byte(`{"value":"hello"}`))
+
+	require.NoError(t, err)
+	require.Equal(t, ctx, calledCtx)
+	require.Equal(t, registerTestParams{Value: "hello"}, calledParams)
+}
+
+func TestRegisterHandlerWrapsUnmarshalError(t *testing.T) {
+	env := &registerTestEnv{}
+
+	Register(env, model.BackgroundDefaultQueue, "test_job", 5,
+		func(_ context.Context, _ registerTestParams) error {
+			t.Fatal("handler must not be called on malformed payload")
+			return nil
+		})
+
+	err := env.handler(context.Background(), []byte(`not-json`))
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "test_job")
+}
+
+func TestRegisterEnqueueFuncBuildsBackgroundTask(t *testing.T) {
+	env := &registerTestEnv{}
+
+	enqueue := Register(env, model.BackgroundTelegramJobQueue, "test_job", 7,
+		func(_ context.Context, _ registerTestParams) error { return nil })
+
+	params := registerTestParams{Value: "payload"}
+	err := enqueue(context.Background(), params)
+
+	require.NoError(t, err)
+	require.Equal(t, 1, env.enqueueCallCount)
+	require.Equal(t, model.BackgroundTask{
+		ID:       "test_job",
+		Queue:    model.BackgroundTelegramJobQueue,
+		Data:     params,
+		Priority: 7,
+	}, env.enqueuedTask)
+}


### PR DESCRIPTION
## Why

`jobs.Register[T any, P any]` took a generic env type `T` alongside the payload type `P`, but `T` bought no compile-time safety: the function did a runtime `env.(T)` type assertion, panicking at startup if it failed, guarded by two `//nolint` comments. The type parameter looked like static typing but was actually a runtime check dressed up as one.

## What changed

`Register` is now `Register[P any]` — payload type only:

```go
func Register[P any](env Env, qID model.BackgroundQueueID, jobID string, priority int, handler func(context.Context, P) error) EnqueueFunc
```

Each call site now passes a closure that captures its already-typed `env` and forwards to `Resolve`:

```go
func New(env UpdateTelegramMessageEnv) *UpdateTelegramMessageJob {
    return &UpdateTelegramMessageJob{
        enqueue: jobs.Register(env, QueueID, JobID, Priority,
            func(ctx context.Context, params model.TelegramUpdatePostParams) error {
                return Resolve(ctx, env, params)
            }),
    }
}
```

The composite `XxxEnv interface { jobs.Env; Env }` per package is unchanged — it's still what makes the closure compile-check `env` against the package's own `Env`, now enforced by the compiler instead of a runtime assertion. No `Resolve` signatures changed. `P` is fully inferred from the closure parameter at every call site — no explicit type arguments needed anywhere.

Removed: the `env.(T)` assert, the startup panic, both `//nolint` comments.

## Touched call sites (17 backjob packages)

- deliverchangewebhook, delivercronwebhook, generatenoteversionembedding, importtelegramchannel, refreshchartdata, sendformsubmit, sendsignincode, sendtelegramaccountmessage, sendtelegramaccountpost, sendtelegrammessage, sendtelegrampost, updateallaccounttelegrampublishposts, updateallchattelegrampublishposts, updatetelegramaccountmessage, updatetelegramaccountpost, updatetelegrammessage, updatetelegrampost

Also updated the `Register` example in `docs/dev/queues.md` to the closure form.

## Tests

Added `internal/jobs/env_test.go` (package had no prior tests): hand-rolled `Env` implementation covering handler unmarshal + call-through, wrapped-error-on-malformed-payload (includes jobID), and `EnqueueFunc` building the expected `model.BackgroundTask`.

## Stacking

Stacked on #218 (`refactor/jobs-tidy`, not yet merged) — base is `refactor/jobs-tidy`. Please retarget to `main` after #218 merges.

## Test plan
- [x] `go build -tags dev ./...`
- [x] `go vet -tags dev ./...`
- [x] `go test ./internal/jobs/... ./internal/case/backjob/... ./internal/cronjobs/... ./cmd/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)