### PR TITLE
feat(auth): shared delegated-admin middleware (viewer{role}) + Caddy /_fleet /_codellm routes

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,5 +1,4 @@
 # Generate certs: mkcert -install && mkcert localhost 127.0.0.1
-
 {
 	auto_https disable_redirects
 }
@@ -16,6 +15,23 @@ http://localhost:9081 {
 
 	handle /graphql {
 		reverse_proxy http://localhost:8081
+	}
+
+	# Same-origin, dumb pass-through to the fleet service (own GraphQL: roles +
+	# roleGraph). Forwards the session cookie; NO auth here — auth is the
+	# delegated viewer{role} middleware (internal/delegatedadmin) inside fleet.
+	# Upstream is a placeholder; the real private addr comes from deploy config.
+	handle /_fleet/* {
+		reverse_proxy http://localhost:8092
+	}
+
+	# Same-origin, dumb pass-through to the codellm service (browser-facing
+	# /v1/* + /graphql for markdown structure). Forwards the session cookie; NO
+	# auth here — codellm gates with the same delegated middleware. The fleet↔
+	# codellm server-to-server /v1 lane is separate and does NOT go through Caddy.
+	# Upstream is a placeholder; the real private addr comes from deploy config.
+	handle /_codellm/* {
+		reverse_proxy http://localhost:8093
 	}
 
 	handle /assets/* {

--- a/docs/dev/caddy.md
+++ b/docs/dev/caddy.md
@@ -8,6 +8,8 @@ Two purposes in development:
 
 2. **HTTPS for third-party integrations** — `https://localhost:7081` provides TLS for features that require secure context (Cloudflare Turnstile captcha, OAuth callbacks, etc.). All traffic goes directly to the Go server.
 
+3. **Same-origin service proxies** — `/_fleet/*` and `/_codellm/*` reverse-proxy to the fleet and codellm services on their private ports, forwarding the session cookie. Caddy does NO auth on these routes; each service gates itself with the delegated admin middleware (`internal/delegatedadmin`), which forwards the caller's cookie to the monolith's `viewer{role}` and allows only admins (fail-closed). The upstream addresses in the Caddyfile are placeholders — the real private addrs come from deploy config. See `fleet_graphql.md`.
+
 ## Setup
 
 ```bash

--- a/internal/delegatedadmin/delegatedadmin.go
+++ b/internal/delegatedadmin/delegatedadmin.go
@@ -143,6 +143,12 @@ func (m *Middleware) fetchViewerRole(ctx context.Context, cookieHeader string) (
 	// Forward the end-user's cookie verbatim — this is the whole point.
 	req.Header.Set("Cookie", cookieHeader)
 
+	// net/http (not fasthttp) deliberately: this propagates the inbound
+	// request's ctx, so a slow/hung monolith fails closed via context
+	// cancellation within the caller's own request lifetime. fasthttp's client
+	// has no context param (only DoTimeout/DoDeadline), which would need a
+	// manually threaded deadline to get the same guarantee. Low-QPS auth gate:
+	// cancellation-correctness beats throughput here.
 	resp, err := m.client.Do(req)
 	if err != nil {
 		return "", err

--- a/internal/delegatedadmin/delegatedadmin.go
+++ b/internal/delegatedadmin/delegatedadmin.go
@@ -1,0 +1,164 @@
+// Package delegatedadmin provides an HTTP middleware that gates a request on the
+// caller being a trip2g admin, by delegating the decision to the monolith.
+//
+// It is the shared auth piece for browser-facing services that live behind a
+// same-origin Caddy proxy (fleet's GraphQL, codellm). Each of those services
+// binds to a private interface; Caddy forwards the browser request — including
+// the trip2g session cookie — verbatim. This middleware then, per request,
+// re-sends THAT cookie to the monolith's `POST /_system/graphql` with
+// `query { viewer { role } }` and allows only when the answer is `ADMIN`.
+//
+// Design guarantees:
+//   - Full parity with the monolith admin check (the ban validator and every
+//     other validator run in the monolith, not a copy here).
+//   - The service holds no secret and verifies nothing itself — it asks the
+//     authority.
+//   - It forwards the END-USER's cookie, never a service token/HAT. Using a
+//     service credential would answer "is the service admin", not "is the
+//     caller admin".
+//   - Fail-closed: monolith unreachable / timeout / non-200 / GraphQL error →
+//     reject. Never allow on uncertainty.
+package delegatedadmin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// DefaultCookieName is the trip2g session cookie name (see usertoken.DefaultConfig).
+const DefaultCookieName = "trip2g_token"
+
+// systemGraphQLPath is the monolith GraphQL endpoint (/graphql is deprecated).
+const systemGraphQLPath = "/_system/graphql"
+
+// viewerRoleQuery asks the monolith who the caller is.
+const viewerRoleQuery = `query { viewer { role } }`
+
+// adminRole is the value the GraphQL Role enum serializes to for admins.
+// The enum is uppercase (GUEST/USER/ADMIN), not the lowercase JWT claim.
+const adminRole = "ADMIN"
+
+// defaultTimeout bounds the delegated round-trip so a slow/hung monolith
+// fails closed instead of holding the caller open.
+const defaultTimeout = 5 * time.Second
+
+// Config configures the middleware.
+type Config struct {
+	// MonolithBaseURL is where viewer{role} is asked, e.g. "http://localhost:8081".
+	// Required. No trailing slash needed.
+	MonolithBaseURL string
+
+	// HTTPClient performs the delegated request. Optional; a client with a sane
+	// timeout is used when nil.
+	HTTPClient *http.Client
+
+	// CookieName is the session cookie whose presence is required before the
+	// delegated call is made. Optional; defaults to DefaultCookieName.
+	CookieName string
+}
+
+// Middleware gates requests on delegated admin authentication.
+type Middleware struct {
+	baseURL    string
+	client     *http.Client
+	cookieName string
+}
+
+// New builds a Middleware. MonolithBaseURL must be non-empty.
+func New(cfg Config) (*Middleware, error) {
+	if cfg.MonolithBaseURL == "" {
+		return nil, fmt.Errorf("delegatedadmin: MonolithBaseURL is required")
+	}
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: defaultTimeout}
+	}
+	cookieName := cfg.CookieName
+	if cookieName == "" {
+		cookieName = DefaultCookieName
+	}
+	return &Middleware{
+		baseURL:    cfg.MonolithBaseURL,
+		client:     client,
+		cookieName: cookieName,
+	}, nil
+}
+
+// Wrap returns a handler that only calls next when the caller is a verified
+// admin; otherwise it writes 401 and does not call next.
+func (m *Middleware) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !m.isAdmin(r) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+type viewerRoleResponse struct {
+	Data struct {
+		Viewer struct {
+			Role string `json:"role"`
+		} `json:"viewer"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+// isAdmin performs the delegated check. Any uncertainty returns false
+// (fail-closed).
+func (m *Middleware) isAdmin(r *http.Request) bool {
+	// Fast-fail with no round-trip when the session cookie is absent.
+	if _, err := r.Cookie(m.cookieName); err != nil {
+		return false
+	}
+
+	role, err := m.fetchViewerRole(r.Context(), r.Header.Get("Cookie"))
+	if err != nil {
+		return false
+	}
+	return role == adminRole
+}
+
+// fetchViewerRole forwards the caller's raw Cookie header to the monolith and
+// returns the viewer role. Any transport/status/decode/GraphQL error is
+// returned so the caller can fail closed.
+func (m *Middleware) fetchViewerRole(ctx context.Context, cookieHeader string) (string, error) {
+	body, err := json.Marshal(map[string]string{"query": viewerRoleQuery})
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, m.baseURL+systemGraphQLPath, bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	// Forward the end-user's cookie verbatim — this is the whole point.
+	req.Header.Set("Cookie", cookieHeader)
+
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("delegatedadmin: monolith returned status %d", resp.StatusCode)
+	}
+
+	var parsed viewerRoleResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return "", err
+	}
+	if len(parsed.Errors) > 0 {
+		return "", fmt.Errorf("delegatedadmin: graphql error: %s", parsed.Errors[0].Message)
+	}
+	return parsed.Data.Viewer.Role, nil
+}

--- a/internal/delegatedadmin/delegatedadmin_test.go
+++ b/internal/delegatedadmin/delegatedadmin_test.go
@@ -1,0 +1,236 @@
+package delegatedadmin_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"trip2g/internal/delegatedadmin"
+)
+
+// newNext returns a handler that records whether it was called and always
+// writes 200 OK.
+func newNext(called *bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		*called = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("served"))
+	})
+}
+
+// monolith spins up a fake /_system/graphql that captures the forwarded Cookie
+// header and replies with the given role (or a custom raw handler).
+func monolith(t *testing.T, gotCookie *string, respond func(w http.ResponseWriter, r *http.Request)) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/_system/graphql" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if gotCookie != nil {
+			*gotCookie = r.Header.Get("Cookie")
+		}
+		// Drain body so the caller's request is complete.
+		_, _ = io.Copy(io.Discard, r.Body)
+		respond(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func roleResponder(role string) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"viewer":{"role":"` + role + `"}}}`))
+	}
+}
+
+func doRequest(t *testing.T, mw *delegatedadmin.Middleware, cookie string) (*httptest.ResponseRecorder, bool) {
+	t.Helper()
+	var called bool
+	h := mw.Wrap(newNext(&called))
+	req := httptest.NewRequest(http.MethodGet, "/_fleet/graphql", nil)
+	if cookie != "" {
+		req.Header.Set("Cookie", cookie)
+	}
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	return rr, called
+}
+
+func newMW(t *testing.T, baseURL string, client *http.Client) *delegatedadmin.Middleware {
+	t.Helper()
+	mw, err := delegatedadmin.New(delegatedadmin.Config{MonolithBaseURL: baseURL, HTTPClient: client})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return mw
+}
+
+func TestAdminCookieAllows(t *testing.T) {
+	var gotCookie string
+	srv := monolith(t, &gotCookie, roleResponder("ADMIN"))
+	mw := newMW(t, srv.URL, nil)
+
+	rr, called := doRequest(t, mw, "trip2g_token=abc.def.ghi")
+
+	if !called {
+		t.Fatal("expected next handler to be called for admin")
+	}
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if gotCookie != "trip2g_token=abc.def.ghi" {
+		t.Fatalf("cookie not forwarded verbatim: got %q", gotCookie)
+	}
+}
+
+func TestNonAdminRejected(t *testing.T) {
+	for _, role := range []string{"USER", "GUEST"} {
+		srv := monolith(t, nil, roleResponder(role))
+		mw := newMW(t, srv.URL, nil)
+
+		rr, called := doRequest(t, mw, "trip2g_token=abc")
+
+		if called {
+			t.Fatalf("role %s: next must not be called", role)
+		}
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("role %s: expected 401, got %d", role, rr.Code)
+		}
+	}
+}
+
+func TestNoCookieRejectedWithoutRoundTrip(t *testing.T) {
+	var reached bool
+	srv := monolith(t, nil, func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.Write([]byte(`{"data":{"viewer":{"role":"ADMIN"}}}`))
+	})
+	mw := newMW(t, srv.URL, nil)
+
+	rr, called := doRequest(t, mw, "")
+
+	if called {
+		t.Fatal("next must not be called without a cookie")
+	}
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
+	}
+	if reached {
+		t.Fatal("monolith should not be contacted when session cookie is absent")
+	}
+}
+
+func TestUnrelatedCookieButNoSessionCookieRejected(t *testing.T) {
+	var reached bool
+	srv := monolith(t, nil, func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.Write([]byte(`{"data":{"viewer":{"role":"ADMIN"}}}`))
+	})
+	mw := newMW(t, srv.URL, nil)
+
+	rr, called := doRequest(t, mw, "other=1; unrelated=2")
+
+	if called {
+		t.Fatal("next must not be called without the session cookie")
+	}
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
+	}
+	if reached {
+		t.Fatal("monolith should not be contacted without the session cookie")
+	}
+}
+
+func TestMonolith500FailsClosed(t *testing.T) {
+	srv := monolith(t, nil, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	mw := newMW(t, srv.URL, nil)
+
+	rr, called := doRequest(t, mw, "trip2g_token=abc")
+
+	if called {
+		t.Fatal("next must not be called when monolith errors")
+	}
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 (fail-closed), got %d", rr.Code)
+	}
+}
+
+func TestMonolithGraphQLErrorFailsClosed(t *testing.T) {
+	srv := monolith(t, nil, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"errors":[{"message":"boom"}]}`))
+	})
+	mw := newMW(t, srv.URL, nil)
+
+	rr, called := doRequest(t, mw, "trip2g_token=abc")
+
+	if called {
+		t.Fatal("next must not be called on graphql error")
+	}
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
+	}
+}
+
+func TestMonolithUnreachableFailsClosed(t *testing.T) {
+	// Point at a closed port; the dial fails immediately.
+	mw := newMW(t, "http://127.0.0.1:1", nil)
+
+	rr, called := doRequest(t, mw, "trip2g_token=abc")
+
+	if called {
+		t.Fatal("next must not be called when monolith is unreachable")
+	}
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 (fail-closed), got %d", rr.Code)
+	}
+}
+
+func TestMonolithTimeoutFailsClosed(t *testing.T) {
+	srv := monolith(t, nil, func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.Write([]byte(`{"data":{"viewer":{"role":"ADMIN"}}}`))
+	})
+	mw := newMW(t, srv.URL, &http.Client{Timeout: 20 * time.Millisecond})
+
+	rr, called := doRequest(t, mw, "trip2g_token=abc")
+
+	if called {
+		t.Fatal("next must not be called on timeout")
+	}
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 (fail-closed), got %d", rr.Code)
+	}
+}
+
+func TestForwardsFullCookieHeaderVerbatim(t *testing.T) {
+	var gotCookie string
+	srv := monolith(t, &gotCookie, roleResponder("ADMIN"))
+	mw := newMW(t, srv.URL, nil)
+
+	const cookie = "trip2g_token=eyJ.header.sig; theme=dark; other=xyz"
+	_, called := doRequest(t, mw, cookie)
+
+	if !called {
+		t.Fatal("expected admin to pass")
+	}
+	if gotCookie != cookie {
+		t.Fatalf("cookie not forwarded verbatim:\n got:  %q\n want: %q", gotCookie, cookie)
+	}
+	// Sanity: no service token/HAT smuggled in.
+	if strings.Contains(gotCookie, "Bearer") {
+		t.Fatal("must not send a bearer/service credential")
+	}
+}
+
+func TestMissingBaseURLIsError(t *testing.T) {
+	if _, err := delegatedadmin.New(delegatedadmin.Config{}); err == nil {
+		t.Fatal("expected error for empty MonolithBaseURL")
+	}
+}


### PR DESCRIPTION
## What

Foundational, reusable **delegated-admin** auth for the browser-facing services (`fleet` GraphQL, `codellm`) plus the same-origin Caddy proxy routes they sit behind. This is the shared piece both services import later — **it is NOT wired into fleet/codellm here** (those integrations are separate, in-flight PRs).

## Middleware contract — `internal/delegatedadmin`

Standard `net/http` middleware (fleet/codellm use `net/http`, confirmed against `internal/fleet/graph/server.go`):

```go
mw, err := delegatedadmin.New(delegatedadmin.Config{
    MonolithBaseURL: "http://localhost:8081", // required
    HTTPClient:      nil,                      // optional; default 5s-timeout client
    CookieName:      "",                       // optional; default "trip2g_token"
})
handler := mw.Wrap(next) // 401 (does not call next) unless caller is a verified admin
```

Per request it:
1. Fast-fails 401 (no round-trip) when the session cookie (`trip2g_token`) is absent.
2. `POST {MonolithBaseURL}/_system/graphql` with `{"query":"query { viewer { role } }"}`, **forwarding the caller's raw `Cookie` header verbatim**.
3. Allows only when `data.viewer.role == "ADMIN"`.

### Guarantees (with test evidence)
- **Cookie-forward, never a service credential** — the end-user's `Cookie` header is forwarded byte-for-byte; no HAT/bearer is ever attached. This answers "is the *caller* admin", not "is the service admin". Covered by `TestAdminCookieAllows` and `TestForwardsFullCookieHeaderVerbatim` (asserts exact multi-cookie header round-trips and no `Bearer`).
- **Fail-closed** — monolith unreachable / timeout / non-200 / GraphQL-error → **reject**. Covered by `TestMonolith500FailsClosed`, `TestMonolithUnreachableFailsClosed`, `TestMonolithTimeoutFailsClosed`, `TestMonolithGraphQLErrorFailsClosed`.
- **Non-admin / missing cookie → 401** — `TestNonAdminRejected` (USER, GUEST), `TestNoCookieRejectedWithoutRoundTrip`, `TestUnrelatedCookieButNoSessionCookieRejected`.

```
ok  trip2g/internal/delegatedadmin  (10 tests, all PASS)
go build -tags dev ./...  → exit 0
go vet   -tags dev ./...  → exit 0
```
(The fresh-worktree `go build ./...` also needs the gitignored embed artifacts `assets/ui/admin/-/web.js` + `onboarding-vault/vault.zip`; with those present the full build/vet are clean. Unrelated to this change.)

## Schema confirmation — `viewer { role }`

Verified against the real monolith schema (`internal/graph/schema.graphqls`):
- `type Viewer { id role: Role! user … }` — the field exists.
- `enum Role { GUEST USER ADMIN }` — **uppercase**. The gqlgen resolver `viewerResolver.Role` upper-cases the token role, so the wire value is `"ADMIN"`, not the lowercase `"admin"` JWT claim carried inside `usertoken.Data`.

**Correction:** the design doc `docs/dev/fleet_graphql.md` says `role == "admin"`; the correct comparison is `role == "ADMIN"`. The middleware compares against `"ADMIN"`. See *Deviations* — the doc is an untracked, in-flight file owned by the parallel fleet PR, so this correction is recorded here rather than committed into it.

## Caddy routes — where they go

Added to the repo `Caddyfile` (dev proxy, `:9081`), mirroring the existing `/_system/*` reverse-proxy block:

```
handle /_fleet/*   { reverse_proxy http://localhost:8092 }  # placeholder addr
handle /_codellm/* { reverse_proxy http://localhost:8093 }  # placeholder addr
```

- Dumb pass-through, forwards the session cookie, **NO auth in Caddy** — auth is the middleware inside each service.
- Upstream addresses are **placeholders**; the real private addrs come from deploy/ansible config.
- `/_codellm/*` is the browser-facing lane only. The fleet↔codellm server-to-server `/v1` channel is separate and does not pass through Caddy (out of scope here).
- `caddy adapt` validates the config (`/_fleet/*`→:8092, `/_codellm/*`→:8093 present).
- Doc note added in `docs/dev/caddy.md`.

## Scope / non-goals
- Does **not** modify fleet or codellm service code (their PRs wire this in).
- Does **not** implement the fleet↔codellm locked server-to-server channel (codellm's concern, different auth).

## Deviations
1. **`docs/dev/fleet_graphql.md` not edited.** It is an untracked file being authored in parallel (the fleet-graphql session) and is on no branch. Committing my copy would clobber theirs, so the `admin`→`ADMIN` correction and the schema confirmation are captured in this PR body + `docs/dev/caddy.md` instead. The fleet PR should fold the `"ADMIN"` correction in.
2. Chose `internal/delegatedadmin` as the package name (the brief's `internal/deleGateadmin` had inconsistent casing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
