### PR TITLE
chore(lint): clear accumulated golangci warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ db-down:
 
 lint:
 	./internal/db/list_queries.sh
-	go tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint run
+	go tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint run --build-tags dev
 
 check-doc-links:
 	./scripts/check-doc-lang-links.sh

--- a/cmd/codellm/main.go
+++ b/cmd/codellm/main.go
@@ -59,7 +59,7 @@ func main() {
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 	log.Printf("codellm listening on %s (sandbox=%s, programs=%v)", cfg.Addr, cfg.Sandbox, cfg.AllowedPrograms)
-	if err := srv.ListenAndServe(); err != nil {
+	if err = srv.ListenAndServe(); err != nil {
 		log.Fatalf("codellm: server error: %v", err)
 	}
 }

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -32,6 +32,8 @@ import (
 	"trip2g/internal/fleet/graph"
 	"trip2g/internal/logger"
 	"trip2g/internal/zerologger"
+
+	"github.com/Khan/genqlient/graphql"
 )
 
 func main() {
@@ -77,7 +79,7 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	if err := cli.appCfg.Validate(); err != nil {
+	if err = cli.appCfg.Validate(); err != nil {
 		return fmt.Errorf("fleet: invalid config: %w", err)
 	}
 
@@ -99,23 +101,12 @@ func run() error {
 
 	reconciler := fleet.NewReconciler(adminGQL, cli.cfg)
 
-	// --graph-addr: localhost-only debug surface serving the dependency graph
-	// (GET / = UI, GET /graph.json = machine JSON). Internal introspection
-	// tool — refuse anything but a loopback bind, and never mount it on the
-	// public delivery listener.
-	var graphSrv *http.Server
-	if cli.graphAddr != "" {
-		if lerr := validateLoopbackAddr(cli.graphAddr); lerr != nil {
-			return fmt.Errorf("--graph-addr: %w", lerr)
-		}
-		gs := graph.NewServer(discovery, adminGQL, cli.cfg)
-		graphSrv = &http.Server{Addr: cli.graphAddr, Handler: gs.Handler(), ReadHeaderTimeout: 10 * time.Second}
-		go func() {
-			lg.Info("fleet graph debug UI listening", "addr", cli.graphAddr)
-			if gerr := graphSrv.ListenAndServe(); gerr != nil && gerr != http.ErrServerClosed {
-				lg.Error("graph debug server failed", "err", gerr)
-			}
-		}()
+	// --graph-addr: localhost-only debug surface serving the dependency graph.
+	graphSrv, err := startGraphDebugServer(lg, discovery, adminGQL, cli)
+	if err != nil {
+		return err
+	}
+	if graphSrv != nil {
 		defer func() { _ = graphSrv.Close() }()
 	}
 
@@ -126,20 +117,11 @@ func run() error {
 	// monolith-unreachable -> fail-closed). This is a separate server from the
 	// webhook delivery listener (cli.cfg.ListenAddr, /deliver/, HMAC-authed), so
 	// the cookie gate never touches the monolith->fleet delivery path.
-	var graphqlSrv *http.Server
-	if cli.appCfg.GraphQLAddr != "" {
-		warnIfGraphQLAddrNonLoopback(lg, cli.appCfg.GraphQLAddr)
-		gqlMux, gErr := newFleetGraphQLHandler(discovery, cli.cfg.Trip2gBaseURL)
-		if gErr != nil {
-			return fmt.Errorf("fleet: graphql auth: %w", gErr)
-		}
-		graphqlSrv = &http.Server{Addr: cli.appCfg.GraphQLAddr, Handler: gqlMux, ReadHeaderTimeout: 10 * time.Second}
-		go func() {
-			lg.Info("fleet GraphQL API listening", "addr", cli.appCfg.GraphQLAddr)
-			if gerr := graphqlSrv.ListenAndServe(); gerr != nil && gerr != http.ErrServerClosed {
-				lg.Error("graphql server failed", "err", gerr)
-			}
-		}()
+	graphqlSrv, err := startFleetGraphQLServer(lg, discovery, cli)
+	if err != nil {
+		return err
+	}
+	if graphqlSrv != nil {
 		defer func() { _ = graphqlSrv.Close() }()
 	}
 
@@ -155,20 +137,7 @@ func run() error {
 	srv := &http.Server{Addr: cli.cfg.ListenAddr, Handler: mux, ReadHeaderTimeout: 10 * time.Second}
 
 	// Optional loopback-only debug surface for step-by-step code-block runs.
-	// Separate server on a separate addr — never mounted on the public mux.
-	// validateConfig already rejected non-loopback addresses.
-	if cli.cfg.DebugListenAddr != "" {
-		dbgSrv := &http.Server{
-			Addr:              cli.cfg.DebugListenAddr,
-			Handler:           f.DebugHandler(),
-			ReadHeaderTimeout: 10 * time.Second,
-		}
-		go func() {
-			lg.Info("fleet debug listening (loopback only)", "addr", cli.cfg.DebugListenAddr)
-			if dbgErr := dbgSrv.ListenAndServe(); dbgErr != nil && dbgErr != http.ErrServerClosed {
-				lg.Error("debug server", "err", dbgErr)
-			}
-		}()
+	if dbgSrv := startDebugServer(lg, f, cli); dbgSrv != nil {
 		defer func() { _ = dbgSrv.Close() }()
 	}
 
@@ -203,6 +172,80 @@ func run() error {
 			syncOnce(ctx, lg, f, discovery, reconciler)
 		}
 	}
+}
+
+// startGraphDebugServer starts the localhost-only dependency-graph debug UI
+// (GET / = UI, GET /graph.json = machine JSON) when --graph-addr is set. It is
+// an internal introspection tool, so a non-loopback bind is refused. Returns
+// nil when disabled; the caller owns Close via defer.
+func startGraphDebugServer(
+	lg logger.Logger,
+	discovery *fleet.Discovery,
+	adminGQL graphql.Client,
+	cli cliFlags,
+) (*http.Server, error) {
+	if cli.graphAddr == "" {
+		return nil, nil
+	}
+	if err := validateLoopbackAddr(cli.graphAddr); err != nil {
+		return nil, fmt.Errorf("--graph-addr: %w", err)
+	}
+	gs := graph.NewServer(discovery, adminGQL, cli.cfg)
+	srv := &http.Server{Addr: cli.graphAddr, Handler: gs.Handler(), ReadHeaderTimeout: 10 * time.Second}
+	go func() {
+		lg.Info("fleet graph debug UI listening", "addr", cli.graphAddr)
+		if gerr := srv.ListenAndServe(); gerr != nil && gerr != http.ErrServerClosed {
+			lg.Error("graph debug server failed", "err", gerr)
+		}
+	}()
+	return srv, nil
+}
+
+// startFleetGraphQLServer starts the fleet's own GraphQL read API (roles +
+// roleGraph) when --graphql-addr is set. The entire mux is gated by the
+// delegated-admin middleware. Returns nil when disabled; the caller owns Close.
+func startFleetGraphQLServer(
+	lg logger.Logger,
+	discovery *fleet.Discovery,
+	cli cliFlags,
+) (*http.Server, error) {
+	if cli.appCfg.GraphQLAddr == "" {
+		return nil, nil
+	}
+	warnIfGraphQLAddrNonLoopback(lg, cli.appCfg.GraphQLAddr)
+	gqlMux, err := newFleetGraphQLHandler(discovery, cli.cfg.Trip2gBaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("fleet: graphql auth: %w", err)
+	}
+	srv := &http.Server{Addr: cli.appCfg.GraphQLAddr, Handler: gqlMux, ReadHeaderTimeout: 10 * time.Second}
+	go func() {
+		lg.Info("fleet GraphQL API listening", "addr", cli.appCfg.GraphQLAddr)
+		if gerr := srv.ListenAndServe(); gerr != nil && gerr != http.ErrServerClosed {
+			lg.Error("graphql server failed", "err", gerr)
+		}
+	}()
+	return srv, nil
+}
+
+// startDebugServer starts the loopback-only step-by-step code-block debug
+// surface when DebugListenAddr is set (validateConfig already rejected
+// non-loopback addresses). Returns nil when disabled; the caller owns Close.
+func startDebugServer(lg logger.Logger, f *fleet.Fleet, cli cliFlags) *http.Server {
+	if cli.cfg.DebugListenAddr == "" {
+		return nil
+	}
+	srv := &http.Server{
+		Addr:              cli.cfg.DebugListenAddr,
+		Handler:           f.DebugHandler(),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	go func() {
+		lg.Info("fleet debug listening (loopback only)", "addr", cli.cfg.DebugListenAddr)
+		if dbgErr := srv.ListenAndServe(); dbgErr != nil && dbgErr != http.ErrServerClosed {
+			lg.Error("debug server", "err", dbgErr)
+		}
+	}()
+	return srv
 }
 
 // newFleetGraphQLHandler builds the fleet GraphQL server's HTTP handler: a mux

--- a/cmd/fleet/main_auth_test.go
+++ b/cmd/fleet/main_auth_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"trip2g/internal/fleet"
@@ -24,7 +25,7 @@ func (s authFakeSource) DiscoverParsed(context.Context) ([]fleet.Role, []error) 
 func fakeMonolith(t *testing.T, role string) *httptest.Server {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/_system/graphql", r.URL.Path)
+		assert.Equal(t, "/_system/graphql", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"viewer":{"role":"` + role + `"}}}`))
 	}))

--- a/internal/agentruntime/runcode.go
+++ b/internal/agentruntime/runcode.go
@@ -157,42 +157,12 @@ func runCodeBlocksCore(ctx context.Context, in CodeInput, capture bool) (codeRun
 	var stdout string
 	var debug []BlockDebug
 	if len(blocks) == 1 {
-		// Single block: use RunBlock for byte-identical behavior.
-		out, _, _, runErr := RunBlock(ctx, CodeSpec{
-			Program:        programs[0],
-			Code:           blocks[0].Code,
-			Input:          in.Input,
-			Timeout:        in.Timeout,
-			EnvPassthrough: in.EnvPassthrough,
-			EnvPrefix:      in.EnvPrefix,
-			MaxStdoutBytes: limit,
-			Sandbox:        in.Sandbox,
-		})
-		if runErr != nil {
-			return codeRunResult{}, fmt.Errorf("coderun: %w", runErr)
-		}
-		stdout = out
-		if capture {
-			debug = []BlockDebug{{Index: 0, Stdout: out}}
-		}
+		stdout, debug, err = runSingleBlock(ctx, blocks[0], programs[0], in, limit, capture)
 	} else {
-		// Multi-block: true streaming pipeline. In debug mode, allocate a tap per
-		// inter-block edge so wirePipeline tees each block's stdout into it.
-		var taps pipelineDebugTaps
-		if capture {
-			taps = make(pipelineDebugTaps, len(blocks)-1)
-			for i := range taps {
-				taps[i] = &limitedBuffer{limit: limit}
-			}
-		}
-		out, pipeErr := runPipeline(ctx, blocks, programs, in, limit, taps)
-		if pipeErr != nil {
-			return codeRunResult{}, pipeErr
-		}
-		stdout = out
-		if capture {
-			debug = buildBlockDebug(taps, out, len(blocks))
-		}
+		stdout, debug, err = runMultiBlock(ctx, blocks, programs, in, limit, capture)
+	}
+	if err != nil {
+		return codeRunResult{}, err
 	}
 
 	rawChanges, answer, perr := parseCodeOutput(stdout)
@@ -200,6 +170,55 @@ func runCodeBlocksCore(ctx context.Context, in CodeInput, capture bool) (codeRun
 		return codeRunResult{}, perr
 	}
 	return codeRunResult{Changes: rawChanges, Answer: answer, Steps: len(blocks), Debug: debug}, nil
+}
+
+// runSingleBlock runs exactly one fenced block via RunBlock for byte-identical
+// behavior with the legacy single-block path. debug is non-nil only when capture.
+func runSingleBlock(
+	ctx context.Context, block FencedBlock, program string, in CodeInput, limit int, capture bool,
+) (string, []BlockDebug, error) {
+	out, _, _, runErr := RunBlock(ctx, CodeSpec{
+		Program:        program,
+		Code:           block.Code,
+		Input:          in.Input,
+		Timeout:        in.Timeout,
+		EnvPassthrough: in.EnvPassthrough,
+		EnvPrefix:      in.EnvPrefix,
+		MaxStdoutBytes: limit,
+		Sandbox:        in.Sandbox,
+	})
+	if runErr != nil {
+		return "", nil, fmt.Errorf("coderun: %w", runErr)
+	}
+	var debug []BlockDebug
+	if capture {
+		debug = []BlockDebug{{Index: 0, Stdout: out}}
+	}
+	return out, debug, nil
+}
+
+// runMultiBlock runs 2+ blocks through the streaming pipeline. In debug mode it
+// allocates a tap per inter-block edge so wirePipeline tees each block's stdout
+// into it. debug is non-nil only when capture.
+func runMultiBlock(
+	ctx context.Context, blocks []FencedBlock, programs []string, in CodeInput, limit int, capture bool,
+) (string, []BlockDebug, error) {
+	var taps pipelineDebugTaps
+	if capture {
+		taps = make(pipelineDebugTaps, len(blocks)-1)
+		for i := range taps {
+			taps[i] = &limitedBuffer{limit: limit}
+		}
+	}
+	out, pipeErr := runPipeline(ctx, blocks, programs, in, limit, taps)
+	if pipeErr != nil {
+		return "", nil, pipeErr
+	}
+	var debug []BlockDebug
+	if capture {
+		debug = buildBlockDebug(taps, out, len(blocks))
+	}
+	return out, debug, nil
 }
 
 // buildBlockDebug assembles per-block debug from the captured inter-block taps

--- a/internal/assetindex/assetindex_test.go
+++ b/internal/assetindex/assetindex_test.go
@@ -19,7 +19,8 @@ func (e *testEnv) LiveNoteViews() *model.NoteViews { return e.nvs }
 func (e *testEnv) Layouts() *model.Layouts         { return e.layouts }
 func (e *testEnv) AssetIndexGeneration() uint64    { return e.generation }
 
-func noteWithAsset(path, hash, fileName string, free bool) *model.NoteView {
+func noteWithAsset(path, fileName string, free bool) *model.NoteView {
+	const hash = "h1"
 	return &model.NoteView{
 		Path: path,
 		Free: free,
@@ -34,7 +35,7 @@ func views(notes ...*model.NoteView) *model.NoteViews {
 }
 
 func TestAssetOwnership_PublicViaFreeNote(t *testing.T) {
-	env := &testEnv{nvs: views(noteWithAsset("post.md", "h1", "img.png", true))}
+	env := &testEnv{nvs: views(noteWithAsset("post.md", "img.png", true))}
 	idx := assetindex.New(env)
 
 	own, ok := idx.AssetOwnership("h1", "img.png")
@@ -44,7 +45,7 @@ func TestAssetOwnership_PublicViaFreeNote(t *testing.T) {
 }
 
 func TestAssetOwnership_PrivateViaPaidNote(t *testing.T) {
-	env := &testEnv{nvs: views(noteWithAsset("post.md", "h1", "img.png", false))}
+	env := &testEnv{nvs: views(noteWithAsset("post.md", "img.png", false))}
 	idx := assetindex.New(env)
 
 	own, ok := idx.AssetOwnership("h1", "img.png")
@@ -54,7 +55,7 @@ func TestAssetOwnership_PrivateViaPaidNote(t *testing.T) {
 }
 
 func TestAssetOwnership_FreeNoteInSigninSubgraphIsNotPublic(t *testing.T) {
-	note := noteWithAsset("post.md", "h1", "img.png", true)
+	note := noteWithAsset("post.md", "img.png", true)
 	note.Subgraphs = map[string]*model.NoteSubgraph{"members": {RequireSignin: true}}
 	idx := assetindex.New(&testEnv{nvs: views(note)})
 
@@ -65,8 +66,8 @@ func TestAssetOwnership_FreeNoteInSigninSubgraphIsNotPublic(t *testing.T) {
 
 func TestAssetOwnership_SharedAssetPublicIfAnyOwnerIsFree(t *testing.T) {
 	env := &testEnv{nvs: views(
-		noteWithAsset("paid.md", "h1", "img.png", false),
-		noteWithAsset("free.md", "h1", "img.png", true),
+		noteWithAsset("paid.md", "img.png", false),
+		noteWithAsset("free.md", "img.png", true),
 	)}
 	idx := assetindex.New(env)
 
@@ -104,7 +105,7 @@ func TestAssetOwnership_UnknownHash(t *testing.T) {
 // publicness must not bleed onto a private sibling row that merely shares
 // the hash.
 func TestAssetOwnership_SameHashDifferentFileNameIsIndependent(t *testing.T) {
-	publicNote := noteWithAsset("free.md", "h1", "public.png", true)
+	publicNote := noteWithAsset("free.md", "public.png", true)
 	privateNote := &model.NoteView{
 		Path: "paid.md",
 		Free: false,
@@ -131,7 +132,7 @@ func TestAssetOwnership_SameHashDifferentFileNameIsIndependent(t *testing.T) {
 // current generation — it self-checks env.AssetIndexGeneration() on every
 // call instead of relying on an explicit invalidation call.
 func TestAssetOwnership_StaleGenerationTriggersRebuild(t *testing.T) {
-	env := &testEnv{nvs: views(noteWithAsset("post.md", "h1", "img.png", true)), generation: 1}
+	env := &testEnv{nvs: views(noteWithAsset("post.md", "img.png", true)), generation: 1}
 	idx := assetindex.New(env)
 
 	own, ok := idx.AssetOwnership("h1", "img.png")
@@ -141,7 +142,7 @@ func TestAssetOwnership_StaleGenerationTriggersRebuild(t *testing.T) {
 	// Simulate a reload that flips the note free -> paid, publishing a new
 	// snapshot AND bumping the generation atomically (as noteloader.Loader
 	// does) — no explicit invalidation call.
-	env.nvs = views(noteWithAsset("post.md", "h1", "img.png", false))
+	env.nvs = views(noteWithAsset("post.md", "img.png", false))
 	env.generation = 2
 
 	own, ok = idx.AssetOwnership("h1", "img.png")
@@ -154,7 +155,7 @@ func TestAssetOwnership_StaleGenerationTriggersRebuild(t *testing.T) {
 // so a stable snapshot doesn't pay the rebuild cost per request.
 func TestAssetOwnership_SameGenerationServesCachedIndex(t *testing.T) {
 	calls := 0
-	env := &countingEnv{testEnv: testEnv{nvs: views(noteWithAsset("post.md", "h1", "img.png", true)), generation: 1}, calls: &calls}
+	env := &countingEnv{testEnv: testEnv{nvs: views(noteWithAsset("post.md", "img.png", true)), generation: 1}, calls: &calls}
 	idx := assetindex.New(env)
 
 	_, _ = idx.AssetOwnership("h1", "img.png")

--- a/internal/case/serveasset/resolve.go
+++ b/internal/case/serveasset/resolve.go
@@ -20,6 +20,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/valyala/fasthttp"
+
 	"trip2g/internal/appreq"
 	"trip2g/internal/assetindex"
 	"trip2g/internal/db"
@@ -54,7 +56,7 @@ func Handle(req *appreq.Request) bool {
 		return false
 	}
 
-	env := req.Env.(Env)
+	env, _ := req.Env.(Env)
 	ctx := req.Req
 
 	if !ctx.IsGet() && !ctx.IsHead() {
@@ -93,33 +95,8 @@ func Handle(req *appreq.Request) bool {
 	ownership, known := env.AssetOwnership(hash, fileName)
 	public := known && ownership.Public
 
-	if !public {
-		token, tokenErr := req.UserToken()
-		if tokenErr != nil || token == nil {
-			ctx.SetStatusCode(http.StatusUnauthorized)
-			ctx.SetBodyString("401 Unauthorized")
-			return true
-		}
-
-		allowed := token.IsAdmin()
-		for _, note := range ownership.Notes {
-			if allowed {
-				break
-			}
-			canRead, readErr := env.CanReadNote(ctx, note)
-			if readErr != nil {
-				env.Logger().Error("serveasset: access check failed", "hash", hash, "error", readErr)
-				ctx.SetStatusCode(http.StatusInternalServerError)
-				return true
-			}
-			allowed = canRead
-		}
-
-		if !allowed {
-			ctx.SetStatusCode(http.StatusForbidden)
-			ctx.SetBodyString("403 Forbidden")
-			return true
-		}
+	if !public && enforceAccess(req, env, ownership, hash) {
+		return true
 	}
 
 	h := &ctx.Response.Header
@@ -139,21 +116,9 @@ func Handle(req *appreq.Request) bool {
 
 	ctx.SetContentType(contentType(fileName))
 
-	offset, length := int64(0), asset.Size
-	status := http.StatusOK
-
-	if rangeHdr := string(ctx.Request.Header.Peek(fasthttpRangeHeader)); rangeHdr != "" {
-		start, end, satisfiable, applied := parseRange(rangeHdr, asset.Size)
-		if !satisfiable {
-			h.Set("Content-Range", fmt.Sprintf("bytes */%d", asset.Size))
-			ctx.SetStatusCode(http.StatusRequestedRangeNotSatisfiable)
-			return true
-		}
-		if applied {
-			offset, length = start, end-start+1
-			status = http.StatusPartialContent
-			h.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, asset.Size))
-		}
+	offset, length, status, handled := resolveRange(ctx, h, asset)
+	if handled {
+		return true
 	}
 
 	ctx.SetStatusCode(status)
@@ -174,6 +139,70 @@ func Handle(req *appreq.Request) bool {
 	return true
 }
 
+// enforceAccess applies the non-public access rules. It returns true when it
+// has written a 401/403/500 response and the caller must stop; false when the
+// requester is allowed to read the asset.
+func enforceAccess(req *appreq.Request, env Env, ownership assetindex.Ownership, hash string) bool {
+	ctx := req.Req
+
+	token, tokenErr := req.UserToken()
+	if tokenErr != nil || token == nil {
+		ctx.SetStatusCode(http.StatusUnauthorized)
+		ctx.SetBodyString("401 Unauthorized")
+		return true
+	}
+
+	allowed := token.IsAdmin()
+	for _, note := range ownership.Notes {
+		if allowed {
+			break
+		}
+		canRead, readErr := env.CanReadNote(ctx, note)
+		if readErr != nil {
+			env.Logger().Error("serveasset: access check failed", "hash", hash, "error", readErr)
+			ctx.SetStatusCode(http.StatusInternalServerError)
+			return true
+		}
+		allowed = canRead
+	}
+
+	if !allowed {
+		ctx.SetStatusCode(http.StatusForbidden)
+		ctx.SetBodyString("403 Forbidden")
+		return true
+	}
+
+	return false
+}
+
+// resolveRange applies a Range header (if any) to asset, setting Content-Range
+// headers as needed. It returns the byte offset/length to stream, the response
+// status code, and handled=true when a 416 response was already written and the
+// caller must stop.
+func resolveRange(ctx *fasthttp.RequestCtx, h *fasthttp.ResponseHeader, asset *db.NoteAsset) (int64, int64, int, bool) {
+	offset, length := int64(0), asset.Size
+	status := http.StatusOK
+
+	rangeHdr := string(ctx.Request.Header.Peek(fasthttpRangeHeader))
+	if rangeHdr == "" {
+		return offset, length, status, false
+	}
+
+	start, end, satisfiable, applied := parseRange(rangeHdr, asset.Size)
+	if !satisfiable {
+		h.Set("Content-Range", fmt.Sprintf("bytes */%d", asset.Size))
+		ctx.SetStatusCode(http.StatusRequestedRangeNotSatisfiable)
+		return 0, 0, 0, true
+	}
+	if applied {
+		offset, length = start, end-start+1
+		status = http.StatusPartialContent
+		h.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, asset.Size))
+	}
+
+	return offset, length, status, false
+}
+
 const fasthttpRangeHeader = "Range"
 
 func notFound(ctx interface {
@@ -186,13 +215,13 @@ func notFound(ctx interface {
 
 // parsePath splits "/_system/assets/{sha256}/{fileName}" and validates the
 // hash (64 lowercase-insensitive hex chars) and fileName (single segment).
-func parsePath(path string) (hash, fileName string, ok bool) {
+func parsePath(path string) (string, string, bool) {
 	rest := path[len(model.AssetRoutePrefix):]
 	slash := strings.IndexByte(rest, '/')
 	if slash < 0 {
 		return "", "", false
 	}
-	hash, fileName = rest[:slash], rest[slash+1:]
+	hash, fileName := rest[:slash], rest[slash+1:]
 	if len(hash) != 64 || !isHex(hash) {
 		return "", "", false
 	}
@@ -203,7 +232,7 @@ func parsePath(path string) (hash, fileName string, ok bool) {
 }
 
 func isHex(s string) bool {
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		c := s[i]
 		if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
 			return false
@@ -223,7 +252,7 @@ func contentType(fileName string) string {
 // applied=false with satisfiable=true means the header should be ignored
 // (multi-range or malformed) and the full body served with 200.
 // satisfiable=false means respond 416.
-func parseRange(header string, size int64) (start, end int64, satisfiable, applied bool) {
+func parseRange(header string, size int64) (int64, int64, bool, bool) {
 	spec, found := strings.CutPrefix(header, "bytes=")
 	if !found || strings.Contains(spec, ",") {
 		return 0, 0, true, false // ignore: not a byte range / multi-range

--- a/internal/codellm/auth_integration_test.go
+++ b/internal/codellm/auth_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	goopenai "github.com/sashabaranov/go-openai"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"trip2g/internal/agentruntime"
@@ -20,7 +21,7 @@ import (
 func fakeMonolith(t *testing.T, role string) *httptest.Server {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/_system/graphql", r.URL.Path)
+		assert.Equal(t, "/_system/graphql", r.URL.Path)
 		_, _ = io.Copy(io.Discard, r.Body)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"viewer":{"role":"` + role + `"}}}`))

--- a/internal/codellm/server.go
+++ b/internal/codellm/server.go
@@ -152,7 +152,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req goopenai.ChatCompletionRequest
-	if err := json.Unmarshal(raw, &req); err != nil {
+	if err = json.Unmarshal(raw, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid_request_error", "decode request: "+err.Error())
 		return
 	}
@@ -247,8 +247,9 @@ func toDebugBlocks(blocks []agentruntime.BlockDebug) []fleetDebugBlock {
 // code (everything except the reserved fleet_input message) into the body to
 // scan, and returns the fleet_input message content as the delivery bag. The
 // system-prompt wrapper has no fences, so only the role body's blocks are found.
-func extractBodyAndBag(messages []goopenai.ChatCompletionMessage) (body string, bag []byte) {
+func extractBodyAndBag(messages []goopenai.ChatCompletionMessage) (string, []byte) {
 	var sb strings.Builder
+	var bag []byte
 	for _, m := range messages {
 		if m.Name == fleetInputMessageName {
 			bag = []byte(m.Content)
@@ -309,7 +310,7 @@ func buildResponse(model string, changes []webhookutil.AgentChange, answer strin
 }
 
 // changeToToolCall maps one AgentChange to a tool name and JSON arguments.
-func changeToToolCall(ch webhookutil.AgentChange) (name, args string) {
+func changeToToolCall(ch webhookutil.AgentChange) (string, string) {
 	if ch.Kind == webhookutil.AgentChangeKindPatch {
 		return "patch_note", mustJSON(map[string]string{
 			"path":    ch.Path,

--- a/internal/codellm/server_debug_test.go
+++ b/internal/codellm/server_debug_test.go
@@ -121,7 +121,10 @@ func TestBrowserAuth_TokenLaneBypass(t *testing.T) {
 	require.Equal(t, http.StatusUnauthorized, rec.Code)
 
 	// With the channel token → fleet lane bypass → served.
-	body, _ := json.Marshal(goopenai.ChatCompletionRequest{Model: "codellm", Messages: []goopenai.ChatCompletionMessage{bashBody(`echo '{"changes":[],"answer":"ok"}'`)}})
+	body, _ := json.Marshal(goopenai.ChatCompletionRequest{
+		Model:    "codellm",
+		Messages: []goopenai.ChatCompletionMessage{bashBody(`echo '{"changes":[],"answer":"ok"}'`)},
+	})
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
 	req.Header.Set("X-Channel-Token", "secret")
 	rec = httptest.NewRecorder()
@@ -129,8 +132,8 @@ func TestBrowserAuth_TokenLaneBypass(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
 }
 
-var errAuth = &authErr{}
+var errAuth = &authError{}
 
-type authErr struct{}
+type authError struct{}
 
-func (*authErr) Error() string { return "no token" }
+func (*authError) Error() string { return "no token" }

--- a/internal/codellm/server_test.go
+++ b/internal/codellm/server_test.go
@@ -114,7 +114,9 @@ func TestChatCompletions_PatchNote(t *testing.T) {
 	require.Len(t, calls, 2)
 	require.Equal(t, "patch_note", calls[0].Function.Name)
 	var pargs struct {
-		Path, Find, Replace string
+		Path    string `json:"path"`
+		Find    string `json:"find"`
+		Replace string `json:"replace"`
 	}
 	require.NoError(t, json.Unmarshal([]byte(calls[0].Function.Arguments), &pargs))
 	require.Equal(t, "index.md", pargs.Path)
@@ -136,7 +138,7 @@ func TestChatCompletions_AlwaysFinish_EmptyAnswer(t *testing.T) {
 	calls := resp.Choices[0].Message.ToolCalls
 	require.Len(t, calls, 1, "no changes → only the mandatory finish")
 	require.Equal(t, "finish", calls[0].Function.Name)
-	require.Equal(t, "", finishArgs(t, calls))
+	require.Empty(t, finishArgs(t, calls))
 }
 
 // TestEveryCompletionEndsWithFinish asserts the always-finish invariant across a
@@ -213,7 +215,7 @@ func TestExtractBodyAndBag(t *testing.T) {
 	require.Contains(t, body, "role body")
 	require.Contains(t, body, "Begin.")
 	require.NotContains(t, body, "changed_files", "fleet_input must not be scanned for code")
-	require.Equal(t, `{"changed_files":[]}`, string(bag))
+	require.JSONEq(t, `{"changed_files":[]}`, string(bag))
 }
 
 func TestModelsAndHealthz(t *testing.T) {

--- a/internal/delegatedadmin/delegatedadmin.go
+++ b/internal/delegatedadmin/delegatedadmin.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -71,7 +72,7 @@ type Middleware struct {
 // New builds a Middleware. MonolithBaseURL must be non-empty.
 func New(cfg Config) (*Middleware, error) {
 	if cfg.MonolithBaseURL == "" {
-		return nil, fmt.Errorf("delegatedadmin: MonolithBaseURL is required")
+		return nil, errors.New("delegatedadmin: MonolithBaseURL is required")
 	}
 	client := cfg.HTTPClient
 	if client == nil {
@@ -160,7 +161,7 @@ func (m *Middleware) fetchViewerRole(ctx context.Context, cookieHeader string) (
 	}
 
 	var parsed viewerRoleResponse
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+	if err = json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
 		return "", err
 	}
 	if len(parsed.Errors) > 0 {

--- a/internal/fleet/fleetgql/http_test.go
+++ b/internal/fleet/fleetgql/http_test.go
@@ -57,11 +57,13 @@ func TestHandlerRoles(t *testing.T) {
 	data := post(t, h, `{ roles { name path executor model triggerInclude writePatterns } }`)
 	var got struct {
 		Roles []struct {
-			Name, Path, Executor string
-			Model                *string
-			TriggerInclude       []string
-			WritePatterns        []string
-		}
+			Name           string   `json:"name"`
+			Path           string   `json:"path"`
+			Executor       string   `json:"executor"`
+			Model          *string  `json:"model"`
+			TriggerInclude []string `json:"triggerInclude"`
+			WritePatterns  []string `json:"writePatterns"`
+		} `json:"Roles"`
 	}
 	require.NoError(t, json.Unmarshal([]byte(`{"Roles":`+string(data["roles"])+`}`), &got))
 	require.Len(t, got.Roles, 2)
@@ -92,18 +94,21 @@ func TestHandlerRoleGraph(t *testing.T) {
 	var got struct {
 		RoleGraph struct {
 			Nodes []struct {
-				Role                  string
-				InboxGlob, OutboxGlob []string
-				Orphan                bool
-			}
+				Role       string   `json:"role"`
+				InboxGlob  []string `json:"inboxGlob"`
+				OutboxGlob []string `json:"outboxGlob"`
+				Orphan     bool     `json:"orphan"`
+			} `json:"nodes"`
 			Edges []struct {
-				From, To, Kind string
-				Exact          bool
-				CutByDepth     bool
-			}
-			Cycles      [][]string
-			ParseErrors []string
-		}
+				From       string `json:"from"`
+				To         string `json:"to"`
+				Kind       string `json:"kind"`
+				Exact      bool   `json:"exact"`
+				CutByDepth bool   `json:"cutByDepth"`
+			} `json:"edges"`
+			Cycles      [][]string `json:"cycles"`
+			ParseErrors []string   `json:"parseErrors"`
+		} `json:"RoleGraph"`
 	}
 	require.NoError(t, json.Unmarshal([]byte(`{"RoleGraph":`+string(data["roleGraph"])+`}`), &got))
 
@@ -132,8 +137,10 @@ func TestHandlerParseErrorsSurfaced(t *testing.T) {
 
 	data := post(t, h, `{ roleParseErrors roleGraph { parseErrors } }`)
 	var got struct {
-		RoleParseErrors []string
-		RoleGraph       struct{ ParseErrors []string }
+		RoleParseErrors []string `json:"roleParseErrors"`
+		RoleGraph       struct {
+			ParseErrors []string `json:"parseErrors"`
+		} `json:"RoleGraph"`
 	}
 	require.NoError(t, json.Unmarshal([]byte(`{"RoleParseErrors":`+string(data["roleParseErrors"])+
 		`,"RoleGraph":`+string(data["roleGraph"])+`}`), &got))

--- a/onboarding-vault/embed.go
+++ b/onboarding-vault/embed.go
@@ -1,3 +1,6 @@
+//go:build !dev
+// +build !dev
+
 package onboardingvault
 
 import (

--- a/onboarding-vault/embed_dev.go
+++ b/onboarding-vault/embed_dev.go
@@ -1,0 +1,22 @@
+//go:build dev
+// +build dev
+
+package onboardingvault
+
+import "os"
+
+// ZipData is read from disk under the dev build tag instead of embedded, so a
+// fresh worktree compiles (for `make lint` and `make air`) without first
+// running generate.sh. It stays nil until onboarding-vault/vault.zip exists;
+// the download endpoint already treats empty ZipData as "unavailable".
+//
+//nolint:gochecknoglobals // mirrors the embedded prod var (see embed.go)
+var ZipData = readZipFromDisk()
+
+func readZipFromDisk() []byte {
+	data, err := os.ReadFile("onboarding-vault/vault.zip")
+	if err != nil {
+		return nil
+	}
+	return data
+}


### PR DESCRIPTION
Clears the 25 golangci-lint warnings that accumulated on main after pushes with `--no-verify`, and fixes the **root cause** of why lint was being skipped locally. `make lint` is now clean (exit 0) in a fresh worktree with **no built assets**.

## Root cause fix (why `--no-verify` was needed)
`make lint` (and the pre-push hook) compiled the production embed variant (`assets/embed.go`, `//go:build !dev`, which `//go:embed`s the built frontend `ui/*/-/web.js`). In a fresh worktree without built assets it fails to compile → devs reach for `git push --no-verify` → the pre-push `make lint` never runs → warnings land on main.

- **`Makefile`**: `lint:` now runs golangci-lint with `--build-tags dev`, so it compiles the disk-reading dev variant (`assets/embed_dev.go`) instead of the embed variant — no built frontend needed. (CI already lints with `--build-tags dev`.)
- **`onboarding-vault/embed.go` / `embed_dev.go`**: mirrored the same `!dev`/`dev` split. The prod file embeds `vault.zip`; the new dev file reads it from disk (nil until `generate.sh` runs — the download endpoint already treats empty `ZipData` as "unavailable"). This removes the last compile dependency on a generated asset for lint.

The 25 warnings are all in normally-compiled `.go` files (not the embed files), so they are still caught under dev tags.

Follow-up (not in this PR): the pre-push hook's `make test` step still compiles the prod embed variant and would need the same `-tags dev` treatment to fully retire `--no-verify`.

## Warning fixes by category (25 total)
- **nonamedreturns ×4** — dropped named returns in `serveasset.parsePath`/`parseRange`, `codellm.extractBodyAndBag`/`changeToToolCall`.
- **govet (shadow) ×4** — reuse the outer `err` (=) instead of shadowing in `cmd/codellm/main.go`, `cmd/fleet/main.go`, `codellm/server.go`, `delegatedadmin.go`.
- **musttag ×4** — added `json:"..."` tags to anonymous unmarshal target structs in `fleetgql/http_test.go` (×3) and `codellm/server_test.go`.
- **testifylint ×4** — `require.Empty` and `require.JSONEq` in `server_test.go`; `require`→`assert` inside the httptest handler goroutines in `codellm/auth_integration_test.go` and `cmd/fleet/main_auth_test.go` (go-require: require must not run in a handler goroutine).
- **gocognit ×2** — see decomposition below.
- **errcheck ×1** — two-value type assertion `env, _ := req.Env.(Env)` in `serveasset/resolve.go`.
- **errname ×1** — renamed error type `authErr` → `authError` in `server_debug_test.go`.
- **golines ×1** — wrapped the long `json.Marshal(...)` line in `server_debug_test.go`.
- **intrange ×1** — `for i := range len(s)` in `serveasset.isHex`.
- **nestif ×1** — flattened the single/multi-block branch in `agentruntime.runCodeBlocksCore` (below).
- **perfsprint ×1** — `fmt.Errorf(const)` → `errors.New` in `delegatedadmin.New`.
- **unparam ×1** — dropped the always-`"h1"` `hash` param from `assetindex_test.noteWithAsset`.

## Decomposed functions (pure refactor, behavior byte-identical)
- **`serveasset.Handle`** (gocognit 34) — extracted `enforceAccess` (the non-public 401/403/500 access-control decision) and `resolveRange` (Range-header parsing + Content-Range/416 setup). Logic moved verbatim; the live asset-serving path is unchanged. Package tests pass.
- **`cmd/fleet.run`** (gocognit 37) — extracted `startGraphDebugServer`, `startFleetGraphQLServer`, `startDebugServer` for the three optional-server setup blocks. Each returns the `*http.Server` (or nil) so `run` keeps ownership of the deferred `Close`. Behavior unchanged.

The **nestif** flatten in `agentruntime.runCodeBlocksCore` extracted the single/multi-block bodies into `runSingleBlock`/`runMultiBlock`; `RunCode` output and error wrapping are identical.

## nolint
One: `//nolint:gochecknoglobals` on `onboarding-vault/embed_dev.go`'s `ZipData` — it must be a package var (referenced as `onboardingvault.ZipData`), mirroring the embedded prod var; matches `assets/embed_dev.go`'s existing pattern.

## Verification (no assets built)
- `make lint` → `0 issues.` (exit 0), in a fresh worktree WITHOUT running any frontend build or generate.sh
- `go build -tags dev ./...` clean; both embed variants (`dev` disk-read and `!dev` embed) compile
- `go vet -tags dev ./...` clean
- Tests green: `serveasset`, `agentruntime`, `codellm`, `fleet` (+ `fleetgql`, `graph`), `delegatedadmin`, `assetindex`, `cmd/fleet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)