### PR TITLE
feat(onboarding-vault): add ?name to set zip filename and archive root

### DIFF
--- a/docs/dev/onboardingvault.md
+++ b/docs/dev/onboardingvault.md
@@ -18,8 +18,23 @@ Code: `internal/case/downloadonboardingvault/` (`endpoint.go`, `resolve.go`).
    - `.obsidian/plugins/trip2g/data.json` → `syncDirs[0].apiKey`
    - `.mcp.json` / `codex.json` → `Authorization: Bearer <key>`
    - `antigravity-mcp-config.json` → same
-4. Renames the vault folder to the instance domain and substitutes
-   `{{publicUrl}}` in `_index.md` / `AGENTS.md`.
+4. Names the vault after `?name` (or the instance domain when absent) and
+   substitutes `{{publicUrl}}` in `_index.md` / `AGENTS.md`.
+
+## `?name`
+
+Sets both the download filename (`<name>.zip`) and the archive's root folder
+(`<name>/`), so the caller knows where the vault unpacks instead of inferring
+it from the host. Absent → falls back to the instance domain (old behaviour).
+
+The name goes into a filesystem path and a `Content-Disposition` filename, so
+it is validated against an allowlist — `^[A-Za-z0-9][A-Za-z0-9._-]*$`, at most
+64 chars. Anything else (empty, `..`, slashes, spaces, unicode, leading dot or
+dash) is a `400`; a present-but-invalid name is never silently replaced by a
+fallback, and no API key is minted for a rejected request.
+
+- `/_system/onboarding-vault?name=secondbrain` → `secondbrain.zip`, root `secondbrain/`
+- `/_system/onboarding-vault` → `<domain>.zip`, root `<domain>/`
 
 ## `?enable_admin_graphql`
 

--- a/e2e/onboarding-vault.spec.js
+++ b/e2e/onboarding-vault.spec.js
@@ -21,4 +21,21 @@ test.describe('Onboarding vault download', () => {
     const body = await res.body();
     expect(body.length).toBeGreaterThan(0);
   });
+
+  test('name sets the download filename', async ({ request }) => {
+    const token = await graphqlSignIn(request);
+    const res = await request.get(`${ENDPOINT}?name=secondbrain`, {
+      headers: { Cookie: `trip2g_e2e=${token}` },
+    });
+    expect(res.status()).toBe(200);
+    expect(res.headers()['content-disposition']).toContain('secondbrain.zip');
+  });
+
+  test('rejects an invalid name with 400', async ({ request }) => {
+    const token = await graphqlSignIn(request);
+    const res = await request.get(`${ENDPOINT}?name=${encodeURIComponent('../etc')}`, {
+      headers: { Cookie: `trip2g_e2e=${token}` },
+    });
+    expect(res.status()).toBe(400);
+  });
 });

--- a/internal/case/downloadonboardingvault/endpoint.go
+++ b/internal/case/downloadonboardingvault/endpoint.go
@@ -1,10 +1,13 @@
 package downloadonboardingvault
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"trip2g/internal/appreq"
 	onboardingvault "trip2g/onboarding-vault"
+
+	"github.com/valyala/fasthttp"
 )
 
 type Endpoint struct{}
@@ -36,12 +39,24 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 	enableAdminGraphQL := qa.Has("enable_admin_graphql") &&
 		(len(qa.Peek("enable_admin_graphql")) == 0 || qa.GetBool("enable_admin_graphql"))
 
