### PR TITLE
feat(fleet): route executor:code through codellm (P3b cutover)

### DIFF
--- a/internal/agentruntime/runtime.go
+++ b/internal/agentruntime/runtime.go
@@ -28,6 +28,11 @@ const (
 	toolExec      = "exec"
 )
 
+// fleetInputMessageName is the reserved message name that carries the delivery
+// bag (Input.InputBag) as a system message. codellm reads it as $FLEET_INPUT and
+// does NOT scan it for fenced code; it must match codellm's fleetInputMessageName.
+const fleetInputMessageName = "fleet_input"
+
 // toolInvoker is the extension-point function type for the tool registry seam.
 // Built-in tools (search, read_note, write_note, patch_note, finish) are
 // handled by execTool's switch. Extension tools (exec, future MCP plug-ins)
@@ -63,6 +68,20 @@ type Input struct {
 	MaxTokens int
 	// MaxSteps bounds tool-loop iterations as a secondary guard. Must be > 0.
 	MaxSteps int
+
+	// InputBag, when non-empty, is delivered as a system message named
+	// "fleet_input" carrying the JSON delivery bag. codellm treats that message
+	// as $FLEET_INPUT (it does not scan it for fenced code); a real LLM sees a
+	// harmless labeled JSON context block. Used by the executor:code→codellm path.
+	InputBag []byte
+
+	// HardFailApply makes a genuine write/patch APPLY failure (a bad or non-unique
+	// patch find, a KB write error — NOT an out-of-scope denial) fail the whole
+	// run instead of feeding the error back to the model as a soft, self-
+	// correctable tool result. Set for executor:code/codellm runs to preserve
+	// RunCode's all-or-nothing semantics; left false for real-LLM roles so they
+	// keep their self-correction loop.
+	HardFailApply bool
 
 	LLM LLM
 	KB  KB
@@ -138,8 +157,17 @@ func Run(ctx context.Context, in Input) (*Result, error) {
 				formatPatterns(in.WritePatterns),
 			),
 		},
-		{Role: RoleUser, Content: "Begin."},
 	}
+	// Delivery bag rides as a labeled system message (fleet_input). codellm
+	// consumes it as $FLEET_INPUT; a real LLM sees a harmless JSON context block.
+	if len(in.InputBag) > 0 {
+		messages = append(messages, Message{
+			Role:    RoleSystem,
+			Name:    fleetInputMessageName,
+			Content: string(in.InputBag),
+		})
+	}
+	messages = append(messages, Message{Role: RoleUser, Content: "Begin."})
 
 	res := &Result{Status: StatusMaxSteps}
 
@@ -189,7 +217,14 @@ func Run(ctx context.Context, in Input) (*Result, error) {
 				})
 				continue
 			}
