### PR TITLE
feat(layoutloader): warn when a component hardcodes its own @lid/@did name

### DIFF
--- a/docs/_layouts/mesh/bar.html
+++ b/docs/_layouts/mesh/bar.html
@@ -96,17 +96,17 @@
   <a class="@did__pill" href="https://github.com/trip2g/trip2g" target="_blank" rel="noopener" style="color:var(--muted); text-decoration:none;">v0.3 · open source</a>
   <div class="@did__spacer"></div>
   <nav class="@did__nav">
-    <a href="#" class="@did__nav-link mesh-bar__nav-link--key" onclick="document.getElementById('mcp-hint').classList.add('mesh-bar__overlay--open'); return false;">⌘K</a>
+    <a href="#" class="@did__nav-link @did__nav-link--key" onclick="document.getElementById('mcp-hint').classList.add('@did__overlay--open'); return false;">⌘K</a>
     <a href="/en/user" class="@did__nav-link">Docs</a>
     <a href="/en/user/use_cases" class="@did__nav-link">Use cases</a>
     <a href="/en/thoughts" class="@did__nav-link">Philosophy</a>
-    <a href="/" class="@did__nav-link mesh-bar__nav-link--key">EN</a>
+    <a href="/" class="@did__nav-link @did__nav-link--key">EN</a>
     <a href="/ru" class="@did__nav-link">RU</a>
     <a href="https://github.com/trip2g/trip2g" target="_blank" rel="noopener" class="@did__nav-link">★ star us</a>
     <a href="/en/user/getting_started" class="@did__nav-link">start →</a>
   </nav>
 </header>
-<div id="mcp-hint" class="@did__overlay" onclick="if(event.target===this)this.classList.remove('mesh-bar__overlay--open')">
+<div id="mcp-hint" class="@did__overlay" onclick="if(event.target===this)this.classList.remove('@did__overlay--open')">
   <div class="@did__dialog">
     <div class="@did__dialog-eyebrow">// YOUR AGENT IS WAITING</div>
     <div class="@did__dialog-title">Add this to your agent.</div>
@@ -118,8 +118,8 @@
       </div>
       <div class="@did__snippet-body">mcp:add https://trip2g.com/_system/mcp</div>
     </div>
-    {{yield mesh_button(label="for AI agents →", href="/simple", modifier="mesh-bar__cta")}}
-    <div class="@did__close" onclick="document.getElementById('mcp-hint').classList.remove('mesh-bar__overlay--open')">[ esc ]</div>
+    {{yield mesh_button(label="for AI agents →", href="/simple", modifier="@did__cta")}}
+    <div class="@did__close" onclick="document.getElementById('mcp-hint').classList.remove('@did__overlay--open')">[ esc ]</div>
   </div>
 </div>
 {{ end }}
@@ -131,17 +131,17 @@
   <a class="@did__pill" href="https://github.com/trip2g/trip2g" target="_blank" rel="noopener" style="color:var(--muted); text-decoration:none;">v0.3 · open source</a>
   <div class="@did__spacer"></div>
   <nav class="@did__nav">
-    <a href="#" class="@did__nav-link mesh-bar__nav-link--key" onclick="document.getElementById('mcp-hint').classList.add('mesh-bar__overlay--open'); return false;">⌘K</a>
+    <a href="#" class="@did__nav-link @did__nav-link--key" onclick="document.getElementById('mcp-hint').classList.add('@did__overlay--open'); return false;">⌘K</a>
     <a href="/ru/user" class="@did__nav-link">Документация</a>
     <a href="/ru/user/use_cases" class="@did__nav-link">Сценарии</a>
     <a href="/ru/thoughts" class="@did__nav-link">Философия</a>
     <a href="/" class="@did__nav-link">EN</a>
-    <a href="/ru" class="@did__nav-link mesh-bar__nav-link--key">RU</a>
+    <a href="/ru" class="@did__nav-link @did__nav-link--key">RU</a>
     <a href="https://github.com/trip2g/trip2g" target="_blank" rel="noopener" class="@did__nav-link">★ star us</a>
     <a href="/ru/user/nachalo_rabotyi" class="@did__nav-link">начать →</a>
   </nav>
 </header>
-<div id="mcp-hint" class="@did__overlay" onclick="if(event.target===this)this.classList.remove('mesh-bar__overlay--open')">
+<div id="mcp-hint" class="@did__overlay" onclick="if(event.target===this)this.classList.remove('@did__overlay--open')">
   <div class="@did__dialog">
     <div class="@did__dialog-eyebrow">// ВАШ АГЕНТ ЖДЁТ</div>
     <div class="@did__dialog-title">Добавь это своему агенту.</div>