-	zipData, err := Resolve(ctx, env, token.ID, enableAdminGraphQL)
+	vaultName, err := resolveVaultName(qa, env.PublicURL())
+	if err != nil {
+		var appErr *appreq.Error
+		if errors.As(err, &appErr) {
+			ctx.SetStatusCode(appErr.Code)
+			ctx.SetBodyString(appErr.Message)
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	zipData, err := Resolve(ctx, env, token.ID, enableAdminGraphQL, vaultName)
 	if err != nil {
 		return nil, err
 	}
 
-	filename := makeFilename(env.PublicURL())
+	filename := vaultName + ".zip"
 
 	ctx.SetStatusCode(http.StatusOK)
 	ctx.SetContentType("application/zip")
@@ -59,8 +74,21 @@ func (*Endpoint) Method() string {
 	return http.MethodGet
 }
 
-// makeFilename creates a zip filename from the public URL domain.
-// Example: "https://trip2g.com" -> "trip2g.com.zip".
-func makeFilename(publicURL string) string {
-	return domainFromURL(publicURL) + ".zip"
+// resolveVaultName picks the archive name: explicit ?name wins, otherwise the
+// instance domain. It names both "<name>.zip" and the "<name>/" folder inside,
+// so a caller that passes it knows where to unpack from instead of guessing.
+// A present but invalid ?name is an error — never a silent fallback.
+func resolveVaultName(qa *fasthttp.Args, publicURL string) (string, error) {
+	if !qa.Has("name") {
+		return domainFromURL(publicURL), nil
+	}
+
+	name := string(qa.Peek("name"))
+
+	err := validateVaultName(name)
+	if err != nil {
+		return "", err
+	}
+
+	return name, nil
 }

--- a/internal/case/downloadonboardingvault/endpoint_test.go
+++ b/internal/case/downloadonboardingvault/endpoint_test.go
@@ -1,0 +1,128 @@
+package downloadonboardingvault
+
+import (
+	"archive/zip"
+	"bytes"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+
+	"trip2g/internal/appreq"
+	"trip2g/internal/usertoken"
+)
+
+func adminRequest(env Env, uri string) *appreq.Request {
+	reqCtx := &fasthttp.RequestCtx{}
+	reqCtx.Request.Header.SetMethod(http.MethodGet)
+	reqCtx.Request.SetRequestURI(uri)
+
+	req := &appreq.Request{Env: env, Req: reqCtx}
+	req.SetUserToken(&usertoken.Data{ID: 1, Role: "admin"})
+
+	return req
+}
+
+// zipRoots collects the first path segment of every entry in the archive.
+func zipRoots(t *testing.T, zipData []byte) map[string]bool {
+	t.Helper()
+
+	reader, err := zip.NewReader(bytes.NewReader(zipData), int64(len(zipData)))
+	require.NoError(t, err)
+
+	roots := map[string]bool{}
+	for _, file := range reader.File {
+		roots[strings.SplitN(file.Name, "/", 2)[0]] = true
+	}
+
+	return roots
+}
+
+func TestEndpoint_NameSetsFilenameAndRoot(t *testing.T) {
+	env := &mockEnv{publicURL: "https://example.com"}
+	req := adminRequest(env, "/_system/onboarding-vault?enable_admin_graphql&name=secondbrain")
+
+	_, err := (&Endpoint{}).Handle(req)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusOK, req.Req.Response.StatusCode())
+	require.Equal(t, `attachment; filename="secondbrain.zip"`,
+		string(req.Req.Response.Header.Peek("Content-Disposition")))
+	require.Equal(t, map[string]bool{"secondbrain": true}, zipRoots(t, req.Req.Response.Body()))
+}
+
+func TestEndpoint_WithoutNameFallsBackToDomain(t *testing.T) {
+	env := &mockEnv{publicURL: "https://example.com"}
+	req := adminRequest(env, "/_system/onboarding-vault")
+
+	_, err := (&Endpoint{}).Handle(req)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusOK, req.Req.Response.StatusCode())
+	require.Equal(t, `attachment; filename="example.com.zip"`,
+		string(req.Req.Response.Header.Peek("Content-Disposition")))
+	require.Equal(t, map[string]bool{"example.com": true}, zipRoots(t, req.Req.Response.Body()))
+}
+
+func TestEndpoint_InvalidNameIsRejected(t *testing.T) {
+	cases := map[string]string{
+		"empty":            "",
+		"slash":            "a/b",
+		"backslash":        "a%5Cb",
+		"traversal":        "..",
+		"traversal path":   "..%2Fetc",
+		"leading dot":      ".hidden",
+		"leading dash":     "-x",
+		"quote":            "a%22b",
+		"space":            "a%20b",
+		"unicode":          "%D0%BC%D0%BE%D0%B7%D0%B3",
+		"newline":          "a%0Ab",
+		"nul":              "a%00b",
+		"absolute":         "%2Fetc%2Fpasswd",
+		"too long":         strings.Repeat("a", maxVaultNameLen+1),
+		"only enable flag": "%20",
+	}
+
+	for name, value := range cases {
+		t.Run(name, func(t *testing.T) {
+			env := &mockEnv{publicURL: "https://example.com"}
+			req := adminRequest(env, "/_system/onboarding-vault?name="+value)
+
+			_, err := (&Endpoint{}).Handle(req)
+			require.NoError(t, err)
+
+			require.Equal(t, http.StatusBadRequest, req.Req.Response.StatusCode(),
+				"name %q must be rejected", value)
+			require.Empty(t, req.Req.Response.Header.Peek("Content-Disposition"))
+		})
+	}
+}
+
+func TestEndpoint_ValidNamesAccepted(t *testing.T) {
+	for _, name := range []string{"secondbrain", "second-brain", "second_brain", "vault.2", "a", "A1"} {
+		t.Run(name, func(t *testing.T) {
+			env := &mockEnv{publicURL: "https://example.com"}
+			req := adminRequest(env, "/_system/onboarding-vault?name="+name)
+
+			_, err := (&Endpoint{}).Handle(req)
+			require.NoError(t, err)
+
+			require.Equal(t, http.StatusOK, req.Req.Response.StatusCode())
+			require.Equal(t, map[string]bool{name: true}, zipRoots(t, req.Req.Response.Body()))
+		})
+	}
+}
+
+// A rejected name must not mint an API key — the request never got far enough.
+func TestEndpoint_InvalidNameIssuesNoAPIKey(t *testing.T) {
+	env := &mockEnv{publicURL: "https://example.com"}
+	req := adminRequest(env, "/_system/onboarding-vault?enable_admin_graphql&name=..")
+
+	_, err := (&Endpoint{}).Handle(req)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusBadRequest, req.Req.Response.StatusCode())
+	require.Empty(t, env.setAdminToolsCalls)
+}