-			output := execTool(ctx, scoped, res, call, invokers)
+			output, applyFailed := execTool(ctx, scoped, res, call, invokers)
+			// Apply-error hard-fail (executor:code/codellm path): a genuine write/
+			// patch apply failure (bad/non-unique find, KB write error) fails the
+			// whole run, preserving RunCode's all-or-nothing semantics. Real-LLM
+			// roles (HardFailApply=false) keep the soft, self-correctable tool result.
+			if applyFailed && in.HardFailApply {
+				return nil, fmt.Errorf("agentruntime: apply %s: %s", call.Name, output)
+			}
 			messages = append(messages, Message{
 				Role:       RoleTool,
 				ToolCallID: call.ID,
@@ -212,13 +247,17 @@ func chatWithBudget(ctx context.Context, llm LLM, model string, messages []Messa
 }
 
 // execTool runs one tool call against the scoped KB and returns the textual
-// result to feed back to the model. Scope denials are recorded and surfaced to
-// the model (so it learns), never silently swallowed.
+// result to feed back to the model, plus applyFailed=true ONLY when a write/patch
+// could not be APPLIED (bad/non-unique find, KB write error). That flag is what
+// the HardFailApply path (executor:code/codellm) fails on; scope denials, invalid
+// arguments, and read/search errors keep applyFailed=false so they stay soft/
+// self-correctable in every path. Scope denials are recorded and surfaced to the
+// model (so it learns), never silently swallowed.
 // Extension tools registered in invokers are dispatched before the built-in
 // switch, forming the tool registry seam for exec and future MCP plug-ins.
-func execTool(ctx context.Context, scoped *ScopedKB, res *Result, call ToolCall, invokers map[string]toolInvoker) string {
+func execTool(ctx context.Context, scoped *ScopedKB, res *Result, call ToolCall, invokers map[string]toolInvoker) (string, bool) {
 	if fn, ok := invokers[call.Name]; ok {
-		return fn(ctx, scoped, res, call)
+		return fn(ctx, scoped, res, call), false
 	}
 	switch call.Name {
 	case toolSearch:
@@ -226,37 +265,37 @@ func execTool(ctx context.Context, scoped *ScopedKB, res *Result, call ToolCall,
 			Query string `json:"query"`
 		}
 		if err := json.Unmarshal([]byte(call.Arguments), &args); err != nil {
-			return "error: invalid arguments: " + err.Error()
+			return "error: invalid arguments: " + err.Error(), false
 		}
 		docs, err := scoped.Search(ctx, args.Query)
 		if err != nil {
-			return "error: " + err.Error()
+			return "error: " + err.Error(), false
 		}
 		if len(docs) == 0 {
-			return "no in-scope documents matched."
+			return "no in-scope documents matched.", false
 		}
 		var b strings.Builder
 		for _, d := range docs {
 			fmt.Fprintf(&b, "- %s\n", d.Path)
 		}
-		return b.String()
+		return b.String(), false
 
 	case toolReadNote:
 		var args struct {
 			Path string `json:"path"`
 		}
 		if err := json.Unmarshal([]byte(call.Arguments), &args); err != nil {
-			return "error: invalid arguments: " + err.Error()
+			return "error: invalid arguments: " + err.Error(), false
 		}
 		content, err := scoped.Read(ctx, args.Path)
 		if errors.Is(err, ErrReadDenied) {
 			res.Denials = append(res.Denials, "read "+args.Path)
-			return "error: " + ErrReadDenied.Error()
+			return "error: " + ErrReadDenied.Error(), false
 		}
 		if err != nil {
-			return "error: " + err.Error()
+			return "error: " + err.Error(), false
 		}
-		return content
+		return content, false
 
 	case toolWriteNote:
 		var args struct {
@@ -264,22 +303,22 @@ func execTool(ctx context.Context, scoped *ScopedKB, res *Result, call ToolCall,
 			Content string `json:"content"`
 		}
 		if err := json.Unmarshal([]byte(call.Arguments), &args); err != nil {
-			return "error: invalid arguments: " + err.Error()
+			return "error: invalid arguments: " + err.Error(), false
 		}
 		err := scoped.Write(ctx, args.Path, args.Content)
 		if errors.Is(err, ErrWriteDenied) {
 			res.Denials = append(res.Denials, "write "+args.Path)
-			return "error: " + ErrWriteDenied.Error()
+			return "error: " + ErrWriteDenied.Error(), false
 		}
 		if err != nil {
-			return "error: " + err.Error()
+			return "error: " + err.Error(), true
 		}
 		res.Changes = append(res.Changes, webhookutil.AgentChange{
 			Path:    args.Path,
 			Content: args.Content,
 			Kind:    webhookutil.AgentChangeKindWrite,
 		})
-		return "ok: wrote " + args.Path
+		return "ok: wrote " + args.Path, false
 
 	case toolPatchNote:
 		var args struct {
@@ -288,15 +327,15 @@ func execTool(ctx context.Context, scoped *ScopedKB, res *Result, call ToolCall,
 			Replace string `json:"replace"`
 		}
 		if err := json.Unmarshal([]byte(call.Arguments), &args); err != nil {
-			return "error: invalid arguments: " + err.Error()
+			return "error: invalid arguments: " + err.Error(), false
 		}
 		err := scoped.Patch(ctx, args.Path, args.Find, args.Replace)
 		if errors.Is(err, ErrWriteDenied) {
 			res.Denials = append(res.Denials, "patch "+args.Path)
-			return "error: " + ErrWriteDenied.Error()
+			return "error: " + ErrWriteDenied.Error(), false
 		}
 		if err != nil {
-			return "error: " + err.Error()
+			return "error: " + err.Error(), true
 		}
 		res.Changes = append(res.Changes, webhookutil.AgentChange{
 			Path:    args.Path,
@@ -304,10 +343,10 @@ func execTool(ctx context.Context, scoped *ScopedKB, res *Result, call ToolCall,
 			Replace: args.Replace,
 			Kind:    webhookutil.AgentChangeKindPatch,
 		})
-		return "ok: patched " + args.Path
+		return "ok: patched " + args.Path, false
 
 	default:
-		return "error: unknown tool " + call.Name
+		return "error: unknown tool " + call.Name, false
 	}
 }
 

--- a/internal/agentruntime/runtime_test.go
+++ b/internal/agentruntime/runtime_test.go
@@ -483,3 +483,140 @@ func TestRun_PassesRemainingBudgetToBudgetedLLM(t *testing.T) {
 	require.Equal(t, StatusCompleted, res.Status)
 	require.Equal(t, []int{1000, 850}, llm.budgets)
 }
+
+// TestRun_InputBagRidesAsFleetInputMessage asserts InputBag is delivered as a
+// system message named "fleet_input" (the codellm $FLEET_INPUT seam), inserted
+// between the system prompt and the "Begin." user turn, and never scanned as a
+// role instruction.
+func TestRun_InputBagRidesAsFleetInputMessage(t *testing.T) {
+	kb := newMemKB(nil)
+	llm := &stubLLM{
+		script: []ChatResult{
+			{ToolCalls: []ToolCall{toolCall("1", toolFinish, map[string]any{"answer": "ok"})}, PromptTokens: 1, CompletionTokens: 1},
+		},
+	}
+	bag := []byte(`{"changed_files":[{"path":"a.md"}],"depth":1}`)
+	res, err := Run(context.Background(), Input{
+		Instruction: "```bash\necho hi\n```",
+		Model:       "m", MaxTokens: 1000, MaxSteps: 5,
+		InputBag: bag,
+		LLM:      llm, KB: kb,
+	})
+	require.NoError(t, err)
+	require.Equal(t, StatusCompleted, res.Status)
+
+	// The first batch the LLM saw: [system prompt, fleet_input, user "Begin."].
+	require.GreaterOrEqual(t, len(llm.seen), 3)
+	require.Equal(t, RoleSystem, llm.seen[0].Role)
+	require.Empty(t, llm.seen[0].Name)
+	require.Equal(t, RoleSystem, llm.seen[1].Role)
+	require.Equal(t, "fleet_input", llm.seen[1].Name)
+	require.Equal(t, string(bag), llm.seen[1].Content)
+	require.Equal(t, RoleUser, llm.seen[2].Role)
+	require.Equal(t, "Begin.", llm.seen[2].Content)
+}
+
+// TestRun_NoInputBagOmitsFleetInputMessage asserts that without an InputBag no
+// fleet_input message is injected (real-LLM roles are unchanged).
+func TestRun_NoInputBagOmitsFleetInputMessage(t *testing.T) {
+	kb := newMemKB(nil)
+	llm := &stubLLM{
+		script: []ChatResult{
+			{ToolCalls: []ToolCall{toolCall("1", toolFinish, map[string]any{"answer": "ok"})}, PromptTokens: 1, CompletionTokens: 1},
+		},
+	}
+	_, err := Run(context.Background(), Input{
+		Instruction: "hi", Model: "m", MaxTokens: 1000, MaxSteps: 5, LLM: llm, KB: kb,
+	})
+	require.NoError(t, err)
+	for _, m := range llm.seen {
+		require.NotEqual(t, "fleet_input", m.Name, "no fleet_input message without InputBag")
+	}
+}
+
+// TestRun_CodeStyleSingleTurnAppliesToolCalls asserts the codellm shape: one
+// completion returns write_note + patch_note + finish, they are applied through
+// ScopedKB in a SINGLE loop turn (always-finish invariant → Steps == 1) even
+// though MaxSteps allows more.
+func TestRun_CodeStyleSingleTurnAppliesToolCalls(t *testing.T) {
+	kb := newMemKB(map[string]string{"boards/b.md": "@status:todo"})
+	llm := &stubLLM{
+		script: []ChatResult{
+			{ToolCalls: []ToolCall{
+				toolCall("1", toolWriteNote, map[string]any{"path": "boards/new.md", "content": "hello"}),
+				toolCall("2", toolPatchNote, map[string]any{"path": "boards/b.md", "find": "@status:todo", "replace": "@status:done"}),
+				toolCall("3", toolFinish, map[string]any{"answer": "done"}),
+			}, PromptTokens: 0, CompletionTokens: 0},
+		},
+	}
+	res, err := Run(context.Background(), Input{
+		Instruction:   "```python\n...\n```",
+		WritePatterns: []string{"boards/**"},
+		Model:         "codellm", MaxTokens: 1000, MaxSteps: 25,
+		InputBag:      []byte(`{"depth":1}`),
+		HardFailApply: true,
+		LLM:           llm, KB: kb,
+	})
+	require.NoError(t, err)
+	require.Equal(t, StatusCompleted, res.Status)
+	require.Equal(t, 1, res.Steps, "always-finish stops the loop in one turn")
+	require.Len(t, res.Changes, 2)
+	require.Equal(t, "hello", kb.docs["boards/new.md"])
+	require.Equal(t, "@status:done", kb.docs["boards/b.md"])
+	require.Equal(t, "done", res.Answer)
+}
+
+// TestRun_HardFailApply_BadPatchFailsRun asserts the executor:code/codellm
+// semantics: a patch whose find is absent is a genuine apply error, and with
+// HardFailApply set the whole run fails (all-or-nothing, matching RunCode).
+func TestRun_HardFailApply_BadPatchFailsRun(t *testing.T) {
+	kb := newMemKB(map[string]string{"boards/b.md": "content without the token"})
+	llm := &stubLLM{
+		script: []ChatResult{
+			{ToolCalls: []ToolCall{
+				toolCall("1", toolPatchNote, map[string]any{"path": "boards/b.md", "find": "MISSING", "replace": "x"}),
+				toolCall("2", toolFinish, map[string]any{"answer": "done"}),
+			}, PromptTokens: 0, CompletionTokens: 0},
+		},
+	}
+	res, err := Run(context.Background(), Input{
+		Instruction:   "```python\n...\n```",
+		WritePatterns: []string{"boards/**"},
+		Model:         "codellm", MaxTokens: 1000, MaxSteps: 25,
+		HardFailApply: true,
+		LLM:           llm, KB: kb,
+	})
+	require.Error(t, err, "a failed apply must fail the run when HardFailApply is set")
+	require.Nil(t, res)
+	require.Contains(t, err.Error(), "apply patch_note")
+}
+
+// TestRun_SoftApply_RealLLMSelfCorrects asserts the DEFAULT (real-LLM) path is
+// UNCHANGED: the same bad-find patch is a soft, self-correctable tool result —
+// the model sees the error, retries with a valid find, and the run completes.
+func TestRun_SoftApply_RealLLMSelfCorrects(t *testing.T) {
+	kb := newMemKB(map[string]string{"boards/b.md": "@status:todo"})
+	llm := &stubLLM{
+		script: []ChatResult{
+			{ToolCalls: []ToolCall{toolCall("1", toolPatchNote, map[string]any{
+				"path": "boards/b.md", "find": "MISSING", "replace": "x",
+			})}, PromptTokens: 5, CompletionTokens: 5},
+			{ToolCalls: []ToolCall{toolCall("2", toolPatchNote, map[string]any{
+				"path": "boards/b.md", "find": "@status:todo", "replace": "@status:done",
+			})}, PromptTokens: 5, CompletionTokens: 5},
+			{ToolCalls: []ToolCall{toolCall("3", toolFinish, map[string]any{"answer": "recovered"})}, PromptTokens: 5, CompletionTokens: 5},
+		},
+	}
+	res, err := Run(context.Background(), Input{
+		Instruction:   "fix it",
+		WritePatterns: []string{"boards/**"},
+		Model:         "gpt-4o", MaxTokens: 1000, MaxSteps: 25,
+		// HardFailApply defaults false for real-LLM roles.
+		LLM: llm, KB: kb,
+	})
+	require.NoError(t, err, "real-LLM roles keep soft, self-correctable apply errors")
+	require.Equal(t, StatusCompleted, res.Status)
+	require.Equal(t, "@status:done", kb.docs["boards/b.md"])
+	require.Len(t, res.Changes, 1, "only the successful retry is recorded")
+	require.Equal(t, "recovered", res.Answer)
+}

--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -1,7 +1,6 @@
 package fleet
 
 import (
-	"context"
 	"net/http"
 	"sync"
 
@@ -18,13 +17,9 @@ type Fleet struct {
 
 	mu       sync.RWMutex
 	registry map[string]Role // urlKey(notePath) -> Role
-
-	// codeRunner is the code-role executor. Defaults to agentruntime.RunCode.
-	// Tests may inject a stub for deterministic testing without subprocess runs.
-	codeRunner func(context.Context, agentruntime.CodeInput) (*agentruntime.Result, error)
 }
 
-// NewFleet builds a Fleet with an empty registry and the default code runner.
+// NewFleet builds a Fleet with an empty registry.
 // hc is the HTTP client used for per-delivery scoped KB requests; nil uses
 // http.DefaultClient.
 func NewFleet(cfg Config, hc *http.Client, llm agentruntime.LLM) *Fleet {
@@ -32,11 +27,10 @@ func NewFleet(cfg Config, hc *http.Client, llm agentruntime.LLM) *Fleet {
 		hc = http.DefaultClient
 	}
 	return &Fleet{
-		cfg:        cfg,
-		hc:         hc,
-		llm:        llm,
-		registry:   map[string]Role{},
-		codeRunner: agentruntime.RunCode,
+		cfg:      cfg,
+		hc:       hc,
+		llm:      llm,
+		registry: map[string]Role{},
 	}
 }
 

--- a/internal/fleet/handler.go
+++ b/internal/fleet/handler.go
@@ -377,16 +377,27 @@ type execRoleInput struct {
 func (f *Fleet) execRole(p execRoleInput) (*agentruntime.Result, error) {
 	kb := newRemoteKB(p.GQL, p.Overlay)
 	if p.Role.Executor == executorCode {
-		return f.codeRunner(p.Ctx, agentruntime.CodeInput{
-			Body:            p.Instr,
-			WritePatterns:   p.Role.WritePatterns,
-			KB:              kb,
-			AllowedPrograms: f.cfg.AllowedPrograms,
-			Input:           p.InputBag,
-			EnvPassthrough:  p.Role.EnvPassthrough,
-			EnvPrefix:       p.Role.EnvPrefix,
-			MaxStdoutBytes:  f.cfg.MaxStdoutBytes,
-			Sandbox:         f.sandboxPolicy(),
+		// P3b cutover: executor:code no longer runs in-process. It routes through
+		// this fleet's LLM client (f.llm) — for a codellm-configured fleet, f.llm
+		// IS codellm (--llm-base-url points at it), which executes the rendered
+		// code body and returns write_note/patch_note/finish tool_calls. The
+		// delivery bag rides as a fleet_input system message (InputBag). Writes go
+		// through the same ScopedKB(write_patterns) enforcement as any llm role.
+		// HardFailApply preserves RunCode's all-or-nothing semantics (a failed
+		// apply fails the run). No MaxSteps pin: codellm's always-finish invariant
+		// stops the loop in one turn, so the normal step ceiling is safe.
+		return agentruntime.Run(p.Ctx, agentruntime.Input{
+			Instruction:   p.Instr,
+			ReadPatterns:  p.Role.ReadPatterns,
+			WritePatterns: p.Role.WritePatterns,
+			Tools:         p.Role.Tools,
+			Model:         orDefault(p.Role.Model, f.cfg.DefaultModel),
+			MaxTokens:     clampBudget(p.Role.MaxTokens, f.cfg.TokenCeiling),
+			MaxSteps:      clampBudget(p.Role.MaxSteps, f.cfg.StepCeiling),
+			InputBag:      p.InputBag,
+			HardFailApply: true,
+			LLM:           f.llm,
+			KB:            kb,
 		})
 	}
 	return agentruntime.Run(p.Ctx, agentruntime.Input{

--- a/internal/fleet/handler_test.go
+++ b/internal/fleet/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -464,8 +465,28 @@ func TestServeDelivery_ForEach_AggregatesCappedStatus(t *testing.T) {
 		"aggregate status must reflect the capped item, not the last completed one")
 }
 
-// newCodeRoleFleet builds a Fleet with a code-executor role and a stub codeRunner.
-func newCodeRoleFleet(stubRunner func(context.Context, agentruntime.CodeInput) (*agentruntime.Result, error)) *Fleet {
+// recordingLLM records every message batch and tool list it is handed, then
+// returns a fixed scripted result. It lets a test assert what Input/messages the
+// executor:code path constructed against f.llm without a live codellm.
+type recordingLLM struct {
+	mu        sync.Mutex
+	seen      []agentruntime.Message
+	seenTools []agentruntime.ToolDef
+	result    agentruntime.ChatResult
+}
+
+func (r *recordingLLM) Chat(_ context.Context, _ string, messages []agentruntime.Message, tools []agentruntime.ToolDef) (agentruntime.ChatResult, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.seen = append(r.seen, messages...)
+	if r.seenTools == nil {
+		r.seenTools = tools
+	}
+	return r.result, nil
+}
+
+// newCodeRoleFleet builds a Fleet with an executor:code role pointed at llm.
+func newCodeRoleFleet(llm agentruntime.LLM) *Fleet {
 	role := Role{
 		NotePath:      "roles/code.md",
 		Mode:          "change",
@@ -476,38 +497,33 @@ func newCodeRoleFleet(stubRunner func(context.Context, agentruntime.CodeInput) (
 	cfg := Config{
 		FleetID: "f1", FleetSecret: "seed", DefaultModel: "gpt-4o-mini",
 		TokenCeiling: 100000, StepCeiling: 25,
-		AllowedPrograms: []string{"bash"},
 	}
-	f := NewFleet(cfg, http.DefaultClient, nil) // llm=nil is fine for code roles
-	f.codeRunner = stubRunner
+	f := NewFleet(cfg, http.DefaultClient, llm)
 	f.SetRoles([]Role{role})
 	return f
 }
 
-// TestServeDelivery_CodeRole_DispatchesRunCode asserts that a role with
-// executor:code invokes the codeRunner (not agentruntime.Run), and that the
-// response reports TokensUsed=0 (code roles have no LLM spend).
-func TestServeDelivery_CodeRole_DispatchesRunCode(t *testing.T) {
-	var runCodeCalled bool
-	var receivedWritePatterns []string
+// TestServeDelivery_CodeRole_RoutesThroughLLM asserts the P3b cutover: an
+// executor:code role now runs as a normal agentruntime.Run against the fleet's
+// LLM (f.llm = codellm), with the rendered code body as the instruction and the
+// delivery bag riding as a fleet_input system message — NOT the deleted
+// in-process code runner.
+func TestServeDelivery_CodeRole_RoutesThroughLLM(t *testing.T) {
+	finishArgs, _ := json.Marshal(map[string]any{"answer": "code done"})
+	llm := &recordingLLM{result: agentruntime.ChatResult{
+		ToolCalls:    []agentruntime.ToolCall{{ID: "1", Name: "finish", Arguments: string(finishArgs)}},
+		PromptTokens: 3, CompletionTokens: 2,
+	}}
 
-	stub := func(_ context.Context, in agentruntime.CodeInput) (*agentruntime.Result, error) {
-		runCodeCalled = true
-		receivedWritePatterns = in.WritePatterns
-		return &agentruntime.Result{
-			Status:     agentruntime.StatusCompleted,
-			Answer:     "code done",
-			TokensUsed: 0,
-			Steps:      1,
-		}, nil
-	}
-
-	f := newCodeRoleFleet(stub)
+	f := newCodeRoleFleet(llm)
 	key := urlKey("roles/code.md")
 	body, _ := json.Marshal(map[string]any{
 		"depth":       0,
 		"instruction": "run code",
 		"api_token":   "scoped-token",
+		"changes": []map[string]any{
+			{"path": "boards/sprint.md", "event": "modified"},
+		},
 	})
 	req := httptest.NewRequest(http.MethodPost, f.WebhookPath()+key, bytes.NewReader(body))
 	role, ok := f.roleByKey(key)
@@ -517,59 +533,25 @@ func TestServeDelivery_CodeRole_DispatchesRunCode(t *testing.T) {
 	f.ServeDelivery(rec, req)
 
 	require.Equal(t, http.StatusOK, rec.Code)
-	require.True(t, runCodeCalled, "code executor role must invoke codeRunner, not agentruntime.Run")
-	require.Equal(t, []string{"boards/**"}, receivedWritePatterns)
+	require.NotEmpty(t, llm.seen, "executor:code must run against the fleet LLM (f.llm), not an in-process runner")
+
+	var sawBody, sawBag bool
+	for _, m := range llm.seen {
+		if strings.Contains(m.Content, "echo hi") {
+			sawBody = true
+		}
+		if m.Role == agentruntime.RoleSystem && m.Name == "fleet_input" {
+			sawBag = true
+			require.Contains(t, m.Content, "changed_files", "fleet_input bag must carry the delivery context")
+		}
+	}
+	require.True(t, sawBody, "rendered code body must reach the LLM as the instruction")
+	require.True(t, sawBag, "delivery bag must ride as a fleet_input system message")
 
 	var resp webhookutil.AgentResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	require.Equal(t, 0, resp.TokensUsed, "code roles have zero LLM token spend")
+	require.Equal(t, "code done", resp.Message)
 	require.Equal(t, agentruntime.StatusCompleted, resp.Status)
-}
-
-// TestServeDelivery_CodeRole_PassesEnvPassthrough asserts that env_passthrough
-// and env_prefix declared on the role are threaded into the CodeInput.
-func TestServeDelivery_CodeRole_PassesEnvPassthrough(t *testing.T) {
-	var receivedEnvPassthrough []string
-	var receivedEnvPrefix []string
-
-	stub := func(_ context.Context, in agentruntime.CodeInput) (*agentruntime.Result, error) {
-		receivedEnvPassthrough = in.EnvPassthrough
-		receivedEnvPrefix = in.EnvPrefix
-		return &agentruntime.Result{Status: agentruntime.StatusCompleted}, nil
-	}
-
-	role := Role{
-		NotePath:       "roles/envcode.md",
-		Mode:           "change",
-		Executor:       "code",
-		WritePatterns:  []string{"notes/**"},
-		Body:           "```bash\necho hi\n```",
-		EnvPassthrough: []string{"MY_TOKEN"},
-		EnvPrefix:      []string{"KRISP_"},
-	}
-	cfg := Config{
-		FleetID: "f1", FleetSecret: "seed", DefaultModel: "gpt-4o-mini",
-		TokenCeiling: 100000, StepCeiling: 25,
-		AllowedPrograms: []string{"bash"},
-	}
-	f := NewFleet(cfg, http.DefaultClient, nil)
-	f.codeRunner = stub
-	f.SetRoles([]Role{role})
-
-	key := urlKey("roles/envcode.md")
-	body, _ := json.Marshal(map[string]any{
-		"depth": 0, "api_token": "tok",
-	})
-	req := httptest.NewRequest(http.MethodPost, f.WebhookPath()+key, bytes.NewReader(body))
-	r, ok := f.roleByKey(key)
-	require.True(t, ok)
-	req.Header.Set("X-Webhook-Signature", webhookutil.SignHMAC(body, f.secretFor(r)))
-	rec := httptest.NewRecorder()
-	f.ServeDelivery(rec, req)
-
-	require.Equal(t, http.StatusOK, rec.Code)
-	require.Equal(t, []string{"MY_TOKEN"}, receivedEnvPassthrough)
-	require.Equal(t, []string{"KRISP_"}, receivedEnvPrefix)
 }
 
 func TestClampBudget(t *testing.T) {


### PR DESCRIPTION
## P3b cutover — route `executor: code` through codellm

Per `docs/dev/codellm_extraction.md` ("P3 plan → P3b"), owner decisions: **direct cutover**, **rely on codellm always-finish (no MaxSteps:1 pin)**, **apply-error hard-fail**.

### Routing change
`execRole`'s `executor: code` branch no longer calls the in-process `f.codeRunner` (`agentruntime.RunCode`). It now builds a normal `agentruntime.Input` and runs it against **this fleet's LLM client** (`f.llm`) — for a codellm-configured fleet, `--llm-base-url` points at codellm, so `f.llm` **is** codellm. codellm executes the rendered role body (markdown-with-code) and returns `write_note`/`patch_note`/`finish` as `tool_calls`, which fleet applies through the same `ScopedKB(write_patterns)` enforcement as any llm role. Read/Write patterns and the role tool set carry over unchanged.

### `InputBag` → `fleet_input` system message
Added `InputBag []byte` to `agentruntime.Input`. When set, the message builder appends a `system` message named `fleet_input` (between the system prompt and the `Begin.` user turn) carrying the JSON delivery bag. codellm consumes it as `$FLEET_INPUT` (its `extractBodyAndBag` already keys off `Name == "fleet_input"` and does not scan it for fenced code); a real LLM sees a harmless labeled JSON context block. The executor:code path sets `InputBag` from the existing `buildInputBag`/`buildCronInputBag`.

### Apply-error hard-fail (+ scope decision)
The tool-apply loop treated a failed `write`/`patch` apply (bad or non-unique `find`, KB write error) as a soft per-tool error string fed back to the model, continuing to `finish` → 200. That silently diverged from `RunCode`'s all-or-nothing 502.

**Scope decision: hard-fail is scoped to the executor:code/codellm path, NOT global.** A real LLM's value in the agentic loop is iterative self-correction — a bad-`find` patch is exactly the kind of recoverable error the model should see and retry. Making hard-fail global would strip self-correction from genuine LLM agents (a behavior regression). RunCode's all-or-nothing semantics are specific to deterministic, single-shot code roles. So a new `HardFailApply bool` on `Input` gates it: the executor:code branch sets it `true`; real-LLM roles default `false` and are unaffected.

`execTool` now returns `(output string, applyFailed bool)` — `applyFailed` is true **only** for genuine apply failures (KB write/patch error, non-denial), false for scope denials, invalid arguments, and read/search errors (those stay soft in every path). When `HardFailApply && applyFailed`, `Run` returns an error → the handler surfaces 502.

**Real-LLM impact:** none. Covered by `TestRun_SoftApply_RealLLMSelfCorrects` (default path: bad find → soft skip → model retries → run completes) alongside `TestRun_HardFailApply_BadPatchFailsRun` (code path: same bad find → run fails).

### Always-finish, no MaxSteps pin
The code Input uses the normal `MaxSteps` (fleet step ceiling), not a `MaxSteps: 1` pin. codellm's always-finish invariant (conformance-tested in `internal/codellm`) stops the loop after one turn. `TestRun_CodeStyleSingleTurnAppliesToolCalls` asserts a single completion of `write_note`+`patch_note`+`finish` applies all changes and stops in `Steps == 1` even with `MaxSteps: 25`.

### In-process RunCode: deferred to P3c
This PR replaces only the executor:code **wiring**. `agentruntime.RunCode` and `internal/coderun` are untouched (coderun still backs the `exec` tool until P5). Removing the now-dead `f.codeRunner` field was required — with the `unused` linter enabled, keeping the field unread would fail `make lint`. `RunCode` itself is now unreferenced by fleet's live path (its only remaining caller is its own tests) → **note for P3c removal**. The old env_passthrough handler test was removed: env passthrough is dropped by design under codellm (no parent env crosses the HTTP boundary).

### Verification
- `make lint` → 0 issues
- `go build -tags dev ./...` → clean
- `go vet -tags dev ./...` → clean
- `go test -tags dev ./internal/fleet/... ./internal/agentruntime/... ./internal/codellm/... ./cmd/fleet/...` → all pass

New tests: `TestServeDelivery_CodeRole_RoutesThroughLLM` (routing + fleet_input bag), `TestRun_InputBagRidesAsFleetInputMessage`, `TestRun_NoInputBagOmitsFleetInputMessage`, `TestRun_CodeStyleSingleTurnAppliesToolCalls`, `TestRun_HardFailApply_BadPatchFailsRun`, `TestRun_SoftApply_RealLLMSelfCorrects`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