@@ -153,8 +153,8 @@
       </div>
       <div class="@did__snippet-body">mcp:add https://trip2g.com/_system/mcp</div>
     </div>
-    {{yield mesh_button(label="для AI-агентов →", href="/ru/simple", modifier="mesh-bar__cta")}}
-    <div class="@did__close" onclick="document.getElementById('mcp-hint').classList.remove('mesh-bar__overlay--open')">[ esc ]</div>
+    {{yield mesh_button(label="для AI-агентов →", href="/ru/simple", modifier="@did__cta")}}
+    <div class="@did__close" onclick="document.getElementById('mcp-hint').classList.remove('@did__overlay--open')">[ esc ]</div>
   </div>
 </div>
 {{ end }}

--- a/docs/_layouts/mesh/foot.html
+++ b/docs/_layouts/mesh/foot.html
@@ -21,7 +21,7 @@
   font-family: var(--sans); font-size: 13px; line-height: 1.5;
   color: var(--muted); margin: 0 0 20px;
 }
-.mesh-foot__cta { display: inline-block; margin-top: 4px; }
+.@did__cta { display: inline-block; margin-top: 4px; }
 .@did__coda {
   padding: 14px 40px;
   font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase;
@@ -38,7 +38,7 @@
   <div>
     <h4 class="@did__heading">// trip2g</h4>
     <p class="@did__about">Open source knowledge network. Keep your notes — your agent finds answers across your bases and the people you trust.</p>
-    {{yield mesh_button(label="start →", href="/en/user/getting_started", variant="primary", modifier="mesh-foot__cta")}}
+    {{yield mesh_button(label="start →", href="/en/user/getting_started", variant="primary", modifier="@did__cta")}}
   </div>
   <div>
     <h4 class="@did__heading">Philosophy</h4>
@@ -82,7 +82,7 @@
   <div>
     <h4 class="@did__heading">// trip2g</h4>
     <p class="@did__about">Open source сеть знаний. Храните заметки где хотите — агент находит ответы по вашим базам и базам людей которым вы доверяете.</p>
-    {{yield mesh_button(label="начать →", href="/ru/user/nachalo_rabotyi", variant="primary", modifier="mesh-foot__cta")}}
+    {{yield mesh_button(label="начать →", href="/ru/user/nachalo_rabotyi", variant="primary", modifier="@did__cta")}}
   </div>
   <div>
     <h4 class="@did__heading">Философия</h4>

--- a/docs/_layouts/mesh/hero.html
+++ b/docs/_layouts/mesh/hero.html
@@ -51,10 +51,10 @@
     {{ yield mesh_section(path="_index_hero.md") }}
   </div>
   <div class="@did__cta-row">
-    {{yield mesh_button(label="start →", href="/en/user/getting_started", variant="primary", modifier="mesh-hero__cta")}}
-    {{yield mesh_button(label="for AI agents →", href="/simple", modifier="mesh-hero__cta")}}
-    {{yield mesh_button(label="github ↗", href="https://github.com/trip2g/trip2g", target="_blank", modifier="mesh-hero__cta")}}
-    {{yield mesh_button(label="docs", href="/en/user", modifier="mesh-hero__cta")}}
+    {{yield mesh_button(label="start →", href="/en/user/getting_started", variant="primary", modifier="@did__cta")}}
+    {{yield mesh_button(label="for AI agents →", href="/simple", modifier="@did__cta")}}
+    {{yield mesh_button(label="github ↗", href="https://github.com/trip2g/trip2g", target="_blank", modifier="@did__cta")}}
+    {{yield mesh_button(label="docs", href="/en/user", modifier="@did__cta")}}
   </div>
 </section>
 {{ end }}
@@ -66,10 +66,10 @@
     {{ yield mesh_section(path="ru/_index_hero.md") }}
   </div>
   <div class="@did__cta-row">
-    {{yield mesh_button(label="начать →", href="/ru/user/nachalo_rabotyi", variant="primary", modifier="mesh-hero__cta")}}
-    {{yield mesh_button(label="для AI-агентов →", href="/ru/simple", modifier="mesh-hero__cta")}}
-    {{yield mesh_button(label="github ↗", href="https://github.com/trip2g/trip2g", target="_blank", modifier="mesh-hero__cta")}}
-    {{yield mesh_button(label="документация", href="/ru/user", modifier="mesh-hero__cta")}}
+    {{yield mesh_button(label="начать →", href="/ru/user/nachalo_rabotyi", variant="primary", modifier="@did__cta")}}
+    {{yield mesh_button(label="для AI-агентов →", href="/ru/simple", modifier="@did__cta")}}
+    {{yield mesh_button(label="github ↗", href="https://github.com/trip2g/trip2g", target="_blank", modifier="@did__cta")}}
+    {{yield mesh_button(label="документация", href="/ru/user", modifier="@did__cta")}}
   </div>
 </section>
 {{ end }}

--- a/docs/_layouts/mesh/matrix.html
+++ b/docs/_layouts/mesh/matrix.html
@@ -33,18 +33,18 @@
 
 {{ block @lid() }}
 <div class="@did">
-  <div class="@did__cell mesh-matrix__cell--red">
-    <pre class="@did__ascii mesh-matrix__ascii--red">
+  <div class="@did__cell @did__cell--red">
+    <pre class="@did__ascii @did__ascii--red">
   ██████╗ ███████╗██████╗
   ██╔══██╗██╔════╝██╔══██╗
   ██████╔╝█████╗  ██║  ██║
   ██╔══██╗██╔══╝  ██║  ██║</pre>
     <div class="@did__title">Take the red pill.</div>
     <div class="@did__desc">Add the MCP. Your agent connects to the network. You see how deep the rabbit hole goes.</div>
-    {{yield mesh_button(label="mcp:add →", href="/simple", modifier="mesh-matrix__cta")}}
+    {{yield mesh_button(label="mcp:add →", href="/simple", modifier="@did__cta")}}
   </div>
-  <div class="@did__cell mesh-matrix__cell--blue">
-    <pre class="@did__ascii mesh-matrix__ascii--blue">
+  <div class="@did__cell @did__cell--blue">
+    <pre class="@did__ascii @did__ascii--blue">
   ██████╗ ██╗     ██╗   ██╗███████╗
   ██╔══██╗██║     ██║   ██║██╔════╝
   ██████╔╝██║     ██║   ██║█████╗
@@ -58,18 +58,18 @@
 
 {{ block @lid_ru() }}
 <div class="@did">
-  <div class="@did__cell mesh-matrix__cell--red">
-    <pre class="@did__ascii mesh-matrix__ascii--red">
+  <div class="@did__cell @did__cell--red">
+    <pre class="@did__ascii @did__ascii--red">
   ██████╗ ███████╗██████╗
   ██╔══██╗██╔════╝██╔══██╗
   ██████╔╝█████╗  ██║  ██║
   ██╔══██╗██╔══╝  ██║  ██║</pre>
     <div class="@did__title">Возьми красную таблетку.</div>
     <div class="@did__desc">Добавь MCP. Твой агент подключается к сети. Ты увидишь насколько глубока кроличья нора.</div>
-    {{yield mesh_button(label="mcp:add →", href="/ru/simple", modifier="mesh-matrix__cta")}}
+    {{yield mesh_button(label="mcp:add →", href="/ru/simple", modifier="@did__cta")}}
   </div>
-  <div class="@did__cell mesh-matrix__cell--blue">
-    <pre class="@did__ascii mesh-matrix__ascii--blue">
+  <div class="@did__cell @did__cell--blue">
+    <pre class="@did__ascii @did__ascii--blue">
   ██████╗ ██╗     ██╗   ██╗███████╗
   ██╔══██╗██║     ██║   ██║██╔════╝
   ██████╔╝██║     ██║   ██║█████╗

--- a/docs/_layouts/mesh/network.html
+++ b/docs/_layouts/mesh/network.html
@@ -94,14 +94,14 @@
     <div class="@did__text">{{ yield mesh_section(path="_index_payoff.md") }}</div>
   </div>
   <div class="@did__right">
-    <div class="@did__frame mesh-network__frame--graph mesh-network__graph">
+    <div class="@did__frame @did__frame--graph @did__graph">
       <div class="@did__frame-head">
         <span>fig.01 · mesh.trace · query.route</span>
         <span class="@did__live">LIVE</span>
       </div>
       <div id="mesh-svg-mount"></div>
     </div>
-    <div class="@did__frame mesh-network__frame--trace">
+    <div class="@did__frame @did__frame--trace">
       <div class="@did__frame-head">
         <span>stdout · /var/log/mesh.trace</span>
         <span style="color: var(--muted)">tail -f</span>
@@ -119,14 +119,14 @@
     <div class="@did__text">{{ yield mesh_section(path="ru/_index_payoff.md") }}</div>
   </div>
   <div class="@did__right">
-    <div class="@did__frame mesh-network__frame--graph mesh-network__graph">
+    <div class="@did__frame @did__frame--graph @did__graph">
       <div class="@did__frame-head">
         <span>fig.01 · mesh.trace · query.route</span>
         <span class="@did__live">LIVE</span>
       </div>
       <div id="mesh-svg-mount"></div>
     </div>
-    <div class="@did__frame mesh-network__frame--trace">
+    <div class="@did__frame @did__frame--trace">
       <div class="@did__frame-head">
         <span>stdout · /var/log/mesh.trace</span>
         <span style="color: var(--muted)">tail -f</span>

--- a/docs/_layouts/mesh/pricing.html
+++ b/docs/_layouts/mesh/pricing.html
@@ -26,7 +26,7 @@
   color: color-mix(in oklab, var(--fg) 85%, transparent);
 }
 .price-list li::before { content: "[+] "; font-family: var(--mono); color: var(--accent); margin-right: 6px; }