--- a/internal/case/downloadonboardingvault/resolve.go
+++ b/internal/case/downloadonboardingvault/resolve.go
@@ -9,11 +9,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 
 	onboardingvault "trip2g/onboarding-vault"
 
+	"trip2g/internal/appreq"
 	"trip2g/internal/db"
 	"trip2g/internal/model"
 	"trip2g/internal/ptr"
@@ -104,7 +107,45 @@ func generateAntigravityJSON(apiKey, publicURL string) ([]byte, error) {
 	return json.MarshalIndent(cfg, "", "  ")
 }
 
-func Resolve(ctx context.Context, env Env, userID int, enableAdminGraphQL bool) ([]byte, error) {
+// maxVaultNameLen caps the vault name so it stays a usable filename.
+const maxVaultNameLen = 64
+
+// vaultNamePattern is an allowlist: the name becomes both a filename and a
+// path inside the archive, so anything that could escape either is rejected
+// rather than sanitised. Leading dot/dash keeps the name out of hidden-file
+// and option-flag territory.
+var vaultNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+
+func validateVaultName(name string) error {
+	if name == "" {
+		return &appreq.Error{Code: http.StatusBadRequest, Message: "name must not be empty"}
+	}
+
+	if len(name) > maxVaultNameLen {
+		return &appreq.Error{
+			Code:    http.StatusBadRequest,
+			Message: fmt.Sprintf("name must be at most %d characters", maxVaultNameLen),
+		}
+	}
+
+	if !vaultNamePattern.MatchString(name) {
+		return &appreq.Error{
+			Code:    http.StatusBadRequest,
+			Message: "name must start with a letter or digit and contain only letters, digits, dot, dash or underscore",
+		}
+	}
+
+	return nil
+}
+
+// Resolve builds the vault ZIP rooted at vaultName, which must already be
+// validated by validateVaultName.
+func Resolve(ctx context.Context, env Env, userID int, enableAdminGraphQL bool, vaultName string) ([]byte, error) {
+	err := validateVaultName(vaultName)
+	if err != nil {
+		return nil, err
+	}
+
 	// Generate new API key
 	apiKey := env.GenerateAPIKey()
 
@@ -182,7 +223,7 @@ func Resolve(ctx context.Context, env Env, userID int, enableAdminGraphQL bool) 
 		}
 	}
 
