### PR TITLE
demo(codellm): python skill pulling latest Krisp calls via codellm

### DIFF
--- a/_private_drafts/krisp_codellm_demo/README.md
+++ b/_private_drafts/krisp_codellm_demo/README.md
@@ -1,0 +1,112 @@
+# Krisp × codellm demo — python skill pulling the latest calls
+
+**What this shows (video-1 flagship):** codellm is "code as a deterministic LLM."
+Hand it markdown with a fenced `python` block; it *executes* the block and returns
+the writes as OpenAI `tool_calls`. Here the block pulls the **latest calls from the
+live Krisp API** and codellm returns them as `write_note` tool_calls + one `finish` —
+a real, runnable pipeline, no LLM in the loop.
+
+End-to-end run succeeded: codellm executed the python, which hit the live Krisp API
+and pulled the **3 latest real calls**, and codellm returned 3 `write_note` calls
+(one note per call) plus a trailing `finish`. Evidence in `transcript.sample.json`
+(sanitized; full real transcript stays local — see "Privacy" below).
+
+## Files
+
+| File | What it is |
+|---|---|
+| `skill.md` | The codellm python skill — a role body (`executor: code`) with one `python` block. Pulls the latest Krisp calls, emits the `{"changes":[...],"answer":"..."}` stdout contract. |
+| `run_demo.sh` | Builds + starts the real `internal/codellm` service (standalone), POSTs the OpenAI request carrying `skill.md`, captures request+response (secrets redacted). |
+| `standalone/main.go` | Thin driver that runs the **real `internal/codellm` service** in its documented no-auth standalone mode (see "The auth-gate finding"). Does not modify codellm. |
+| `transcript.sample.json` | **Committed.** Sanitized transcript: real call bodies + meeting titles elided; shows the wire contract and that it worked. |
+| `transcript.json` | **Local only, never committed** (gitignored `_private_drafts`). The full run with real call content. |
+
+Run it:
+
+```bash
+bash _private_drafts/krisp_codellm_demo/run_demo.sh    # needs KRISP_TOKEN in the env file below
+```
+
+## The real Krisp fetch mechanism
+
+Krisp has a **live private API** (there is no local export — the demo pulls from the
+real source). Reverse-engineered from `~/krisp-run/krisp_analyze.py` (itself ported
+from `trip2g_agent_queue/krisp/extract_krisp_transcripts.py`):
+
+- Base: `https://api.krisp.ai/v2`, bearer auth via `KRISP_TOKEN`, plus Krisp's web
+  headers (`krisp_header_app: web`, `krisp_header_web_project: note`, `Origin: https://app.krisp.ai`).
+- `POST /meetings/list` `{sort:"desc", sortKey:"created_at", page, limit, isOwner:true}`
+  → latest meetings (metadata: id, name, started_at, duration, speakers).
+- `GET /block/{id}/tree` → the transcript tree; walk nodes with `speakerIndex` +
+  `speech.text`, sort by `speech.start` → ordered turns.
+- "Latest calls" = list sorted desc by `started_at`, drop demos / <60s, take N.
+
+The token lives in `/home/alexes/projects2/trip2g_agent_queue/.env` as `KRISP_TOKEN`
+(override with `KRISP_ENV_FILE=`). Verified live: `python3 ~/krisp-run/krisp_analyze.py list`.
+
+## Secrets — how the key reaches the code, and the real path
+
+The productized path (per `docs/dev/codellm_extraction.md`) is a **`requires_secrets`
+manifest**: a skill declares `requires_secrets: [KRISP_TOKEN]` (capability, not value),
+codellm holds the value in its own secret config and injects **only** the declared keys
+into that skill's sandbox. **That manifest is designed, NOT built.**
+
+**Reality of codellm as-merged:** it goes further than "not built" — codellm scrubs the
+executed child's env to `PATH` + `FLEET_INPUT` only (`buildChildEnv`,
+`internal/agentruntime/coderun.go:388`) and **never sets `EnvPassthrough`**
+(`internal/codellm/server.go:171`). codellm's own `Config` has **no secret field** at
+all. So even the "minimal: put the key in codellm's env" fallback is **not wired** —
+codellm's process env cannot reach the python.
+
+The **only** runtime channel into the executed block is the delivery bag →
+`$FLEET_INPUT`. So for this demo the `KRISP_TOKEN` rides the bag: the `run_demo.sh`
+request includes a `fleet_input` system message `{"krisp_token":"…","n":3}`, and the
+python reads it from `$FLEET_INPUT`. The `codellm_extraction.md` design explicitly
+calls "put the secret in the bag" the *wrong* long-term answer (the bag rides the HTTP
+request, crossing the boundary we're hardening) — hence this is a **demo-only shortcut**,
+and the manifest is the real path. The key is **never** in `skill.md` and **never**
+committed; the runner redacts it from the captured transcript.
+
+## Sandbox: network must be on
+
+The python must reach `api.krisp.ai`, but codellm's default `native` sandbox denies
+egress (`SandboxPolicy.Network` defaults false). The demo runs `CODELLM_SANDBOX=off`
+so the block has network. A production Krisp skill needs the codellm container to allow
+egress to Krisp (per-skill network policy), which the current on/native/besteffort knob
+does not express at skill granularity.
+
+## The auth-gate finding (why the standalone driver)
+
+The shipped `cmd/codellm` binary hard-wires a **delegated-admin browser gate**: every
+`/v1/chat/completions` request's session cookie is forwarded to the trip2g monolith's
+`viewer{role}`; admin → serve, else **401**. Its server-to-server **fleet lane**
+(`TokenCheck`, the mTLS/shared-token seam) is explicitly **left nil / not built**
+(`cmd/codellm/main.go:49`). Confirmed: hitting the `cmd/codellm` binary directly returns
+`401 unauthorized` with no monolith session.
+
+Consequence: as-merged, **nothing can call codellm's `/v1` server-to-server** — not this
+demo, and not fleet — until either the monolith is up with an admin cookie forwarded, or
+the fleet-channel token is built. This demo therefore runs the **identical
+`internal/codellm` service package** via `standalone/main.go` in its documented no-auth
+mode (`Config.Auth` nil → no-op passthrough; the mode codellm's own tests use). Same
+`handleChatCompletions` → `ExecCode` → `buildResponse` path; only the auth wrapper is
+skipped. No codellm Go code was modified.
+
+## What is needed for a fully-live, production demo
+
+Everything below the app layer already works live (Krisp API + real calls + codellm
+execution + the tool_calls contract). To make it production-live end-to-end:
+
+1. **Fleet-channel auth** on `cmd/codellm` (`TokenCheck`), so a service — fleet, or a
+   demo client — can call `/v1` without a browser admin cookie. Not built.
+2. **`requires_secrets` manifest + per-skill secret injection** in codellm, so
+   `KRISP_TOKEN` comes from codellm's secret store instead of the request bag. Not built.
+3. **Per-skill egress policy** so a Krisp skill gets network to `api.krisp.ai` under a
+   real sandbox (not the blunt `CODELLM_SANDBOX=off`).
+4. Optionally, route this as a real fleet `executor: code` role (the `fleet_graphql.md`
+   per-provider-fleet model) instead of a hand-built request.
+
+None of these block the *story*: the demo proves codellm deterministically executes
+python that pulls live Krisp data and returns structured writes. The gaps are the
+secret-delivery and channel-auth productization, both already designed in
+`docs/dev/codellm_extraction.md`.

--- a/_private_drafts/krisp_codellm_demo/run_demo.sh
+++ b/_private_drafts/krisp_codellm_demo/run_demo.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# End-to-end demo: run the Krisp python skill THROUGH the real codellm service.
+#
+# It builds+starts the codellm binary on loopback, POSTs an OpenAI
+# /v1/chat/completions request whose message carries the skill markdown and whose
+# fleet_input message carries the delivery bag (krisp_token + n), then captures
+# the request+response with secrets redacted.
+#
+# codellm as-built scrubs the child env to PATH+FLEET_INPUT only (no secret
+# passthrough is wired), so the token reaches the python via the $FLEET_INPUT bag.
+# The native sandbox denies network egress, so we run CODELLM_SANDBOX=off for this
+# demo (the python must reach api.krisp.ai). See README.md for the productized path.
+#
+# It runs the REAL internal/codellm service via the standalone driver in
+# ./standalone (no-auth mode the package documents). The cmd/codellm binary
+# hard-wires a delegated-admin browser gate whose fleet-lane token is not built
+# yet, so it 401s any server-to-server call without a monolith cookie. Same
+# handler/execution path either way. See README.md.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+ENV_FILE="${KRISP_ENV_FILE:-/home/alexes/projects2/trip2g_agent_queue/.env}"
+N="${N:-3}"
+ADDR="127.0.0.1:8092"
+OUT="$HERE/transcript.json"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"; [ -n "${SRV_PID:-}" ] && kill "$SRV_PID" 2>/dev/null || true' EXIT
+
+# --- read the secret (never printed, never committed) ---
+KRISP_TOKEN="$(grep -E '^KRISP_TOKEN=' "$ENV_FILE" | tail -1 | cut -d= -f2- | tr -d '"'"'"'')"
+[ -n "$KRISP_TOKEN" ] || { echo "no KRISP_TOKEN in $ENV_FILE" >&2; exit 1; }
+
+# --- build + start codellm (real internal/codellm service, standalone no-auth) ---
+echo "building codellm-standalone..." >&2
+( cd "$REPO" && go build -o "$WORK/codellm" ./_private_drafts/krisp_codellm_demo/standalone )
+CODELLM_ADDR="$ADDR" CODELLM_SANDBOX=off CODELLM_ALLOWED_PROGRAMS=python \
+  "$WORK/codellm" >"$WORK/codellm.log" 2>&1 &
+SRV_PID=$!
+
+# wait for /healthz
+for _ in $(seq 1 50); do
+  curl -sf "http://$ADDR/healthz" >/dev/null 2>&1 && break
+  sleep 0.2
+done
+curl -sf "http://$ADDR/healthz" >/dev/null || { echo "codellm did not start"; cat "$WORK/codellm.log"; exit 1; }
+
+# --- build the OpenAI request: skill body + fleet_input bag + Begin ---
+SKILL="$(cat "$HERE/skill.md")"
+BAG="$(jq -nc --arg t "$KRISP_TOKEN" --argjson n "$N" '{krisp_token:$t, n:$n}')"
+REQ="$(jq -nc --arg body "$SKILL" --arg bag "$BAG" '{
+  model: "codellm",
+  messages: [
+    {role:"system", content:("You are a scoped trip2g micro-agent.\n" + $body)},
+    {role:"system", name:"fleet_input", content:$bag},
+    {role:"user", content:"Begin."}
+  ],
+  tools: [{type:"function", function:{name:"write_note"}}]
+}')"
+
+echo "POST http://$ADDR/v1/chat/completions ..." >&2
+RESP="$(curl -sS -X POST "http://$ADDR/v1/chat/completions" \
+  -H 'Content-Type: application/json' --data "$REQ")"
+
+if ! printf '%s' "$RESP" | jq -e . >/dev/null 2>&1; then
+  echo "non-JSON response from codellm:" >&2
+  printf '%s\n' "$RESP" >&2
+  RESP="$(jq -nc --arg raw "$RESP" '{error:{message:$raw, type:"non_json_response"}}')"
+fi
+
+# --- redact secret from the captured request, save transcript (via files: the
+#     full transcripts blow past ARG_MAX if passed on the command line) ---
+printf '%s' "$REQ" | jq -c --arg t "$KRISP_TOKEN" \
+  '(.messages[] | select(.name=="fleet_input") | .content) |= (fromjson | .krisp_token = "***REDACTED***" | tojson)' \
+  >"$WORK/req_redacted.json"
+printf '%s' "$RESP" >"$WORK/resp.json"
+
+jq -n --slurpfile request "$WORK/req_redacted.json" --slurpfile response "$WORK/resp.json" \
+  --arg addr "$ADDR" --arg when "$(date -u +%FT%TZ)" '{
+    note: "codellm Krisp python skill — end-to-end transcript (secrets redacted)",
+    captured_at: $when, endpoint: ("http://" + $addr + "/v1/chat/completions"),
+    sandbox: "off (network needed for api.krisp.ai)",
+    request: $request[0], response: $response[0]
+  }' >"$OUT"
+
+echo "transcript written to $OUT" >&2
+
+# --- public-safe sample: real Krisp note bodies + meeting titles elided, so the
+#     contract/flow is reviewable in the (PUBLIC) repo without leaking private
+#     call content. transcript.json (full, real) stays local under gitignored
+#     _private_drafts and is NEVER committed. ---
+SAMPLE="$HERE/transcript.sample.json"
+jq '
+  .note = "codellm Krisp python skill — SANITIZED sample (real call content elided; full transcript stays local)"
+  | .request.messages = [ .request.messages[]
+      | if .name == "fleet_input" then .
+        elif .role == "system" then {role, content: ("<system message: skill.md body, \(.content|length) chars — see skill.md>")}
+        else . end ]
+  | .response.choices[0].message.tool_calls = [ .response.choices[0].message.tool_calls[]
+      | if .function.name == "write_note" then
+          .function.arguments = ((.function.arguments|fromjson)
+            | {path: "calls/YYYY-MM-DD-xxxxxxxx.md",
+               content: "<elided: \(.content|length) chars of a real Krisp note (frontmatter + transcript)>"} | tojson)
+        elif .function.name == "finish" then
+          .function.arguments = ((.function.arguments|fromjson)
+            | {answer: "Pulled 3 latest Krisp call(s) [titles/details elided for public repo]"} | tojson)
+        else . end ]
+' "$OUT" >"$SAMPLE"
+echo "sanitized sample written to $SAMPLE" >&2
+# Print a short human summary of what codellm returned.
+printf '%s' "$RESP" | jq -r '
+  .choices[0].message.tool_calls as $tc |
+  if $tc then
+    ($tc | map(select(.function.name=="write_note") | (.function.arguments|fromjson.path)) ) as $paths |
+    ($tc | map(select(.function.name=="finish") | (.function.arguments|fromjson.answer)) | .[0]) as $ans |
+    "wrote \($paths|length) note(s): \($paths|join(", "))\nanswer: \($ans)"
+  else "ERROR: " + (.error.message // "no tool_calls") end'

--- a/_private_drafts/krisp_codellm_demo/skill.md
+++ b/_private_drafts/krisp_codellm_demo/skill.md
@@ -1,0 +1,139 @@
+---
+executor: code
+write_patterns:
+  - "calls/**"
+requires_secrets:
+  - KRISP_TOKEN
+---
+
+# Pull the latest Krisp calls
+
+This is a codellm **python skill**: a role body whose fenced block codellm executes.
+It pulls the latest meetings from the live Krisp API and writes each one as a note.
+
+The block reads its input from `$FLEET_INPUT` (the delivery bag): a JSON object with
+`krisp_token` (the Krisp bearer token) and `n` (how many latest calls to pull). It calls
+the Krisp API (`https://api.krisp.ai/v2`) directly with the stdlib — no third-party
+packages, so it runs under codellm's scrubbed sandbox env. It emits the codellm stdout
+contract on the last line of stdout: `{"changes":[...],"answer":"..."}`.
+
+```python
+import json, os, urllib.request, sys
+
+# --- codellm delivery bag: $FLEET_INPUT points at a temp file with the JSON bag ---
+bag = {}
+p = os.environ.get("FLEET_INPUT")
+if p and os.path.exists(p):
+    bag = json.loads(open(p).read() or "{}")
+
+token = (bag.get("krisp_token") or "").strip()
+n = int(bag.get("n") or 3)
+if not token:
+    # Fail loud: the productized path injects KRISP_TOKEN at codellm (requires_secrets
+    # manifest). For this demo it rides the bag. Either way, no token => no run.
+    print(json.dumps({"changes": [], "answer": "error: KRISP_TOKEN missing from $FLEET_INPUT"}))
+    sys.exit(0)
+
+KRISP_BASE = "https://api.krisp.ai/v2"
+
+
+def krisp(method, path, body=None):
+    req = urllib.request.Request(
+        KRISP_BASE + path,
+        data=json.dumps(body).encode() if body is not None else None, method=method,
+        headers={"Authorization": "Bearer " + token, "krisp_header_app": "web",
+                 "krisp_header_web_project": "note", "krisp_origin_timezone": "+00:00",
+                 "Origin": "https://app.krisp.ai", "Content-Type": "application/json",
+                 "Accept": "application/json, text/plain, */*"})
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.loads(r.read())
+
+
+def list_latest(limit):
+    data = krisp("POST", "/meetings/list",
+                 {"sort": "desc", "sortKey": "created_at", "page": 1,
+                  "limit": max(limit * 4, 20), "isOwner": True}).get("data", {})
+    rows = [m for m in (data.get("rows", []) or [])
+            if m.get("id") and not m.get("is_demo") and int(m.get("duration", 0) or 0) >= 60]
+    rows.sort(key=lambda m: m.get("started_at") or "", reverse=True)
+    return rows[:limit]
+
+
+def speaker_names(m):
+    out = {}
+    for i, s in enumerate(m.get("speakers", []) or [], start=1):
+        nm = (s.get("first_name") or s.get("name") or "").strip()
+        if nm:
+            out[i] = nm
+    return out
+
+
+def extract_rows(tree):
+    rows = []
+
+    def walk(x):
+        if isinstance(x, dict):
+            if "speakerIndex" in x and isinstance(x.get("speech"), dict):
+                sp = x["speech"]
+                t = str(sp.get("text", "")).strip()
+                if t:
+                    rows.append({"start": float(sp.get("start", 0) or 0),
+                                 "spk": int(x.get("speakerIndex", 0) or 0), "text": t})
+            for v in x.values():
+                walk(v)
+        elif isinstance(x, list):
+            for v in x:
+                walk(v)
+
+    walk(tree)
+    rows.sort(key=lambda r: r["start"])
+    return rows
+
+
+def rows_to_text(rows, names):
+    parts = []
+    for r in rows:
+        mm, ss = int(r["start"]) // 60, int(r["start"]) % 60
+        label = names.get(r["spk"]) or ("Speaker %d" % r["spk"])
+        parts.append("%s | %02d:%02d\n%s" % (label, mm, ss, r["text"]))
+    return "\n".join(parts)
+
+
+changes = []
+pulled = []
+for m in list_latest(n):
+    mid = m["id"]
+    names = speaker_names(m)
+    try:
+        rows = extract_rows(krisp("GET", "/block/" + mid + "/tree"))
+    except Exception as e:
+        rows = []
+        err = str(e)
+    else:
+        err = ""
+    started = (m.get("started_at") or "")[:16]
+    title = (m.get("name") or "(no name)").strip()
+    dur_min = int(m.get("duration", 0) or 0) // 60
+    body = ["---",
+            "krisp_id: %s" % mid,
+            "started_at: %s" % started,
+            "duration_min: %d" % dur_min,
+            "speakers: %d" % len(m.get("speakers", []) or []),
+            "---",
+            "",
+            "# %s" % title,
+            "",
+            "Pulled from the live Krisp API (`/meetings/list` + `/block/{id}/tree`).",
+            ""]
+    if rows:
+        body += ["## Transcript", "", rows_to_text(rows, names)]
+    else:
+        body += ["## Transcript", "", "_(transcript unavailable: %s)_" % (err or "empty")]
+    path = "calls/%s-%s.md" % ((m.get("started_at") or "")[:10], mid[:8])
+    changes.append({"path": path, "content": "\n".join(body)})
+    pulled.append("%s (%s, %dm, %d turns)" % (title, started, dur_min, len(rows)))
+
+answer = "Pulled %d latest Krisp call(s): %s" % (len(changes), "; ".join(pulled)) if changes \
+    else "No Krisp calls found."
+print(json.dumps({"changes": changes, "answer": answer}))
+```

--- a/_private_drafts/krisp_codellm_demo/standalone/main.go
+++ b/_private_drafts/krisp_codellm_demo/standalone/main.go
@@ -1,0 +1,55 @@
+// Command codellm-standalone runs the REAL internal/codellm service in its
+// documented standalone (no-auth) mode — the same mode its own tests use
+// (Config.Auth nil -> no-op passthrough, see internal/codellm/server.go).
+//
+// Why not cmd/codellm directly? That binary hard-wires the delegated-admin
+// browser gate (session cookie -> monolith viewer{role}), and its fleet-lane
+// TokenCheck seam is explicitly NOT built yet. So /v1/chat/completions returns
+// 401 for any server-to-server caller unless the trip2g monolith is up AND an
+// admin cookie is forwarded. This driver instantiates the identical service
+// package (same handleChatCompletions / ExecCode / buildResponse path), only
+// skipping the auth wrapper, so the demo can exercise code execution end-to-end
+// without standing up the monolith. It does NOT modify codellm's Go code.
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"trip2g/internal/agentruntime"
+	"trip2g/internal/codellm"
+)
+
+func main() {
+	// The per-block sandbox re-execs THIS binary as a confined child; run the
+	// marker check first (no-op when the marker env var is absent), exactly as
+	// cmd/codellm/main.go does.
+	agentruntime.MaybeRunSandboxChild()
+
+	addr := envOr("CODELLM_ADDR", "127.0.0.1:8092")
+	programs := strings.Split(envOr("CODELLM_ALLOWED_PROGRAMS", "python"), ",")
+	sandbox := agentruntime.SandboxMode(envOr("CODELLM_SANDBOX", "off"))
+
+	srv := &http.Server{
+		Addr: addr,
+		Handler: codellm.New(codellm.Config{
+			AllowedPrograms: programs,
+			Sandbox:         agentruntime.SandboxPolicy{Mode: sandbox},
+			Timeout:         300 * time.Second,
+			// Auth left nil -> no-op passthrough (standalone mode).
+		}).Handler(),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	log.Printf("codellm-standalone listening on %s (sandbox=%s, programs=%v)", addr, sandbox, programs)
+	log.Fatal(srv.ListenAndServe())
+}
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}

