### PR TITLE
fix(forms): enforce note readability on submit, fail-closed turnstile, default field cap

### DIFF
--- a/cmd/server/forms.go
+++ b/cmd/server/forms.go
@@ -6,6 +6,18 @@ import (
 	"trip2g/internal/db"
 )
 
+// CanReadNoteVersion is the opaque cross-case port used by submitform to gate
+// the submit path on note readability. It resolves the note for the (untrusted,
+// enumerable) noteVersionID and reuses the shared canreadnote check. A missing
+// note returns false so the caller denies without leaking existence.
+func (a *app) CanReadNoteVersion(ctx context.Context, noteVersionID int64) (bool, error) {
+	note := a.LatestNoteViews().GetByVersionID(noteVersionID)
+	if note == nil {
+		return false, nil
+	}
+	return a.CanReadNote(ctx, note)
+}
+
 func (a *app) InsertFormSubmit(ctx context.Context, noteVersionID int64, formID string, userID *int64, ip string) (int64, error) {
 	return a.WriteQueries.InsertFormSubmit(ctx, db.InsertFormSubmitParams{
 		NoteVersionID: noteVersionID,

--- a/internal/case/submitform/mocks_test.go
+++ b/internal/case/submitform/mocks_test.go
@@ -21,6 +21,9 @@ var _ submitform.Env = &EnvMock{}
 //
 //		// make and configure a mocked submitform.Env
 //		mockedEnv := &EnvMock{
+//			CanReadNoteVersionFunc: func(ctx context.Context, noteVersionID int64) (bool, error) {
+//				panic("mock out the CanReadNoteVersion method")
+//			},
 //			EnqueueSendFormSubmitEmailFunc: func(ctx context.Context, submitID int64) error {
 //				panic("mock out the EnqueueSendFormSubmitEmail method")
 //			},
@@ -64,6 +67,9 @@ var _ submitform.Env = &EnvMock{}
 //
 //	}
 type EnvMock struct {
+	// CanReadNoteVersionFunc mocks the CanReadNoteVersion method.
+	CanReadNoteVersionFunc func(ctx context.Context, noteVersionID int64) (bool, error)
+
 	// EnqueueSendFormSubmitEmailFunc mocks the EnqueueSendFormSubmitEmail method.
 	EnqueueSendFormSubmitEmailFunc func(ctx context.Context, submitID int64) error
 
@@ -102,6 +108,13 @@ type EnvMock struct {
 
 	// calls tracks calls to the methods.
 	calls struct {
+		// CanReadNoteVersion holds details about calls to the CanReadNoteVersion method.
+		CanReadNoteVersion []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// NoteVersionID is the noteVersionID argument value.
+			NoteVersionID int64
+		}
 		// EnqueueSendFormSubmitEmail holds details about calls to the EnqueueSendFormSubmitEmail method.
 		EnqueueSendFormSubmitEmail []struct {
 			// Ctx is the ctx argument value.
@@ -195,6 +208,7 @@ type EnvMock struct {
 			IP string
 		}
 	}
+	lockCanReadNoteVersion         sync.RWMutex
 	lockEnqueueSendFormSubmitEmail sync.RWMutex
 	lockGetFormSpec                sync.RWMutex
 	lockInsertFormBoolValue        sync.RWMutex
@@ -207,6 +221,42 @@ type EnvMock struct {
 	lockTurnstileSiteKey           sync.RWMutex
 	lockUserID                     sync.RWMutex
 	lockVerifyTurnstile            sync.RWMutex
+}
+
+// CanReadNoteVersion calls CanReadNoteVersionFunc.
+func (mock *EnvMock) CanReadNoteVersion(ctx context.Context, noteVersionID int64) (bool, error) {
+	if mock.CanReadNoteVersionFunc == nil {
+		panic("EnvMock.CanReadNoteVersionFunc: method is nil but Env.CanReadNoteVersion was just called")
+	}
+	callInfo := struct {
+		Ctx           context.Context
+		NoteVersionID int64
+	}{
+		Ctx:           ctx,
+		NoteVersionID: noteVersionID,
+	}
+	mock.lockCanReadNoteVersion.Lock()
+	mock.calls.CanReadNoteVersion = append(mock.calls.CanReadNoteVersion, callInfo)
+	mock.lockCanReadNoteVersion.Unlock()
+	return mock.CanReadNoteVersionFunc(ctx, noteVersionID)
+}
+
+// CanReadNoteVersionCalls gets all the calls that were made to CanReadNoteVersion.
+// Check the length with:
+//
+//	len(mockedEnv.CanReadNoteVersionCalls())
+func (mock *EnvMock) CanReadNoteVersionCalls() []struct {
+	Ctx           context.Context
+	NoteVersionID int64
+} {
+	var calls []struct {
+		Ctx           context.Context
+		NoteVersionID int64
+	}
+	mock.lockCanReadNoteVersion.RLock()
+	calls = mock.calls.CanReadNoteVersion
+	mock.lockCanReadNoteVersion.RUnlock()
+	return calls
 }
 
 // EnqueueSendFormSubmitEmail calls EnqueueSendFormSubmitEmailFunc.

--- a/internal/case/submitform/resolve.go
+++ b/internal/case/submitform/resolve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/mail"
+	"unicode/utf8"
 
 	"trip2g/internal/formspec"
 	gmodel "trip2g/internal/graph/model"
@@ -12,7 +13,16 @@ import (
 
 //go:generate go tool github.com/matryer/moq -out mocks_test.go -pkg submitform_test . Env
 
+// maxFieldRunes is a global hard cap applied to every string/email field
+// regardless of the spec, counted in runes. Prevents oversized submissions
+// (up to the request body limit) from being stored verbatim.
+const maxFieldRunes = 8192
+
 type Env interface {
+	// CanReadNoteVersion reports whether the current viewer may READ the note
+	// identified by noteVersionID. Returns false for a nonexistent note so the
+	// submit path can deny opaquely without leaking existence.
+	CanReadNoteVersion(ctx context.Context, noteVersionID int64) (bool, error)
 	GetFormSpec(ctx context.Context, noteVersionID int64, formID string) (*formspec.FormSpec, error)
 	InsertFormSubmit(ctx context.Context, noteVersionID int64, formID string, userID *int64, ip string) (int64, error)
 	InsertFormStringValue(ctx context.Context, submitID int64, fieldName, value string) error
@@ -50,6 +60,18 @@ const (
 )
 
 func Resolve(ctx context.Context, env Env, input Input) (gmodel.SubmitFormOrErrorPayload, error) { //nolint:gocognit
+	// Gate on note readability first. note_version_id is enumerable, so without
+	// this a guest could fetch the spec of / submit to a paywalled, subgraph, or
+	// signin-gated note. Deny with the same shape as a missing form so the
+	// response does not leak whether the note exists or its access policy.
+	readable, err := env.CanReadNoteVersion(ctx, input.NoteVersionID)
+	if err != nil {
+		return nil, fmt.Errorf("submitform: check note readability: %w", err)
+	}
+	if !readable {
+		return &gmodel.ErrorPayload{Message: "form_not_found"}, nil
+	}
+
 	spec, err := env.GetFormSpec(ctx, input.NoteVersionID, input.FormID)
 	if err != nil {
 		return nil, fmt.Errorf("submitform: get form spec: %w", err)
@@ -160,10 +182,14 @@ func validateFields(spec *formspec.FormSpec, values []FieldValue) error { //noli
 				continue
 			}
 			v := *fv.StringValue
-			if field.MinLength != nil && len(v) < *field.MinLength {
+			n := utf8.RuneCountInString(v)
+			if n > maxFieldRunes {
+				return fmt.Errorf("%s: too long", field.Name)
+			}
+			if field.MinLength != nil && n < *field.MinLength {
 				return fmt.Errorf("%s: too short", field.Name)
 			}
-			if field.MaxLength != nil && len(v) > *field.MaxLength {
+			if field.MaxLength != nil && n > *field.MaxLength {
 				return fmt.Errorf("%s: too long", field.Name)
 			}
 			if len(field.StringEnum) > 0 && !containsStr(field.StringEnum, v) {
@@ -175,6 +201,9 @@ func validateFields(spec *formspec.FormSpec, values []FieldValue) error { //noli
 					return fmt.Errorf("%s: required", field.Name)
 				}
 				continue
+			}
+			if utf8.RuneCountInString(*fv.StringValue) > maxFieldRunes {
+				return fmt.Errorf("%s: too long", field.Name)
 			}
 			if _, parseErr := mail.ParseAddress(*fv.StringValue); parseErr != nil {
 				return fmt.Errorf("%s: invalid email", field.Name)

--- a/internal/case/submitform/resolve_test.go
+++ b/internal/case/submitform/resolve_test.go
@@ -2,7 +2,9 @@ package submitform_test
 
 import (
 	"context"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"trip2g/internal/case/submitform"
 	"trip2g/internal/formspec"
@@ -14,6 +16,7 @@ import (
 
 func TestResolve_form_not_found(t *testing.T) {
 	env := &EnvMock{
+		CanReadNoteVersionFunc: func(ctx context.Context, noteVersionID int64) (bool, error) { return true, nil },
 		GetFormSpecFunc: func(ctx context.Context, noteVersionID int64, formID string) (*formspec.FormSpec, error) {
 			return nil, nil
 		},
@@ -28,12 +31,93 @@ func TestResolve_form_not_found(t *testing.T) {
 	require.Equal(t, "form_not_found", errP.Message)
 }
 
+func TestResolve_unreadable_note_denied_opaquely(t *testing.T) {
+	specCalled := false
+	env := &EnvMock{
+		CanReadNoteVersionFunc: func(ctx context.Context, noteVersionID int64) (bool, error) { return false, nil },
+		GetFormSpecFunc: func(ctx context.Context, noteVersionID int64, formID string) (*formspec.FormSpec, error) {
+			specCalled = true
+			return &formspec.FormSpec{CanSubmit: formspec.CanSubmitGuest}, nil
+		},
+		RequestIPFunc: func(ctx context.Context) string { return "1.2.3.4" },
+		UserIDFunc:    func(ctx context.Context) *int64 { return nil },
+		IsAdminFunc:   func(ctx context.Context) bool { return false },
+	}
+	payload, err := submitform.Resolve(context.Background(), env, submitform.Input{NoteVersionID: 42})
+	require.NoError(t, err)
+	errP, ok := payload.(*gmodel.ErrorPayload)
+	require.True(t, ok, "expected ErrorPayload, got %T", payload)
+	// Same shape as a nonexistent form — does not confirm the note exists.
+	require.Equal(t, "form_not_found", errP.Message)
+	require.False(t, specCalled, "spec must not be fetched for an unreadable note")
+	require.Empty(t, env.InsertFormSubmitCalls())
+}
+
+func TestResolve_default_field_cap_without_max_length(t *testing.T) {
+	spec := &formspec.FormSpec{
+		CanSubmit: formspec.CanSubmitGuest,
+		Fields:    []formspec.FormField{{Name: "msg", Type: formspec.FieldTypeText}}, // no max_length
+	}
+	env := &EnvMock{
+		CanReadNoteVersionFunc: func(ctx context.Context, noteVersionID int64) (bool, error) { return true, nil },
+		GetFormSpecFunc: func(ctx context.Context, noteVersionID int64, formID string) (*formspec.FormSpec, error) {
+			return spec, nil
+		},
+		RequestIPFunc: func(ctx context.Context) string { return "" },
+		UserIDFunc:    func(ctx context.Context) *int64 { return nil },
+		IsAdminFunc:   func(ctx context.Context) bool { return false },
+	}
+	oversized := strings.Repeat("a", 8193)
+	payload, err := submitform.Resolve(context.Background(), env, submitform.Input{
+		NoteVersionID: 1,
+		Fields:        []submitform.FieldValue{{Name: "msg", StringValue: &oversized}},
+	})
+	require.NoError(t, err)
+	errP, ok := payload.(*gmodel.ErrorPayload)
+	require.True(t, ok, "expected ErrorPayload, got %T", payload)
+	require.Contains(t, errP.Message, "too long")
+	require.Empty(t, env.InsertFormSubmitCalls())
+}
+
+func TestResolve_length_counts_runes_not_bytes(t *testing.T) {
+	maxLen := 5
+	spec := &formspec.FormSpec{
+		CanSubmit: formspec.CanSubmitGuest,
+		Fields:    []formspec.FormField{{Name: "msg", Type: formspec.FieldTypeText, MaxLength: &maxLen}},
+	}
+	env := &EnvMock{
+		CanReadNoteVersionFunc: func(ctx context.Context, noteVersionID int64) (bool, error) { return true, nil },
+		GetFormSpecFunc: func(ctx context.Context, noteVersionID int64, formID string) (*formspec.FormSpec, error) {
+			return spec, nil
+		},
+		InsertFormSubmitFunc: func(ctx context.Context, noteVersionID int64, formID string, userID *int64, ip string) (int64, error) {
+			return 5, nil
+		},
+		InsertFormStringValueFunc:      func(ctx context.Context, submitID int64, fieldName, value string) error { return nil },
+		EnqueueSendFormSubmitEmailFunc: func(ctx context.Context, submitID int64) error { return nil },
+		RequestIPFunc:                  func(ctx context.Context) string { return "" },
+		UserIDFunc:                     func(ctx context.Context) *int64 { return nil },
+		IsAdminFunc:                    func(ctx context.Context) bool { return false },
+	}
+	// 5 multibyte runes = 10 bytes. Byte counting would reject; rune counting accepts.
+	fiveRunes := "привет"[:10] // "приве" is 5 runes / 10 bytes
+	require.Equal(t, 5, utf8.RuneCountInString(fiveRunes))
+	payload, err := submitform.Resolve(context.Background(), env, submitform.Input{
+		NoteVersionID: 1,
+		Fields:        []submitform.FieldValue{{Name: "msg", StringValue: &fiveRunes}},
+	})
+	require.NoError(t, err)
+	_, ok := payload.(*gmodel.SubmitFormPayload)
+	require.True(t, ok, "expected SubmitFormPayload (5 runes within max=5), got %T", payload)
+}
+
 func TestResolve_required_field_missing(t *testing.T) {
 	spec := &formspec.FormSpec{
 		CanSubmit: formspec.CanSubmitGuest,
 		Fields:    []formspec.FormField{{Name: "email", Type: formspec.FieldTypeEmail, Required: true}},
 	}
 	env := &EnvMock{
+		CanReadNoteVersionFunc: func(ctx context.Context, noteVersionID int64) (bool, error) { return true, nil },
 		GetFormSpecFunc: func(ctx context.Context, noteVersionID int64, formID string) (*formspec.FormSpec, error) {
 			return spec, nil
 		},
@@ -57,6 +141,7 @@ func TestResolve_file_type_not_supported(t *testing.T) {
 		Fields:    []formspec.FormField{{Name: "attach", Type: formspec.FieldTypeFile}},
 	}
 	env := &EnvMock{
+		CanReadNoteVersionFunc: func(ctx context.Context, noteVersionID int64) (bool, error) { return true, nil },
 		GetFormSpecFunc: func(ctx context.Context, noteVersionID int64, formID string) (*formspec.FormSpec, error) {
 			return spec, nil
 		},
@@ -92,6 +177,7 @@ func TestResolve_success(t *testing.T) {
 	var emailEnqueued bool
 
 	env := &EnvMock{
+		CanReadNoteVersionFunc: func(ctx context.Context, noteVersionID int64) (bool, error) { return true, nil },
 		GetFormSpecFunc: func(ctx context.Context, noteVersionID int64, formID string) (*formspec.FormSpec, error) {
 			return spec, nil
 		},
@@ -144,6 +230,7 @@ func TestResolve_can_submit_admin_denies_non_admin(t *testing.T) {
 		Fields:    []formspec.FormField{{Name: "msg", Type: formspec.FieldTypeText, Required: true}},
 	}
 	env := &EnvMock{
+		CanReadNoteVersionFunc: func(ctx context.Context, noteVersionID int64) (bool, error) { return true, nil },
 		GetFormSpecFunc: func(ctx context.Context, noteVersionID int64, formID string) (*formspec.FormSpec, error) {
 			return spec, nil
 		},
@@ -169,6 +256,7 @@ func TestResolve_can_submit_admin_allows_admin(t *testing.T) {
 		Fields:    []formspec.FormField{{Name: "msg", Type: formspec.FieldTypeText, Required: true}},
 	}
 	env := &EnvMock{
+		CanReadNoteVersionFunc: func(ctx context.Context, noteVersionID int64) (bool, error) { return true, nil },
 		GetFormSpecFunc: func(ctx context.Context, noteVersionID int64, formID string) (*formspec.FormSpec, error) {
 			return spec, nil
 		},
@@ -198,6 +286,7 @@ func TestResolve_can_submit_paid_user_not_implemented(t *testing.T) {
 		Fields:    []formspec.FormField{{Name: "msg", Type: formspec.FieldTypeText, Required: true}},
 	}
 	env := &EnvMock{
+		CanReadNoteVersionFunc: func(ctx context.Context, noteVersionID int64) (bool, error) { return true, nil },
 		GetFormSpecFunc: func(ctx context.Context, noteVersionID int64, formID string) (*formspec.FormSpec, error) {
 			return spec, nil
 		},
@@ -223,6 +312,7 @@ func TestResolve_turnstile_required_when_missing_token(t *testing.T) {
 		Fields:    []formspec.FormField{{Name: "msg", Type: formspec.FieldTypeText, Required: true}},
 	}
 	env := &EnvMock{
+		CanReadNoteVersionFunc: func(ctx context.Context, noteVersionID int64) (bool, error) { return true, nil },
 		GetFormSpecFunc: func(ctx context.Context, noteVersionID int64, formID string) (*formspec.FormSpec, error) {
 			return spec, nil
 		},
@@ -252,6 +342,7 @@ func TestResolve_turnstile_passes_with_valid_token(t *testing.T) {
 		Fields:    []formspec.FormField{{Name: "msg", Type: formspec.FieldTypeText, Required: true}},
 	}
 	env := &EnvMock{
+		CanReadNoteVersionFunc: func(ctx context.Context, noteVersionID int64) (bool, error) { return true, nil },
 		GetFormSpecFunc: func(ctx context.Context, noteVersionID int64, formID string) (*formspec.FormSpec, error) {
 			return spec, nil
 		},

--- a/internal/turnstile/verify.go
+++ b/internal/turnstile/verify.go
@@ -33,10 +33,16 @@ func New(config Config) *Client {
 
 // VerifyCaptcha verifies a Turnstile token.
 // Returns nil on success, error on failure.
-// If SecretKey is empty, verification is skipped (dev mode).
+// Empty secret is a no-op ONLY when Turnstile is fully unconfigured (no site key
+// either) — genuine local dev. If a site key is configured but the secret is
+// empty, Turnstile is expected but misconfigured: fail closed instead of
+// silently passing every submit.
 func (c *Client) VerifyCaptcha(ctx context.Context, token, remoteIP string) error {
 	if c.config.SecretKey == "" {
-		return nil // skip in dev
+		if c.config.SiteKey != "" {
+			return errors.New("turnstile misconfigured: site key set but secret key empty")
+		}
+		return nil // dev/off: neither key configured
 	}
 
 	if token == "" {

--- a/internal/turnstile/verify_test.go
+++ b/internal/turnstile/verify_test.go
@@ -15,6 +15,13 @@ func TestClient_EmptySecretSkips(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestClient_SiteKeySetSecretEmptyFailsClosed(t *testing.T) {
+	c := New(Config{SiteKey: "site-key", SecretKey: ""})
+	err := c.VerifyCaptcha(context.Background(), "some-token", "1.2.3.4")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "misconfigured")
+}
+
 func TestClient_EmptyTokenFails(t *testing.T) {
 	c := New(Config{SecretKey: "secret"})
 	err := c.VerifyCaptcha(context.Background(), "", "1.2.3.4")


### PR DESCRIPTION
Fixes three security bugs in the forms submit pipeline, found by two independent security reviews (Codex + Fable, 2026-07-14). Decoupled from the undecided note-generation redesign — see `docs/dev/forms_note_generation.md` "Critical fixes".

## Fix 1 (HIGH) — enforce note READABILITY on submit

**Before:** `submitform.Resolve` only checked `spec.CanSubmit` (guest/admin/paid). `note_version_id` is sequential/enumerable and never read-gated, so a guest could fetch the form spec of — and submit to — a paywalled / subgraph / signin-gated note's guest form.

**After:** `submitform.Resolve` gates on note readability **before** fetching the spec. New opaque cross-case port `submitform.Env.CanReadNoteVersion(ctx, noteVersionID)`; `app.CanReadNoteVersion` (cmd/server/forms.go) resolves the note by version id and reuses the shared `canreadnote.Resolve` (via existing `app.CanReadNote`). A missing note returns `false`. Denial returns the **same** `ErrorPayload{"form_not_found"}` as a nonexistent form, so the response does not leak whether the note exists or its access policy (opaque denial, not a distinct "you can't read this"). Compile-time port style (no `req.Env` cast), matching `handlenotewebhooks`/`getpublicnote`.

**Exploit closed:** enumerating `note_version_id` to reach guest forms attached to gated notes.

### GetFormSpec analysis (requested)

`app.GetFormSpec` (cmd/server/notes.go:292) has exactly **one caller**: `submitform.Resolve` via the Env interface (confirmed by grep across `cmd/` + `internal/`). It is never called at render time. The default template embeds form specs via `defaulttemplate.Ctx.FormSpecJSON()` (internal/defaulttemplate/template.go:428), which reads `ctx.Note` — the note currently being rendered, already read-gated upstream in `rendernotepage` (sign-in wall / paywall) — and never fetches by an arbitrary version id.

**Conclusion:** gating `submitform.Resolve` fully closes the exploit; since `GetFormSpec`'s sole consumer is the now-gated submit path, no separate gate was added there (smallest-diff, no redundant work). The render path was already safe and is untouched.

## Fix 2 (HIGH) — Turnstile fail-closed on misconfiguration

**Before:** `turnstile/verify.go` returned `nil` (pass) whenever `SecretKey == ""` — the same code path in prod, so an empty secret silently passed every `turnstile: true` submit.

**After:** empty secret is a no-op **only** when Turnstile is fully unconfigured (no `SiteKey` either) — genuine local dev. If a `SiteKey` **is** configured but `SecretKey` is empty, that is an expected-but-misconfigured Turnstile: `VerifyCaptcha` now returns a distinct error (`turnstile misconfigured: site key set but secret key empty`) and the submit is rejected. The error is surfaced/logged by the existing caller (`submitform.Resolve` → `Logger().Warn`). Correctly-configured instances (both keys set) and dev (neither set) are unchanged — no new env var, no migration. Same fail-closed behavior also protects the signin captcha path (`oauth.go` `VerifyTurnstile`).

**Exploit closed:** a prod deploy with a site key but a missing/blank secret no longer accepts unverified submissions.

## Fix 3 (MED) — default per-field length cap + rune counting

**Before:** `max_length`/`min_length` were enforced only when the author set them, and via `len()` (bytes). Fields with no `max_length` accepted up to the request body limit, stored verbatim; email fields had no length bound at all.

**After:** a global hard cap `maxFieldRunes = 8192` (named const; no existing form limit in appconfig to reuse — `MaxRequestBodySize` is a 10 MB transport cap, not per-field) is applied to **every** text and email field regardless of spec, returning the existing user-facing `FieldError` ("too long"). All length bounds now use `utf8.RuneCountInString` instead of `len()`. Email fields are now length-capped too.

**Exploit closed:** oversized single-field submissions (memory/storage amplification) even when the spec omits `max_length`.

## Tests

- `internal/turnstile`: existing pass; **new** `TestClient_SiteKeySetSecretEmptyFailsClosed`.
- `internal/case/submitform`: existing pass (moq regenerated for the new port); **new** `TestResolve_unreadable_note_denied_opaquely` (guest denied opaquely, spec never fetched, no insert), `TestResolve_default_field_cap_without_max_length` (8193-char field rejected with no spec max), `TestResolve_length_counts_runes_not_bytes` (5 runes / 10 bytes accepted at max=5).

```
go build -tags dev ./...   -> ok
go vet   -tags dev ./...   -> ok
go test  ./internal/case/submitform/... ./internal/turnstile/... ./internal/case/canreadnote/...  -> ok
go test -tags dev ./cmd/server/...  -> ok (37.9s)
```
(cmd/server tests require `-tags dev`; the non-dev build needs the frontend bundle `assets/ui/**/web.js`. `onboarding-vault/vault.zip` was regenerated via `onboarding-vault/generate.sh` — pre-existing generated asset.)

## Deferred (NOT in this PR)

Per-IP rate limiting on `submitForm` and the spoofable `X-Forwarded-For` IP trust are real gaps but are coupled to the note-generation/comments redesign and are larger changes. Tracked in `docs/dev/forms_note_generation.md` (see "Critical fixes" + constraint 3), intentionally left out here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