-	newPrefix := domainFromURL(publicURL) + "/"
+	newPrefix := vaultName + "/"
 
 	// Read embedded ZIP and modify files, replacing {{publicUrl}} placeholder.
 	modifiedZip, err := modifyZipFiles(onboardingvault.ZipData, replacements, publicURL, newPrefix)

--- a/internal/case/downloadonboardingvault/resolve_test.go
+++ b/internal/case/downloadonboardingvault/resolve_test.go
@@ -48,7 +48,7 @@ func (m *mockEnv) PublicURL() string {
 func TestResolve_IndexMDContainsPublicURL(t *testing.T) {
 	env := &mockEnv{publicURL: "https://example.com"}
 
-	zipData, err := Resolve(context.Background(), env, 1, false)
+	zipData, err := Resolve(context.Background(), env, 1, false, "example.com")
 	require.NoError(t, err)
 	require.NotEmpty(t, zipData)
 
@@ -79,7 +79,7 @@ func TestResolve_IndexMDContainsPublicURL(t *testing.T) {
 func TestResolve_EnableAdminGraphQL(t *testing.T) {
 	env := &mockEnv{publicURL: "https://example.com"}
 
-	_, err := Resolve(context.Background(), env, 7, true)
+	_, err := Resolve(context.Background(), env, 7, true, "example.com")
 	require.NoError(t, err)
 
 	require.Len(t, env.setAdminToolsCalls, 1)
@@ -91,16 +91,16 @@ func TestResolve_EnableAdminGraphQL(t *testing.T) {
 func TestResolve_AdminGraphQLDisabledByDefault(t *testing.T) {
 	env := &mockEnv{publicURL: "https://example.com"}
 
-	_, err := Resolve(context.Background(), env, 7, false)
+	_, err := Resolve(context.Background(), env, 7, false, "example.com")
 	require.NoError(t, err)
 
 	require.Empty(t, env.setAdminToolsCalls)
 }
 
-func TestResolve_FolderRenamedToDomain(t *testing.T) {
+func TestResolve_FolderRenamedToVaultName(t *testing.T) {
 	env := &mockEnv{publicURL: "https://trip2g.com"}
 
-	zipData, err := Resolve(context.Background(), env, 1, false)
+	zipData, err := Resolve(context.Background(), env, 1, false, "trip2g.com")
 	require.NoError(t, err)
 
 	reader, err := zip.NewReader(bytes.NewReader(zipData), int64(len(zipData)))
@@ -114,10 +114,80 @@ func TestResolve_FolderRenamedToDomain(t *testing.T) {
 	}
 }
 
+// The vault name drives the archive root independently of the instance domain.
+func TestResolve_VaultNameDrivesRoot(t *testing.T) {
+	env := &mockEnv{publicURL: "https://trip2g.com"}
+
+	zipData, err := Resolve(context.Background(), env, 1, false, "secondbrain")
+	require.NoError(t, err)
+
+	reader, err := zip.NewReader(bytes.NewReader(zipData), int64(len(zipData)))
+	require.NoError(t, err)
+
+	for _, file := range reader.File {
+		require.True(t, strings.HasPrefix(file.Name, "secondbrain/"),
+			"file %s should start with secondbrain/", file.Name)
+	}
+}
+
+// data.json carries the sync credentials; it must land under the requested root.
+func TestResolve_DataJSONUnderVaultName(t *testing.T) {
+	env := &mockEnv{publicURL: "https://trip2g.com"}
+
+	zipData, err := Resolve(context.Background(), env, 1, false, "secondbrain")
+	require.NoError(t, err)
+
+	reader, err := zip.NewReader(bytes.NewReader(zipData), int64(len(zipData)))
+	require.NoError(t, err)
+
+	var content string
+	for _, file := range reader.File {
+		if file.Name != "secondbrain/.obsidian/plugins/trip2g/data.json" {
+			continue
+		}
+
+		rc, openErr := file.Open()
+		require.NoError(t, openErr)
+
+		data, readErr := io.ReadAll(rc)
+		rc.Close()
+		require.NoError(t, readErr)
+
+		content = string(data)
+		break
+	}
+
+	require.NotEmpty(t, content, "data.json should exist under secondbrain/")
+	require.Contains(t, content, "test-api-key-12345")
+}
+
+func TestResolve_EmptyVaultNameIsRejected(t *testing.T) {
+	env := &mockEnv{publicURL: "https://trip2g.com"}
+
+	_, err := Resolve(context.Background(), env, 1, false, "")
+	require.Error(t, err)
+}
+
+func TestValidateVaultName(t *testing.T) {
+	valid := []string{"secondbrain", "trip2g.com", "second-brain", "second_brain", "a", "A1", "vault.2"}
+	for _, name := range valid {
+		require.NoError(t, validateVaultName(name), "name %q should be valid", name)
+	}
+
+	invalid := []string{
+		"", ".", "..", "../etc", "a/b", `a\b`, "/etc/passwd", ".hidden", "-x",
+		"a b", "a\nb", "a\x00b", `a"b`, "мозг", "a\tb", "c:",
+		strings.Repeat("a", maxVaultNameLen+1),
+	}
+	for _, name := range invalid {
+		require.Error(t, validateVaultName(name), "name %q should be rejected", name)
+	}
+}
+
 func TestResolve_ExtractsWithoutDirFileCollision(t *testing.T) {
 	env := &mockEnv{publicURL: "https://example.com"}
 
-	zipData, err := Resolve(context.Background(), env, 1, false)
+	zipData, err := Resolve(context.Background(), env, 1, false, "example.com")
 	require.NoError(t, err)
 
 	reader, err := zip.NewReader(bytes.NewReader(zipData), int64(len(zipData)))
@@ -150,7 +220,7 @@ func TestResolve_UnzipCLIExtractsCleanly(t *testing.T) {
 	}
 
 	env := &mockEnv{publicURL: "https://example.com"}
-	zipData, err := Resolve(context.Background(), env, 1, false)
+	zipData, err := Resolve(context.Background(), env, 1, false, "example.com")
 	require.NoError(t, err)
 
 	dir := t.TempDir()


### PR DESCRIPTION
## What

Add an optional `?name` query parameter to `GET /_system/onboarding-vault`. The
name sets **both** the download filename (`<name>.zip`) and the **root folder
inside the archive** (`<name>/`), so a caller knows exactly where the vault
unpacks instead of inferring it from the host and picking "the first directory".

Example:

```
/_system/onboarding-vault?enable_admin_graphql&name=secondbrain
  → secondbrain.zip, archive rooted at secondbrain/
```

## Why

Today the archive root is derived from the instance domain
(`domainFromURL(PublicURL())`), and consumers guess the folder name by scanning
for the first directory in the zip. Making the name explicit removes that
guesswork on both sides.

## Behaviour

- **No `?name`** — unchanged: root and filename come from the instance domain.
- **Valid `?name`** — drives filename and root.
- **Invalid `?name`** — explicit `400`, never a silent fallback, and no API key
  is minted for the rejected request.

Because the name flows into a filesystem path and a `Content-Disposition`
filename, it is validated against a strict allowlist rather than sanitised:
`^[A-Za-z0-9][A-Za-z0-9._-]*$`, max 64 chars. This rejects empty, `..`,
slashes/backslashes, spaces, control chars, unicode, and leading `.`/`-`
(hidden-file and option-flag shapes).

## Tests

- `endpoint_test.go` — name → filename + root; no name → domain fallback;
  invalid names → `400` (table incl. traversal, slashes, unicode, NUL, too-long);
  valid names accepted; rejected name mints no API key.
- `resolve_test.go` — name drives root and `data.json` location; empty name
  errors; `validateVaultName` allowlist table.
- `e2e/onboarding-vault.spec.js` — name sets download filename; invalid name → `400`.

Existing tests updated for the new `Resolve(..., vaultName)` signature.
