### PR TITLE
feat(fleet): gate GraphQL with delegated-admin, keep webhook HMAC, private bind

### DIFF
--- a/cmd/fleet/appconfig/config.go
+++ b/cmd/fleet/appconfig/config.go
@@ -26,6 +26,12 @@ const (
 	DefaultTrip2gBaseURL = "http://localhost:8081"
 	DefaultModel         = "gpt-4o-mini"
 	DefaultOfferedTools  = "search,read_note,patch_note,write_note"
+
+	// DefaultGraphQLAddr binds the fleet GraphQL API to loopback by default so
+	// exposure is an explicit operator opt-in, with Caddy /_fleet/* as the sole
+	// ingress (mirrors codellm's loopback default). The API is gated by the
+	// delegated-admin middleware regardless of bind.
+	DefaultGraphQLAddr = "127.0.0.1:9093"
 )
 
 // Config holds the subset of fleet's machine-level settings layered via
@@ -55,6 +61,7 @@ func DefaultConfig() *Config {
 		AgentsFolder:    DefaultAgentsFolder,
 		ListenAddr:      DefaultListenAddr,
 		Trip2gBaseURL:   DefaultTrip2gBaseURL,
+		GraphQLAddr:     DefaultGraphQLAddr,
 		DefaultModel:    DefaultModel,
 		offeredToolsCSV: DefaultOfferedTools,
 	}
