### PR TITLE
feat(codellm): P1 standalone OpenAI-compatible code-execution service

### DIFF
--- a/cmd/codellm/appconfig/config.go
+++ b/cmd/codellm/appconfig/config.go
@@ -1,0 +1,176 @@
+// Package appconfig loads codellm's runtime configuration. It mirrors the
+// STYLE of internal/appconfig (typed Config, a Get() that layers env vars and
+// flags on top of defaults, ozzo validation) but is deliberately lightweight:
+// codellm is one small binary with half a dozen settings, so it does not pull
+// in the monolith's dependency surface (envflag's TRIP2G_ global-flag binding,
+// MinIO/Patreon/audit-log sub-configs, etc.) — just the typed-Config + Get() +
+// validate shape, sized to this service.
+package appconfig
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	ozzo "github.com/go-ozzo/ozzo-validation/v4"
+
+	"trip2g/internal/agentruntime"
+)
+
+// Config holds codellm's runtime configuration.
+type Config struct {
+	// Addr is the listen address for the OpenAI-compatible API. Defaults to
+	// loopback: codellm's Auth/TokenCheck seams are no-op in Phase 1, so
+	// binding to all interfaces must be an explicit operator opt-in, not the
+	// default.
+	Addr string
+
+	// AllowedPrograms is the interpreter allowlist (python, bash, node, ...).
+	// Empty disables code execution (every request then fails 422).
+	AllowedPrograms []string
+
+	// Sandbox is the OS-level isolation mode for each executed block.
+	Sandbox agentruntime.SandboxMode
+
+	// Timeout bounds a single completion's code run; 0 = request-context bound.
+	Timeout time.Duration
+
+	// MaxStdoutBytes caps each block's captured stdout; 0 = 1 MiB default.
+	MaxStdoutBytes int
+
+	// ChannelToken is a placeholder for the future fleet<->codellm locked-channel
+	// check (shared token / mTLS material, per docs/dev/codellm_extraction.md).
+	// Not enforced yet — a later PR wires channel auth using this value.
+	ChannelToken string
+}
+
+// Defaults.
+const (
+	DefaultAddr            = "127.0.0.1:8082"
+	DefaultAllowedPrograms = "python,bash,node"
+	DefaultTimeout         = 300 * time.Second
+)
+
+// DefaultConfig returns Config's baseline values, before env/flag overrides.
+func DefaultConfig() Config {
+	return Config{
+		Addr:            DefaultAddr,
+		AllowedPrograms: splitCSV(DefaultAllowedPrograms),
+		Sandbox:         agentruntime.SandboxNative,
+		Timeout:         DefaultTimeout,
+		MaxStdoutBytes:  0,
+	}
+}
+
+// Get loads Config from defaults, then CODELLM_* environment variables, then
+// os.Args command-line flags (highest precedence — matching internal/appconfig's
+// "env overrides defaults, flags override env" layering), and validates it.
+func Get() (*Config, error) {
+	return GetArgs(os.Args[1:])
+}
+
+// GetArgs is Get with an explicit argv, so tests can drive flag parsing without
+// touching the process's real os.Args.
+func GetArgs(args []string) (*Config, error) {
+	cfg := DefaultConfig()
+	cfg.applyEnv()
+
+	if err := cfg.defineAndParseFlags(args); err != nil {
+		return nil, fmt.Errorf("appconfig: parse flags: %w", err)
+	}
+
+	if err := cfg.validate(); err != nil {
+		return nil, fmt.Errorf("appconfig: invalid configuration: %w", err)
+	}
+	return &cfg, nil
+}
+
+// applyEnv overrides defaults from CODELLM_* environment variables. Flags
+// (defineAndParseFlags), parsed afterward with these values as their defaults,
+// take precedence when explicitly passed.
+func (c *Config) applyEnv() {
+	if v := os.Getenv("CODELLM_ADDR"); v != "" {
+		c.Addr = v
+	}
+	if v := os.Getenv("CODELLM_ALLOWED_PROGRAMS"); v != "" {
+		c.AllowedPrograms = splitCSV(v)
+	}
+	if v := os.Getenv("CODELLM_SANDBOX"); v != "" {
+		c.Sandbox = agentruntime.SandboxMode(v)
+	}
+	if v := os.Getenv("CODELLM_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			c.Timeout = d
+		}
+	}
+	if v := os.Getenv("CODELLM_MAX_STDOUT_BYTES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			c.MaxStdoutBytes = n
+		}
+	}
+	if v := os.Getenv("CODELLM_CHANNEL_TOKEN"); v != "" {
+		c.ChannelToken = v
+	}
+}
+
+// defineAndParseFlags registers flags seeded from the env-resolved config (so
+// an unset flag keeps the env/default value) and parses args. A dedicated
+// FlagSet (not flag.CommandLine) keeps Get() safely repeatable in tests.
+func (c *Config) defineAndParseFlags(args []string) error {
+	fs := flag.NewFlagSet("codellm", flag.ContinueOnError)
+
+	allowedPrograms := strings.Join(c.AllowedPrograms, ",")
+	sandbox := string(c.Sandbox)
+
+	fs.StringVar(&c.Addr, "addr", c.Addr, "listen address for the OpenAI-compatible API; defaults to loopback since auth is a no-op seam")
+	fs.StringVar(&allowedPrograms, "allowed-programs", allowedPrograms, "comma-separated interpreter allowlist; empty disables code execution")
+	fs.StringVar(&sandbox, "sandbox", sandbox, "sandbox mode: native | besteffort | off")
+	fs.DurationVar(&c.Timeout, "timeout", c.Timeout, "per-completion code-run timeout; 0 = request-context bound")
+	fs.IntVar(&c.MaxStdoutBytes, "max-stdout-bytes", c.MaxStdoutBytes, "stdout cap per code block; 0 = 1 MiB default")
+	fs.StringVar(&c.ChannelToken, "channel-token", c.ChannelToken, "shared fleet<->codellm channel token (not yet enforced)")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	c.AllowedPrograms = splitCSV(allowedPrograms)
+	c.Sandbox = agentruntime.SandboxMode(sandbox)
+	return nil
+}
+
+func (c *Config) validate() error {
+	return ozzo.ValidateStruct(c,
+		ozzo.Field(&c.Addr, ozzo.Required),
+		ozzo.Field(&c.MaxStdoutBytes, ozzo.Min(0)),
+		ozzo.Field(&c.Timeout, ozzo.By(nonNegativeDuration)),
+		ozzo.Field(&c.Sandbox, ozzo.In(agentruntime.SandboxNative, agentruntime.SandboxBestEffort, agentruntime.SandboxOff)),
+	)
+}
+
+// nonNegativeDuration rejects a negative timeout (0 is valid: request-context
+// bound).
+func nonNegativeDuration(value any) error {
+	d, ok := value.(time.Duration)
+	if !ok {
+		return errors.New("not a duration")
+	}
+	if d < 0 {
+		return errors.New("must not be negative")
+	}
+	return nil
+}
+
+// splitCSV splits a comma-separated value into a trimmed, empty-free slice.
+func splitCSV(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/cmd/codellm/appconfig/config_test.go
+++ b/cmd/codellm/appconfig/config_test.go
@@ -1,0 +1,68 @@
+package appconfig
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trip2g/internal/agentruntime"
+)
+
+func TestGetArgs_Defaults(t *testing.T) {
+	cfg, err := GetArgs(nil)
+	require.NoError(t, err)
+	require.Equal(t, DefaultAddr, cfg.Addr, "must default to loopback, not all-interfaces")
+	require.Equal(t, []string{"python", "bash", "node"}, cfg.AllowedPrograms)
+	require.Equal(t, agentruntime.SandboxNative, cfg.Sandbox)
+	require.Equal(t, DefaultTimeout, cfg.Timeout)
+	require.Equal(t, 0, cfg.MaxStdoutBytes)
+	require.Empty(t, cfg.ChannelToken)
+}
+
+func TestGetArgs_EnvOverridesDefaults(t *testing.T) {
+	t.Setenv("CODELLM_ADDR", "0.0.0.0:9999")
+	t.Setenv("CODELLM_ALLOWED_PROGRAMS", "bash")
+	t.Setenv("CODELLM_SANDBOX", "besteffort")
+	t.Setenv("CODELLM_TIMEOUT", "5s")
+	t.Setenv("CODELLM_MAX_STDOUT_BYTES", "1024")
+	t.Setenv("CODELLM_CHANNEL_TOKEN", "secret")
+
+	cfg, err := GetArgs(nil)
+	require.NoError(t, err)
+	require.Equal(t, "0.0.0.0:9999", cfg.Addr)
+	require.Equal(t, []string{"bash"}, cfg.AllowedPrograms)
+	require.Equal(t, agentruntime.SandboxBestEffort, cfg.Sandbox)
+	require.Equal(t, 5*time.Second, cfg.Timeout)
+	require.Equal(t, 1024, cfg.MaxStdoutBytes)
+	require.Equal(t, "secret", cfg.ChannelToken)
+}
+
+func TestGetArgs_FlagsOverrideEnv(t *testing.T) {
+	t.Setenv("CODELLM_ADDR", "0.0.0.0:9999")
+
+	cfg, err := GetArgs([]string{"-addr", "127.0.0.1:7777"})
+	require.NoError(t, err)
+	require.Equal(t, "127.0.0.1:7777", cfg.Addr, "explicit flag must win over env")
+}
+
+func TestGetArgs_InvalidSandboxRejected(t *testing.T) {
+	_, err := GetArgs([]string{"-sandbox", "bogus"})
+	require.Error(t, err)
+}
+
+func TestGetArgs_NegativeTimeoutRejected(t *testing.T) {
+	_, err := GetArgs([]string{"-timeout", "-1s"})
+	require.Error(t, err)
+}
+
+func TestGetArgs_NegativeMaxStdoutRejected(t *testing.T) {
+	_, err := GetArgs([]string{"-max-stdout-bytes", "-1"})
+	require.Error(t, err)
+}
+
+func TestGetArgs_EmptyAllowedProgramsDisablesExecution(t *testing.T) {
+	cfg, err := GetArgs([]string{"-allowed-programs", ""})
+	require.NoError(t, err)
+	require.Empty(t, cfg.AllowedPrograms)
+}