--- a/_private_drafts/krisp_codellm_demo/transcript.sample.json
+++ b/_private_drafts/krisp_codellm_demo/transcript.sample.json
@@ -1,0 +1,111 @@
+{
+  "note": "codellm Krisp python skill — SANITIZED sample (real call content elided; full transcript stays local)",
+  "captured_at": "2026-07-14T09:39:31Z",
+  "endpoint": "http://127.0.0.1:8092/v1/chat/completions",
+  "sandbox": "off (network needed for api.krisp.ai)",
+  "request": {
+    "model": "codellm",
+    "messages": [
+      {
+        "role": "system",
+        "content": "<system message: skill.md body, 5006 chars — see skill.md>"
+      },
+      {
+        "role": "system",
+        "name": "fleet_input",
+        "content": "{\"krisp_token\":\"***REDACTED***\",\"n\":3}"
+      },
+      {
+        "role": "user",
+        "content": "Begin."
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "write_note"
+        }
+      }
+    ]
+  },
+  "response": {
+    "id": "codellm-605f6f0ff2b5",
+    "object": "chat.completion",
+    "created": 1784021971,
+    "model": "codellm",
+    "choices": [
+      {
+        "index": 0,
+        "message": {
+          "role": "assistant",
+          "tool_calls": [
+            {
+              "id": "call_0",
+              "type": "function",
+              "function": {
+                "name": "write_note",
+                "arguments": "{\"path\":\"calls/YYYY-MM-DD-xxxxxxxx.md\",\"content\":\"<elided: 25246 chars of a real Krisp note (frontmatter + transcript)>\"}"
+              }
+            },
+            {
+              "id": "call_1",
+              "type": "function",
+              "function": {
+                "name": "write_note",
+                "arguments": "{\"path\":\"calls/YYYY-MM-DD-xxxxxxxx.md\",\"content\":\"<elided: 19096 chars of a real Krisp note (frontmatter + transcript)>\"}"
+              }
+            },
+            {
+              "id": "call_2",
+              "type": "function",
+              "function": {
+                "name": "write_note",
+                "arguments": "{\"path\":\"calls/YYYY-MM-DD-xxxxxxxx.md\",\"content\":\"<elided: 64306 chars of a real Krisp note (frontmatter + transcript)>\"}"
+              }
+            },
+            {
+              "id": "call_3",
+              "type": "function",
+              "function": {
+                "name": "finish",
+                "arguments": "{\"answer\":\"Pulled 3 latest Krisp call(s) [titles/details elided for public repo]\"}"
+              }
+            }
+          ]
+        },
+        "finish_reason": "tool_calls",
+        "content_filter_results": {
+          "hate": {
+            "filtered": false
+          },
+          "self_harm": {
+            "filtered": false
+          },
+          "sexual": {
+            "filtered": false
+          },
+          "violence": {
+            "filtered": false
+          },
+          "jailbreak": {
+            "filtered": false,
+            "detected": false
+          },
+          "profanity": {
+            "filtered": false,
+            "detected": false
+          }
+        }
+      }
+    ],
+    "usage": {
+      "prompt_tokens": 0,
+      "completion_tokens": 0,
+      "total_tokens": 0,
+      "prompt_tokens_details": null,
+      "completion_tokens_details": null
+    },
+    "system_fingerprint": ""
+  }
+}


