### PR TITLE
fix(admin): wire SignOut button to inherited signout

### DIFF
--- a/assets/ui/admin/admin.view.tree
+++ b/assets/ui/admin/admin.view.tree
@@ -4,7 +4,8 @@ $trip2g_admin $trip2g_auth
 		- ProfileEmail <= ProfileInfo $trip2g_admin_cell
 			content <= me_user_email
 		SignOutButton <= SignOut $mol_button_major
-			click? <=> signout? null
+			title \Sign out
+			click? <=> signout?
 
 $trip2g_admin_app $trip2g_admin_catalog
 	param \nav

--- a/assets/ui/admin/admin.view.ts
+++ b/assets/ui/admin/admin.view.ts
@@ -1,5 +1,8 @@
 namespace $.$$ {
 	export class $trip2g_admin extends $.$trip2g_admin {
+		override signout() {
+			super.signout()
+		}
 	}
 
 	export class $trip2g_admin_app extends $.$trip2g_admin_app {


### PR DESCRIPTION
## Summary
- Admin panel's SignOut button click bound to `signout? null` in `admin.view.tree`, which made $mol codegen emit a `signout()` stub returning `null` on `$trip2g_admin_app` that shadowed the real inherited `signout()` from `$trip2g_auth` (which fires the `signOut` GraphQL mutation). Result: click did nothing — no network request, no error.
- Mirrors the working sibling `user/space` (`space.view.tree`/`space.view.ts`), which uses the same pattern without the `null` stub.

## Changes
- `assets/ui/admin/admin.view.tree`: drop the trailing `null` on `click? <=> signout?` for the AppView-level `SignOutButton` override (this override lives in `$trip2g_admin`, the only place that inherits `signout` from `$trip2g_auth` — the button's actual field definition lives in `$trip2g_admin_app`, which has no `signout`, so the override can't be moved there). Re-added `title \Sign out` on that override so the rendered (major) button keeps its label, since it fully shadows the minor-styled field definition in `$trip2g_admin_app`.
- `assets/ui/admin/admin.view.ts`: added `override signout() { super.signout() }` on `$trip2g_admin`, matching `space.view.ts`.

## Bundle status
The `.view.tree`/`.view.ts` sources compile to `assets/ui/{admin,user,forms}/-/web.js` via a Docker-based `$mol` build stage (see `Dockerfile` `frontend` target and `.github/workflows/release-binaries.yml`), and those bundle files are **not tracked in git** (confirmed via `git ls-files` / `git check-ignore` — no gitignore entry needed since they're simply never committed; only two stray locale JSON files under `user/-/` and `editor/-/` are tracked, unrelated to this change). This is a source-only fix; the bundle regenerates automatically on the next Docker/release build. No follow-up step needed.

I did verify the fix compiles cleanly through the real `$mol` build tool by running `docker build --target frontend` locally: before the fix it failed the mol build's own TS audit with `admin.view.tree.d.ts(32,33): error TS2339: Property 'signout' does not exist on type '$trip2g_admin_app'` (confirming why the click binding must stay in `$trip2g_admin`, not `$trip2g_admin_app`); after the fix the build completed successfully with `web.js` emitted for the admin bundle. I did not commit the built artifacts (not part of this repo's workflow).

## Test plan
- [x] `docker build --target frontend` (mirrors CI's frontend stage) builds `trip2g/admin` cleanly, including the mol TS audit, with the fix applied
- [ ] Orchestrator to verify live: click SignOut in admin panel fires the `signOut` GraphQL mutation and logs the user out