### PR TITLE
fix(uploadnoteasset): heal missing MinIO object when DB row exists

### DIFF
--- a/internal/case/uploadnoteasset/mocks_test.go
+++ b/internal/case/uploadnoteasset/mocks_test.go
@@ -41,6 +41,9 @@ var _ uploadnoteasset.Env = &EnvMock{}
 //			NoteAssetByPathAndHashFunc: func(ctx context.Context, arg db.NoteAssetByPathAndHashParams) (db.NoteAsset, error) {
 //				panic("mock out the NoteAssetByPathAndHash method")
 //			},
+//			NoteAssetExistsFunc: func(ctx context.Context, asset db.NoteAsset) (bool, error) {
+//				panic("mock out the NoteAssetExists method")
+//			},
 //			NoteVersionAssetPathsFunc: func(ctx context.Context, id int64) (map[string]struct{}, error) {
 //				panic("mock out the NoteVersionAssetPaths method")
 //			},
@@ -77,6 +80,9 @@ type EnvMock struct {
 
 	// NoteAssetByPathAndHashFunc mocks the NoteAssetByPathAndHash method.
 	NoteAssetByPathAndHashFunc func(ctx context.Context, arg db.NoteAssetByPathAndHashParams) (db.NoteAsset, error)
+
+	// NoteAssetExistsFunc mocks the NoteAssetExists method.
+	NoteAssetExistsFunc func(ctx context.Context, asset db.NoteAsset) (bool, error)
 
 	// NoteVersionAssetPathsFunc mocks the NoteVersionAssetPaths method.
 	NoteVersionAssetPathsFunc func(ctx context.Context, id int64) (map[string]struct{}, error)
@@ -130,6 +136,13 @@ type EnvMock struct {
 			// Arg is the arg argument value.
 			Arg db.NoteAssetByPathAndHashParams
 		}
+		// NoteAssetExists holds details about calls to the NoteAssetExists method.
+		NoteAssetExists []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Asset is the asset argument value.
+			Asset db.NoteAsset
+		}
 		// NoteVersionAssetPaths holds details about calls to the NoteVersionAssetPaths method.
 		NoteVersionAssetPaths []struct {
 			// Ctx is the ctx argument value.
@@ -167,6 +180,7 @@ type EnvMock struct {
 	lockDeleteNoteAsset        sync.RWMutex
 	lockLogger                 sync.RWMutex
 	lockNoteAssetByPathAndHash sync.RWMutex
+	lockNoteAssetExists        sync.RWMutex
 	lockNoteVersionAssetPaths  sync.RWMutex
 	lockPrepareLatestNotes     sync.RWMutex
 	lockPutAssetObject         sync.RWMutex
@@ -377,6 +391,42 @@ func (mock *EnvMock) NoteAssetByPathAndHashCalls() []struct {
 	mock.lockNoteAssetByPathAndHash.RLock()
 	calls = mock.calls.NoteAssetByPathAndHash
 	mock.lockNoteAssetByPathAndHash.RUnlock()
+	return calls
+}
+
+// NoteAssetExists calls NoteAssetExistsFunc.
+func (mock *EnvMock) NoteAssetExists(ctx context.Context, asset db.NoteAsset) (bool, error) {
+	if mock.NoteAssetExistsFunc == nil {
+		panic("EnvMock.NoteAssetExistsFunc: method is nil but Env.NoteAssetExists was just called")
+	}
+	callInfo := struct {
+		Ctx   context.Context
+		Asset db.NoteAsset
+	}{
+		Ctx:   ctx,
+		Asset: asset,
+	}
+	mock.lockNoteAssetExists.Lock()
+	mock.calls.NoteAssetExists = append(mock.calls.NoteAssetExists, callInfo)
+	mock.lockNoteAssetExists.Unlock()
+	return mock.NoteAssetExistsFunc(ctx, asset)
+}
+
+// NoteAssetExistsCalls gets all the calls that were made to NoteAssetExists.
+// Check the length with:
+//
+//	len(mockedEnv.NoteAssetExistsCalls())
+func (mock *EnvMock) NoteAssetExistsCalls() []struct {
+	Ctx   context.Context
+	Asset db.NoteAsset
+} {
+	var calls []struct {
+		Ctx   context.Context
+		Asset db.NoteAsset
+	}
+	mock.lockNoteAssetExists.RLock()
+	calls = mock.calls.NoteAssetExists
+	mock.lockNoteAssetExists.RUnlock()
 	return calls
 }
 

--- a/internal/case/uploadnoteasset/resolve.go
+++ b/internal/case/uploadnoteasset/resolve.go
@@ -24,6 +24,7 @@ type Env interface {
 	CreateNoteAsset(ctx context.Context, params db.CreateNoteAssetParams) (db.NoteAsset, error)
 	UpsertNoteVersionAsset(ctx context.Context, arg db.UpsertNoteVersionAssetParams) error
 	NoteAssetByPathAndHash(ctx context.Context, arg db.NoteAssetByPathAndHashParams) (db.NoteAsset, error)
+	NoteAssetExists(ctx context.Context, asset db.NoteAsset) (bool, error)
 	NoteVersionAssetPaths(ctx context.Context, id int64) (map[string]struct{}, error)
 	PrepareLatestNotes(ctx context.Context, partial bool) (*appmodel.NoteViews, error)
 	CheckStorageLimits(ctx context.Context, additionalAssetBytes int64) (string, error)
@@ -90,7 +91,22 @@ func Resolve(ctx context.Context, env Env, input Input) (Payload, error) {
 			return nil, uploadErr
 		}
 	} else {
-		// Asset already exists, just link it to this note version
+		// Asset already exists in the DB. Self-heal: the underlying object may be
+		// missing (e.g. bucket wipe/reseed) even though the row survived, which
+		// would otherwise serve a permanently 404ing presigned URL. Re-upload it
+		// from the client's bytes before linking if it's gone.
+		exists, existsErr := env.NoteAssetExists(ctx, existingAsset)
+		if existsErr != nil {
+			return nil, fmt.Errorf("failed to check if asset object exists: %w", existsErr)
+		}
+
+		if !exists {
+			if uploadErr := env.PutAssetObject(ctx, input.File.File, existingAsset); uploadErr != nil {
+				return nil, fmt.Errorf("failed to re-upload missing asset object: %w", uploadErr)
+			}
+		}
+
+		// Link it to this note version
 		err = env.UpsertNoteVersionAsset(ctx, db.UpsertNoteVersionAssetParams{
 			AssetID:   existingAsset.ID,
 			VersionID: input.NoteID,

--- a/internal/case/uploadnoteasset/resolve.go
+++ b/internal/case/uploadnoteasset/resolve.go
@@ -95,12 +95,12 @@ func Resolve(ctx context.Context, env Env, input Input) (Payload, error) {
 		// missing (e.g. bucket wipe/reseed) even though the row survived, which
 		// would otherwise serve a permanently 404ing presigned URL. Re-upload it
 		// from the client's bytes before linking if it's gone.
-		exists, existsErr := env.NoteAssetExists(ctx, existingAsset)
+		objExists, existsErr := env.NoteAssetExists(ctx, existingAsset)
 		if existsErr != nil {
 			return nil, fmt.Errorf("failed to check if asset object exists: %w", existsErr)
 		}
 
-		if !exists {
+		if !objExists {
 			if uploadErr := env.PutAssetObject(ctx, input.File.File, existingAsset); uploadErr != nil {
 				return nil, fmt.Errorf("failed to re-upload missing asset object: %w", uploadErr)
 			}

--- a/internal/case/uploadnoteasset/resolve_test.go
+++ b/internal/case/uploadnoteasset/resolve_test.go
@@ -29,6 +29,7 @@ type Env interface {
 	CreateNoteAsset(ctx context.Context, params db.CreateNoteAssetParams) (db.NoteAsset, error)
 	UpsertNoteVersionAsset(ctx context.Context, arg db.UpsertNoteVersionAssetParams) error
 	NoteAssetByPathAndHash(ctx context.Context, arg db.NoteAssetByPathAndHashParams) (db.NoteAsset, error)
+	NoteAssetExists(ctx context.Context, asset db.NoteAsset) (bool, error)
 	NoteVersionAssetPaths(ctx context.Context, id int64) (map[string]struct{}, error)
 	PrepareLatestNotes(ctx context.Context, partial bool) (*appmodel.NoteViews, error)
 	CheckStorageLimits(ctx context.Context, additionalAssetBytes int64) (string, error)
@@ -271,6 +272,10 @@ func TestResolve(t *testing.T) {
 							Size:         int64(len(testContent)),
 						}, nil
 					},
+					NoteAssetExistsFunc: func(ctx context.Context, asset db.NoteAsset) (bool, error) {
+						// Object is still present in storage - no heal needed
+						return true, nil
+					},
 					UpsertNoteVersionAssetFunc: func(ctx context.Context, arg db.UpsertNoteVersionAssetParams) error {
 						return nil
 					},
@@ -287,8 +292,72 @@ func TestResolve(t *testing.T) {
 
 				// CreateNoteAsset should NOT be called (asset already exists)
 				require.Empty(t, env.CreateNoteAssetCalls())
-				// PutAssetObject should NOT be called (no upload needed)
+				// PutAssetObject should NOT be called (object still present, no heal needed)
 				require.Empty(t, env.PutAssetObjectCalls())
+				// UpsertNoteVersionAsset SHOULD be called to link existing asset
+				require.Len(t, env.UpsertNoteVersionAssetCalls(), 1)
+				// PrepareLatestNotes should be called to update views
+				require.Len(t, env.PrepareLatestNotesCalls(), 1)
+			},
+		},
+		{
+			name: "success - asset row exists but object missing from storage (self-heal)",
+			input: model.UploadNoteAssetInput{
+				NoteID:       456,
+				Path:         "images/test.png",
+				AbsolutePath: "/absolute/path/test.png",
+				Sha256Hash:   testHash,
+				File: graphql.Upload{
+					File:     bytes.NewReader(testContent),
+					Filename: "test.png",
+					Size:     int64(len(testContent)),
+				},
+			},
+			setupEnv: func() *EnvMock {
+				return &EnvMock{
+					LoggerFunc: func() logger.Logger {
+						return &logger.TestLogger{}
+					},
+					NoteVersionAssetPathsFunc: func(ctx context.Context, id int64) (map[string]struct{}, error) {
+						return map[string]struct{}{
+							"images/test.png": {},
+						}, nil
+					},
+					NoteAssetByPathAndHashFunc: func(ctx context.Context, arg db.NoteAssetByPathAndHashParams) (db.NoteAsset, error) {
+						// DB row exists, but the underlying object was lost (e.g. bucket wipe)
+						return db.NoteAsset{
+							ID:           99,
+							AbsolutePath: arg.AbsolutePath,
+							FileName:     "test.png",
+							Sha256Hash:   arg.Sha256Hash,
+							Size:         int64(len(testContent)),
+						}, nil
+					},
+					NoteAssetExistsFunc: func(ctx context.Context, asset db.NoteAsset) (bool, error) {
+						return false, nil
+					},
+					PutAssetObjectFunc: func(ctx context.Context, reader io.Reader, info db.NoteAsset) error {
+						_, err := io.ReadAll(reader)
+						return err
+					},
+					UpsertNoteVersionAssetFunc: func(ctx context.Context, arg db.UpsertNoteVersionAssetParams) error {
+						return nil
+					},
+					PrepareLatestNotesFunc: func(ctx context.Context, partial bool) (*appmodel.NoteViews, error) {
+						return &appmodel.NoteViews{}, nil
+					},
+				}
+			},
+			wantErr: false,
+			validate: func(t *testing.T, payload model.UploadNoteAssetOrErrorPayload, env *EnvMock) {
+				require.IsType(t, &model.UploadNoteAssetPayload{}, payload)
+				p := payload.(*model.UploadNoteAssetPayload)
+				require.True(t, p.UploadSkipped)
+
+				// CreateNoteAsset should NOT be called (DB row already exists)
+				require.Empty(t, env.CreateNoteAssetCalls())
+				// PutAssetObject SHOULD be called to re-upload the missing object
+				require.Len(t, env.PutAssetObjectCalls(), 1)
 				// UpsertNoteVersionAsset SHOULD be called to link existing asset
 				require.Len(t, env.UpsertNoteVersionAssetCalls(), 1)
 				// PrepareLatestNotes should be called to update views


### PR DESCRIPTION
## Summary
- The "already uploaded" branch in `internal/case/uploadnoteasset/resolve.go` only linked the existing `note_assets` row to the note version; it never verified the underlying object was still present in storage.
- If MinIO lost the object (bucket wipe/recreate, partial reseed, seeded rows) while the row survived, the server would serve a valid-looking presigned URL for a missing object — a permanent 404 that re-syncing never fixed.
- Fix: when a matching row is found, call `NoteAssetExists` first; if the object is missing, re-upload it via the existing `PutAssetObject` path before linking. If present, behavior is unchanged.
- `NoteAssetExists` added to `uploadnoteasset.Env`; no app-side wiring needed since `cmd/server`'s `Storage` interface (embedded in `app`) already implements it — the method promotes automatically.

## Test plan
- [x] TDD: new test case ("row exists but object missing from storage (self-heal)") added first, confirmed RED against unfixed `resolve.go` (`PutAssetObjectCalls()` had 0 items)
- [x] Fix applied, test confirmed GREEN
- [x] Existing "asset reuse" test extended to assert `PutAssetObject` is NOT called when the object is still present (regression guard)
- [x] `go test ./internal/case/uploadnoteasset/...` passes
- [x] `go vet -tags dev ./cmd/server/...` clean (confirms `*app` satisfies the extended `Env` interface)