### PR TITLE
feat(fleet): fleet_id identity + role partitioning + hash-in-webhook-url registry (no migration)

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -91,7 +91,7 @@ func run() error {
 	llm := agentruntime.NewOpenAILLM(cli.cfg.LLMAPIKey, cli.cfg.LLMBaseURL)
 
 	f := fleet.NewFleet(cli.cfg, httpClient, llm)
-	discovery := fleet.NewDiscovery(adminGQL, cli.cfg.AgentsFolder, cli.cfg.OfferedTools)
+	discovery := fleet.NewDiscovery(adminGQL, cli.cfg.FleetID, cli.cfg.AgentsFolder, cli.cfg.OfferedTools)
 
 	// --dry-run: connect, print + flag each role's resolved config, then exit
 	// WITHOUT registering/reconciling any webhooks (eyeball roles before go-live).
@@ -116,8 +116,8 @@ func run() error {
 	// mux on this port is gated by the delegated-admin middleware (forwards the
 	// caller's cookie to the monolith's viewer{role}; admin -> serve, else 401,
 	// monolith-unreachable -> fail-closed). This is a separate server from the
-	// webhook delivery listener (cli.cfg.ListenAddr, /deliver/, HMAC-authed), so
-	// the cookie gate never touches the monolith->fleet delivery path.
+	// webhook delivery listener (cli.cfg.ListenAddr, /_fleet/<h>/webhook/,
+	// HMAC-authed), so the cookie gate never touches the monolith->fleet path.
 	graphqlSrv, err := startFleetGraphQLServer(lg, discovery, cli)
 	if err != nil {
 		return err
@@ -130,7 +130,7 @@ func run() error {
 	syncOnce(ctx, lg, f, discovery, reconciler)
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/deliver/", f.ServeDelivery)
+	mux.HandleFunc(f.WebhookPath(), f.ServeDelivery)
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
@@ -446,6 +446,9 @@ func normalizeCallbackURL(u string) string {
 // validateConfig returns an error if any required field is missing or invalid.
 func validateConfig(cfg fleet.Config) error {
 	missing := []string{}
+	if cfg.FleetID == "" {
+		missing = append(missing, "FleetID (--fleet-id / TRIP2G_FLEET_FLEET_ID)")
+	}
 	if cfg.CallbackURL == "" {
 		missing = append(missing, "CallbackURL (--callback-url / TRIP2G_FLEET_CALLBACK_URL)")
 	}
@@ -568,8 +571,8 @@ func parseFlags(ctx context.Context) (cliFlags, error) {
 	// Daemon flags.
 	fs.BoolVar(&cli.dryRun, "dry-run", false,
 		"discover roles, print + flag their resolved config, then exit without registering webhooks")
-	fs.StringVar(&cli.cfg.FleetID, "fleet-id", "fleet1",
-		"reconcile marker id")
+	fs.StringVar(&cli.cfg.FleetID, "fleet-id", "",
+		"REQUIRED fleet identity: partition key for role fleet_id + the /_fleet/<sha256(\"fleet:\"+id)>/webhook delivery path")
 	fs.StringVar(&cli.cfg.AdminAPIKey, "admin-api-key", "",
 		"DEPRECATED/unused: legacy full-admin X-Api-Key")
 	fs.StringVar(&cli.cfg.JWTSecret, "jwt-secret", "",

--- a/cmd/fleet/main_agentpaths_test.go
+++ b/cmd/fleet/main_agentpaths_test.go
@@ -159,7 +159,7 @@ func TestRunDryRun_Integration(t *testing.T) {
 		AgentsFolder: "roles/",
 	}
 	gql := graphql.NewClient(gqlSrv.URL, &http.Client{Timeout: 5 * time.Second})
-	discovery := fleet.NewDiscovery(gql, cfg.AgentsFolder, cfg.OfferedTools)
+	discovery := fleet.NewDiscovery(gql, cfg.FleetID, cfg.AgentsFolder, cfg.OfferedTools)
 
 	var out bytes.Buffer
 	runDryRun(context.Background(), &logger.DummyLogger{}, discovery, cfg, &out)

--- a/cmd/fleet/main_auth_test.go
+++ b/cmd/fleet/main_auth_test.go
@@ -97,20 +97,21 @@ func TestGraphQLServerGatesEntireMux(t *testing.T) {
 
 // TestWebhookDeliveryNotCookieGated documents the auth split. The webhook
 // delivery path (monolith -> fleet, HMAC-authed) runs on a SEPARATE server
-// (cli.cfg.ListenAddr, /deliver/) that main builds WITHOUT the delegated-admin
-// wrapper — see run(). This mirrors that delivery mux with a stub handler and
-// asserts a cookieless request reaches the handler (i.e. is NOT rejected by the
-// admin-cookie gate), unlike the GraphQL mux above. Real HMAC-signature
-// coverage of ServeDelivery itself lives in internal/fleet/handler_test.go.
+// (cli.cfg.ListenAddr, /_fleet/<h>/webhook/) that main builds WITHOUT the
+// delegated-admin wrapper — see run(). This mirrors that delivery mux with a
+// stub handler and asserts a cookieless request reaches the handler (i.e. is
+// NOT rejected by the admin-cookie gate), unlike the GraphQL mux above. Real
+// HMAC-signature coverage of ServeDelivery itself lives in
+// internal/fleet/handler_test.go.
 func TestWebhookDeliveryNotCookieGated(t *testing.T) {
 	var reached bool
 	deliveryMux := http.NewServeMux()
-	deliveryMux.HandleFunc("/deliver/", func(w http.ResponseWriter, _ *http.Request) {
+	deliveryMux.HandleFunc("/_fleet/", func(w http.ResponseWriter, _ *http.Request) {
 		reached = true // real fleet verifies HMAC here (f.ServeDelivery)
 		w.WriteHeader(http.StatusOK)
 	})
 
-	req := httptest.NewRequest(http.MethodPost, "/deliver/somekey", strings.NewReader("{}"))
+	req := httptest.NewRequest(http.MethodPost, "/_fleet/abc123/webhook/somekey", strings.NewReader("{}"))
 	rec := httptest.NewRecorder()
 	deliveryMux.ServeHTTP(rec, req)
 

--- a/cmd/fleet/main_test.go
+++ b/cmd/fleet/main_test.go
@@ -40,6 +40,11 @@ func TestValidateConfig_RejectsMissingFields(t *testing.T) {
 		wantErr string
 	}{
 		{
+			name:    "missing_fleet_id",
+			mutate:  func(c *fleet.Config) { c.FleetID = "" },
+			wantErr: "FleetID",
+		},
+		{
 			name:    "missing_callback_url",
 			mutate:  func(c *fleet.Config) { c.CallbackURL = "" },
 			wantErr: "CallbackURL",

--- a/internal/case/admin/updatewebhook/resolve_test.go
+++ b/internal/case/admin/updatewebhook/resolve_test.go
@@ -61,6 +61,42 @@ func TestResolve_UpdatesConcurrencyAndAttach(t *testing.T) {
 	require.Equal(t, "{ y: 2 }", *env.updated.TransformJsonnet)
 }
 
+// TestResolve_IDAndURLOnly_PassesPatchSemantics is a regression guard for the
+// fleet hash-registry takeover (internal/fleet/reconcile.go's update()): a
+// caller that sends ONLY {id, url} — every other field left nil/absent — must
+// pass validateBounds and PATCH-merge cleanly, leaving every other existing
+// field (enabled, description, onCreate/onUpdate/onRemove, timeoutSeconds,
+// ...) untouched. This is the shape genqlient marshals when fleet re-claims a
+// webhook after a restart/move; if any of these fields were a present zero
+// instead of an absent pointer, timeoutSeconds:0 would fail validateBounds
+// ("must be between 1 and 3600") and every takeover would hard-fail.
+func TestResolve_IDAndURLOnly_PassesPatchSemantics(t *testing.T) {
+	env := &mockEnv{
+		existing: db.ChangeWebhook{
+			ID: 7, Url: "https://old-host.example/_fleet/abc/webhook/xyz",
+			Description: "fleet:f1:roles/triage.md#deadbeef", Enabled: true,
+			OnCreate: true, OnUpdate: true, TimeoutSeconds: 300,
+		},
+	}
+	out, err := updatewebhook.Resolve(context.Background(), env, model.ChangeWebhookUpdateInput{
+		ID:  7,
+		URL: ptr.To("https://new-host.example/_fleet/abc/webhook/xyz"),
+	})
+	require.NoError(t, err)
+	_, isErr := out.(*model.ErrorPayload)
+	require.False(t, isErr, "an {id,url}-only update must not trip validateBounds: %+v", out)
+	require.NotNil(t, env.updated, "the webhook must be updated")
+	require.NotNil(t, env.updated.Url)
+	require.Equal(t, "https://new-host.example/_fleet/abc/webhook/xyz", *env.updated.Url)
+	// Every other field is absent (nil), i.e. "keep existing" under patch semantics.
+	require.Nil(t, env.updated.Enabled)
+	require.Nil(t, env.updated.Description)
+	require.Nil(t, env.updated.OnCreate)
+	require.Nil(t, env.updated.OnUpdate)
+	require.Nil(t, env.updated.OnRemove)
+	require.Nil(t, env.updated.TimeoutSeconds)
+}
+
 func TestResolve_RejectsBadConcurrencyMode(t *testing.T) {
 	env := &mockEnv{}
 	out, err := updatewebhook.Resolve(context.Background(), env, model.ChangeWebhookUpdateInput{

--- a/internal/fleet/config.go
+++ b/internal/fleet/config.go
@@ -11,9 +11,9 @@ import "time"
 // ceiling (TokenCeiling/StepCeiling) is the non-overridable floor: the
 // effective budget is min(frontmatter, ceiling).
 type Config struct {
-	FleetID                string        // reconcile marker prefix "fleet:<FleetID>:"
+	FleetID                string        // required identity: reconcile marker prefix "fleet:<FleetID>:", role fleet_id partition key, and /_fleet/<sha256("fleet:"+id)>/webhook delivery path
 	ListenAddr             string        // ":9090"
-	CallbackURL            string        // trip2g-reachable base; webhook url = CallbackURL + "/deliver/" + urlKey(path)
+	CallbackURL            string        // trip2g-reachable base; webhook url = CallbackURL + "/_fleet/<h>/webhook/" + urlKey(path)
 	Trip2gBaseURL          string        // e.g. "http://localhost:20081"
 	AdminAPIKey            string        // DEPRECATED/unused: legacy full-admin X-Api-Key (admin lane now authenticates via HAT)
 	JWTSecret              string        // shared user-token/JWT secret used to mint admin HATs (= trip2g UserToken.Secret)

--- a/internal/fleet/discovery.go
+++ b/internal/fleet/discovery.go
@@ -12,21 +12,38 @@ import (
 // Discovery polls trip2g for role notes under AgentsFolder over the admin lane.
 type Discovery struct {
 	gql          graphql.Client
+	fleetID      string
 	agentsFolder string
 	offeredTools []string
 }
 
-// NewDiscovery builds a Discovery over the genqlient admin lane.
-func NewDiscovery(gql graphql.Client, agentsFolder string, offeredTools []string) *Discovery {
-	return &Discovery{gql: gql, agentsFolder: agentsFolder, offeredTools: offeredTools}
+// NewDiscovery builds a Discovery over the genqlient admin lane. fleetID is this
+// fleet's partition key: DiscoverRoles processes only roles whose fleet_id
+// matches it.
+func NewDiscovery(gql graphql.Client, fleetID, agentsFolder string, offeredTools []string) *Discovery {
+	return &Discovery{gql: gql, fleetID: fleetID, agentsFolder: agentsFolder, offeredTools: offeredTools}
 }
 
-// DiscoverRoles returns the valid roles plus a slice of per-note validation
-// errors (invalid roles are excluded, never registered).
+// DiscoverRoles returns this fleet's valid roles plus a slice of per-note
+// errors. Roles are partitioned by fleet_id: only roles whose fleet_id equals
+// this fleet's --fleet-id are processed. A role with an empty fleet_id is
+// skipped with a warning (untagged roles are never claimed — belonging to no
+// fleet keeps two fleets from both processing it). A role tagged for another
+// fleet is skipped silently. Invalid roles that match this fleet are excluded
+// and reported. DiscoverParsed stays unpartitioned for cross-fleet introspection.
 func (d *Discovery) DiscoverRoles(ctx context.Context) ([]Role, []error) {
 	parsed, errs := d.DiscoverParsed(ctx)
 	var roles []Role
 	for _, role := range parsed {
+		if role.FleetID == "" {
+			errs = append(errs, fmt.Errorf(
+				"role %s: fleet_id is empty; skipped (set fleet_id: %s to assign it to this fleet)",
+				role.NotePath, d.fleetID))
+			continue
+		}
+		if role.FleetID != d.fleetID {
+			continue // belongs to another fleet
+		}
 		if verr := role.Validate(d.offeredTools); verr != nil {
 			errs = append(errs, verr)
 			continue

--- a/internal/fleet/discovery_test.go
+++ b/internal/fleet/discovery_test.go
@@ -11,6 +11,7 @@ import (
 func TestDiscoverRoles_ParsesValidSkipsInvalid(t *testing.T) {
 	resp := `{"notePaths":[
 		{"value":"roles/triage.md","content":"Triage the board.","latestNoteView":{"meta":[
+			{"key":"fleet_id","raw":"f1"},
 			{"key":"mode","raw":"change"},
 			{"key":"model","raw":"gpt-4o-mini"},
 			{"key":"tools","raw":"[search, patch_note]"},
@@ -22,6 +23,7 @@ func TestDiscoverRoles_ParsesValidSkipsInvalid(t *testing.T) {
 			{"key":"concurrency","raw":"skip"}
 		]}},
 		{"value":"roles/bad.md","content":"x","latestNoteView":{"meta":[
+			{"key":"fleet_id","raw":"f1"},
 			{"key":"mode","raw":"change"},
 			{"key":"tools","raw":"[shell]"}
 		]}}
@@ -35,11 +37,77 @@ func TestDiscoverRoles_ParsesValidSkipsInvalid(t *testing.T) {
 		require.Equal(t, "roles/%", v.Like)
 		return resp, nil
 	})
-	d := NewDiscovery(gql, "roles/", []string{"search", "read_note", "patch_note"})
+	d := NewDiscovery(gql, "f1", "roles/", []string{"search", "read_note", "patch_note"})
 	roles, errs := d.DiscoverRoles(context.Background())
 	require.Len(t, roles, 1)
 	require.Equal(t, "roles/triage.md", roles[0].NotePath)
 	require.Equal(t, []string{"search", "patch_note"}, roles[0].Tools)
 	require.Len(t, errs, 1) // roles/bad.md rejected (shell not offered)
 	require.Contains(t, errs[0].Error(), "roles/bad.md")
+}
+
+// roleNote renders one notePaths entry with a fleet_id and the minimal valid
+// change-mode meta so it passes Validate when it belongs to this fleet.
+func roleNote(path, fleetID string) string {
+	fid := ""
+	if fleetID != "" {
+		fid = `{"key":"fleet_id","raw":"` + fleetID + `"},`
+	}
+	return `{"value":"` + path + `","content":"Body.","latestNoteView":{"meta":[
+		` + fid + `
+		{"key":"mode","raw":"change"},
+		{"key":"trigger_include","raw":"[\"boards/**\"]"},
+		{"key":"trigger_on","raw":"[update]"}
+	]}}`
+}
+
+// TestDiscoverRoles_PartitionsByFleetID asserts the fleet_id partition:
+// only matching-fleet_id roles are processed; a mismatched role is skipped
+// silently; an untagged (empty fleet_id) role is skipped WITH an error/warning.
+func TestDiscoverRoles_PartitionsByFleetID(t *testing.T) {
+	resp := `{"notePaths":[` +
+		roleNote("roles/mine.md", "f1") + `,` +
+		roleNote("roles/theirs.md", "f2") + `,` +
+		roleNote("roles/untagged.md", "") +
+		`]}`
+	gql := fakeAdminGQL(func(op string, _ json.RawMessage) (string, error) {
+		require.Equal(t, "DiscoverRoles", op)
+		return resp, nil
+	})
+	d := NewDiscovery(gql, "f1", "roles/", []string{"search"})
+	roles, errs := d.DiscoverRoles(context.Background())
+
+	require.Len(t, roles, 1, "only the matching-fleet_id role is processed")
+	require.Equal(t, "roles/mine.md", roles[0].NotePath)
+
+	// theirs.md is skipped silently (belongs to f2); untagged.md is a warning.
+	require.Len(t, errs, 1, "untagged role warns; foreign role is silent")
+	require.Contains(t, errs[0].Error(), "roles/untagged.md")
+	require.Contains(t, errs[0].Error(), "fleet_id is empty")
+	for _, e := range errs {
+		require.NotContains(t, e.Error(), "roles/theirs.md", "foreign-fleet role must not warn")
+	}
+}
+
+// TestDiscoverParsed_UnpartitionedForIntrospection asserts DiscoverParsed does
+// NOT partition (it powers the cross-fleet graph/dry-run views): it returns
+// every parsed role regardless of fleet_id, with fleet_id populated.
+func TestDiscoverParsed_UnpartitionedForIntrospection(t *testing.T) {
+	resp := `{"notePaths":[` +
+		roleNote("roles/mine.md", "f1") + `,` +
+		roleNote("roles/theirs.md", "f2") +
+		`]}`
+	gql := fakeAdminGQL(func(_ string, _ json.RawMessage) (string, error) {
+		return resp, nil
+	})
+	d := NewDiscovery(gql, "f1", "roles/", []string{"search"})
+	parsed, errs := d.DiscoverParsed(context.Background())
+	require.Empty(t, errs)
+	require.Len(t, parsed, 2, "DiscoverParsed keeps all roles for introspection")
+	byPath := map[string]string{}
+	for _, r := range parsed {
+		byPath[r.NotePath] = r.FleetID
+	}
+	require.Equal(t, "f1", byPath["roles/mine.md"])
+	require.Equal(t, "f2", byPath["roles/theirs.md"])
 }

--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -51,6 +51,13 @@ func (f *Fleet) SetRoles(roles []Role) {
 	f.mu.Unlock()
 }
 
+// WebhookPath is this fleet's delivery path prefix ("/_fleet/<h>/webhook/"),
+// used both to mount the receive handler and to strip the prefix off incoming
+// delivery requests.
+func (f *Fleet) WebhookPath() string {
+	return webhookPathPrefix(f.cfg.FleetID)
+}
+
 func (f *Fleet) roleByKey(key string) (Role, bool) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()

--- a/internal/fleet/graph/server_test.go
+++ b/internal/fleet/graph/server_test.go
@@ -99,7 +99,7 @@ func newTestServer() *Server {
 		OfferedTools:  []string{"read_note", "write_note"},
 		Trip2gBaseURL: "http://hub.local:20081",
 	}
-	return NewServer(fleet.NewDiscovery(gql, cfg.AgentsFolder, cfg.OfferedTools), gql, cfg)
+	return NewServer(fleet.NewDiscovery(gql, cfg.FleetID, cfg.AgentsFolder, cfg.OfferedTools), gql, cfg)
 }
 
 func TestServerJSON(t *testing.T) {

--- a/internal/fleet/handler.go
+++ b/internal/fleet/handler.go
@@ -69,10 +69,12 @@ const inputKeyDepth = "depth"
 // statusError is the AgentResponse status value for hard-failure responses.
 const statusError = "error"
 
-// ServeDelivery handles POST /deliver/<urlKey> (change deliveries) and
-// POST /deliver/cron/<urlKey> (cron-triggered deliveries).
+// ServeDelivery handles POST /_fleet/<h>/webhook/<urlKey> (change deliveries)
+// and POST /_fleet/<h>/webhook/cron/<urlKey> (cron-triggered deliveries), where
+// <h> is this fleet's identity hash. Authenticated by the per-role HMAC secret,
+// NOT the delegated-admin cookie (that gates the separate GraphQL server).
 func (f *Fleet) ServeDelivery(w http.ResponseWriter, r *http.Request) {
-	rawPath := strings.TrimPrefix(r.URL.Path, "/deliver/")
+	rawPath := strings.TrimPrefix(r.URL.Path, f.WebhookPath())
 	isCron := strings.HasPrefix(rawPath, "cron/")
 	key := rawPath
 	if isCron {
@@ -286,7 +288,7 @@ func statusSeverity(status string) int {
 	}
 }
 
-// serveCronDelivery handles a cron-triggered POST /deliver/cron/<key>.
+// serveCronDelivery handles a cron-triggered POST /_fleet/<h>/webhook/cron/<key>.
 // Unlike change delivery, there are no changed_files; the role body is rendered
 // once with an empty change context and the wall-clock `now` variable.
 func (f *Fleet) serveCronDelivery(w http.ResponseWriter, r *http.Request, role Role, body []byte) {

--- a/internal/fleet/handler_test.go
+++ b/internal/fleet/handler_test.go
@@ -75,7 +75,7 @@ func newScopedKBServer(t *testing.T, respond func(auth, body string) string) (*h
 
 func post(t *testing.T, f *Fleet, key string, body []byte, sign bool) *httptest.ResponseRecorder {
 	t.Helper()
-	req := httptest.NewRequest(http.MethodPost, "/deliver/"+key, bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, f.WebhookPath()+key, bytes.NewReader(body))
 	if sign {
 		role, ok := f.roleByKey(key)
 		require.True(t, ok)
@@ -242,7 +242,7 @@ func TestServeDelivery_RunDetachedFromRequestContext(t *testing.T) {
 	key := urlKey("roles/triage.md")
 	body := deliveryBody(t)
 	reqCtx, cancel := context.WithCancel(context.Background())
-	req := httptest.NewRequest(http.MethodPost, "/deliver/"+key, bytes.NewReader(body)).WithContext(reqCtx)
+	req := httptest.NewRequest(http.MethodPost, f.WebhookPath()+key, bytes.NewReader(body)).WithContext(reqCtx)
 	r, ok := f.roleByKey(key)
 	require.True(t, ok)
 	req.Header.Set("X-Webhook-Signature", webhookutil.SignHMAC(body, f.secretFor(r)))
@@ -509,7 +509,7 @@ func TestServeDelivery_CodeRole_DispatchesRunCode(t *testing.T) {
 		"instruction": "run code",
 		"api_token":   "scoped-token",
 	})
-	req := httptest.NewRequest(http.MethodPost, "/deliver/"+key, bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, f.WebhookPath()+key, bytes.NewReader(body))
 	role, ok := f.roleByKey(key)
 	require.True(t, ok)
 	req.Header.Set("X-Webhook-Signature", webhookutil.SignHMAC(body, f.secretFor(role)))
@@ -560,7 +560,7 @@ func TestServeDelivery_CodeRole_PassesEnvPassthrough(t *testing.T) {
 	body, _ := json.Marshal(map[string]any{
 		"depth": 0, "api_token": "tok",
 	})
-	req := httptest.NewRequest(http.MethodPost, "/deliver/"+key, bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, f.WebhookPath()+key, bytes.NewReader(body))
 	r, ok := f.roleByKey(key)
 	require.True(t, ok)
 	req.Header.Set("X-Webhook-Signature", webhookutil.SignHMAC(body, f.secretFor(r)))
@@ -624,7 +624,7 @@ func cronDeliveryBody(t *testing.T) []byte {
 // postCron sends a POST to /deliver/cron/<key> with a cron-signed HMAC.
 func postCron(t *testing.T, f *Fleet, key string, body []byte, sign bool) *httptest.ResponseRecorder {
 	t.Helper()
-	req := httptest.NewRequest(http.MethodPost, "/deliver/cron/"+key, bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, f.WebhookPath()+"cron/"+key, bytes.NewReader(body))
 	if sign {
 		role, ok := f.roleByKey(key)
 		require.True(t, ok)
@@ -687,7 +687,7 @@ func TestServeCronDelivery_ChangeHMACRejected(t *testing.T) {
 	// Sign with the change secret (not the cron secret).
 	role, ok := f.roleByKey(key)
 	require.True(t, ok)
-	req := httptest.NewRequest(http.MethodPost, "/deliver/cron/"+key, bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, f.WebhookPath()+"cron/"+key, bytes.NewReader(body))
 	req.Header.Set("X-Webhook-Signature", webhookutil.SignHMAC(body, f.secretFor(role)))
 	rec := httptest.NewRecorder()
 	f.ServeDelivery(rec, req)
@@ -725,7 +725,7 @@ func TestServeCronDelivery_WithAttachedNotes(t *testing.T) {
 			{"path": "kb/b.md", "content": "content B"},
 		},
 	})
-	req := httptest.NewRequest(http.MethodPost, "/deliver/cron/"+key, bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, f.WebhookPath()+"cron/"+key, bytes.NewReader(body))
 	req.Header.Set("X-Webhook-Signature", webhookutil.SignHMAC(body, f.cronSecretFor(role)))
 	rec := httptest.NewRecorder()
 	f.ServeDelivery(rec, req)
@@ -816,7 +816,7 @@ func TestServeDelivery_MaxBytesReader413(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodPost, "/deliver/"+key, bytes.NewReader(oversized))
+	req := httptest.NewRequest(http.MethodPost, f.WebhookPath()+key, bytes.NewReader(oversized))
 	role, ok := f.roleByKey(key)
 	require.True(t, ok)
 	req.Header.Set("X-Webhook-Signature", webhookutil.SignHMAC(oversized, f.secretFor(role)))

--- a/internal/fleet/identity.go
+++ b/internal/fleet/identity.go
@@ -1,0 +1,38 @@
+package fleet
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// fleetHash derives the stable, namespaced identity marker folded into the
+// fleet's webhook delivery URL: h = sha256("fleet:" + fleetID) in hex. The
+// "fleet:" prefix namespaces it against other sha256 uses and keeps the
+// plaintext fleet_id out of the URL. It is NOT a secret and is never used for
+// auth — just an opaque, stable id the monolith routes deliveries on and the
+// reconcile loop de-dups by (see docs/dev/fleet_graphql.md).
+func fleetHash(fleetID string) string {
+	sum := sha256.Sum256([]byte("fleet:" + fleetID))
+	return hex.EncodeToString(sum[:])
+}
+
+// webhookPathPrefix is the delivery path segment identifying this fleet:
+// "/_fleet/<h>/webhook/". Both the change and cron delivery URLs extend it, and
+// the receive handler strips it. The trailing slash makes it a valid
+// http.ServeMux subtree prefix.
+func webhookPathPrefix(fleetID string) string {
+	return "/_fleet/" + fleetHash(fleetID) + "/webhook/"
+}
+
+// changeDeliveryURL builds the monolith->fleet change-delivery URL:
+// <callbackURL>/_fleet/<h>/webhook/<urlKey(notePath)>. The <h> segment is the
+// fleet identity (takeover/dedup key); the trailing urlKey identifies the role.
+func changeDeliveryURL(callbackURL, fleetID, notePath string) string {
+	return callbackURL + webhookPathPrefix(fleetID) + urlKey(notePath)
+}
+
+// cronDeliveryURL builds the monolith->fleet cron-delivery URL:
+// <callbackURL>/_fleet/<h>/webhook/cron/<urlKey(notePath)>.
+func cronDeliveryURL(callbackURL, fleetID, notePath string) string {
+	return callbackURL + webhookPathPrefix(fleetID) + "cron/" + urlKey(notePath)
+}

--- a/internal/fleet/identity_test.go
+++ b/internal/fleet/identity_test.go
@@ -1,0 +1,54 @@
+package fleet
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFleetHash_MatchesNamespacedSHA256 pins the hash derivation:
+// h = hex(sha256("fleet:" + fleetID)), stable and namespaced by the "fleet:"
+// prefix.
+func TestFleetHash_MatchesNamespacedSHA256(t *testing.T) {
+	want := func(id string) string {
+		sum := sha256.Sum256([]byte("fleet:" + id))
+		return hex.EncodeToString(sum[:])
+	}
+	cases := []string{"", "fleet1", "codellm", "prod-eu"}
+	for _, id := range cases {
+		require.Equal(t, want(id), fleetHash(id), "fleet_id %q", id)
+	}
+	// Distinct fleet_ids get distinct hashes (the partition is meaningful).
+	require.NotEqual(t, fleetHash("a"), fleetHash("b"))
+	// 64 hex chars (sha256).
+	require.Len(t, fleetHash("x"), 64)
+}
+
+// TestFleetHash_NamespacePrefixMatters asserts the "fleet:" prefix is folded in,
+// so h is not a bare sha256 of the id (namespacing against other sha256 uses).
+func TestFleetHash_NamespacePrefixMatters(t *testing.T) {
+	bare := sha256.Sum256([]byte("fleet1"))
+	require.NotEqual(t, hex.EncodeToString(bare[:]), fleetHash("fleet1"))
+}
+
+// TestDeliveryURLs_FoldInHashSegment asserts both change and cron delivery URLs
+// carry the identity segment /_fleet/<h>/webhook/ and the role's urlKey.
+func TestDeliveryURLs_FoldInHashSegment(t *testing.T) {
+	const base, id, path = "https://fleet.example", "fleet1", "roles/triage.md"
+	h := fleetHash(id)
+
+	change := changeDeliveryURL(base, id, path)
+	require.Equal(t, base+"/_fleet/"+h+"/webhook/"+urlKey(path), change)
+	require.Contains(t, change, "/"+h+"/", "change url must contain the /<h>/ segment")
+
+	cron := cronDeliveryURL(base, id, path)
+	require.Equal(t, base+"/_fleet/"+h+"/webhook/cron/"+urlKey(path), cron)
+	require.Contains(t, cron, "/"+h+"/", "cron url must contain the /<h>/ segment")
+
+	// The path prefix the receive handler strips matches what the URL builders emit.
+	require.True(t, strings.HasPrefix(change, base+webhookPathPrefix(id)))
+	require.True(t, strings.HasPrefix(cron, base+webhookPathPrefix(id)))
+}

--- a/internal/fleet/reconcile.go
+++ b/internal/fleet/reconcile.go
@@ -51,21 +51,35 @@ func (r *Reconciler) reconcileChange(ctx context.Context, roles []Role) error {
 		desired[markerFor(r.cfg.FleetID, role)] = role
 	}
 
-	// Delete owned webhooks whose marker is no longer desired.
-	for marker, id := range existing {
+	// Delete owned webhooks whose marker is no longer desired (also drops extras
+	// sharing this fleet's /<h>/ from a superseded spec version).
+	for marker, have := range existing {
 		if _, keep := desired[marker]; !keep {
-			if derr := r.delete(ctx, id); derr != nil {
+			if derr := r.delete(ctx, have.id); derr != nil {
 				return derr
 			}
 		}
 	}
-	// Create webhooks for desired markers not yet present.
+	// Create webhooks for desired markers not yet present; take over stale ones.
 	for marker, role := range desired {
-		if _, present := existing[marker]; present {
-			continue // marker already matches => spec unchanged (ver is content-derived)
+		have, present := existing[marker]
+		if !present {
+			if cerr := r.create(ctx, role); cerr != nil {
+				return cerr
+			}
+			continue
 		}
-		if cerr := r.create(ctx, role); cerr != nil {
-			return cerr
+		// Marker present => spec unchanged (ver is content-derived). But a
+		// restarted/moved fleet with the same fleet_id computes the same marker
+		// yet the stored url may point at the old address. Re-claim it
+		// (last-writer-wins takeover) by pointing the /<h>/ webhook at this
+		// fleet's current delivery url. An empty stored url means the row shape
+		// carries no url to compare (test fakes), so leave it alone.
+		want := changeDeliveryURL(r.cfg.CallbackURL, r.cfg.FleetID, role.NotePath)
+		if have.url != "" && have.url != want {
+			if uerr := r.update(ctx, have.id, want); uerr != nil {
+				return uerr
+			}
 		}
 	}
 	return nil
@@ -111,8 +125,8 @@ func (r *Reconciler) Deregister(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	for _, id := range existing {
-		if derr := r.delete(ctx, id); derr != nil {
+	for _, have := range existing {
+		if derr := r.delete(ctx, have.id); derr != nil {
 			return derr
 		}
 	}
@@ -128,16 +142,23 @@ func (r *Reconciler) Deregister(ctx context.Context) error {
 	return nil
 }
 
-func (r *Reconciler) listOwned(ctx context.Context) (map[string]int64, error) {
+// ownedWebhook is a listed change-webhook this fleet owns (by description
+// marker): its id (for update/delete) and current delivery url (for takeover).
+type ownedWebhook struct {
+	id  int64
+	url string
+}
+
+func (r *Reconciler) listOwned(ctx context.Context) (map[string]ownedWebhook, error) {
 	resp, err := trip2ggql.ListChangeWebhooks(ctx, r.gql)
 	if err != nil {
 		return nil, err
 	}
 	prefix := "fleet:" + r.cfg.FleetID + ":"
-	owned := map[string]int64{}
+	owned := map[string]ownedWebhook{}
 	for _, n := range resp.Admin.AllChangeWebhooks.Nodes {
 		if strings.HasPrefix(n.Description, prefix) {
-			owned[n.Description] = n.Id
+			owned[n.Description] = ownedWebhook{id: n.Id, url: n.Url}
 		}
 	}
 	return owned, nil
@@ -145,7 +166,7 @@ func (r *Reconciler) listOwned(ctx context.Context) (map[string]int64, error) {
 
 func (r *Reconciler) create(ctx context.Context, role Role) error {
 	input := trip2ggql.ChangeWebhookCreateInput{
-		Url:              r.cfg.CallbackURL + "/deliver/" + urlKey(role.NotePath),
+		Url:              changeDeliveryURL(r.cfg.CallbackURL, r.cfg.FleetID, role.NotePath),
 		IncludePatterns:  orEmpty(role.TriggerInclude),
 		ExcludePatterns:  orEmpty(role.TriggerExclude),
 		ReadPatterns:     orEmpty(role.ReadPatterns),
@@ -189,6 +210,20 @@ func (r *Reconciler) delete(ctx context.Context, id int64) error {
 	return nil
 }
 
+// update re-points an existing owned change-webhook at url (hash-registry
+// takeover). Only id+url are set, so trip2g updates the delivery target and
+// leaves the rest of the webhook spec untouched.
+func (r *Reconciler) update(ctx context.Context, id int64, url string) error {
+	resp, err := trip2ggql.UpdateChangeWebhook(ctx, r.gql, trip2ggql.ChangeWebhookUpdateInput{Id: id, Url: url})
+	if err != nil {
+		return err
+	}
+	if ep, ok := resp.Admin.ChangeWebhookUpdate.(*trip2ggql.UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateErrorPayload); ok {
+		return fmt.Errorf("changeWebhookUpdate: %s", ep.Message)
+	}
+	return nil
+}
+
 func (r *Reconciler) listOwnedCron(ctx context.Context) (map[string]int64, error) {
 	resp, err := trip2ggql.ListCronWebhooks(ctx, r.gql)
 	if err != nil {
@@ -206,7 +241,7 @@ func (r *Reconciler) listOwnedCron(ctx context.Context) (map[string]int64, error
 
 func (r *Reconciler) createCron(ctx context.Context, role Role) error {
 	input := trip2ggql.CreateCronWebhookInput{
-		Url:             r.cfg.CallbackURL + "/deliver/cron/" + urlKey(role.NotePath),
+		Url:             cronDeliveryURL(r.cfg.CallbackURL, r.cfg.FleetID, role.NotePath),
 		CronSchedule:    role.CronSchedule,
 		ReadPatterns:    orEmpty(role.ReadPatterns),
 		WritePatterns:   orEmpty(role.WritePatterns),

--- a/internal/fleet/reconcile.go
+++ b/internal/fleet/reconcile.go
@@ -51,8 +51,10 @@ func (r *Reconciler) reconcileChange(ctx context.Context, roles []Role) error {
 		desired[markerFor(r.cfg.FleetID, role)] = role
 	}
 
-	// Delete owned webhooks whose marker is no longer desired (also drops extras
-	// sharing this fleet's /<h>/ from a superseded spec version).
+	// Delete owned webhooks whose marker is no longer desired (this also drops
+	// extras from a superseded spec version: they share this fleet's
+	// "fleet:<FleetID>:" description-marker prefix — listOwned already filtered
+	// to it — but their old marker/spec-hash suffix no longer matches desired).
 	for marker, have := range existing {
 		if _, keep := desired[marker]; !keep {
 			if derr := r.delete(ctx, have.id); derr != nil {

--- a/internal/fleet/reconcile_test.go
+++ b/internal/fleet/reconcile_test.go
@@ -44,9 +44,115 @@ func nodesData(nodes ...[2]string) string {
 	return `{"admin":{"allChangeWebhooks":{"nodes":[` + strings.Join(parts, ",") + `]}}}`
 }
 
+// nodesDataURL is like nodesData but carries a url per node, for takeover tests.
+func nodesDataURL(nodes ...[3]string) string {
+	parts := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		parts = append(parts, fmt.Sprintf(`{"id":%s,"description":%q,"url":%q}`, n[0], n[1], n[2]))
+	}
+	return `{"admin":{"allChangeWebhooks":{"nodes":[` + strings.Join(parts, ",") + `]}}}`
+}
+
 const createOKData = `{"admin":{"changeWebhookCreate":{"__typename":"ChangeWebhookCreatePayload","webhook":{"id":8}}}}`
 
 const deleteOKData = `{"admin":{"changeWebhookDelete":{"__typename":"ChangeWebhookDeletePayload","deletedId":0}}}`
+
+const updateOKData = `{"admin":{"changeWebhookUpdate":{"__typename":"ChangeWebhookUpdatePayload","webhook":{"id":7}}}}`
+
+// updateInputFrom decodes an UpdateChangeWebhook request's typed input variable.
+func updateInputFrom(t *testing.T, vars json.RawMessage) trip2ggql.ChangeWebhookUpdateInput {
+	t.Helper()
+	var v struct {
+		Input trip2ggql.ChangeWebhookUpdateInput `json:"input"`
+	}
+	require.NoError(t, json.Unmarshal(vars, &v))
+	return v.Input
+}
+
+// TestReconcile_TakesOverStaleURL asserts the hash-registry takeover: a webhook
+// with this fleet's marker but pointing at a stale address (a restarted/moved
+// fleet with the same fleet_id) is re-pointed at the fleet's current /<h>/
+// delivery url via changeWebhookUpdate — no create, no delete (last-writer-wins).
+func TestReconcile_TakesOverStaleURL(t *testing.T) {
+	role := Role{NotePath: "roles/triage.md", Mode: "change", MaxDepth: 1, Concurrency: "skip"}
+	marker := markerFor("f1", role)
+	staleURL := "https://OLD-host.example/_fleet/" + fleetHash("f1") + "/webhook/" + urlKey(role.NotePath)
+
+	var updates []trip2ggql.ChangeWebhookUpdateInput
+	var createCalls, deleteCalls int
+	gql := fakeAdminGQL(func(op string, vars json.RawMessage) (string, error) {
+		switch op {
+		case "ListChangeWebhooks":
+			return nodesDataURL([3]string{"7", marker, staleURL}), nil
+		case "UpdateChangeWebhook":
+			updates = append(updates, updateInputFrom(t, vars))
+			return updateOKData, nil
+		case "CreateChangeWebhook":
+			createCalls++
+			return createOKData, nil
+		case "DeleteChangeWebhook":
+			deleteCalls++
+			return deleteOKData, nil
+		}
+		return "", fmt.Errorf("unexpected op %q", op)
+	})
+	require.NoError(t, newReconciler(gql).Reconcile(context.Background(), []Role{role}))
+	require.Zero(t, createCalls, "takeover updates, never recreates")
+	require.Zero(t, deleteCalls, "takeover updates, never deletes")
+	require.Len(t, updates, 1, "the stale-url webhook must be taken over via update")
+	require.Equal(t, int64(7), updates[0].Id)
+	require.Equal(t, changeDeliveryURL("https://fleet.example", "f1", role.NotePath), updates[0].Url)
+}
+
+// TestReconcile_NoUpdateWhenURLMatches asserts that when the marker AND the url
+// already match this fleet's current address, reconcile is a no-op (no update).
+func TestReconcile_NoUpdateWhenURLMatches(t *testing.T) {
+	role := Role{NotePath: "roles/triage.md", Mode: "change", MaxDepth: 1, Concurrency: "skip"}
+	marker := markerFor("f1", role)
+	currentURL := changeDeliveryURL("https://fleet.example", "f1", role.NotePath)
+
+	var updateCalls, createCalls, deleteCalls int
+	gql := fakeAdminGQL(func(op string, _ json.RawMessage) (string, error) {
+		switch op {
+		case "ListChangeWebhooks":
+			return nodesDataURL([3]string{"7", marker, currentURL}), nil
+		case "UpdateChangeWebhook":
+			updateCalls++
+			return updateOKData, nil
+		case "CreateChangeWebhook":
+			createCalls++
+			return createOKData, nil
+		case "DeleteChangeWebhook":
+			deleteCalls++
+			return deleteOKData, nil
+		}
+		return "", fmt.Errorf("unexpected op %q", op)
+	})
+	require.NoError(t, newReconciler(gql).Reconcile(context.Background(), []Role{role}))
+	require.Zero(t, updateCalls, "url already current => no takeover update")
+	require.Zero(t, createCalls)
+	require.Zero(t, deleteCalls)
+}
+
+// TestReconcile_Update_ErrorPayload_SurfacesAsError asserts an ErrorPayload from
+// changeWebhookUpdate propagates instead of being swallowed.
+func TestReconcile_Update_ErrorPayload_SurfacesAsError(t *testing.T) {
+	role := Role{NotePath: "roles/triage.md", Mode: "change", MaxDepth: 1}
+	marker := markerFor("f1", role)
+	staleURL := "https://old.example/_fleet/x/webhook/" + urlKey(role.NotePath)
+	gql := fakeAdminGQL(func(op string, _ json.RawMessage) (string, error) {
+		switch op {
+		case "ListChangeWebhooks":
+			return nodesDataURL([3]string{"7", marker, staleURL}), nil
+		case "UpdateChangeWebhook":
+			return `{"admin":{"changeWebhookUpdate":{"__typename":"ErrorPayload","message":"url is required"}}}`, nil
+		}
+		return "", fmt.Errorf("unexpected op %q", op)
+	})
+	err := newReconciler(gql).Reconcile(context.Background(), []Role{role})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "url is required")
+}
 
 // TestSpecVer_SchemaBumpRotatesMarker asserts the schema-version bump makes
 // specVer differ from the legacy hash for a fixed role, so every marker rotates
@@ -86,6 +192,44 @@ func TestReconcile_SchemaBumpRecreatesLegacyWebhook(t *testing.T) {
 		"recreated webhook must enable include_content")
 }
 
+// TestReconcile_DropsExtrasSharingHashSegment asserts that when two webhooks
+// share this fleet's /<h>/ (same fleet_id) — the desired one plus a stale
+// superseded-spec extra — the extra is deleted while the desired one is kept.
+func TestReconcile_DropsExtrasSharingHashSegment(t *testing.T) {
+	role := Role{NotePath: "roles/triage.md", Mode: "change", MaxDepth: 1, Concurrency: "skip"}
+	marker := markerFor("f1", role)
+	currentURL := changeDeliveryURL("https://fleet.example", "f1", role.NotePath)
+	h := fleetHash("f1")
+	staleMarker := "fleet:f1:" + role.NotePath + "#deadbeef"           // same /<h>/, superseded spec
+	staleURL := "https://fleet.example/_fleet/" + h + "/webhook/stale" // shares /<h>/
+
+	var deletedIDs []int64
+	var updateCalls, createCalls int
+	gql := fakeAdminGQL(func(op string, vars json.RawMessage) (string, error) {
+		switch op {
+		case "ListChangeWebhooks":
+			return nodesDataURL(
+				[3]string{"7", marker, currentURL},
+				[3]string{"9", staleMarker, staleURL},
+			), nil
+		case "DeleteChangeWebhook":
+			deletedIDs = append(deletedIDs, deleteIDFrom(t, vars))
+			return deleteOKData, nil
+		case "UpdateChangeWebhook":
+			updateCalls++
+			return updateOKData, nil
+		case "CreateChangeWebhook":
+			createCalls++
+			return createOKData, nil
+		}
+		return "", fmt.Errorf("unexpected op %q", op)
+	})
+	require.NoError(t, newReconciler(gql).Reconcile(context.Background(), []Role{role}))
+	require.Equal(t, []int64{9}, deletedIDs, "the superseded extra sharing /<h>/ is dropped")
+	require.Zero(t, createCalls, "desired marker already present")
+	require.Zero(t, updateCalls, "desired url already current")
+}
+
 func newReconciler(gql graphql.Client) *Reconciler {
 	return NewReconciler(gql, Config{
 		FleetID:     "f1",
@@ -119,7 +263,8 @@ func TestReconcile_CreatesMissingWebhook(t *testing.T) {
 	require.True(t, created.PassApiKey)
 	require.Equal(t, int64(1), created.MaxDepth)
 	require.Contains(t, created.Description, "fleet:f1:roles/triage.md#")
-	require.True(t, strings.HasPrefix(created.Url, "https://fleet.example/deliver/"))
+	require.Equal(t, changeDeliveryURL("https://fleet.example", "f1", "roles/triage.md"), created.Url)
+	require.Contains(t, created.Url, "/_fleet/"+fleetHash("f1")+"/webhook/")
 }
 
 // TestReconcile_RequestsNoteContent is a regression test for the content gap:
@@ -344,7 +489,8 @@ func TestReconcile_CreatesCronWebhookForCronRole(t *testing.T) {
 	require.True(t, createdInput.PassApiKey, "cron webhook must pass api_key")
 	require.True(t, createdInput.Enabled, "cron webhook must be enabled")
 	require.Equal(t, int64(120), createdInput.TimeoutSeconds)
-	require.Contains(t, createdInput.Url, "/deliver/cron/")
+	require.Equal(t, cronDeliveryURL("https://fleet.example", "f1", "roles/kb-refresh.md"), createdInput.Url)
+	require.Contains(t, createdInput.Url, "/_fleet/"+fleetHash("f1")+"/webhook/cron/")
 	require.Contains(t, createdInput.Description, "fleetcron:f1:roles/kb-refresh.md#")
 }
 

--- a/internal/fleet/reconcile_test.go
+++ b/internal/fleet/reconcile_test.go
@@ -104,6 +104,57 @@ func TestReconcile_TakesOverStaleURL(t *testing.T) {
 	require.Equal(t, changeDeliveryURL("https://fleet.example", "f1", role.NotePath), updates[0].Url)
 }
 
+// TestReconcile_TakeoverUpdate_SendsOnlyIdAndURL is the CRITICAL regression
+// guard: it captures the RAW JSON variables genqlient actually marshals for
+// the changeWebhookUpdate call (not a typed-struct decode, which can't tell a
+// present zero-value field from an absent one and would hide this bug) and
+// asserts the "input" object contains EXACTLY the keys "id" and "url".
+//
+// Why this matters: ChangeWebhookUpdateInput's other fields (enabled,
+// description, onCreate/onUpdate/onRemove, timeoutSeconds, ...) are plain Go
+// zero values in update()'s {Id, Url}-only literal. trip2g's
+// changeWebhookUpdate resolver applies PATCH semantics (an absent JSON field
+// keeps the existing DB value), but a *present* zero would be applied as a
+// real value: enabled:false disables the webhook, description:"" wipes the
+// reconcile marker, onCreate/onUpdate/onRemove:false stops it firing, and
+// timeoutSeconds:0 fails the resolver's validateBounds check outright (making
+// every takeover a hard reconcile error). The omitempty directives on
+// ChangeWebhookUpdateInput (operations.graphql) are what make genqlient omit
+// these fields from the marshaled JSON instead of sending them as zeros.
+func TestReconcile_TakeoverUpdate_SendsOnlyIdAndURL(t *testing.T) {
+	role := Role{NotePath: "roles/triage.md", Mode: "change", MaxDepth: 1, Concurrency: "skip"}
+	marker := markerFor("f1", role)
+	staleURL := "https://OLD-host.example/_fleet/" + fleetHash("f1") + "/webhook/" + urlKey(role.NotePath)
+
+	var rawVars json.RawMessage
+	gql := fakeAdminGQL(func(op string, vars json.RawMessage) (string, error) {
+		switch op {
+		case "ListChangeWebhooks":
+			return nodesDataURL([3]string{"7", marker, staleURL}), nil
+		case "UpdateChangeWebhook":
+			rawVars = vars
+			return updateOKData, nil
+		}
+		return "", fmt.Errorf("unexpected op %q", op)
+	})
+	require.NoError(t, newReconciler(gql).Reconcile(context.Background(), []Role{role}))
+	require.NotNil(t, rawVars, "changeWebhookUpdate must have been called")
+
+	var v struct {
+		Input map[string]json.RawMessage `json:"input"`
+	}
+	require.NoError(t, json.Unmarshal(rawVars, &v))
+
+	keys := make([]string, 0, len(v.Input))
+	for k := range v.Input {
+		keys = append(keys, k)
+	}
+	require.ElementsMatch(t, []string{"id", "url"}, keys,
+		"the wire variables for a takeover update must carry ONLY id and url; "+
+			"any other present key is a zero-value field that will overwrite the "+
+			"existing webhook row under trip2g's PATCH semantics")
+}
+
 // TestReconcile_NoUpdateWhenURLMatches asserts that when the marker AND the url
 // already match this fleet's current address, reconcile is a no-op (no update).
 func TestReconcile_NoUpdateWhenURLMatches(t *testing.T) {
@@ -193,15 +244,20 @@ func TestReconcile_SchemaBumpRecreatesLegacyWebhook(t *testing.T) {
 }
 
 // TestReconcile_DropsExtrasSharingHashSegment asserts that when two webhooks
-// share this fleet's /<h>/ (same fleet_id) — the desired one plus a stale
-// superseded-spec extra — the extra is deleted while the desired one is kept.
+// for the same role both carry this fleet's "fleet:<FleetID>:" description
+// marker prefix — the current one plus a stale extra from a superseded spec
+// version (different specVer suffix) — the extra is deleted (marker mismatch
+// against desired) while the current one is kept untouched. Both happen to
+// share the same /<h>/ url segment (same fleet_id), since dedup here is
+// marker-keyed, not url-keyed; the url-keyed path is the takeover/update tests
+// above.
 func TestReconcile_DropsExtrasSharingHashSegment(t *testing.T) {
 	role := Role{NotePath: "roles/triage.md", Mode: "change", MaxDepth: 1, Concurrency: "skip"}
 	marker := markerFor("f1", role)
 	currentURL := changeDeliveryURL("https://fleet.example", "f1", role.NotePath)
 	h := fleetHash("f1")
-	staleMarker := "fleet:f1:" + role.NotePath + "#deadbeef"           // same /<h>/, superseded spec
-	staleURL := "https://fleet.example/_fleet/" + h + "/webhook/stale" // shares /<h>/
+	staleMarker := "fleet:f1:" + role.NotePath + "#deadbeef"           // same fleet, superseded spec
+	staleURL := "https://fleet.example/_fleet/" + h + "/webhook/stale" // shares /<h>/ (same fleet_id)
 
 	var deletedIDs []int64
 	var updateCalls, createCalls int
@@ -225,7 +281,7 @@ func TestReconcile_DropsExtrasSharingHashSegment(t *testing.T) {
 		return "", fmt.Errorf("unexpected op %q", op)
 	})
 	require.NoError(t, newReconciler(gql).Reconcile(context.Background(), []Role{role}))
-	require.Equal(t, []int64{9}, deletedIDs, "the superseded extra sharing /<h>/ is dropped")
+	require.Equal(t, []int64{9}, deletedIDs, "the superseded-marker extra is dropped")
 	require.Zero(t, createCalls, "desired marker already present")
 	require.Zero(t, updateCalls, "desired url already current")
 }

--- a/internal/fleet/role.go
+++ b/internal/fleet/role.go
@@ -20,6 +20,7 @@ const (
 type Role struct {
 	NotePath       string
 	Body           string
+	FleetID        string // partition key: only the fleet whose --fleet-id matches processes this role
 	Executor       string // "" | "llm" | "code" (default: llm)
 	Model          string
 	Tools          []string
@@ -48,6 +49,7 @@ func ParseRole(notePath, body string, m map[string]string) (Role, error) {
 	r := Role{
 		NotePath:       notePath,
 		Body:           body,
+		FleetID:        strings.TrimSpace(m["fleet_id"]),
 		Executor:       strings.TrimSpace(m["executor"]),
 		Model:          strings.TrimSpace(m["model"]),
 		Tools:          parseList(m["tools"]),

--- a/internal/fleet/trip2ggql/genqlient.gen.go
+++ b/internal/fleet/trip2ggql/genqlient.gen.go
@@ -96,6 +96,89 @@ type ChangeWebhookDeleteInput struct {
 // GetId returns ChangeWebhookDeleteInput.Id, and is useful for accessing the field via an interface.
 func (v *ChangeWebhookDeleteInput) GetId() int64 { return v.Id }
 
+type ChangeWebhookUpdateInput struct {
+	Id               int64    `json:"id"`
+	Url              string   `json:"url"`
+	IncludePatterns  []string `json:"includePatterns"`
+	ExcludePatterns  []string `json:"excludePatterns"`
+	Instruction      string   `json:"instruction"`
+	MaxDepth         int64    `json:"maxDepth"`
+	PassApiKey       bool     `json:"passApiKey"`
+	IncludeContent   bool     `json:"includeContent"`
+	TimeoutSeconds   int64    `json:"timeoutSeconds"`
+	MaxRetries       int64    `json:"maxRetries"`
+	Enabled          bool     `json:"enabled"`
+	Description      string   `json:"description"`
+	OnCreate         bool     `json:"onCreate"`
+	OnUpdate         bool     `json:"onUpdate"`
+	OnRemove         bool     `json:"onRemove"`
+	ReadPatterns     []string `json:"readPatterns"`
+	WritePatterns    []string `json:"writePatterns"`
+	TransformJsonnet string   `json:"transformJsonnet"`
+	AttachNotes      []string `json:"attachNotes"`
+	ConcurrencyMode  string   `json:"concurrencyMode"`
+}
+
+// GetId returns ChangeWebhookUpdateInput.Id, and is useful for accessing the field via an interface.
+func (v *ChangeWebhookUpdateInput) GetId() int64 { return v.Id }
+
+// GetUrl returns ChangeWebhookUpdateInput.Url, and is useful for accessing the field via an interface.
+func (v *ChangeWebhookUpdateInput) GetUrl() string { return v.Url }
+
+// GetIncludePatterns returns ChangeWebhookUpdateInput.IncludePatterns, and is useful for accessing the field via an interface.
+func (v *ChangeWebhookUpdateInput) GetIncludePatterns() []string { return v.IncludePatterns }
+
+// GetExcludePatterns returns ChangeWebhookUpdateInput.ExcludePatterns, and is useful for accessing the field via an interface.
+func (v *ChangeWebhookUpdateInput) GetExcludePatterns() []string { return v.ExcludePatterns }
+
+// GetInstruction returns ChangeWebhookUpdateInput.Instruction, and is useful for accessing the field via an interface.
+func (v *ChangeWebhookUpdateInput) GetInstruction() string { return v.Instruction }
+
+// GetMaxDepth returns ChangeWebhookUpdateInput.MaxDepth, and is useful for accessing the field via an interface.
+func (v *ChangeWebhookUpdateInput) GetMaxDepth() int64 { return v.MaxDepth }
+
+// GetPassApiKey returns ChangeWebhookUpdateInput.PassApiKey, and is useful for accessing the field via an interface.
+func (v *ChangeWebhookUpdateInput) GetPassApiKey() bool { return v.PassApiKey }
+
+// GetIncludeContent returns ChangeWebhookUpdateInput.IncludeContent, and is useful for accessing the field via an interface.
+func (v *ChangeWebhookUpdateInput) GetIncludeContent() bool { return v.IncludeContent }
+
+// GetTimeoutSeconds returns ChangeWebhookUpdateInput.TimeoutSeconds, and is useful for accessing the field via an interface.
+func (v *ChangeWebhookUpdateInput) GetTimeoutSeconds() int64 { return v.TimeoutSeconds }
+
+// GetMaxRetries returns ChangeWebhookUpdateInput.MaxRetries, and is useful for accessing the field via an interface.
+func (v *ChangeWebhookUpdateInput) GetMaxRetries() int64 { return v.MaxRetries }
+
+// GetEnabled returns ChangeWebhookUpdateInput.Enabled, and is useful for accessing the field via an interface.
+func (v *ChangeWebhookUpdateInput) GetEnabled() bool { return v.Enabled }
+
+// GetDescription returns ChangeWebhookUpdateInput.Description, and is useful for accessing the field via an interface.
+func (v *ChangeWebhookUpdateInput) GetDescription() string { return v.Description }
+
+// GetOnCreate returns ChangeWebhookUpdateInput.OnCreate, and is useful for accessing the field via an interface.
+func (v *ChangeWebhookUpdateInput) GetOnCreate() bool { return v.OnCreate }
+
+// GetOnUpdate returns ChangeWebhookUpdateInput.OnUpdate, and is useful for accessing the field via an interface.
+func (v *ChangeWebhookUpdateInput) GetOnUpdate() bool { return v.OnUpdate }
+
+// GetOnRemove returns ChangeWebhookUpdateInput.OnRemove, and is useful for accessing the field via an interface.
+func (v *ChangeWebhookUpdateInput) GetOnRemove() bool { return v.OnRemove }
+
+// GetReadPatterns returns ChangeWebhookUpdateInput.ReadPatterns, and is useful for accessing the field via an interface.
+func (v *ChangeWebhookUpdateInput) GetReadPatterns() []string { return v.ReadPatterns }
+
+// GetWritePatterns returns ChangeWebhookUpdateInput.WritePatterns, and is useful for accessing the field via an interface.
+func (v *ChangeWebhookUpdateInput) GetWritePatterns() []string { return v.WritePatterns }
+
+// GetTransformJsonnet returns ChangeWebhookUpdateInput.TransformJsonnet, and is useful for accessing the field via an interface.
+func (v *ChangeWebhookUpdateInput) GetTransformJsonnet() string { return v.TransformJsonnet }
+
+// GetAttachNotes returns ChangeWebhookUpdateInput.AttachNotes, and is useful for accessing the field via an interface.
+func (v *ChangeWebhookUpdateInput) GetAttachNotes() []string { return v.AttachNotes }
+
+// GetConcurrencyMode returns ChangeWebhookUpdateInput.ConcurrencyMode, and is useful for accessing the field via an interface.
+func (v *ChangeWebhookUpdateInput) GetConcurrencyMode() string { return v.ConcurrencyMode }
+
 // CreateChangeWebhookAdminAdminMutation includes the requested fields of the GraphQL type AdminMutation.
 type CreateChangeWebhookAdminAdminMutation struct {
 	ChangeWebhookCreate CreateChangeWebhookAdminAdminMutationChangeWebhookCreateChangeWebhookCreateOrErrorPayload `json:"-"`
@@ -1007,6 +1090,7 @@ func (v *ListChangeWebhooksAdminAdminQueryAllChangeWebhooksAdminChangeWebhooksCo
 type ListChangeWebhooksAdminAdminQueryAllChangeWebhooksAdminChangeWebhooksConnectionNodesAdminChangeWebhook struct {
 	Id          int64  `json:"id"`
 	Description string `json:"description"`
+	Url         string `json:"url"`
 }
 
 // GetId returns ListChangeWebhooksAdminAdminQueryAllChangeWebhooksAdminChangeWebhooksConnectionNodesAdminChangeWebhook.Id, and is useful for accessing the field via an interface.
@@ -1017,6 +1101,11 @@ func (v *ListChangeWebhooksAdminAdminQueryAllChangeWebhooksAdminChangeWebhooksCo
 // GetDescription returns ListChangeWebhooksAdminAdminQueryAllChangeWebhooksAdminChangeWebhooksConnectionNodesAdminChangeWebhook.Description, and is useful for accessing the field via an interface.
 func (v *ListChangeWebhooksAdminAdminQueryAllChangeWebhooksAdminChangeWebhooksConnectionNodesAdminChangeWebhook) GetDescription() string {
 	return v.Description
+}
+
+// GetUrl returns ListChangeWebhooksAdminAdminQueryAllChangeWebhooksAdminChangeWebhooksConnectionNodesAdminChangeWebhook.Url, and is useful for accessing the field via an interface.
+func (v *ListChangeWebhooksAdminAdminQueryAllChangeWebhooksAdminChangeWebhooksConnectionNodesAdminChangeWebhook) GetUrl() string {
+	return v.Url
 }
 
 // ListChangeWebhooksResponse is returned by ListChangeWebhooks on success.
@@ -1329,6 +1418,204 @@ func (v *SearchScopedSearchSearchConnectionNodesSearchResultDocumentPublicNote) 
 // GetPath returns SearchScopedSearchSearchConnectionNodesSearchResultDocumentPublicNote.Path, and is useful for accessing the field via an interface.
 func (v *SearchScopedSearchSearchConnectionNodesSearchResultDocumentPublicNote) GetPath() string {
 	return v.Path
+}
+
+// UpdateChangeWebhookAdminAdminMutation includes the requested fields of the GraphQL type AdminMutation.
+type UpdateChangeWebhookAdminAdminMutation struct {
+	ChangeWebhookUpdate UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdateOrErrorPayload `json:"-"`
+}
+
+// GetChangeWebhookUpdate returns UpdateChangeWebhookAdminAdminMutation.ChangeWebhookUpdate, and is useful for accessing the field via an interface.
+func (v *UpdateChangeWebhookAdminAdminMutation) GetChangeWebhookUpdate() UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdateOrErrorPayload {
+	return v.ChangeWebhookUpdate
+}
+
+func (v *UpdateChangeWebhookAdminAdminMutation) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*UpdateChangeWebhookAdminAdminMutation
+		ChangeWebhookUpdate json.RawMessage `json:"changeWebhookUpdate"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.UpdateChangeWebhookAdminAdminMutation = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.ChangeWebhookUpdate
+		src := firstPass.ChangeWebhookUpdate
+		if len(src) != 0 && string(src) != "null" {
+			err = __unmarshalUpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdateOrErrorPayload(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal UpdateChangeWebhookAdminAdminMutation.ChangeWebhookUpdate: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalUpdateChangeWebhookAdminAdminMutation struct {
+	ChangeWebhookUpdate json.RawMessage `json:"changeWebhookUpdate"`
+}
+
+func (v *UpdateChangeWebhookAdminAdminMutation) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *UpdateChangeWebhookAdminAdminMutation) __premarshalJSON() (*__premarshalUpdateChangeWebhookAdminAdminMutation, error) {
+	var retval __premarshalUpdateChangeWebhookAdminAdminMutation
+
+	{
+
+		dst := &retval.ChangeWebhookUpdate
+		src := v.ChangeWebhookUpdate
+		var err error
+		*dst, err = __marshalUpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdateOrErrorPayload(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal UpdateChangeWebhookAdminAdminMutation.ChangeWebhookUpdate: %w", err)
+		}
+	}
+	return &retval, nil
+}
+
+// UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdateOrErrorPayload includes the requested fields of the GraphQL interface ChangeWebhookUpdateOrErrorPayload.
+//
+// UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdateOrErrorPayload is implemented by the following types:
+// UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdatePayload
+// UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateErrorPayload
+type UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdateOrErrorPayload interface {
+	implementsGraphQLInterfaceUpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdateOrErrorPayload()
+	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
+	GetTypename() string
+}
+
+func (v *UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdatePayload) implementsGraphQLInterfaceUpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdateOrErrorPayload() {
+}
+func (v *UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateErrorPayload) implementsGraphQLInterfaceUpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdateOrErrorPayload() {
+}
+
+func __unmarshalUpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdateOrErrorPayload(b []byte, v *UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdateOrErrorPayload) error {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var tn struct {
+		TypeName string `json:"__typename"`
+	}
+	err := json.Unmarshal(b, &tn)
+	if err != nil {
+		return err
+	}
+
+	switch tn.TypeName {
+	case "ChangeWebhookUpdatePayload":
+		*v = new(UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdatePayload)
+		return json.Unmarshal(b, *v)
+	case "ErrorPayload":
+		*v = new(UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateErrorPayload)
+		return json.Unmarshal(b, *v)
+	case "":
+		return fmt.Errorf(
+			"response was missing ChangeWebhookUpdateOrErrorPayload.__typename")
+	default:
+		return fmt.Errorf(
+			`unexpected concrete type for UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdateOrErrorPayload: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalUpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdateOrErrorPayload(v *UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdateOrErrorPayload) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdatePayload:
+		typename = "ChangeWebhookUpdatePayload"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdatePayload
+		}{typename, v}
+		return json.Marshal(result)
+	case *UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateErrorPayload:
+		typename = "ErrorPayload"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateErrorPayload
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`unexpected concrete type for UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdateOrErrorPayload: "%T"`, v)
+	}
+}
+
+// UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdatePayload includes the requested fields of the GraphQL type ChangeWebhookUpdatePayload.
+type UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdatePayload struct {
+	Typename string                                                                                                      `json:"__typename"`
+	Webhook  UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdatePayloadWebhookAdminChangeWebhook `json:"webhook"`
+}
+
+// GetTypename returns UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdatePayload.Typename, and is useful for accessing the field via an interface.
+func (v *UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdatePayload) GetTypename() string {
+	return v.Typename
+}
+
+// GetWebhook returns UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdatePayload.Webhook, and is useful for accessing the field via an interface.
+func (v *UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdatePayload) GetWebhook() UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdatePayloadWebhookAdminChangeWebhook {
+	return v.Webhook
+}
+
+// UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdatePayloadWebhookAdminChangeWebhook includes the requested fields of the GraphQL type AdminChangeWebhook.
+type UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdatePayloadWebhookAdminChangeWebhook struct {
+	Id int64 `json:"id"`
+}
+
+// GetId returns UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdatePayloadWebhookAdminChangeWebhook.Id, and is useful for accessing the field via an interface.
+func (v *UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateChangeWebhookUpdatePayloadWebhookAdminChangeWebhook) GetId() int64 {
+	return v.Id
+}
+
+// UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateErrorPayload includes the requested fields of the GraphQL type ErrorPayload.
+type UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateErrorPayload struct {
+	Typename string `json:"__typename"`
+	Message  string `json:"message"`
+}
+
+// GetTypename returns UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateErrorPayload.Typename, and is useful for accessing the field via an interface.
+func (v *UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateErrorPayload) GetTypename() string {
+	return v.Typename
+}
+
+// GetMessage returns UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateErrorPayload.Message, and is useful for accessing the field via an interface.
+func (v *UpdateChangeWebhookAdminAdminMutationChangeWebhookUpdateErrorPayload) GetMessage() string {
+	return v.Message
+}
+
+// UpdateChangeWebhookResponse is returned by UpdateChangeWebhook on success.
+type UpdateChangeWebhookResponse struct {
+	Admin UpdateChangeWebhookAdminAdminMutation `json:"admin"`
+}
+
+// GetAdmin returns UpdateChangeWebhookResponse.Admin, and is useful for accessing the field via an interface.
+func (v *UpdateChangeWebhookResponse) GetAdmin() UpdateChangeWebhookAdminAdminMutation {
+	return v.Admin
 }
 
 // UpdateCronWebhookAdminAdminMutation includes the requested fields of the GraphQL type AdminMutation.
@@ -1891,6 +2178,14 @@ type __SearchScopedInput struct {
 // GetQ returns __SearchScopedInput.Q, and is useful for accessing the field via an interface.
 func (v *__SearchScopedInput) GetQ() string { return v.Q }
 
+// __UpdateChangeWebhookInput is used internally by genqlient
+type __UpdateChangeWebhookInput struct {
+	Input ChangeWebhookUpdateInput `json:"input"`
+}
+
+// GetInput returns __UpdateChangeWebhookInput.Input, and is useful for accessing the field via an interface.
+func (v *__UpdateChangeWebhookInput) GetInput() ChangeWebhookUpdateInput { return v.Input }
+
 // __UpdateCronWebhookInput is used internally by genqlient
 type __UpdateCronWebhookInput struct {
 	Input UpdateCronWebhookInput `json:"input"`
@@ -2134,6 +2429,7 @@ query ListChangeWebhooks {
 			nodes {
 				id
 				description
+				url
 			}
 		}
 	}
@@ -2272,6 +2568,53 @@ func SearchScoped(
 	}
 
 	data_ = &SearchScopedResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
+
+// The mutation executed by UpdateChangeWebhook.
+const UpdateChangeWebhook_Operation = `
+mutation UpdateChangeWebhook ($input: ChangeWebhookUpdateInput!) {
+	admin {
+		changeWebhookUpdate(input: $input) {
+			__typename
+			... on ChangeWebhookUpdatePayload {
+				webhook {
+					id
+				}
+			}
+			... on ErrorPayload {
+				message
+			}
+		}
+	}
+}
+`
+
+// UpdateChangeWebhook points an existing owned webhook at this fleet's current
+// delivery URL (hash-registry takeover: a restarted/moved fleet with the same
+// fleet_id re-claims the /<h>/ webhook, last-writer-wins).
+func UpdateChangeWebhook(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	input ChangeWebhookUpdateInput,
+) (data_ *UpdateChangeWebhookResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "UpdateChangeWebhook",
+		Query:  UpdateChangeWebhook_Operation,
+		Variables: &__UpdateChangeWebhookInput{
+			Input: input,
+		},
+	}
+
+	data_ = &UpdateChangeWebhookResponse{}
 	resp_ := &graphql.Response{Data: data_}
 
 	err_ = client_.MakeRequest(

--- a/internal/fleet/trip2ggql/genqlient.gen.go
+++ b/internal/fleet/trip2ggql/genqlient.gen.go
@@ -99,24 +99,24 @@ func (v *ChangeWebhookDeleteInput) GetId() int64 { return v.Id }
 type ChangeWebhookUpdateInput struct {
 	Id               int64    `json:"id"`
 	Url              string   `json:"url"`
-	IncludePatterns  []string `json:"includePatterns"`
-	ExcludePatterns  []string `json:"excludePatterns"`
-	Instruction      string   `json:"instruction"`
-	MaxDepth         int64    `json:"maxDepth"`
-	PassApiKey       bool     `json:"passApiKey"`
-	IncludeContent   bool     `json:"includeContent"`
-	TimeoutSeconds   int64    `json:"timeoutSeconds"`
-	MaxRetries       int64    `json:"maxRetries"`
-	Enabled          bool     `json:"enabled"`
-	Description      string   `json:"description"`
-	OnCreate         bool     `json:"onCreate"`
-	OnUpdate         bool     `json:"onUpdate"`
-	OnRemove         bool     `json:"onRemove"`
-	ReadPatterns     []string `json:"readPatterns"`
-	WritePatterns    []string `json:"writePatterns"`
-	TransformJsonnet string   `json:"transformJsonnet"`
-	AttachNotes      []string `json:"attachNotes"`
-	ConcurrencyMode  string   `json:"concurrencyMode"`
+	IncludePatterns  []string `json:"includePatterns,omitempty"`
+	ExcludePatterns  []string `json:"excludePatterns,omitempty"`
+	Instruction      string   `json:"instruction,omitempty"`
+	MaxDepth         int64    `json:"maxDepth,omitempty"`
+	PassApiKey       bool     `json:"passApiKey,omitempty"`
+	IncludeContent   bool     `json:"includeContent,omitempty"`
+	TimeoutSeconds   int64    `json:"timeoutSeconds,omitempty"`
+	MaxRetries       int64    `json:"maxRetries,omitempty"`
+	Enabled          bool     `json:"enabled,omitempty"`
+	Description      string   `json:"description,omitempty"`
+	OnCreate         bool     `json:"onCreate,omitempty"`
+	OnUpdate         bool     `json:"onUpdate,omitempty"`
+	OnRemove         bool     `json:"onRemove,omitempty"`
+	ReadPatterns     []string `json:"readPatterns,omitempty"`
+	WritePatterns    []string `json:"writePatterns,omitempty"`
+	TransformJsonnet string   `json:"transformJsonnet,omitempty"`
+	AttachNotes      []string `json:"attachNotes,omitempty"`
+	ConcurrencyMode  string   `json:"concurrencyMode,omitempty"`
 }
 
 // GetId returns ChangeWebhookUpdateInput.Id, and is useful for accessing the field via an interface.
@@ -2601,6 +2601,19 @@ mutation UpdateChangeWebhook ($input: ChangeWebhookUpdateInput!) {
 // UpdateChangeWebhook points an existing owned webhook at this fleet's current
 // delivery URL (hash-registry takeover: a restarted/moved fleet with the same
 // fleet_id re-claims the /<h>/ webhook, last-writer-wins).
+//
+// update() (reconcile.go) sets ONLY {Id, Url} — every other field below must
+// omitempty so a Go zero value is NEVER sent to the monolith. trip2g's
+// changeWebhookUpdate resolver uses PATCH semantics (an absent field keeps the
+// existing value); a *present* zero would disable the webhook (enabled:false),
+// wipe the reconcile marker (description:""), stop it firing
+// (onCreate/onUpdate/onRemove:false), and fail validateBounds outright
+// (timeoutSeconds:0 below the required minimum), turning every takeover into a
+// hard reconcile error instead of a narrow url update. NOTE: $input must stay
+// on its own line below — a genqlient quirk attributes a directive comment to
+// the $input variable (not the operation) when it shares the "mutation ...("
+// line, which rejects "for" with "for is only applicable to operations and
+// arguments".
 func UpdateChangeWebhook(
 	ctx_ context.Context,
 	client_ graphql.Client,

--- a/internal/fleet/trip2ggql/operations.graphql
+++ b/internal/fleet/trip2ggql/operations.graphql
@@ -34,7 +34,40 @@ query ListChangeWebhooks {
 # UpdateChangeWebhook points an existing owned webhook at this fleet's current
 # delivery URL (hash-registry takeover: a restarted/moved fleet with the same
 # fleet_id re-claims the /<h>/ webhook, last-writer-wins).
-mutation UpdateChangeWebhook($input: ChangeWebhookUpdateInput!) {
+#
+# update() (reconcile.go) sets ONLY {Id, Url} — every other field below must
+# omitempty so a Go zero value is NEVER sent to the monolith. trip2g's
+# changeWebhookUpdate resolver uses PATCH semantics (an absent field keeps the
+# existing value); a *present* zero would disable the webhook (enabled:false),
+# wipe the reconcile marker (description:""), stop it firing
+# (onCreate/onUpdate/onRemove:false), and fail validateBounds outright
+# (timeoutSeconds:0 below the required minimum), turning every takeover into a
+# hard reconcile error instead of a narrow url update. NOTE: $input must stay
+# on its own line below — a genqlient quirk attributes a directive comment to
+# the $input variable (not the operation) when it shares the "mutation ...("
+# line, which rejects "for" with "for is only applicable to operations and
+# arguments".
+# @genqlient(for: "ChangeWebhookUpdateInput.includePatterns", omitempty: true)
+# @genqlient(for: "ChangeWebhookUpdateInput.excludePatterns", omitempty: true)
+# @genqlient(for: "ChangeWebhookUpdateInput.instruction", omitempty: true)
+# @genqlient(for: "ChangeWebhookUpdateInput.maxDepth", omitempty: true)
+# @genqlient(for: "ChangeWebhookUpdateInput.passApiKey", omitempty: true)
+# @genqlient(for: "ChangeWebhookUpdateInput.includeContent", omitempty: true)
+# @genqlient(for: "ChangeWebhookUpdateInput.timeoutSeconds", omitempty: true)
+# @genqlient(for: "ChangeWebhookUpdateInput.maxRetries", omitempty: true)
+# @genqlient(for: "ChangeWebhookUpdateInput.enabled", omitempty: true)
+# @genqlient(for: "ChangeWebhookUpdateInput.description", omitempty: true)
+# @genqlient(for: "ChangeWebhookUpdateInput.onCreate", omitempty: true)
+# @genqlient(for: "ChangeWebhookUpdateInput.onUpdate", omitempty: true)
+# @genqlient(for: "ChangeWebhookUpdateInput.onRemove", omitempty: true)
+# @genqlient(for: "ChangeWebhookUpdateInput.readPatterns", omitempty: true)
+# @genqlient(for: "ChangeWebhookUpdateInput.writePatterns", omitempty: true)
+# @genqlient(for: "ChangeWebhookUpdateInput.transformJsonnet", omitempty: true)
+# @genqlient(for: "ChangeWebhookUpdateInput.attachNotes", omitempty: true)
+# @genqlient(for: "ChangeWebhookUpdateInput.concurrencyMode", omitempty: true)
+mutation UpdateChangeWebhook(
+  $input: ChangeWebhookUpdateInput!
+) {
   admin {
     changeWebhookUpdate(input: $input) {
       ... on ChangeWebhookUpdatePayload {

--- a/internal/fleet/trip2ggql/operations.graphql
+++ b/internal/fleet/trip2ggql/operations.graphql
@@ -25,6 +25,25 @@ query ListChangeWebhooks {
       nodes {
         id
         description
+        url
+      }
+    }
+  }
+}
+
+# UpdateChangeWebhook points an existing owned webhook at this fleet's current
+# delivery URL (hash-registry takeover: a restarted/moved fleet with the same
+# fleet_id re-claims the /<h>/ webhook, last-writer-wins).
+mutation UpdateChangeWebhook($input: ChangeWebhookUpdateInput!) {
+  admin {
+    changeWebhookUpdate(input: $input) {
+      ... on ChangeWebhookUpdatePayload {
+        webhook {
+          id
+        }
+      }
+      ... on ErrorPayload {
+        message
       }
     }
   }


### PR DESCRIPTION
## What

P3a of the codellm/per-provider-fleet plan: **fleet identity + role partitioning + hash-in-webhook-url registry** — the routing/identity foundation. Fleet-side only; does **not** touch the code-exec path.

## The hash marker

Each fleet now takes a **required `--fleet-id`**. Its identity hash is `h = sha256("fleet:" + fleet_id)` (hex). The `fleet:` prefix namespaces it against other sha256 uses and keeps the plaintext id out of the URL. `h` is **not a secret** and is **never used for auth** — it is an opaque, stable id the monolith routes deliveries on and the reconcile loop de-dups by.

## Role partitioning (untagged-role rule)

A role picks its fleet with `fleet_id:` in frontmatter (new `Role.FleetID`, parsed in `ParseRole`). `DiscoverRoles` processes **only** roles whose `fleet_id == --fleet-id`:
- **matching** `fleet_id` → processed.
- **mismatched** `fleet_id` → skipped **silently** (belongs to another fleet; no log spam).
- **empty** `fleet_id` → **skipped with a warning**. Untagged roles are claimed by no fleet, so two fleets can never both process the same role. (No default-fleet notion — kept minimal per the spec's "empty = skipped, log it".)

`DiscoverParsed` stays **unpartitioned** so the cross-fleet graph/`--dry-run` introspection still sees every role with its `fleet_id`.

## Webhook URL = the hash

Delivery URLs now fold in the identity segment (was `<callback>/deliver/<key>`):
- change: `<callback>/_fleet/<h>/webhook/<urlKey(path)>`
- cron: `<callback>/_fleet/<h>/webhook/cron/<urlKey(path)>`

The `<h>` segment is the fleet identity; the trailing `urlKey` still identifies the role, so per-role receive routing is unchanged.

## Takeover / dedup

On reconcile, when a webhook already carries this fleet's `fleet:<FleetID>:` description marker but its stored `url` differs from the fleet's current delivery url (a restarted/moved fleet with the same `fleet_id`), it is **re-pointed** at the current address via `changeWebhookUpdate` (last-writer-wins takeover) — no delete/recreate, so `created_at` observability survives. Extras carrying a superseded spec-version marker (still prefixed `fleet:<FleetID>:`, same fleet) are dropped by the existing stale-marker delete — that delete path is marker-keyed, not url-keyed; the takeover/re-point path above is the one that inspects the `/<h>/` url segment. A duplicate fleet with the same `fleet_id` computes the same `h`, matches the same webhook, and takes over its url → the monolith delivers to exactly one fleet.

**Crash recovery is free:** a restarted fleet recomputes `h` and re-claims the webhook. No lease, no TTL, no heartbeat.

## Receive path + auth split

`ServeDelivery` strips the `/_fleet/<h>/webhook/` prefix (via `Fleet.WebhookPath()`) and keeps the per-role **HMAC** verification. It runs on the delivery listener (`ListenAddr`), which has **no** delegated-admin cookie middleware — the cookie gate lives only on the separate fleet GraphQL server. Auth split preserved.

## No migration — why

Identity lives in the **existing `change_webhooks.url`** column (the `/<h>/` path segment) and the existing `description` marker. No new column, no lease table, no unique index → **no SQL migration**. Mutual exclusion is application-enforced in reconcile; the accepted bounded flip-window is documented in `fleet_graphql.md` and is safe for idempotent roles.

## Fix-up commit: patch-safe takeover update (critical)

Adversarial review caught that the takeover `changeWebhookUpdate` call was **dead-on-arrival** against the real monolith. Root cause: genqlient's generated `ChangeWebhookUpdateInput` had plain (non-pointer, no-`omitempty`) Go fields for every optional column. `update()` only sets `{Id, Url}`, but `json.Marshal` still emitted every other field as a *present* zero value (`enabled:false`, `description:""`, `onCreate/onUpdate/onRemove:false`, `timeoutSeconds:0`, ...). The monolith's `changeWebhookUpdate` resolver (`internal/case/admin/updatewebhook/resolve.go`) uses PATCH semantics — an *absent* field keeps the existing value, but a present zero is applied as a real value. Consequences: `validateBounds` rejects `timeoutSeconds:0` outright (`"must be between 1 and 3600"`), so **every takeover would hard-fail reconcile**; and even without that bound, the present zeros would silently disable the webhook, wipe the reconcile marker, and stop it firing.

**Fix:** added `# @genqlient(for: "ChangeWebhookUpdateInput.<field>", omitempty: true)` directives (`operations.graphql`) for every field except `id`/`url`, so genqlient marks them `omitempty` in the generated struct — a Go zero value is now omitted from the marshaled JSON instead of sent as a real patch value. Chose this over a second narrow mutation/input because `ChangeWebhookUpdateInput` already exists in the schema and is used by exactly one operation in this package, so the directives apply cleanly with no risk of conflicting with another operation's shape.

One genqlient quirk hit along the way: a `for:`-targeted directive comment placed directly above `mutation UpdateChangeWebhook($input: ChangeWebhookUpdateInput!) {` gets mis-attributed to the `$input` *variable definition* (since it shares that line) and genqlient rejects it ("for is only applicable to operations and arguments"). Fix: `$input` now sits on its own line inside the parens, matching genqlient's own docs example, so the directive block correctly attaches to the whole operation.

Verified two ways:
1. A direct `json.Marshal` of `ChangeWebhookUpdateInput{Id: 7, Url: "..."}` now produces exactly `{"id":7,"url":"..."}`.
2. New regression test `TestReconcile_TakeoverUpdate_SendsOnlyIdAndURL` drives the *real* genqlient marshal path through `fakeAdminGQL` (not a hand-typed struct decode, which can't distinguish an absent field from a present zero) and asserts the raw JSON `input` object's key set is **exactly** `{"id", "url"}`.
3. New monolith-side test `TestResolve_IDAndURLOnly_PassesPatchSemantics` (`internal/case/admin/updatewebhook/resolve_test.go`) feeds an `{ID, URL}`-only input through the real `Resolve`/`validateBounds` and asserts it passes cleanly, with every other field left as `nil` (patch "keep existing") in the params handed to the DB layer.

Also tightened a LOW-severity comment: the stale-marker delete loop in `reconcileChange` said it drops extras "sharing this fleet's `/<h>/`" — it's actually keyed on the `fleet:<FleetID>:` description-marker prefix, not the url segment (the url-segment check lives only in the takeover/re-point path). Comment now says marker-prefix explicitly; no behavior change.

## Scope

Does **not** do the codellm cutover (P3b): no changes to the code-exec path, `handler.go`'s `executor: code` branch, `RunCode`, or codellm.

## Verification

- `make lint` → 0 issues
- `go build -tags dev ./...` → clean
- `go vet -tags dev ./internal/fleet/... ./cmd/fleet/...` → clean
- `go test -tags dev ./internal/fleet/... ./cmd/fleet/... ./internal/case/admin/updatewebhook/...` → all pass

Table tests: hash derivation + namespacing, delivery-URL construction, role partitioning (matching/mismatched/empty + unpartitioned DiscoverParsed), `/<h>/` takeover-on-stale-url / no-update-when-current / drop-extras / update ErrorPayload, the required `--fleet-id`, **and** the two new patch-safety regression tests above.

## Deviations / notes

- **`--fleet-id` validation** is enforced in `validateConfig` via the file's existing required-field `missing`-slice pattern (alongside CallbackURL/JWTSecret/etc.), not ozzo. `FleetID` lives on `fleet.Config` (threaded through reconcile/graph/handler), not `appconfig.Config`, so wiring ozzo there would have meant a large out-of-scope move.
- **Caddy**: the `/_fleet/*` block routes browser traffic to the cookie-gated GraphQL server. The monolith→fleet delivery uses `CallbackURL` (a private/internal addr to the fleet's `ListenAddr`), exactly as the old `/deliver/` scheme did, so it bypasses Caddy and needs no Caddy change for correctness. If a deployment ever fronts *deliveries* through public `/_fleet/*`, a more specific `/_fleet/*/webhook/*` → delivery-listener route would be required (deploy follow-up, out of P3a code scope).
- **genqlient `$input`-on-its-own-line** requirement (see fix-up section) is a workaround for a real genqlient parser quirk, not a style choice — noted in a code comment in `operations.graphql` so a future edit doesn't reflow it back onto the `mutation` line and silently break the directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