@@ -74,10 +81,11 @@ func (c *Config) DefineFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.Trip2gBaseURL, "trip2g-url", c.Trip2gBaseURL,
 		"trip2g base URL")
 	fs.StringVar(&c.GraphQLAddr, "graphql-addr", c.GraphQLAddr,
-		"listen address serving the fleet GraphQL read API (POST /graphql: roles + roleGraph), "+
-			"e.g. 127.0.0.1:9093; empty = disabled. Intended behind Caddy /_fleet/* with the "+
-			"delegated-admin check; auth is a no-op seam until that middleware is wired, so do "+
-			"NOT expose a non-loopback bind publicly yet")
+		"listen address serving the fleet GraphQL read API (POST /graphql: roles + roleGraph); "+
+			"defaults to loopback (127.0.0.1:9093), empty = disabled. The whole port is gated by "+
+			"the delegated-admin middleware (forwards the caller's cookie to the monolith's "+
+			"viewer{role}; admin -> serve, else 401, monolith-unreachable -> fail-closed). Front it "+
+			"with Caddy /_fleet/* as the sole ingress; expose a non-loopback bind only behind that proxy")
 	fs.StringVar(&c.DefaultModel, "default-model", c.DefaultModel,
 		"default model when a role omits model")
 	fs.StringVar(&c.offeredToolsCSV, "offered-tools", c.offeredToolsCSV,

--- a/cmd/fleet/appconfig/config_test.go
+++ b/cmd/fleet/appconfig/config_test.go
@@ -13,7 +13,7 @@ func TestDefaultConfig(t *testing.T) {
 	require.Equal(t, DefaultListenAddr, cfg.ListenAddr)
 	require.Equal(t, DefaultTrip2gBaseURL, cfg.Trip2gBaseURL)
 	require.Equal(t, DefaultModel, cfg.DefaultModel)
-	require.Empty(t, cfg.GraphQLAddr) // disabled by default
+	require.Equal(t, DefaultGraphQLAddr, cfg.GraphQLAddr) // loopback by default
 	require.Empty(t, cfg.CodellmBaseURL)
 
 	cfg.Prepare()

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -128,6 +128,7 @@ func run() error {
 	// the cookie gate never touches the monolith->fleet delivery path.
 	var graphqlSrv *http.Server
 	if cli.appCfg.GraphQLAddr != "" {
+		warnIfGraphQLAddrNonLoopback(lg, cli.appCfg.GraphQLAddr)
 		gqlMux, gErr := newFleetGraphQLHandler(discovery, cli.cfg.Trip2gBaseURL)
 		if gErr != nil {
 			return fmt.Errorf("fleet: graphql auth: %w", gErr)
@@ -372,6 +373,25 @@ func validateLoopbackAddr(addr string) error {
 		return fmt.Errorf("host %q is not loopback; bind 127.0.0.1, ::1 or localhost", host)
 	}
 	return nil
+}
+
+// warnIfGraphQLAddrNonLoopback logs a loud warning when --graphql-addr is
+// bound off loopback. Unlike --graph-addr/--debug-listen, a non-loopback
+// GraphQL bind is not hard-blocked — a remote-fleet-behind-its-own-Caddy setup
+// is a legitimate topology, and the delegated-admin gate still authenticates
+// every request — but the operator should see the exposure explicitly.
+func warnIfGraphQLAddrNonLoopback(lg logger.Logger, addr string) {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return
+	}
+	if host == "localhost" {
+		return
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+		return
+	}
+	lg.Warn("fleet GraphQL bound non-loopback; ensure Caddy is the sole ingress + delegated-admin gate", "addr", addr)
 }
 
 // normalizeCallbackURL strips trailing slashes so webhook URLs assemble cleanly.

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -26,6 +26,7 @@ import (
 	fleetappconfig "trip2g/cmd/fleet/appconfig"
 	"trip2g/internal/agentruntime"
 	"trip2g/internal/appconfig"
+	"trip2g/internal/delegatedadmin"
 	"trip2g/internal/fleet"
 	"trip2g/internal/fleet/fleetgql"
 	"trip2g/internal/fleet/graph"
@@ -119,15 +120,19 @@ func run() error {
 	}
 
 	// --graphql-addr: the fleet's own GraphQL read API (roles + roleGraph).
-	// Reuses fleet.ParseRole via the same Discovery. Auth is a no-op seam
-	// (pass nil) until the shared delegated-admin middleware lands; the design
-	// puts this behind Caddy /_fleet/* with per-request cookie delegation.
+	// Reuses fleet.ParseRole via the same Discovery. The ENTIRE browser-facing
+	// mux on this port is gated by the delegated-admin middleware (forwards the
+	// caller's cookie to the monolith's viewer{role}; admin -> serve, else 401,
+	// monolith-unreachable -> fail-closed). This is a separate server from the
+	// webhook delivery listener (cli.cfg.ListenAddr, /deliver/, HMAC-authed), so
+	// the cookie gate never touches the monolith->fleet delivery path.
 	var graphqlSrv *http.Server
 	if cli.appCfg.GraphQLAddr != "" {
-		gqlHandler := fleetgql.NewHTTPHandler(discovery, nil)
-		mux := http.NewServeMux()
-		mux.Handle("/graphql", gqlHandler)
-		graphqlSrv = &http.Server{Addr: cli.appCfg.GraphQLAddr, Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+		gqlMux, gErr := newFleetGraphQLHandler(discovery, cli.cfg.Trip2gBaseURL)
+		if gErr != nil {
+			return fmt.Errorf("fleet: graphql auth: %w", gErr)
+		}
+		graphqlSrv = &http.Server{Addr: cli.appCfg.GraphQLAddr, Handler: gqlMux, ReadHeaderTimeout: 10 * time.Second}
 		go func() {
 			lg.Info("fleet GraphQL API listening", "addr", cli.appCfg.GraphQLAddr)
 			if gerr := graphqlSrv.ListenAndServe(); gerr != nil && gerr != http.ErrServerClosed {
@@ -197,6 +202,23 @@ func run() error {
 			syncOnce(ctx, lg, f, discovery, reconciler)
 		}
 	}
+}
+
+// newFleetGraphQLHandler builds the fleet GraphQL server's HTTP handler: a mux
+// serving POST /graphql (roles + roleGraph), with the ENTIRE mux wrapped by the
+// delegated-admin middleware so every browser-facing path on this port — not
+// just /graphql — is gated on the caller being a verified trip2g admin.
+// monolithBaseURL is where viewer{role} is asked (fleet's Trip2gBaseURL). The
+// webhook delivery path lives on a different server and is intentionally NOT
+// wrapped here (it authenticates via HMAC, not the admin cookie).
+func newFleetGraphQLHandler(roles fleetgql.RoleSource, monolithBaseURL string) (http.Handler, error) {
+	da, err := delegatedadmin.New(delegatedadmin.Config{MonolithBaseURL: monolithBaseURL})
+	if err != nil {
+		return nil, err
+	}
+	mux := http.NewServeMux()
+	mux.Handle("/graphql", fleetgql.NewHTTPHandler(roles, nil))
+	return da.Wrap(mux), nil
 }
 
 // runOnce reads cli.oncePath as a role-note, parses it, validates against the

--- a/cmd/fleet/main_auth_test.go
+++ b/cmd/fleet/main_auth_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trip2g/internal/fleet"
+)
+
+// authFakeSource is a static fleetgql.RoleSource for the auth integration test.
+type authFakeSource struct{ roles []fleet.Role }
+
+func (s authFakeSource) DiscoverParsed(context.Context) ([]fleet.Role, []error) {
+	return s.roles, nil
+}
+
+// fakeMonolith stands in for the trip2g monolith's POST /_system/graphql,
+// answering viewer{role} with the given role (mirrors #229's middleware tests).
+func fakeMonolith(t *testing.T, role string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/_system/graphql", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"viewer":{"role":"` + role + `"}}}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func graphqlPOST(t *testing.T, h http.Handler, path, cookie string) *httptest.ResponseRecorder {
+	t.Helper()
+	body := `{"query":"{ roles { name } }"}`
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if cookie != "" {
+		req.Header.Set("Cookie", cookie)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestGraphQLServerRejectsUnauthenticated is the gate the #229 review demanded:
+// an unauthenticated request to the fleet GraphQL port returns 401 (the
+// delegated-admin middleware fails closed with no session cookie).
+func TestGraphQLServerRejectsUnauthenticated(t *testing.T) {
+	mono := fakeMonolith(t, "ADMIN") // never reached: no cookie short-circuits
+	h, err := newFleetGraphQLHandler(authFakeSource{}, mono.URL)
+	require.NoError(t, err)
+
+	rec := graphqlPOST(t, h, "/graphql", "")
+	require.Equal(t, http.StatusUnauthorized, rec.Code, rec.Body.String())
+}
+
+// TestGraphQLServerAllowsAdmin: an admin-cookie request passes the gate and the
+// GraphQL query executes (the monolith's viewer{role} answers ADMIN).
+func TestGraphQLServerAllowsAdmin(t *testing.T) {
+	mono := fakeMonolith(t, "ADMIN")
+	h, err := newFleetGraphQLHandler(
+		authFakeSource{roles: []fleet.Role{{NotePath: "roles/indexer.md"}}}, mono.URL)
+	require.NoError(t, err)
+
+	rec := graphqlPOST(t, h, "/graphql", "trip2g_token=abc.def.ghi")
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	require.Contains(t, rec.Body.String(), "indexer")
+}
+
+// TestGraphQLServerRejectsNonAdmin: a valid session cookie for a non-admin
+// viewer is still rejected with 401.
+func TestGraphQLServerRejectsNonAdmin(t *testing.T) {
+	for _, role := range []string{"USER", "GUEST"} {
+		mono := fakeMonolith(t, role)
+		h, err := newFleetGraphQLHandler(authFakeSource{}, mono.URL)
+		require.NoError(t, err)
+
+		rec := graphqlPOST(t, h, "/graphql", "trip2g_token=abc")
+		require.Equal(t, http.StatusUnauthorized, rec.Code, "role %s", role)
+	}
+}
+
+// TestGraphQLServerGatesEntireMux proves the wrap covers the whole port, not
+// only /graphql: any other browser path on this server is 401 without admin.
+func TestGraphQLServerGatesEntireMux(t *testing.T) {
+	mono := fakeMonolith(t, "ADMIN")
+	h, err := newFleetGraphQLHandler(authFakeSource{}, mono.URL)
+	require.NoError(t, err)
+
+	rec := graphqlPOST(t, h, "/anything-else", "")
+	require.Equal(t, http.StatusUnauthorized, rec.Code, rec.Body.String())
+}
+
+// TestWebhookDeliveryNotCookieGated documents the auth split. The webhook
+// delivery path (monolith -> fleet, HMAC-authed) runs on a SEPARATE server
+// (cli.cfg.ListenAddr, /deliver/) that main builds WITHOUT the delegated-admin
+// wrapper — see run(). This mirrors that delivery mux with a stub handler and
+// asserts a cookieless request reaches the handler (i.e. is NOT rejected by the
+// admin-cookie gate), unlike the GraphQL mux above.
+func TestWebhookDeliveryNotCookieGated(t *testing.T) {
+	var reached bool
+	deliveryMux := http.NewServeMux()
+	deliveryMux.HandleFunc("/deliver/", func(w http.ResponseWriter, _ *http.Request) {
+		reached = true // real fleet verifies HMAC here (f.ServeDelivery)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/deliver/somekey", strings.NewReader("{}"))
+	rec := httptest.NewRecorder()
+	deliveryMux.ServeHTTP(rec, req)
+
+	require.True(t, reached, "delivery handler must run without an admin cookie")
+	require.NotEqual(t, http.StatusUnauthorized, rec.Code)
+}

--- a/cmd/fleet/main_auth_test.go
+++ b/cmd/fleet/main_auth_test.go
@@ -99,7 +99,8 @@ func TestGraphQLServerGatesEntireMux(t *testing.T) {
 // (cli.cfg.ListenAddr, /deliver/) that main builds WITHOUT the delegated-admin
 // wrapper — see run(). This mirrors that delivery mux with a stub handler and
 // asserts a cookieless request reaches the handler (i.e. is NOT rejected by the
-// admin-cookie gate), unlike the GraphQL mux above.
+// admin-cookie gate), unlike the GraphQL mux above. Real HMAC-signature
+// coverage of ServeDelivery itself lives in internal/fleet/handler_test.go.
 func TestWebhookDeliveryNotCookieGated(t *testing.T) {
 	var reached bool
 	deliveryMux := http.NewServeMux()
@@ -114,4 +115,47 @@ func TestWebhookDeliveryNotCookieGated(t *testing.T) {
 
 	require.True(t, reached, "delivery handler must run without an admin cookie")
 	require.NotEqual(t, http.StatusUnauthorized, rec.Code)
+}
+
+// spyLogger records Warn calls; other levels are no-ops.
+type spyLogger struct {
+	warned bool
+	msg    string
+	kv     []interface{}
+}
+
+func (s *spyLogger) Info(string, ...interface{})  {}
+func (s *spyLogger) Error(string, ...interface{}) {}
+func (s *spyLogger) Debug(string, ...interface{}) {}
+func (s *spyLogger) Warn(msg string, kv ...interface{}) {
+	s.warned = true
+	s.msg = msg
+	s.kv = kv
+}
+
+// TestWarnIfGraphQLAddrNonLoopback verifies the loud opt-in warning fires only
+// for a non-loopback bind, matching --graph-addr/--debug-listen's loopback
+// notion but without hard-blocking (a remote-fleet-behind-Caddy setup is
+// legitimate; the delegated-admin gate still authenticates every request).
+func TestWarnIfGraphQLAddrNonLoopback(t *testing.T) {
+	tests := []struct {
+		addr      string
+		wantWarn  bool
+		wantMatch bool // for wantWarn cases: addr must appear in the logged kv
+	}{
+		{"127.0.0.1:9093", false, false},
+		{"localhost:9093", false, false},
+		{"[::1]:9093", false, false},
+		{":9093", true, true},
+		{"0.0.0.0:9093", true, true},
+		{"192.168.1.10:9093", true, true},
+	}
+	for _, tt := range tests {
+		lg := &spyLogger{}
+		warnIfGraphQLAddrNonLoopback(lg, tt.addr)
+		require.Equal(t, tt.wantWarn, lg.warned, tt.addr)
+		if tt.wantMatch {
+			require.Contains(t, lg.kv, tt.addr)
+		}
+	}
 }


### PR DESCRIPTION
Closes the hard gate from #229's review: fleet's own GraphQL API (added in #231) shipped with a **nil auth seam** — open to anyone who could reach the port. This wires the shared `internal/delegatedadmin` middleware (#229) in front of it and locks the bind down.

## How the mux is wrapped

The GraphQL server's **entire mux** is wrapped, not just `/graphql`. `newFleetGraphQLHandler(roles, monolithBaseURL)` builds a `delegatedadmin.Middleware` from the monolith base URL, mounts `/graphql`, and returns `da.Wrap(mux)`. So every browser-facing path on the graphql-addr port — current or future — is gated on the caller being a verified trip2g admin. The middleware is built from config: `monolithBaseURL = cli.cfg.Trip2gBaseURL` (the existing `--trip2g-url` / `Trip2gBaseURL`, reused). Non-admin / no-cookie / monolith-unreachable → 401 (the middleware already fails closed).

## The auth split (browser cookie vs webhook HMAC)

fleet runs **two separate HTTP servers on two ports**, so the split is structural, not path-routing inside one mux:

| Server | Bind | Path | Auth |
|--------|------|------|------|
| GraphQL API (browser) | `--graphql-addr` (default `127.0.0.1:9093`) | `POST /graphql` | delegated-admin cookie (this PR) |
| Webhook delivery (monolith → fleet) | `--listen` (default `:9090`) | `POST /deliver/<urlKey>` | HMAC (`X-Webhook-Signature`, `webhookutil.VerifyHMAC`) — unchanged |

Because the delegated-admin wrap is applied only to the graphql-addr server, the `monolith → fleet` delivery path keeps its HMAC check and is **never** subjected to the admin cookie. Requirement 2 is satisfied by the existing two-server topology.

**Webhook-path note / follow-up:** `docs/dev/fleet_graphql.md` describes the target ingress convention `/_fleet/<h>/webhook` (h = `sha256("fleet:"+fleet_id)`). The current delivery path is `/deliver/<urlKey>` on the delivery server. The auth split is wired against the **actual current path/topology** (delivery server left unwrapped). The full `fleet_id`/hash URL registry is a separate design step and is intentionally not implemented here — this PR only ensures delegatedadmin does not wrap the webhook path.

## Private-bind default

`--graphql-addr` now defaults to loopback `127.0.0.1:9093` (was empty/disabled), mirroring codellm's `DefaultAddr` loopback default. Exposure off-box is an explicit operator opt-in behind Caddy `/_fleet/*` as the sole ingress. Flag help updated to state the delegated-admin gate and the Caddy-fronting expectation.

## Integration test evidence (`cmd/fleet/main_auth_test.go`)

Tests build the real handler via `newFleetGraphQLHandler` against a fake monolith `POST /_system/graphql` returning `viewer{role}` (same technique as #229's middleware tests):

```
--- PASS: TestGraphQLServerRejectsUnauthenticated  (no cookie -> 401)
--- PASS: TestGraphQLServerAllowsAdmin              (admin cookie -> 200, query runs)
--- PASS: TestGraphQLServerRejectsNonAdmin          (USER/GUEST -> 401)
--- PASS: TestGraphQLServerGatesEntireMux           (non-/graphql path -> 401: whole mux gated)
--- PASS: TestWebhookDeliveryNotCookieGated         (delivery mux reached without a cookie)
```

Verification:
- `go build -tags dev ./...` → pass
- `go vet -tags dev ./...` → pass
- `go test ./cmd/fleet/... ./internal/fleet/... ./internal/delegatedadmin/...` → all `ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update: security-review follow-up (APPROVE + 1 LOW hardening applied)

Security review of this PR came back **APPROVE** (gate genuinely closed). One LOW item was applied before merge:

- **Warn on non-loopback `--graphql-addr` bind.** Unlike `--graph-addr`/`--debug-listen` (which hard-enforce loopback), `--graphql-addr` accepts `0.0.0.0`/any host with no signal. Added `warnIfGraphQLAddrNonLoopback` in `cmd/fleet/main.go`, called right after the GraphQL server config is read in `run()`. It does **not** hard-block — a remote-fleet-behind-its-own-Caddy topology is legitimate and the delegated-admin gate still authenticates every request — but it logs a loud `Warn` so the operator sees the exposure: `"fleet GraphQL bound non-loopback; ensure Caddy is the sole ingress + delegated-admin gate"`.
- Covered by a new table-driven unit test (`TestWarnIfGraphQLAddrNonLoopback` in `cmd/fleet/main_auth_test.go`): loopback/localhost/`::1` → no warning; `:9093`, `0.0.0.0:9093`, a LAN IP → warning logged with the addr in the fields.

A second suggested item (refactoring the webhook delivery mux into `newDeliveryHandler` for a "real" HMAC-based delivery test) was explicitly descoped by the repo owner — `internal/fleet/handler_test.go` already has direct HMAC coverage of `ServeDelivery`, and the existing `TestWebhookDeliveryNotCookieGated` stub was left as-is.

Verification (same scope as before):
- `go build -tags dev ./cmd/fleet/... ./internal/fleet/... ./internal/delegatedadmin/...` → pass
- `go vet -tags dev ./cmd/fleet/... ./internal/fleet/... ./internal/delegatedadmin/...` → pass
- `go test ./cmd/fleet/... ./internal/fleet/... ./internal/delegatedadmin/...` → all `ok`