--- a/cmd/codellm/main.go
+++ b/cmd/codellm/main.go
@@ -8,14 +8,14 @@
 package main
 
 import (
-	"flag"
 	"log"
 	"net/http"
-	"strings"
 	"time"
 
 	"trip2g/internal/agentruntime"
 	"trip2g/internal/codellm"
+
+	"trip2g/cmd/codellm/appconfig"
 )
 
 func main() {
@@ -25,41 +25,28 @@ func main() {
 	// absent. Phase 2 completes the sandbox story (move + tests).
 	agentruntime.MaybeRunSandboxChild()
 
-	addr := flag.String("addr", "127.0.0.1:8082", "listen address for the OpenAI-compatible API; defaults to loopback since auth is a no-op seam — binding to all interfaces is an explicit operator opt-in")
-	allowedPrograms := flag.String("allowed-programs", "python,bash,node", "comma-separated interpreter allowlist; empty disables code execution")
-	sandboxMode := flag.String("sandbox", string(agentruntime.SandboxNative), "sandbox mode: native | besteffort | off")
-	timeout := flag.Duration("timeout", 300*time.Second, "per-completion code-run timeout; 0 = request-context bound")
-	maxStdout := flag.Int("max-stdout-bytes", 0, "stdout cap per code block; 0 = 1 MiB default")
-	flag.Parse()
+	cfg, err := appconfig.Get()
+	if err != nil {
+		log.Fatalf("codellm: config: %v", err)
+	}
 
-	cfg := codellm.Config{
-		AllowedPrograms: splitCSV(*allowedPrograms),
-		Sandbox:         agentruntime.SandboxPolicy{Mode: agentruntime.SandboxMode(*sandboxMode)},
-		MaxStdoutBytes:  *maxStdout,
-		Timeout:         *timeout,
+	srvCfg := codellm.Config{
+		AllowedPrograms: cfg.AllowedPrograms,
+		Sandbox:         agentruntime.SandboxPolicy{Mode: cfg.Sandbox},
+		MaxStdoutBytes:  cfg.MaxStdoutBytes,
+		Timeout:         cfg.Timeout,
 		// Auth/TokenCheck seams intentionally left nil (no-op) in Phase 1 — a
 		// separate PR builds the shared delegated-admin auth helper and the
-		// channel token/mTLS check and wires them here.
+		// channel token/mTLS check (cfg.ChannelToken is the placeholder for it).
 	}
 
 	srv := &http.Server{
-		Addr:              *addr,
-		Handler:           codellm.New(cfg).Handler(),
+		Addr:              cfg.Addr,
+		Handler:           codellm.New(srvCfg).Handler(),
 		ReadHeaderTimeout: 10 * time.Second,
 	}
-	log.Printf("codellm listening on %s (sandbox=%s, programs=%v)", *addr, *sandboxMode, cfg.AllowedPrograms)
+	log.Printf("codellm listening on %s (sandbox=%s, programs=%v)", cfg.Addr, cfg.Sandbox, cfg.AllowedPrograms)
 	if err := srv.ListenAndServe(); err != nil {
 		log.Fatalf("codellm: server error: %v", err)
 	}
-}
-
-// splitCSV splits a comma-separated flag value into a trimmed, empty-free slice.
-func splitCSV(s string) []string {
-	var out []string
-	for _, p := range strings.Split(s, ",") {
-		if p = strings.TrimSpace(p); p != "" {
-			out = append(out, p)
-		}
-	}
-	return out
 }

--- a/cmd/codellm/main.go
+++ b/cmd/codellm/main.go
@@ -25,7 +25,7 @@ func main() {
 	// absent. Phase 2 completes the sandbox story (move + tests).
 	agentruntime.MaybeRunSandboxChild()
 
-	addr := flag.String("addr", ":8082", "listen address for the OpenAI-compatible API")
+	addr := flag.String("addr", "127.0.0.1:8082", "listen address for the OpenAI-compatible API; defaults to loopback since auth is a no-op seam — binding to all interfaces is an explicit operator opt-in")
 	allowedPrograms := flag.String("allowed-programs", "python,bash,node", "comma-separated interpreter allowlist; empty disables code execution")
 	sandboxMode := flag.String("sandbox", string(agentruntime.SandboxNative), "sandbox mode: native | besteffort | off")
 	timeout := flag.Duration("timeout", 300*time.Second, "per-completion code-run timeout; 0 = request-context bound")

--- a/cmd/codellm/main.go
+++ b/cmd/codellm/main.go
@@ -1,0 +1,65 @@
+// Command codellm is a standalone OpenAI-compatible chat-completions service
+// that executes the fenced code in incoming markdown and returns the writes as
+// OpenAI tool_calls. See docs/dev/codellm_extraction.md (Phase 1).
+//
+// SECURITY: an unauthenticated /v1/chat/completions is RCE-as-a-service. The
+// fleet↔codellm channel MUST be locked (mTLS / shared token / loopback) before
+// exposure — the auth/token seams in internal/codellm are wired by a later PR.
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"trip2g/internal/agentruntime"
+	"trip2g/internal/codellm"
+)
+
+func main() {
+	// The per-block sandbox works by re-execing THIS binary as a confined child
+	// (marker env var). It must run first so a re-exec lands in the child branch
+	// and never falls through to start a second server. No-op when the marker is
+	// absent. Phase 2 completes the sandbox story (move + tests).
+	agentruntime.MaybeRunSandboxChild()
+
+	addr := flag.String("addr", ":8082", "listen address for the OpenAI-compatible API")
+	allowedPrograms := flag.String("allowed-programs", "python,bash,node", "comma-separated interpreter allowlist; empty disables code execution")
+	sandboxMode := flag.String("sandbox", string(agentruntime.SandboxNative), "sandbox mode: native | besteffort | off")
+	timeout := flag.Duration("timeout", 300*time.Second, "per-completion code-run timeout; 0 = request-context bound")
+	maxStdout := flag.Int("max-stdout-bytes", 0, "stdout cap per code block; 0 = 1 MiB default")
+	flag.Parse()
+
+	cfg := codellm.Config{
+		AllowedPrograms: splitCSV(*allowedPrograms),
+		Sandbox:         agentruntime.SandboxPolicy{Mode: agentruntime.SandboxMode(*sandboxMode)},
+		MaxStdoutBytes:  *maxStdout,
+		Timeout:         *timeout,
+		// Auth/TokenCheck seams intentionally left nil (no-op) in Phase 1 — a
+		// separate PR builds the shared delegated-admin auth helper and the
+		// channel token/mTLS check and wires them here.
+	}
+
+	srv := &http.Server{
+		Addr:              *addr,
+		Handler:           codellm.New(cfg).Handler(),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	log.Printf("codellm listening on %s (sandbox=%s, programs=%v)", *addr, *sandboxMode, cfg.AllowedPrograms)
+	if err := srv.ListenAndServe(); err != nil {
+		log.Fatalf("codellm: server error: %v", err)
+	}
+}
+
+// splitCSV splits a comma-separated flag value into a trimmed, empty-free slice.
+func splitCSV(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/agentruntime/runcode.go
+++ b/internal/agentruntime/runcode.go
@@ -53,50 +53,9 @@ func RunCode(ctx context.Context, in CodeInput) (*Result, error) {
 		return nil, errors.New("coderun: KB is required")
 	}
 
-	blocks := ExtractFencedBlocks(in.Body)
-	if len(blocks) == 0 {
-		return nil, errors.New("coderun: no fenced code block found in rendered body")
-	}
-
-	programs, err := resolvePrograms(blocks, in)
+	rawChanges, answer, steps, err := runCodeBlocks(ctx, in)
 	if err != nil {
 		return nil, err
-	}
-
-	limit := in.MaxStdoutBytes
-	if limit == 0 {
-		limit = 1 << 20
-	}
-
-	var stdout string
-	if len(blocks) == 1 {
-		// Single block: use RunBlock for byte-identical behavior.
-		out, _, _, runErr := RunBlock(ctx, CodeSpec{
-			Program:        programs[0],
-			Code:           blocks[0].Code,
-			Input:          in.Input,
-			Timeout:        in.Timeout,
-			EnvPassthrough: in.EnvPassthrough,
-			EnvPrefix:      in.EnvPrefix,
-			MaxStdoutBytes: limit,
-			Sandbox:        in.Sandbox,
-		})
-		if runErr != nil {
-			return nil, fmt.Errorf("coderun: %w", runErr)
-		}
-		stdout = out
-	} else {
-		// Multi-block: true streaming pipeline.
-		out, pipeErr := runPipeline(ctx, blocks, programs, in, limit, nil)
-		if pipeErr != nil {
-			return nil, pipeErr
-		}
-		stdout = out
-	}
-
-	rawChanges, answer, perr := parseCodeOutput(stdout)
-	if perr != nil {
-		return nil, perr
 	}
 
 	// Apply changes through ScopedKB — NOT a scope bypass. Every write goes
@@ -105,7 +64,7 @@ func RunCode(ctx context.Context, in CodeInput) (*Result, error) {
 	scoped := NewScopedKB(in.KB, nil, in.WritePatterns)
 	res := &Result{
 		Status:     StatusCompleted,
-		Steps:      len(blocks),
+		Steps:      steps,
 		TokensUsed: 0,
 		Answer:     answer,
 	}
@@ -127,6 +86,72 @@ func RunCode(ctx context.Context, in CodeInput) (*Result, error) {
 		res.Changes = append(res.Changes, ch)
 	}
 	return res, nil
+}
+
+// ExecCode extracts and runs the fenced blocks in in.Body and returns the parsed
+// {changes, answer} stdout contract WITHOUT applying the changes to a KB and
+// WITHOUT scope enforcement. It is the execution-only half of RunCode: codellm
+// uses it to map the changes onto OpenAI tool_calls, leaving scope enforcement
+// (write_patterns via ScopedKB) to the caller (fleet). in.KB and in.WritePatterns
+// are ignored. A block execution failure or a stdout-parse failure returns an
+// error, which codellm maps to HTTP 422 (deterministic hard-fail, no retry).
+func ExecCode(ctx context.Context, in CodeInput) ([]webhookutil.AgentChange, string, error) {
+	changes, answer, _, err := runCodeBlocks(ctx, in)
+	return changes, answer, err
+}
+
+// runCodeBlocks is the shared execution core of RunCode and ExecCode: it extracts
+// the fenced blocks, resolves+allowlist-checks their programs, runs them (single
+// block via RunBlock, multiple via the streaming pipeline), and parses the last
+// block's stdout as the {changes, answer} contract. It performs no KB writes and
+// no scope checks. Returns the parsed changes, answer, and block count (Steps).
+func runCodeBlocks(ctx context.Context, in CodeInput) ([]webhookutil.AgentChange, string, int, error) {
+	blocks := ExtractFencedBlocks(in.Body)
+	if len(blocks) == 0 {
+		return nil, "", 0, errors.New("coderun: no fenced code block found in rendered body")
+	}
+
+	programs, err := resolvePrograms(blocks, in)
+	if err != nil {
+		return nil, "", 0, err
+	}
+
+	limit := in.MaxStdoutBytes
+	if limit == 0 {
+		limit = 1 << 20
+	}
+
+	var stdout string
+	if len(blocks) == 1 {
+		// Single block: use RunBlock for byte-identical behavior.
+		out, _, _, runErr := RunBlock(ctx, CodeSpec{
+			Program:        programs[0],
+			Code:           blocks[0].Code,
+			Input:          in.Input,
+			Timeout:        in.Timeout,
+			EnvPassthrough: in.EnvPassthrough,
+			EnvPrefix:      in.EnvPrefix,
+			MaxStdoutBytes: limit,
+			Sandbox:        in.Sandbox,
+		})
+		if runErr != nil {
+			return nil, "", 0, fmt.Errorf("coderun: %w", runErr)
+		}
+		stdout = out
+	} else {
+		// Multi-block: true streaming pipeline.
+		out, pipeErr := runPipeline(ctx, blocks, programs, in, limit, nil)
+		if pipeErr != nil {
+			return nil, "", 0, pipeErr
+		}
+		stdout = out
+	}
+
+	rawChanges, answer, perr := parseCodeOutput(stdout)
+	if perr != nil {
+		return nil, "", 0, perr
+	}
+	return rawChanges, answer, len(blocks), nil
 }
 
 // resolvePrograms resolves and allowlist-checks every block's program before

--- a/internal/codellm/server.go
+++ b/internal/codellm/server.go
@@ -1,0 +1,267 @@
+// Package codellm implements a standalone OpenAI-compatible chat-completions
+// service that *pretends to be an LLM*: it receives chat messages containing
+// markdown-with-fenced-code, executes the fenced blocks, and returns the writes
+// as OpenAI tool_calls (write_note / patch_note / finish).
+//
+// This is Phase 1 of docs/dev/codellm_extraction.md: the wire protocol + the
+// {changes}→tool_calls mapping + the hard invariants (always-finish, 422 on
+// apply/parse failure). It reuses internal/agentruntime for execution (RunBlock /
+// pipeline / sandbox) — the sandbox move (Phase 2) and the fleet cutover
+// (Phase 3) are deliberately NOT part of this service yet. codellm holds no
+// vault, no KB, no auth, no secrets; scope enforcement stays in fleet.
+package codellm
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	goopenai "github.com/sashabaranov/go-openai"
+
+	"trip2g/internal/agentruntime"
+	"trip2g/internal/webhookutil"
+)
+
+// fleetInputMessageName is the reserved message name that carries the delivery
+// bag (the JSON exposed to executed code as $FLEET_INPUT). It rides as a system
+// message per the wire protocol; its content is NOT scanned for fenced blocks.
+const fleetInputMessageName = "fleet_input"
+
+// modelID is the synthetic model advertised by GET /v1/models. codellm echoes
+// whatever model the request asks for, so this is only for client compatibility.
+const modelID = "codellm"
+
+// Config configures a codellm Server. codellm holds no vault/KB/secrets; the
+// only knobs are the code-execution policy and the auth seam.
+type Config struct {
+	// AllowedPrograms is the interpreter allowlist (python, bash, node, ...).
+	// Empty disables code execution (every request then fails 422). Phase 2
+	// moves the full --allowed-programs/--sandbox/... flag set here.
+	AllowedPrograms []string
+
+	// Sandbox is the OS-level isolation policy for each executed block. The zero
+	// value is the safe default (native, enforcing). Phase 2 wires
+	// MaybeRunSandboxChild() so native mode is fully operational.
+	Sandbox agentruntime.SandboxPolicy
+
+	// MaxStdoutBytes caps each block's captured stdout; 0 → 1 MiB default.
+	MaxStdoutBytes int
+
+	// Timeout bounds a single completion's code run; 0 → bounded by the request
+	// context only.
+	Timeout time.Duration
+
+	// Auth is the middleware SEAM for the delegated-admin / shared-token check.
+	// The fleet↔codellm channel MUST be locked down (mTLS / shared token /
+	// loopback) before exposure — an unauthenticated /v1/chat/completions is
+	// RCE-as-a-service. A separate PR builds the shared auth helper and wires it
+	// here; nil defaults to a no-op passthrough for now.
+	Auth func(http.Handler) http.Handler
+
+	// TokenCheck is the seam for the fleet↔codellm shared-token/mTLS check.
+	// Not built in Phase 1 (see the channel-locking note above); nil → no check.
+	// Kept distinct from Auth so the transport-lock and the caller-identity
+	// concerns can be wired independently.
+	TokenCheck func(*http.Request) error
+}
+
+// Server is the codellm HTTP service.
+type Server struct {
+	cfg Config
+}
+
+// New builds a Server from cfg, filling in nil seams with no-op defaults.
+func New(cfg Config) *Server {
+	if cfg.Auth == nil {
+		cfg.Auth = func(next http.Handler) http.Handler { return next }
+	}
+	return &Server{cfg: cfg}
+}
+
+// Handler returns the HTTP handler for the service, with the auth seam applied.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/chat/completions", s.handleChatCompletions)
+	mux.HandleFunc("GET /v1/models", s.handleModels)
+	mux.HandleFunc("GET /healthz", s.handleHealthz)
+	return s.cfg.Auth(mux)
+}
+
+// handleChatCompletions is the OpenAI-compatible surface. It decodes the chat
+// request, extracts the markdown-with-code and the delivery bag, executes the
+// fenced blocks, and returns the writes as tool_calls ending in exactly one
+// finish. Execution/parse failures are a deterministic 422 (not retried).
+func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.TokenCheck != nil {
+		if err := s.cfg.TokenCheck(r); err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", err.Error())
+			return
+		}
+	}
+
+	var req goopenai.ChatCompletionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request_error", "decode request: "+err.Error())
+		return
+	}
+
+	body, bag := extractBodyAndBag(req.Messages)
+
+	changes, answer, err := agentruntime.ExecCode(r.Context(), agentruntime.CodeInput{
+		Body:            body,
+		AllowedPrograms: s.cfg.AllowedPrograms,
+		Sandbox:         s.cfg.Sandbox,
+		MaxStdoutBytes:  s.cfg.MaxStdoutBytes,
+		Timeout:         s.cfg.Timeout,
+		Input:           bag,
+		// No EnvPassthrough/EnvPrefix: env passthrough is dropped by design —
+		// no parent env crosses the HTTP boundary.
+	})
+	if err != nil {
+		// Apply-error semantics = hard-fail 422 (decision b): a failing block,
+		// timeout, or unparseable stdout is a deterministic failure, not a soft
+		// skip. 422 (not 5xx) so fleet's OpenAILLM does not retry it.
+		writeError(w, http.StatusUnprocessableEntity, "code_execution_error", err.Error())
+		return
+	}
+
+	resp := buildResponse(req.Model, changes, answer)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// extractBodyAndBag concatenates the message contents that may contain fenced
+// code (everything except the reserved fleet_input message) into the body to
+// scan, and returns the fleet_input message content as the delivery bag. The
+// system-prompt wrapper has no fences, so only the role body's blocks are found.
+func extractBodyAndBag(messages []goopenai.ChatCompletionMessage) (body string, bag []byte) {
+	var sb strings.Builder
+	for _, m := range messages {
+		if m.Name == fleetInputMessageName {
+			bag = []byte(m.Content)
+			continue
+		}
+		sb.WriteString(m.Content)
+		sb.WriteString("\n")
+	}
+	return sb.String(), bag
+}
+
+// buildResponse maps the parsed {changes, answer} onto an OpenAI tool_calls
+// completion: content-change → write_note(path, content), find/replace →
+// patch_note(path, find, replace), then a trailing finish(answer) kept LAST.
+//
+// Hard invariant: every successful completion ends with exactly ONE finish
+// tool_call — even an empty answer becomes finish(""). This is the
+// re-execution defense: fleet's stateless loop re-calls codellm (which
+// re-extracts and re-applies every write) unless a finish stops it.
+func buildResponse(model string, changes []webhookutil.AgentChange, answer string) goopenai.ChatCompletionResponse {
+	toolCalls := make([]goopenai.ToolCall, 0, len(changes)+1)
+	for i, ch := range changes {
+		name, args := changeToToolCall(ch)
+		toolCalls = append(toolCalls, goopenai.ToolCall{
+			ID:       fmt.Sprintf("call_%d", i),
+			Type:     goopenai.ToolTypeFunction,
+			Function: goopenai.FunctionCall{Name: name, Arguments: args},
+		})
+	}
+	// finish is always LAST and always present (even with an empty answer).
+	toolCalls = append(toolCalls, goopenai.ToolCall{
+		ID:       fmt.Sprintf("call_%d", len(changes)),
+		Type:     goopenai.ToolTypeFunction,
+		Function: goopenai.FunctionCall{Name: "finish", Arguments: mustJSON(map[string]string{"answer": answer})},
+	})
+
+	if model == "" {
+		model = modelID
+	}
+	return goopenai.ChatCompletionResponse{
+		ID:      "codellm-" + randomID(),
+		Object:  "chat.completion",
+		Created: time.Now().Unix(),
+		Model:   model,
+		Choices: []goopenai.ChatCompletionChoice{{
+			Index: 0,
+			Message: goopenai.ChatCompletionMessage{
+				Role:      goopenai.ChatMessageRoleAssistant,
+				Content:   "",
+				ToolCalls: toolCalls,
+			},
+			FinishReason: goopenai.FinishReasonToolCalls,
+		}},
+		// codellm does no token accounting: usage is always zero (matching the
+		// old TokensUsed: 0 for in-process code runs).
+		Usage: goopenai.Usage{},
+	}
+}
+
+// changeToToolCall maps one AgentChange to a tool name and JSON arguments.
+func changeToToolCall(ch webhookutil.AgentChange) (name, args string) {
+	if ch.Kind == webhookutil.AgentChangeKindPatch {
+		return "patch_note", mustJSON(map[string]string{
+			"path":    ch.Path,
+			"find":    ch.Find,
+			"replace": ch.Replace,
+		})
+	}
+	return "write_note", mustJSON(map[string]string{
+		"path":    ch.Path,
+		"content": ch.Content,
+	})
+}
+
+func (s *Server) handleModels(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"object": "list",
+		"data": []map[string]any{{
+			"id":       modelID,
+			"object":   "model",
+			"owned_by": "trip2g",
+		}},
+	})
+}
+
+func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+// apiError is the OpenAI-shaped error envelope.
+type apiError struct {
+	Error apiErrorBody `json:"error"`
+}
+
+type apiErrorBody struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+}
+
+func writeError(w http.ResponseWriter, status int, errType, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(apiError{Error: apiErrorBody{Message: msg, Type: errType}})
+}
+
+// randomID returns a short hex token for the completion id.
+func randomID() string {
+	var b [6]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "000000000000"
+	}
+	return hex.EncodeToString(b[:])
+}
+
+func mustJSON(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		// The inputs are plain string maps; marshaling cannot fail.
+		panic(errors.New("codellm: marshal tool arguments: " + err.Error()))
+	}
+	return string(b)
+}

