### PR TITLE
refactor(cronjob): unexport job structs so New is the only entry

### DIFF
--- a/internal/case/cronjob/cleanupapikeylogs/job.go
+++ b/internal/case/cronjob/cleanupapikeylogs/job.go
@@ -2,31 +2,32 @@ package cleanupapikeylogs
 
 import (
 	"context"
+	"trip2g/internal/cronjobs"
 )
 
 // Job implements the cronjobs.Job interface.
-type Job struct {
+type job struct {
 	env    Env
 	config Config
 }
 
-func New(env Env, config Config) *Job {
-	return &Job{env: env, config: config}
+func New(env Env, config Config) cronjobs.Job {
+	return &job{env: env, config: config}
 }
 
-func (j *Job) Name() string {
+func (j *job) Name() string {
 	return "cleanup_api_key_logs"
 }
 
 // Schedule runs daily at 1:00 AM.
-func (j *Job) Schedule() string {
+func (j *job) Schedule() string {
 	return "0 0 1 * * *"
 }
 
-func (j *Job) ExecuteAfterStart() bool {
+func (j *job) ExecuteAfterStart() bool {
 	return false
 }
 
-func (j *Job) Execute(ctx context.Context) (any, error) {
+func (j *job) Execute(ctx context.Context) (any, error) {
 	return Resolve(ctx, j.env, j.config)
 }

--- a/internal/case/cronjob/cleanupwebhookdeliveries/job.go
+++ b/internal/case/cronjob/cleanupwebhookdeliveries/job.go
@@ -2,30 +2,31 @@ package cleanupwebhookdeliveries
 
 import (
 	"context"
+	"trip2g/internal/cronjobs"
 )
 
 // Job implements the cronjobs.Job interface.
-type Job struct {
+type job struct {
 	env Env
 }
 
-func New(env Env) *Job {
-	return &Job{env: env}
+func New(env Env) cronjobs.Job {
+	return &job{env: env}
 }
 
-func (j *Job) Name() string {
+func (j *job) Name() string {
 	return "cleanup_webhook_deliveries"
 }
 
 // Schedule runs daily at 3:00 AM.
-func (j *Job) Schedule() string {
+func (j *job) Schedule() string {
 	return "0 0 3 * * *"
 }
 
-func (j *Job) ExecuteAfterStart() bool {
+func (j *job) ExecuteAfterStart() bool {
 	return false
 }
 
-func (j *Job) Execute(ctx context.Context) (any, error) {
+func (j *job) Execute(ctx context.Context) (any, error) {
 	return Resolve(ctx, j.env)
 }

--- a/internal/case/cronjob/cleanupwebhookdeliverylogs/job.go
+++ b/internal/case/cronjob/cleanupwebhookdeliverylogs/job.go
@@ -2,32 +2,33 @@ package cleanupwebhookdeliverylogs
 
 import (
 	"context"
+	"trip2g/internal/cronjobs"
 )
 
 // Job implements the cronjobs.Job interface.
-type Job struct {
+type job struct {
 	env Env
 }
 
-func New(env Env) *Job {
-	return &Job{env: env}
+func New(env Env) cronjobs.Job {
+	return &job{env: env}
 }
 
-func (j *Job) Name() string {
+func (j *job) Name() string {
 	return "cleanup_webhook_delivery_logs"
 }
 
 // Schedule runs daily at midnight. Cron webhook response bodies store full agent
 // payloads (hundreds of KB each), so logs must be pruned frequently to prevent
 // the database from growing into the hundreds of MB range.
-func (j *Job) Schedule() string {
+func (j *job) Schedule() string {
 	return "0 0 0 * * *"
 }
 
-func (j *Job) ExecuteAfterStart() bool {
+func (j *job) ExecuteAfterStart() bool {
 	return false
 }
 
-func (j *Job) Execute(ctx context.Context) (any, error) {
+func (j *job) Execute(ctx context.Context) (any, error) {
 	return Resolve(ctx, j.env)
 }

--- a/internal/case/cronjob/clearcronjobexecutionhistory/job.go
+++ b/internal/case/cronjob/clearcronjobexecutionhistory/job.go
@@ -2,28 +2,29 @@ package clearcronjobexecutionhistory
 
 import (
 	"context"
+	"trip2g/internal/cronjobs"
 )
 
-type Job struct {
+type job struct {
 	env Env
 }
 
-func New(env Env) *Job {
-	return &Job{env: env}
+func New(env Env) cronjobs.Job {
+	return &job{env: env}
 }
 
-func (j *Job) Name() string {
+func (j *job) Name() string {
 	return "clear_cronjob_execution_history"
 }
 
-func (j *Job) Schedule() string {
+func (j *job) Schedule() string {
 	return "0 0 0 * * *" // every day at midnight
 }
 
-func (j *Job) ExecuteAfterStart() bool {
+func (j *job) ExecuteAfterStart() bool {
 	return false // Don't run immediately on startup
 }
 
-func (j *Job) Execute(ctx context.Context) (any, error) {
+func (j *job) Execute(ctx context.Context) (any, error) {
 	return Resolve(ctx, j.env, Filter{})
 }

--- a/internal/case/cronjob/executecronwebhooks/job.go
+++ b/internal/case/cronjob/executecronwebhooks/job.go
@@ -2,35 +2,36 @@ package executecronwebhooks
 
 import (
 	"context"
+	"trip2g/internal/cronjobs"
 )
 
 // Job implements the cronjobs.Job interface.
-type Job struct {
+type job struct {
 	env Env
 	// cron is the schedule expression, injected from appconfig (env/flag).
 	cron string
 }
 
-func New(env Env, cron string) *Job {
-	return &Job{env: env, cron: cron}
+func New(env Env, cron string) cronjobs.Job {
+	return &job{env: env, cron: cron}
 }
 
-func (j *Job) Name() string {
+func (j *job) Name() string {
 	return "execute_cron_webhooks"
 }
 
 // Schedule returns the configured cron expression; defaults to every minute.
-func (j *Job) Schedule() string {
+func (j *job) Schedule() string {
 	if j.cron != "" {
 		return j.cron
 	}
 	return "0 * * * * *"
 }
 
-func (j *Job) ExecuteAfterStart() bool {
+func (j *job) ExecuteAfterStart() bool {
 	return false
 }
 
-func (j *Job) Execute(ctx context.Context) (any, error) {
+func (j *job) Execute(ctx context.Context) (any, error) {
 	return Resolve(ctx, j.env)
 }

--- a/internal/case/cronjob/expirestalewebhookdeliveries/job.go
+++ b/internal/case/cronjob/expirestalewebhookdeliveries/job.go
@@ -1,23 +1,26 @@
 package expirestalewebhookdeliveries
 
-import "context"
+import (
+	"context"
+	"trip2g/internal/cronjobs"
+)
 
 // Job implements the cronjobs.Job interface.
-type Job struct {
+type job struct {
 	env Env
 }
 
-func New(env Env) *Job {
-	return &Job{env: env}
+func New(env Env) cronjobs.Job {
+	return &job{env: env}
 }
 
-func (j *Job) Name() string { return "expire_stale_webhook_deliveries" }
+func (j *job) Name() string { return "expire_stale_webhook_deliveries" }
 
 // Schedule runs every minute to bound orphan-lock lifetime.
-func (j *Job) Schedule() string { return "0 * * * * *" }
+func (j *job) Schedule() string { return "0 * * * * *" }
 
-func (j *Job) ExecuteAfterStart() bool { return false }
+func (j *job) ExecuteAfterStart() bool { return false }
 
-func (j *Job) Execute(ctx context.Context) (any, error) {
+func (j *job) Execute(ctx context.Context) (any, error) {
 	return Resolve(ctx, j.env)
 }

--- a/internal/case/cronjob/materializegitmirror/job.go
+++ b/internal/case/cronjob/materializegitmirror/job.go
@@ -2,28 +2,29 @@ package materializegitmirror
 
 import (
 	"context"
+	"trip2g/internal/cronjobs"
 )
 
-type Job struct {
+type job struct {
 	env Env
 }
 
-func New(env Env) *Job {
-	return &Job{env: env}
+func New(env Env) cronjobs.Job {
+	return &job{env: env}
 }
 
-func (j *Job) Name() string {
+func (j *job) Name() string {
 	return "materialize_git_mirror"
 }
 
-func (j *Job) Schedule() string {
+func (j *job) Schedule() string {
 	return "0 0 0 * * *"
 }
 
-func (j *Job) ExecuteAfterStart() bool {
+func (j *job) ExecuteAfterStart() bool {
 	return false // Don't run immediately on startup
 }
 
-func (j *Job) Execute(ctx context.Context) (any, error) {
+func (j *job) Execute(ctx context.Context) (any, error) {
 	return Resolve(ctx, j.env)
 }

--- a/internal/case/cronjob/refreshtelegramaccounts/job.go
+++ b/internal/case/cronjob/refreshtelegramaccounts/job.go
@@ -2,28 +2,29 @@ package refreshtelegramaccounts
 
 import (
 	"context"
+	"trip2g/internal/cronjobs"
 )
 
-type Job struct {
+type job struct {
 	env Env
 }
 
-func New(env Env) *Job {
-	return &Job{env: env}
+func New(env Env) cronjobs.Job {
+	return &job{env: env}
 }
 
-func (j *Job) Name() string {
+func (j *job) Name() string {
 	return "refresh_telegram_accounts"
 }
 
-func (j *Job) Schedule() string {
+func (j *job) Schedule() string {
 	return "0 0 3 * * *" // daily at 3:00 AM
 }
 
-func (j *Job) ExecuteAfterStart() bool {
+func (j *job) ExecuteAfterStart() bool {
 	return false
 }
 
-func (j *Job) Execute(ctx context.Context) (any, error) {
+func (j *job) Execute(ctx context.Context) (any, error) {
 	return Resolve(ctx, j.env)
 }

--- a/internal/case/cronjob/refreshtelegramchatusernames/job.go
+++ b/internal/case/cronjob/refreshtelegramchatusernames/job.go
@@ -1,6 +1,9 @@
 package refreshtelegramchatusernames
 
-import "context"
+import (
+	"context"
+	"trip2g/internal/cronjobs"
+)
 
 const refreshBatchSize = 100
 
@@ -10,27 +13,27 @@ type Env interface {
 
 // Job delegates to a single app method; the logic stays in Execute rather than a
 // resolve.go — a thin wrapper would add ceremony without testable behavior.
-type Job struct {
+type job struct {
 	env Env
 }
 
-func New(env Env) *Job {
-	return &Job{env: env}
+func New(env Env) cronjobs.Job {
+	return &job{env: env}
 }
 
-func (j *Job) Name() string {
+func (j *job) Name() string {
 	return "refresh_telegram_chat_usernames"
 }
 
-func (j *Job) Schedule() string {
+func (j *job) Schedule() string {
 	return "0 0 */6 * * *" // every 6 hours
 }
 
-func (j *Job) ExecuteAfterStart() bool {
+func (j *job) ExecuteAfterStart() bool {
 	return false
 }
 
-func (j *Job) Execute(ctx context.Context) (any, error) {
+func (j *job) Execute(ctx context.Context) (any, error) {
 	n, err := j.env.RefreshStaleTelegramChatUsernames(ctx, refreshBatchSize)
 	if err != nil {
 		return nil, err

--- a/internal/case/cronjob/regeneratenoteembeddings/job.go
+++ b/internal/case/cronjob/regeneratenoteembeddings/job.go
@@ -2,28 +2,29 @@ package regeneratenoteembeddings
 
 import (
 	"context"
+	"trip2g/internal/cronjobs"
 )
 
-type Job struct {
+type job struct {
 	env Env
 }
 
-func New(env Env) *Job {
-	return &Job{env: env}
+func New(env Env) cronjobs.Job {
+	return &job{env: env}
 }
 
-func (j *Job) Name() string {
+func (j *job) Name() string {
 	return "regenerate_note_embeddings"
 }
 
-func (j *Job) Schedule() string {
+func (j *job) Schedule() string {
 	return "0 0 3 * * 0" // weekly on Sunday at 3:00 AM
 }
 
-func (j *Job) ExecuteAfterStart() bool {
+func (j *job) ExecuteAfterStart() bool {
 	return true // Run on startup to catch any missing embeddings
 }
 
-func (j *Job) Execute(ctx context.Context) (any, error) {
+func (j *job) Execute(ctx context.Context) (any, error) {
 	return Resolve(ctx, j.env)
 }

--- a/internal/case/cronjob/removeexpiredtgchatmembers/job.go
+++ b/internal/case/cronjob/removeexpiredtgchatmembers/job.go
@@ -2,28 +2,29 @@ package removeexpiredtgchatmembers
 
 import (
 	"context"
+	"trip2g/internal/cronjobs"
 )
 
-type Job struct {
+type job struct {
 	env Env
 }
 
-func New(env Env) *Job {
-	return &Job{env: env}
+func New(env Env) cronjobs.Job {
+	return &job{env: env}
 }
 
-func (j *Job) Name() string {
+func (j *job) Name() string {
 	return "remove_expired_tg_chat_members"
 }
 
-func (j *Job) Schedule() string {
+func (j *job) Schedule() string {
 	return "0 0 * * * *" // every hour
 }
 
-func (j *Job) ExecuteAfterStart() bool {
+func (j *job) ExecuteAfterStart() bool {
 	return true
 }
 
-func (j *Job) Execute(ctx context.Context) (any, error) {
+func (j *job) Execute(ctx context.Context) (any, error) {
 	return Resolve(ctx, j.env, Filter{})
 }

--- a/internal/case/cronjob/sendscheduledtelegrampublishposts/job.go
+++ b/internal/case/cronjob/sendscheduledtelegrampublishposts/job.go
@@ -2,33 +2,34 @@ package sendscheduledtelegrampublishposts
 
 import (
 	"context"
+	"trip2g/internal/cronjobs"
 )
 
-type Job struct {
+type job struct {
 	env Env
 	// cron is the schedule expression, injected from appconfig (env/flag).
 	cron string
 }
 
-func New(env Env, cron string) *Job {
-	return &Job{env: env, cron: cron}
+func New(env Env, cron string) cronjobs.Job {
+	return &job{env: env, cron: cron}
 }
 
-func (j *Job) Name() string {
+func (j *job) Name() string {
 	return "send_scheduled_telegram_publishposts"
 }
 
-func (j *Job) Schedule() string {
+func (j *job) Schedule() string {
 	if j.cron != "" {
 		return j.cron
 	}
 	return "0 * * * * *" // default: every minute
 }
 
-func (j *Job) ExecuteAfterStart() bool {
+func (j *job) ExecuteAfterStart() bool {
 	return true // Don't run immediately on startup
 }
 
-func (j *Job) Execute(ctx context.Context) (any, error) {
+func (j *job) Execute(ctx context.Context) (any, error) {
 	return Resolve(ctx, j.env)
 }

--- a/internal/case/cronjob/simplebackup/job.go
+++ b/internal/case/cronjob/simplebackup/job.go
@@ -2,26 +2,27 @@ package simplebackup
 
 import (
 	"context"
+	"trip2g/internal/cronjobs"
 	"trip2g/internal/simplebackup"
 )
 
-type Job struct {
+type job struct {
 	env Env
 }
 
-func New(env Env) *Job {
-	return &Job{env: env}
+func New(env Env) cronjobs.Job {
+	return &job{env: env}
 }
 
-func (j *Job) Name() string {
+func (j *job) Name() string {
 	return "simple_backup"
 }
 
-func (j *Job) Schedule() string {
+func (j *job) Schedule() string {
 	return "0 0 * * * *" // Every hour at :00
 }
 
-func (j *Job) ExecuteAfterStart() bool {
+func (j *job) ExecuteAfterStart() bool {
 	return false
 }
 
@@ -32,7 +33,7 @@ type Env interface {
 	BackupManager() *simplebackup.Manager
 }
 
-func (j *Job) Execute(ctx context.Context) (any, error) {
+func (j *job) Execute(ctx context.Context) (any, error) {
 	mgr := j.env.BackupManager()
 	if mgr == nil {
 		return nil, nil // Backup disabled

--- a/internal/case/cronjob/updatetelegrampublishposts/job.go
+++ b/internal/case/cronjob/updatetelegrampublishposts/job.go
@@ -2,28 +2,29 @@ package updatetelegrampublishposts
 
 import (
 	"context"
+	"trip2g/internal/cronjobs"
 )
 
-type Job struct {
+type job struct {
 	env Env
 }
 
-func New(env Env) *Job {
-	return &Job{env: env}
+func New(env Env) cronjobs.Job {
+	return &job{env: env}
 }
 
-func (j *Job) Name() string {
+func (j *job) Name() string {
 	return "update_telegram_publish_posts"
 }
 
-func (j *Job) Schedule() string {
+func (j *job) Schedule() string {
 	return "0 0 0 * * *" // daily at midnight
 }
 
-func (j *Job) ExecuteAfterStart() bool {
+func (j *job) ExecuteAfterStart() bool {
 	return false
 }
 
-func (j *Job) Execute(ctx context.Context) (any, error) {
+func (j *job) Execute(ctx context.Context) (any, error) {
 	return Resolve(ctx, j.env)
 }

--- a/internal/case/cronjob/vacuumdatabase/job.go
+++ b/internal/case/cronjob/vacuumdatabase/job.go
@@ -2,29 +2,30 @@ package vacuumdatabase
 
 import (
 	"context"
+	"trip2g/internal/cronjobs"
 )
 
-type Job struct {
+type job struct {
 	env Env
 }
 
-func New(env Env) *Job {
-	return &Job{env: env}
+func New(env Env) cronjobs.Job {
+	return &job{env: env}
 }
 
-func (j *Job) Name() string {
+func (j *job) Name() string {
 	return "vacuum_database"
 }
 
-func (j *Job) Schedule() string {
+func (j *job) Schedule() string {
 	// Run weekly on Sunday at 3 AM
 	return "0 0 3 * * 0"
 }
 
-func (j *Job) ExecuteAfterStart() bool {
+func (j *job) ExecuteAfterStart() bool {
 	return false // Don't run immediately on startup
 }
 
-func (j *Job) Execute(ctx context.Context) (any, error) {
+func (j *job) Execute(ctx context.Context) (any, error) {
 	return Resolve(ctx, j.env, Filter{})
 }


### PR DESCRIPTION
Why: PR #218 left cronjob job structs exported (`type Job struct { env Env; ... }`), so callers could construct `&pkg.Job{}` directly with a nil env, bypassing `New` and causing a runtime panic. The constructor call must be the only construction path (compile-time proof that env is wired).

Mechanically unexports `Job` -> `job` in all 15 `internal/case/cronjob/*` packages; `New` now returns the `cronjobs.Job` interface instead of `*job`. No behavior change, no wrinkles across packages — all 15 followed the identical pattern.

## Test plan
- `go build -tags dev ./internal/case/cronjob/... ./internal/cronjobs/...` -> pass
- `go vet -tags dev ./internal/case/cronjob/... ./internal/cronjobs/...` -> pass
- `go test ./internal/case/cronjob/... ./internal/cronjobs/...` -> all pass
- `go build -tags dev ./cmd/...` -> pass (verified with local placeholder generated assets; `cmd/server` normally needs `make gqlgen`/frontend build artifacts present, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)