-.mesh-pricing__cta { margin-top: auto; align-self: flex-start; }
+.@did__cta { margin-top: auto; align-self: flex-start; }
 @media (max-width: 900px) {
   .pricing { grid-template-columns: 1fr; }
   .price { border-right: 0; border-bottom: 1px solid var(--rule); }

--- a/internal/layoutloader/loader.go
+++ b/internal/layoutloader/loader.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
 	"trip2g/internal/logger"
@@ -96,6 +97,14 @@ func Load(env Env, sourceFiles []model.LayoutSourceFile, options Options) (*mode
 			}
 			content = jetContent
 		}
+		// Scan the pre-expansion source for the file's own hardcoded @lid/@did
+		// names before expandBlockName rewrites the placeholders.
+		if selfLit := scanSelfLiteral(content, source.ID); len(selfLit) > 0 {
+			jl.pendingWarnings[source.ID] = append(jl.pendingWarnings[source.ID], selfLit...)
+			for _, w := range selfLit {
+				log.Warn(w.Message)
+			}
+		}
 		jl.templates[source.ID] = expandBlockName(content, source.ID)
 		jl.sourceIDs = append(jl.sourceIDs, source.ID)
 	}
@@ -154,12 +163,30 @@ func Load(env Env, sourceFiles []model.LayoutSourceFile, options Options) (*mode
 			// Normalize ID to match production format: strip /_layouts prefix and .html
 			// extension. Production loader strips these when building the templates map,
 			// so Jet import resolution (relative paths) only works with normalized IDs.
+			providedMainContent := main.Content
 			main.ID = normalizeLayoutID(main.ID)
 
 			// If no inline content provided, fill from snapshot so load() does not
 			// overwrite the server template with an empty string.
 			if main.Content == "" {
 				main.Content = snap[main.ID]
+			}
+
+			// Scan the user-authored (pre-expansion) sources for self-literal
+			// @lid/@did drift. Only extra (caller-supplied) files and an explicitly
+			// provided main content are raw; snapshot templates are already expanded.
+			selfLit := make(map[string]struct{})
+			rawSources := make(map[string]string)
+			for k, v := range extra {
+				rawSources[normalizeLayoutID(k)] = v
+			}
+			if providedMainContent != "" {
+				rawSources[main.ID] = providedMainContent
+			}
+			for id, content := range rawSources {
+				for _, w := range scanSelfLiteral(content, id) {
+					selfLit[w.Message] = struct{}{}
+				}
 			}
 
 			// Fresh isolated loader — never touches the production jl.
@@ -183,6 +210,14 @@ func Load(env Env, sourceFiles []model.LayoutSourceFile, options Options) (*mode
 			var warnings []string
 			if errStr != "" {
 				warnings = append(warnings, "compile: "+errStr)
+			}
+			if len(selfLit) > 0 {
+				msgs := make([]string, 0, len(selfLit))
+				for m := range selfLit {
+					msgs = append(msgs, m)
+				}
+				sort.Strings(msgs)
+				warnings = append(warnings, msgs...)
 			}
 			if view == nil {
 				return model.Layout{}, warnings

--- a/internal/layoutloader/self_literal.go
+++ b/internal/layoutloader/self_literal.go
@@ -1,0 +1,115 @@
+package layoutloader
+
+import (
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"trip2g/internal/model"
+)
+
+// derivePlaceholderIDs derives the @lid/@did expansions from a component's source ID.
+// @lid = lodash id (underscores), used for Jet block names.
+// @did = dash id (hyphens), used for BEM CSS class names.
+// Examples: "/mesh/bar" → lid="mesh_bar", did="mesh-bar".
+func derivePlaceholderIDs(sourceID string) (lid, did string) {
+	base := strings.TrimPrefix(sourceID, "/")
+	if idx := strings.LastIndex(base, "."); idx != -1 {
+		base = base[:idx]
+	}
+	lid = strings.ReplaceAll(base, "/", "_")
+	did = strings.ReplaceAll(base, "/", "-")
+	return lid, did
+}
+
+// scanSelfLiteral scans a component's PRE-expansion source for literal occurrences
+// of its own expanded @lid/@did names. Such literals silently break the rename
+// guarantee: the placeholders are optional, so a hardcoded "mesh-bar" survives a
+// file rename while "@did" would follow it. Escaped @@lid/@@did stay literal in the
+// raw source (they read "@@lid"), so they never match the expanded name.
+//
+// Rules:
+//   - Only the file's OWN lid/did. Referencing another component's expanded name
+//     (e.g. index.html yielding mesh_bar()) is correct composition, never flagged.
+//   - JS/CSS strings are in scope: querySelector('.mesh-bar__nav') is exactly the
+//     drift to catch — the expansion is textual everywhere.
+//   - did matches with a BEM/CSS boundary so "mesh-bar" does not match inside
+//     "mesh-barometer".
+//   - lid matches only call/definition forms so "mesh_art" does not match inside
+//     "mesh_article".
+func scanSelfLiteral(content, sourceID string) []model.NoteWarning {
+	lid, did := derivePlaceholderIDs(sourceID)
+	if lid == "" && did == "" {
+		return nil
+	}
+
+	type hit struct {
+		line int
+		kind string // "@lid" or "@did"
+		text string
+	}
+	var hits []hit
+
+	addHits := func(re *regexp.Regexp, group int, kind, text string) {
+		for _, m := range re.FindAllStringSubmatchIndex(content, -1) {
+			start := m[2*group]
+			if start < 0 {
+				continue
+			}
+			line := 1 + strings.Count(content[:start], "\n")
+			hits = append(hits, hit{line: line, kind: kind, text: text})
+		}
+	}
+
+	if did != "" {
+		// non-word (or start) before; BEM/CSS boundary (or end) after.
+		didRe := regexp.MustCompile(`(?:^|[^\w])(` + regexp.QuoteMeta(did) + `)(?:__|--|[\s'"` + "`" + `.#:\[)\{,;]|$)`)
+		addHits(didRe, 1, "@did", did)
+	}
+
+	if lid != "" {
+		q := regexp.QuoteMeta(lid)
+		// <lid>_ru( — RU variant call/definition (checked first so the _ru form wins).
+		addHits(regexp.MustCompile(`(?:^|[^\w])(`+q+`)_ru\(`), 1, "@lid", lid)
+		// <lid>( — call or block definition.
+		addHits(regexp.MustCompile(`(?:^|[^\w])(`+q+`)\(`), 1, "@lid", lid)
+		// _style_<lid> — the paired CSS block, boundary (or end) after.
+		addHits(regexp.MustCompile(`_style_(`+q+`)(?:[^\w]|$)`), 1, "@lid", lid)
+		// yield <lid> — a yield reference, boundary (or end) after.
+		addHits(regexp.MustCompile(`yield\s+(`+q+`)(?:[^\w]|$)`), 1, "@lid", lid)
+	}
+
+	if len(hits) == 0 {
+		return nil
+	}
+
+	// Dedupe by (line, kind): one warning per line per placeholder kind.
+	seen := make(map[string]struct{})
+	unique := hits[:0]
+	for _, h := range hits {
+		key := h.kind + ":" + strconv.Itoa(h.line)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		unique = append(unique, h)
+	}
+
+	sort.Slice(unique, func(i, j int) bool {
+		if unique[i].line != unique[j].line {
+			return unique[i].line < unique[j].line
+		}
+		return unique[i].kind < unique[j].kind
+	})
+
+	warnings := make([]model.NoteWarning, 0, len(unique))
+	for _, h := range unique {
+		warnings = append(warnings, model.NoteWarning{
+			Level: model.NoteWarningWarning,
+			Message: "layout " + sourceID + " line " + strconv.Itoa(h.line) +
+				`: literal "` + h.text + `" matches this file's ` + h.kind +
+				`; replace with ` + h.kind + " so renames keep working",
+		})
+	}
+	return warnings
+}

--- a/internal/layoutloader/self_literal_test.go
+++ b/internal/layoutloader/self_literal_test.go
@@ -1,0 +1,158 @@
+package layoutloader
+
+import (
+	"strings"
+	"testing"
+	"trip2g/internal/logger"
+	"trip2g/internal/model"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDerivePlaceholderIDs(t *testing.T) {
+	cases := []struct {
+		id      string
+		wantLid string
+		wantDid string
+	}{
+		{"/mesh/bar", "mesh_bar", "mesh-bar"},
+		{"/mesh/bar.html", "mesh_bar", "mesh-bar"},
+		{"mesh/bar", "mesh_bar", "mesh-bar"},
+		{"/mesh/index", "mesh_index", "mesh-index"},
+	}
+	for _, c := range cases {
+		lid, did := derivePlaceholderIDs(c.id)
+		require.Equal(t, c.wantLid, lid, "lid for %s", c.id)
+		require.Equal(t, c.wantDid, did, "did for %s", c.id)
+	}
+}
+
+// lines returns the 1-based line numbers referenced by the warnings, for terse assertions.
+func warnLines(t *testing.T, ws []model.NoteWarning, kind string) []string {
+	t.Helper()
+	var out []string
+	for _, w := range ws {
+		if strings.Contains(w.Message, "this file's "+kind) {
+			out = append(out, w.Message)
+		}
+	}
+	return out
+}
+
+func TestScanSelfLiteral_DidInCSSAndJS(t *testing.T) {
+	// bar.html style: @did placeholders are fine, but a hardcoded mesh-bar class
+	// (here in a JS querySelector string) is the drift to catch.
+	src := "line1\n" +
+		`.@did__nav { color: red; }` + "\n" +
+		`document.querySelector('.mesh-bar__nav')` + "\n"
+	ws := scanSelfLiteral(src, "/mesh/bar")
+	require.Len(t, ws, 1)
+	require.Contains(t, ws[0].Message, "line 3")
+	require.Contains(t, ws[0].Message, `literal "mesh-bar"`)
+	require.Contains(t, ws[0].Message, "this file's @did")
+	require.Equal(t, model.NoteWarningWarning, ws[0].Level)
+}
+
+func TestScanSelfLiteral_EscapedPlaceholderNotFlagged(t *testing.T) {
+	// @@did is an escape that stays literal "@did" in the raw source, so it never
+	// matches the expanded "mesh-bar". Even when the expanded literal appears on the
+	// SAME line elsewhere, only the true literal is flagged.
+	src := `<div class="@did__x @@did">` + "\n" +
+		`<div class="@did__y mesh-bar__z @@did">` + "\n"
+	ws := scanSelfLiteral(src, "/mesh/bar")
+	// Only line 2 has a real literal (mesh-bar__z); the @@did escapes are ignored.
+	require.Len(t, ws, 1)
+	require.Contains(t, ws[0].Message, "line 2")
+}
+
+func TestScanSelfLiteral_OtherComponentNotFlagged(t *testing.T) {
+	// index.html composing other components by their expanded names is correct.
+	src := `{{ yield mesh_bar() }}` + "\n" +
+		`<div class="mesh-bar__nav"></div>` + "\n"
+	ws := scanSelfLiteral(src, "/mesh/index")
+	require.Empty(t, ws)
+}
+
+func TestScanSelfLiteral_DidWordBoundary(t *testing.T) {
+	// mesh-bar must not match inside mesh-barometer.
+	src := `.mesh-barometer { x: 1 }` + "\n"
+	ws := scanSelfLiteral(src, "/mesh/bar")
+	require.Empty(t, ws)
+}
+
+func TestScanSelfLiteral_DidBoundaryVariants(t *testing.T) {
+	src := `a .mesh-bar { }` + "\n" + // whitespace after
+		`b .mesh-bar__el { }` + "\n" + // __ suffix
+		`c .mesh-bar--mod { }` + "\n" + // -- suffix
+		`d "mesh-bar"` + "\n" + // quote after
+		`e mesh-bar` + "\n" // end of line
+	ws := scanSelfLiteral(src, "/mesh/bar")
+	require.Len(t, warnLines(t, ws, "@did"), 5)
+}
+
+func TestScanSelfLiteral_LidCallForms(t *testing.T) {
+	src := `{{ block mesh_bar() }}` + "\n" + // <lid>(
+		`{{ block mesh_bar_ru() }}` + "\n" + // <lid>_ru(
+		`{{ block _style_mesh_bar() }}` + "\n" + // _style_<lid>
+		`{{ yield mesh_bar() }}` + "\n" // yield <lid>
+	ws := scanSelfLiteral(src, "/mesh/bar")
+	require.Len(t, warnLines(t, ws, "@lid"), 4)
+}
+
+func TestScanSelfLiteral_LidWordBoundary(t *testing.T) {
+	// mesh_art must not match inside mesh_article.
+	src := `{{ yield mesh_article() }}` + "\n" +
+		`{{ block _style_mesh_articles() }}` + "\n"
+	ws := scanSelfLiteral(src, "/mesh/art")
+	require.Empty(t, ws)
+}
+
+func TestScanSelfLiteral_DedupePerLine(t *testing.T) {
+	// Two literals on one line collapse to a single warning for that line/kind.
+	src := `<a class="mesh-bar__x mesh-bar__y">` + "\n"
+	ws := scanSelfLiteral(src, "/mesh/bar")
+	require.Len(t, ws, 1)
+}
+
+func TestScanSelfLiteral_Clean(t *testing.T) {
+	src := `{{ block @lid() }}<div class="@did__x">@@did</div>{{ end }}` + "\n"
+	ws := scanSelfLiteral(src, "/mesh/bar")
+	require.Empty(t, ws)
+}
+
+// Load surfaces self-literal warnings on the layout (which doclint reads) and
+// preview returns them as strings.
+func TestLoad_SurfacesSelfLiteralWarning(t *testing.T) {
+	sources := []model.LayoutSourceFile{{
+		ID:      "/mesh/bar",
+		Path:    "_layouts/mesh/bar.html",
+		Content: `{{ block @lid() }}<div class="mesh-bar__nav"></div>{{ end }}`,
+	}}
+	env := &testEnv{logger: &logger.TestLogger{}}
+	layouts, err := Load(env, sources, Options{})
+	require.NoError(t, err)
+	got := layouts.Map["/mesh/bar"].Warnings
+	require.NotEmpty(t, got)
+	require.Contains(t, got[0].Message, `literal "mesh-bar"`)
+}
+
+func TestLoadPreview_SelfLiteralWarning(t *testing.T) {
+	env := &testEnv{logger: &logger.TestLogger{}}
+	layouts, err := Load(env, nil, Options{})
+	require.NoError(t, err)
+
+	main := model.LayoutSourceFile{
+		ID:      "/mesh/bar",
+		Path:    "_layouts/mesh/bar.html",
+		Content: `{{ block @lid() }}<div class="mesh-bar__nav"></div>{{ end }}`,
+	}
+	_, warnings := layouts.LoadPreview(main, nil)
+
+	var found bool
+	for _, w := range warnings {
+		if strings.Contains(w, `literal "mesh-bar"`) {
+			found = true
+		}
+	}
+	require.True(t, found, "expected self-literal warning in preview, got %v", warnings)
+}

--- a/internal/layoutloader/yield_blocks.go
+++ b/internal/layoutloader/yield_blocks.go
@@ -47,13 +47,7 @@ func expandBlockName(content, sourceID string) string {
 	if !strings.Contains(content, "@lid") && !strings.Contains(content, "@did") {
 		return content
 	}
-	// derive base: strip leading slash, strip extension
-	base := strings.TrimPrefix(sourceID, "/")
-	if idx := strings.LastIndex(base, "."); idx != -1 {
-		base = base[:idx]
-	}
-	lid := strings.ReplaceAll(base, "/", "_") // lodash id
-	did := strings.ReplaceAll(base, "/", "-") // dash id (hyphens throughout)
+	lid, did := derivePlaceholderIDs(sourceID)
 
 	const sentinelLid = "\x00at_lid\x00"
 	const sentinelDid = "\x00at_did\x00"


### PR DESCRIPTION
## What

Loader-level warning when a `docs/_layouts/<theme>/` component file contains its **own** expanded `@lid`/`@did` name as a literal. Placeholders are optional, so a hardcoded `mesh-bar` silently survives a file rename while `@did` would follow it — this closes that hole. Plus cleans up the existing offenders in `docs/_layouts/mesh/`.

WARNING only — no error, no autofix.

## The check (`internal/layoutloader`)

- Extracted `derivePlaceholderIDs(sourceID) (lid, did)`, now shared by `expandBlockName` and the new scan (`self_literal.go`).
- `scanSelfLiteral(content, sourceID)` scans the **pre-expansion** source for the file's own expanded names. Rules (all covered by tests in `self_literal_test.go`):
  - Escaped `@@lid`/`@@did` stay literal (`@@did`) in raw source, so they never match the expanded `mesh-bar` — not flagged. A real literal on the same line as an escape is still caught.
  - Only the file's **own** lid/did. Referencing another component (e.g. `index.html` yielding `mesh_bar()`) is correct composition — never flagged.
  - JS/CSS strings are in scope: `querySelector('.mesh-bar__nav')` inside `bar.html` is the drift to catch.
  - `did` word boundary: non-word (or start) before; `__`/`--`/whitespace/quote/`.`/`#`/`:`/`[`/`)`/`{`/`,`/`;`/end after — so `mesh-bar` does not match inside `mesh-barometer`, nor single-dash namespaces like the `mesh-network-blink` keyframe.
  - `lid` matches only call/definition forms: `<lid>(`, `<lid>_ru(`, `_style_<lid>`, `yield <lid>` — so `mesh_art` does not match inside `mesh_article`.
- Message (mechanical, actionable): `layout /mesh/bar line 99: literal "mesh-bar" matches this file's @did; replace with @did so renames keep working`.
- Deduped one warning per line per placeholder kind.

## Surfacing

- **Log**: loader first pass (`loader.go`, before expansion) collects warnings per source ID into `pendingWarnings` and logs each via the loader logger (`log.Warn`).
- **Preview**: `LoadPreview` scans the user-authored (raw) `extra` files + explicitly-provided main content and appends the messages to its returned `[]string` warnings, so the admin layout preview shows them. (Snapshot templates are already expanded, so they are deliberately not re-scanned.)
- **doclint**: `internal/doclint/lint.go:181` already iterates `layout.Warnings`; the self-literal warnings flow there via `pendingWarnings` → `processTemplates` → `layout.Warnings`, so `trip2g-lint`/doclint reports them for the repo's own `docs/`. No doclint code change needed.

## Offender cleanup

Ran the scanner over `docs/_layouts/mesh/` and fixed every self-literal (deduped per line): `bar.html` (10), `matrix.html` (10), `hero.html` (8), `network.html` (4), `foot.html` (3), `pricing.html` (1). Only each file's **own** `did` was replaced with `@did`. Single-dash namespaces left untouched — e.g. `network.html` keeps `@keyframes mesh-network-blink`/`mesh-network-dashflow` and `#mesh-svg-mount`; only the BEM `mesh-network__…` classes were converted.

After cleanup the loader logs **zero** warnings for `docs/_layouts/`.

### Byte-identical proof

The expansion is textual (`@did` → `mesh-bar`), so replacing `mesh-bar` with `@did` must produce byte-identical output. A boundary-aware replacer (mirroring the scanner's `did` rules, so single-dash namespaces are never touched) rewrote each file, and a throwaway test asserted `expandBlockName(fixed, id) == expandBlockName(original, id)` for all 6 files and that `scanSelfLiteral(fixed, id)` is empty before writing. The throwaway test was removed after applying the fix.

## Verification

- `go build -tags dev ./internal/layoutloader/... ./internal/doclint/... ./internal/case/renderlayout/... ./internal/case/rendernotepage/... ./internal/case/admin/renderpreview/... ./internal/case/admin/renderlayoutpreview/...` → clean. (Full `./...` build fails only on the pre-existing missing generated `onboarding-vault/vault.zip`, unrelated.)
- `go vet -tags dev` on the above → clean.
- `go test ./internal/layoutloader/... ./internal/doclint/... ./internal/case/renderlayout/... ./internal/case/rendernotepage/... ./internal/case/admin/renderpreview/... ./internal/case/admin/renderlayoutpreview/... ./internal/noteloader/...` → all pass.

## Deviations

- No dedicated end-to-end mesh test exists (grep found only unit tests referencing mesh); covered via layoutloader unit tests + the byte-identical expansion proof.
- doclint needed no code change — the existing `layout.Warnings` path already carries these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