### PR DESCRIPTION
Flagship codellm demo (video 1): **code as a deterministic LLM.** A markdown python skill is handed to the real `internal/codellm` service, which *executes* the fenced block and returns the writes as OpenAI `tool_calls`. The block pulls the **latest calls from the live Krisp API** — a genuine, runnable pipeline, no LLM in the loop.

Artifacts under `_private_drafts/krisp_codellm_demo/` (private drafts dir; force-added since it is gitignored):

- `skill.md` — the `executor: code` role body with one `python` block; pulls latest Krisp calls, emits the `{"changes":[...],"answer":"..."}` stdout contract.
- `run_demo.sh` — builds + starts the real codellm service, POSTs the OpenAI request carrying the skill, captures request+response (secrets redacted).
- `standalone/main.go` — thin driver running the **real `internal/codellm` package** in its documented no-auth standalone mode (codellm Go code unmodified).
- `transcript.sample.json` — sanitized evidence (real call bodies + meeting titles elided). The full real transcript stays local and is never committed.

## End-to-end result — succeeded
codellm executed the python, which hit the live Krisp API (`https://api.krisp.ai/v2`, `POST /meetings/list` + `GET /block/{id}/tree`) and pulled the **3 latest real calls**; codellm returned 3 `write_note` tool_calls (one note per call) + a trailing `finish`. See `transcript.sample.json`.

## Findings reported (no codellm code changed)
- **Krisp is a live private API**, not a local export — the demo pulls from the real source. Token = `KRISP_TOKEN` in the agent-queue `.env`.
- **Secrets:** the `requires_secrets` manifest is designed but not built. codellm as-merged scrubs the child env to `PATH`+`FLEET_INPUT` and never sets `EnvPassthrough`; its `Config` has no secret field — so even a "minimal env key" path is not wired. The only runtime channel is the `$FLEET_INPUT` bag, used here as a documented demo-only shortcut (never in the role note, never committed, redacted in the transcript).
- **Sandbox:** native mode denies egress; the demo runs `CODELLM_SANDBOX=off` so the block can reach `api.krisp.ai`.
- **Auth gate:** the shipped `cmd/codellm` binary hard-wires a delegated-admin browser gate and its fleet-lane `TokenCheck` is not built, so `/v1` returns `401` for any server-to-server caller without a monolith admin cookie. Hence the standalone driver (identical service package, no-auth mode).

See `_private_drafts/krisp_codellm_demo/README.md` for the full write-up and exactly what is needed for a fully-live production demo.