--- a/internal/codellm/server.go
+++ b/internal/codellm/server.go
@@ -40,13 +40,14 @@ const modelID = "codellm"
 // only knobs are the code-execution policy and the auth seam.
 type Config struct {
 	// AllowedPrograms is the interpreter allowlist (python, bash, node, ...).
-	// Empty disables code execution (every request then fails 422). Phase 2
-	// moves the full --allowed-programs/--sandbox/... flag set here.
+	// Empty disables code execution (every request then fails 422).
 	AllowedPrograms []string
 
 	// Sandbox is the OS-level isolation policy for each executed block. The zero
-	// value is the safe default (native, enforcing). Phase 2 wires
-	// MaybeRunSandboxChild() so native mode is fully operational.
+	// value is the safe default (native, enforcing). main.go calls
+	// agentruntime.MaybeRunSandboxChild() first and defaults --sandbox to
+	// native, so native mode is already operational in Phase 1; Phase 2 moves
+	// the sandbox/interpreters/debug-surface source out of agentruntime.
 	Sandbox agentruntime.SandboxPolicy
 
 	// MaxStdoutBytes caps each block's captured stdout; 0 → 1 MiB default.

--- a/internal/codellm/server_test.go
+++ b/internal/codellm/server_test.go
@@ -1,0 +1,246 @@
+package codellm
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	goopenai "github.com/sashabaranov/go-openai"
+	"github.com/stretchr/testify/require"
+
+	"trip2g/internal/agentruntime"
+)
+
+// newTestServer builds a codellm server that runs bash blocks unsandboxed, so
+// the wire-protocol tests are portable (no unprivileged-userns dependency). The
+// sandbox itself is exercised in agentruntime's own tests; Phase 2 wires it here.
+func newTestServer() *Server {
+	return New(Config{
+		AllowedPrograms: []string{"bash"},
+		Sandbox:         agentruntime.SandboxPolicy{Mode: agentruntime.SandboxOff},
+	})
+}
+
+// doChat posts a chat-completions request built from the given messages and
+// returns the raw recorder.
+func doChat(t *testing.T, srv *Server, messages []goopenai.ChatCompletionMessage) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(goopenai.ChatCompletionRequest{Model: "codellm", Messages: messages})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+// bashBody wraps a bash script as a fenced markdown block inside the system
+// prompt, mirroring how fleet delivers a rendered code-role body.
+func bashBody(script string) goopenai.ChatCompletionMessage {
+	return goopenai.ChatCompletionMessage{
+		Role:    goopenai.ChatMessageRoleSystem,
+		Content: "You are a scoped micro-agent.\n```bash\n" + script + "\n```",
+	}
+}
+
+func decodeResp(t *testing.T, rec *httptest.ResponseRecorder) goopenai.ChatCompletionResponse {
+	t.Helper()
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	var resp goopenai.ChatCompletionResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	return resp
+}
+
+// finishArgs finds the finish tool call and returns its answer argument.
+func finishArgs(t *testing.T, calls []goopenai.ToolCall) string {
+	t.Helper()
+	var answer string
+	var count int
+	for _, c := range calls {
+		if c.Function.Name == "finish" {
+			count++
+			var a struct {
+				Answer string `json:"answer"`
+			}
+			require.NoError(t, json.Unmarshal([]byte(c.Function.Arguments), &a))
+			answer = a.Answer
+		}
+	}
+	require.Equal(t, 1, count, "exactly one finish tool_call required")
+	return answer
+}
+
+func TestChatCompletions_WriteNoteAndFinish(t *testing.T) {
+	srv := newTestServer()
+	script := `echo '{"changes":[{"path":"notes/a.md","content":"generated"}],"answer":"done"}'`
+	rec := doChat(t, srv, []goopenai.ChatCompletionMessage{
+		bashBody(script),
+		{Role: goopenai.ChatMessageRoleUser, Content: "Begin."},
+	})
+	resp := decodeResp(t, rec)
+
+	require.Len(t, resp.Choices, 1)
+	choice := resp.Choices[0]
+	require.Equal(t, goopenai.FinishReasonToolCalls, choice.FinishReason)
+	require.Equal(t, 0, resp.Usage.TotalTokens)
+	require.Equal(t, 0, resp.Usage.PromptTokens)
+	require.Equal(t, 0, resp.Usage.CompletionTokens)
+
+	calls := choice.Message.ToolCalls
+	require.Len(t, calls, 2, "one write_note + trailing finish")
+
+	require.Equal(t, "write_note", calls[0].Function.Name)
+	var wargs struct {
+		Path    string `json:"path"`
+		Content string `json:"content"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(calls[0].Function.Arguments), &wargs))
+	require.Equal(t, "notes/a.md", wargs.Path)
+	require.Equal(t, "generated", wargs.Content)
+
+	// finish must be LAST.
+	require.Equal(t, "finish", calls[len(calls)-1].Function.Name)
+	require.Equal(t, "done", finishArgs(t, calls))
+}
+
+func TestChatCompletions_PatchNote(t *testing.T) {
+	srv := newTestServer()
+	script := `echo '{"changes":[{"path":"index.md","find":"a","replace":"b"}],"answer":"patched"}'`
+	rec := doChat(t, srv, []goopenai.ChatCompletionMessage{bashBody(script)})
+	resp := decodeResp(t, rec)
+
+	calls := resp.Choices[0].Message.ToolCalls
+	require.Len(t, calls, 2)
+	require.Equal(t, "patch_note", calls[0].Function.Name)
+	var pargs struct {
+		Path, Find, Replace string
+	}
+	require.NoError(t, json.Unmarshal([]byte(calls[0].Function.Arguments), &pargs))
+	require.Equal(t, "index.md", pargs.Path)
+	require.Equal(t, "a", pargs.Find)
+	require.Equal(t, "b", pargs.Replace)
+	require.Equal(t, "finish", calls[1].Function.Name)
+}
+
+// TestChatCompletions_AlwaysFinish_EmptyAnswer is the core conformance guard:
+// even with zero changes and an empty answer, the completion ends with exactly
+// one finish(""). Missing finish would let fleet's stateless loop re-run the
+// blocks and re-apply every write.
+func TestChatCompletions_AlwaysFinish_EmptyAnswer(t *testing.T) {
+	srv := newTestServer()
+	script := `echo '{"changes":[],"answer":""}'`
+	rec := doChat(t, srv, []goopenai.ChatCompletionMessage{bashBody(script)})
+	resp := decodeResp(t, rec)
+
+	calls := resp.Choices[0].Message.ToolCalls
+	require.Len(t, calls, 1, "no changes → only the mandatory finish")
+	require.Equal(t, "finish", calls[0].Function.Name)
+	require.Equal(t, "", finishArgs(t, calls))
+}
+
+// TestEveryCompletionEndsWithFinish asserts the always-finish invariant across a
+// spread of bodies: no successful completion omits finish, and finish is last.
+func TestEveryCompletionEndsWithFinish(t *testing.T) {
+	srv := newTestServer()
+	scripts := []string{
+		`echo '{"changes":[],"answer":""}'`,
+		`echo '{"changes":[],"answer":"just an answer"}'`,
+		`echo '{"changes":[{"path":"a.md","content":"x"}],"answer":"one write"}'`,
+		`echo '{"changes":[{"path":"a.md","content":"x"},{"path":"b.md","find":"p","replace":"q"}],"answer":"mixed"}'`,
+	}
+	for _, script := range scripts {
+		rec := doChat(t, srv, []goopenai.ChatCompletionMessage{bashBody(script)})
+		resp := decodeResp(t, rec)
+		calls := resp.Choices[0].Message.ToolCalls
+		require.NotEmpty(t, calls, "script %q: expected tool_calls", script)
+		require.Equal(t, "finish", calls[len(calls)-1].Function.Name, "script %q: finish must be last", script)
+		_ = finishArgs(t, calls) // asserts exactly one finish
+	}
+}
+
+// TestChatCompletions_FleetInputBag verifies the delivery bag rides as the
+// fleet_input system message and is exposed to code as $FLEET_INPUT.
+func TestChatCompletions_FleetInputBag(t *testing.T) {
+	srv := newTestServer()
+	script := `printf '{"changes":[],"answer":"%s"}' "$(cat "$FLEET_INPUT")"`
+	rec := doChat(t, srv, []goopenai.ChatCompletionMessage{
+		bashBody(script),
+		{Role: goopenai.ChatMessageRoleSystem, Name: fleetInputMessageName, Content: "hello-bag"},
+	})
+	resp := decodeResp(t, rec)
+	require.Equal(t, "hello-bag", finishArgs(t, resp.Choices[0].Message.ToolCalls))
+}
+
+// TestChatCompletions_ParseError422 asserts unparseable stdout is a hard 422
+// (decision b: preserve today's hard-fail parity, not a soft skip).
+func TestChatCompletions_ParseError422(t *testing.T) {
+	srv := newTestServer()
+	script := `echo 'not json at all'`
+	rec := doChat(t, srv, []goopenai.ChatCompletionMessage{bashBody(script)})
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code, "body: %s", rec.Body.String())
+
+	var e apiError
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &e))
+	require.Equal(t, "code_execution_error", e.Error.Type)
+	require.NotEmpty(t, e.Error.Message)
+}
+
+// TestChatCompletions_ExecError422 asserts a non-zero block exit is a hard 422.
+func TestChatCompletions_ExecError422(t *testing.T) {
+	srv := newTestServer()
+	script := `echo 'boom' >&2; exit 3`
+	rec := doChat(t, srv, []goopenai.ChatCompletionMessage{bashBody(script)})
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code, "body: %s", rec.Body.String())
+}
+
+// TestChatCompletions_NoFencedBlock422 asserts a request carrying no fenced code
+// is a hard 422 (nothing to execute), not a silent empty success.
+func TestChatCompletions_NoFencedBlock422(t *testing.T) {
+	srv := newTestServer()
+	rec := doChat(t, srv, []goopenai.ChatCompletionMessage{
+		{Role: goopenai.ChatMessageRoleUser, Content: "Begin."},
+	})
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code, "body: %s", rec.Body.String())
+}
+
+func TestExtractBodyAndBag(t *testing.T) {
+	body, bag := extractBodyAndBag([]goopenai.ChatCompletionMessage{
+		{Role: "system", Content: "role body ```code```"},
+		{Role: "system", Name: fleetInputMessageName, Content: `{"changed_files":[]}`},
+		{Role: "user", Content: "Begin."},
+	})
+	require.Contains(t, body, "role body")
+	require.Contains(t, body, "Begin.")
+	require.NotContains(t, body, "changed_files", "fleet_input must not be scanned for code")
+	require.Equal(t, `{"changed_files":[]}`, string(bag))
+}
+
+func TestModelsAndHealthz(t *testing.T) {
+	srv := newTestServer()
+
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), modelID)
+}
+
+// TestAuthSeam asserts the auth middleware seam is honored (a custom middleware
+// can reject requests before they reach the handler).
+func TestAuthSeam(t *testing.T) {
+	srv := New(Config{
+		AllowedPrograms: []string{"bash"},
+		Sandbox:         agentruntime.SandboxPolicy{Mode: agentruntime.SandboxOff},
+		Auth: func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+			})
+		},
+	})
+	rec := doChat(t, srv, []goopenai.ChatCompletionMessage{bashBody(`echo '{"changes":[],"answer":""}'`)})
+	require.Equal(t, http.StatusForbidden, rec.Code)
+}


### PR DESCRIPTION
Phase 1 of `docs/dev/codellm_extraction.md`: a **standalone** OpenAI-compatible service that pretends to be an LLM — it executes the fenced code in incoming markdown and returns the writes as OpenAI `tool_calls`.

**Does NOT touch fleet. Does NOT move the sandbox.** Those are later phases: the sandbox move is Phase 2, the fleet cutover (`f.codeLLM`, `InputBag`, `MaxSteps:1` on the fleet side) is Phase 3. This PR imports the existing `internal/agentruntime` execution code as a library.

## Wire protocol implemented
- `POST /v1/chat/completions` — decodes a standard `goopenai.ChatCompletionRequest` (exactly what fleet's `OpenAILLM` sends), returns a standard `ChatCompletionResponse` with `finish_reason: "tool_calls"` and `usage` all-zero. Non-streaming.
- `GET /v1/models` (synthetic model), `GET /healthz`.
- **Body extraction:** all message contents are concatenated and scanned with `ExtractFencedBlocks` — the system-prompt wrapper has no fences, so only the role body's blocks are found. Works whether fleet puts the code in the `system` message (real path) or a `user` message.
- **Delivery bag:** rides as the `system` message named `fleet_input`; its content is exposed to executed code as `$FLEET_INPUT`. It is excluded from fenced-block scanning.
- **Env passthrough dropped by design** — no parent env crosses the HTTP boundary (`EnvPassthrough`/`EnvPrefix` are never set).

## `{changes}` → tool_calls mapping
Mechanical, lossless:
- content-change → `write_note(path, content)`
- find/replace → `patch_note(path, find, replace)`
- `answer` → trailing `finish(answer)`, kept **LAST** so writes apply before fleet's loop returns.
- Token usage `0` (matches the old `TokensUsed: 0` for code runs).

## Hard invariants (from the Codex review)
1. **Always-`finish`.** Every successful completion ends with exactly ONE `finish` — even zero changes + empty answer → `finish("")`. This is the re-execution defense: fleet's stateless loop would otherwise re-call codellm, re-extract the same blocks, and re-apply every write up to the step ceiling. (Fleet pins `MaxSteps:1` on its side in Phase 3; codellm's job is the always-finish guarantee.)
   - Conformance test `TestEveryCompletionEndsWithFinish` asserts no completion omits `finish` and it is last, across a spread of bodies; `TestChatCompletions_AlwaysFinish_EmptyAnswer` covers the empty case.
2. **Apply-error = 422 hard-fail (decision b).** A failing/timing-out block or unparseable stdout returns HTTP **422** (not a soft skip, not 5xx — so fleet's `OpenAILLM.createWithRetry` does not retry it), preserving today's hard-fail parity.
   - `TestChatCompletions_ParseError422` (bad stdout) and `TestChatCompletions_ExecError422` (non-zero exit) prove it; `TestChatCompletions_NoFencedBlock422` covers the empty request.

## Seams left for later PRs
- **Auth middleware** (`Config.Auth func(http.Handler) http.Handler`) — no-op default; the delegated-admin check is a separate PR. `TestAuthSeam` proves the seam works.
- **Channel token/mTLS** (`Config.TokenCheck`) — nil default; the fleet↔codellm channel MUST be locked before exposure (an unauthenticated `/v1/chat/completions` is RCE-as-a-service). Documented in `main.go`.
- `main.go` calls `agentruntime.MaybeRunSandboxChild()` first and defaults `--sandbox native`, so native per-block sandboxing is already operational in Phase 1 (Phase 2 moves the sandbox/interpreters/debug-surface source out of `agentruntime` into `internal/codellm`, no behavior change). Phase 1 tests run blocks with `SandboxOff` for portability (no unprivileged-userns dependency in CI); the sandbox mechanics themselves are covered by agentruntime's own tests.

**SECURITY (addressed post-review):** since `Auth`/`TokenCheck` are no-op seams in Phase 1, `-addr` now **defaults to loopback** (`127.0.0.1:8082` instead of `:8082`) so unauthenticated network exposure is an explicit operator opt-in, not the default. An operator who wires the auth middleware and a private bind can still pass a different `-addr`.

## Minimal agentruntime change
`RunCode` refactored to share a `runCodeBlocks` execution core, and a new exported `ExecCode(ctx, CodeInput) ([]AgentChange, string, error)` returns the parsed `{changes, answer}` **without** KB/scope (scope stays in fleet). `RunCode`'s behavior is unchanged — all existing `internal/agentruntime` tests pass.

## Config: appconfig pattern (post-review)
Raw flags in `main.go` replaced with `cmd/codellm/appconfig` (package `appconfig`), mirroring `internal/appconfig`'s STYLE — typed `Config` + `Get()` + ozzo `validate()` — sized to codellm (no envflag/TRIP2G_ global-flag binding, no MinIO/Patreon/audit-log sub-configs pulled in).
- `Config`: `Addr` (loopback default preserved: `127.0.0.1:8082`), `AllowedPrograms`, `Sandbox` (`agentruntime.SandboxMode`), `Timeout`, `MaxStdoutBytes`, and `ChannelToken` — a placeholder field for the future fleet↔codellm locked-channel token (not enforced yet, wired by the same later PR as `TokenCheck`).
- `Get()` layers defaults → `CODELLM_*` env vars → flags (flags win when explicitly passed), then validates via `ozzo.ValidateStruct` (`Addr` required, `Sandbox` in `{native,besteffort,off}`, non-negative `Timeout`/`MaxStdoutBytes`). Uses its own `flag.FlagSet` (not the global `flag.CommandLine`), so `Get()`/`GetArgs()` is safely repeatable in tests.
- `main.go` now just calls `appconfig.Get()` and wires the result into `codellm.Config` — no behavior change (same defaults, same loopback safety).
- Tests in `cmd/codellm/appconfig/config_test.go`: defaults, env-overrides-defaults, flag-overrides-env, and validation rejections (bad sandbox mode, negative timeout, negative max-stdout-bytes).

## Verification
- `go build -tags dev ./...` — clean (pre-existing unrelated `onboarding-vault/embed.go: vault.zip` missing-embed error also present on `main`).
- `go vet -tags dev ./cmd/codellm/... ./internal/codellm/...` — clean.
- `go test ./cmd/codellm/... ./internal/codellm/... ./internal/agentruntime/...` — `ok` (agentruntime 4.35s; `cmd/codellm/appconfig` and `internal/codellm` both `ok`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


