### PR TITLE
fix(security): deny writes for scoped tokens with empty write_patterns

### DIFF
--- a/internal/case/updatenotes/resolve.go
+++ b/internal/case/updatenotes/resolve.go
@@ -58,10 +58,13 @@ func normalizeNotePath(p string) string {
 
 func webhookWriteDenied(ctx context.Context, path string) *model.ErrorPayload {
 	wp := appreq.WebhookWritePatterns(ctx)
-	// Scoped-token requests (fleet calls via shortapitoken): deny-all when
-	// write_patterns is empty, and deny on no-match when non-empty.
+	// Scoped-token requests (shortapitoken): deny-all when write_patterns is
+	// empty, and deny on no-match when non-empty. Keyed off Scoped — the flag
+	// every shortapitoken carries — not off DeliveryKind, which is an optional
+	// claim: a scoped token minted without it must not fall through to the
+	// legacy allow-all. DeliveryKind kept as a defensive second signal.
 	// Unscoped/admin requests keep the legacy behaviour: empty = allow all.
-	if appreq.WebhookDeliveryKind(ctx) != "" {
+	if appreq.Scoped(ctx) || appreq.WebhookDeliveryKind(ctx) != "" {
 		if len(wp) == 0 || !webhookutil.MatchesAny(path, wp) {
 			return &model.ErrorPayload{Message: "write denied for path: " + path}
 		}

--- a/internal/case/updatenotes/resolve_test.go
+++ b/internal/case/updatenotes/resolve_test.go
@@ -843,6 +843,85 @@ func TestResolve_ScopedToken_LeadingSlashHideNotDenied(t *testing.T) {
 	require.True(t, called)
 }
 
+// A scoped credential (WebhookScoped=true) minted WITHOUT a DeliveryKind —
+// e.g. a future visitor-facing shortapitoken, since the dk claim is omitempty —
+// must still be deny-all on empty write_patterns. The deny-all branch used to
+// key off DeliveryKind, so such a token fell into the legacy empty=allow-all
+// path and could write ANY note.
+func TestResolve_ScopedNoDeliveryKind_EmptyWritePatterns_DenyAll(t *testing.T) {
+	tests := []struct {
+		name   string
+		change model.NoteChangeInput
+	}{
+		{
+			name:   "upsert outside any scope denied",
+			change: model.NoteChangeInput{Upsert: &model.NoteChangeUpsertInput{Path: "secrets/private.md", Content: "pwned"}},
+		},
+		{
+			name:   "patch denied",
+			change: model.NoteChangeInput{Patch: &model.NoteChangePatchInput{Path: "secrets/private.md", Find: "x", Replace: "y"}},
+		},
+		{
+			name:   "hide denied",
+			change: model.NoteChangeInput{Hide: &model.NoteChangeHideInput{Path: "secrets/private.md"}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Scoped shortapitoken with NO DeliveryKind and NO write scope.
+			req := &appreq.Request{
+				WebhookScoped:        true,
+				WebhookWritePatterns: []string{},
+			}
+			ctx := appreq.NewContext(context.Background(), req)
+
+			nvs := makeNVSWithNote("secrets/private.md", "x", 1)
+			env := &mockEnv{
+				latestNoteViews: func() *appmodel.NoteViews { return nvs },
+				// insertNote and hideNotePath intentionally nil — must NOT be reached.
+			}
+
+			out, err := updatenotes.Resolve(ctx, env, model.UpdateNotesInput{
+				ApiKey:  db.ApiKey{},
+				Changes: []model.NoteChangeInput{tc.change},
+			})
+			require.NoError(t, err)
+			ep, ok := out.(*model.ErrorPayload)
+			require.True(t, ok, "expected *ErrorPayload (write denied), got %T", out)
+			require.Contains(t, ep.Message, "write denied")
+		})
+	}
+}
+
+// Scoped, no DeliveryKind, non-empty matching write_patterns → allowed
+// (the fix must not over-deny in-scope writes).
+func TestResolve_ScopedNoDeliveryKind_MatchingPattern_Allowed(t *testing.T) {
+	req := &appreq.Request{
+		WebhookScoped:        true,
+		WebhookWritePatterns: []string{"notes/**"},
+	}
+	ctx := appreq.NewContext(context.Background(), req)
+
+	called := false
+	env := &mockEnv{
+		latestNoteViews:            appmodel.NewNoteViews,
+		insertNoteWithVersion:      func(_ context.Context, _ appmodel.RawNote) (int64, int64, error) { called = true; return 1, 0, nil },
+		prepareLatestNotes:         noopPrepare,
+		handleLatestNotesAfterSave: noopHandle,
+	}
+
+	out, err := updatenotes.Resolve(ctx, env, model.UpdateNotesInput{
+		ApiKey: db.ApiKey{},
+		Changes: []model.NoteChangeInput{
+			{Upsert: &model.NoteChangeUpsertInput{Path: "notes/todo.md", Content: "x"}},
+		},
+	})
+	require.NoError(t, err)
+	require.IsType(t, model.UpdateNotesSuccessPayload{}, out)
+	require.True(t, called)
+}
+
 // F2: unscoped/admin request (no DeliveryKind) + empty write_patterns → allowed (unchanged behavior).
 func TestResolve_Unscoped_EmptyWritePatterns_Allowed(t *testing.T) {
 	// No appreq in context — simulates admin/unscoped request.


### PR DESCRIPTION
## The hole (fixed)

A validly-signed shortapitoken sets `req.WebhookScoped = true` and copies `DeliveryKind` from the token (`checkapikey/resolve.go:123-146`). `updatenotes/resolve.go`'s deny-all branch fired only when `WebhookDeliveryKind != ""`. A scoped token minted **without** a DeliveryKind → `Scoped=true, DeliveryKind=""` → fell into the legacy "empty write_patterns = allow all" branch → **could write any note**, bypassing its scope. This is exactly the future visitor-facing-token shape.

**Not currently exploitable via minted tokens** — both existing minters always set DeliveryKind (`deliverchangewebhook` "change", `delivercronwebhook` "cron"). Latent, and the read side already fails closed on `Scoped`, so the write side was the asymmetric odd one out.

## Fix

`updatenotes/resolve.go:59-72`: the scoped deny-all branch now triggers on `appreq.Scoped(ctx) || WebhookDeliveryKind != ""` (was DeliveryKind only). A scoped credential with empty write_patterns = **no writes** (empty scope ≠ full permission). Unscoped full keys / admin never set `Scoped`, so normal sync is unaffected. One-line condition change.

TDD: RED proven (`TestResolve_ScopedNoDeliveryKind_EmptyWritePatterns_DenyAll` — the write reached `InsertNoteWithVersion` before the fix), GREEN after. No over-deny (`..._MatchingPattern_Allowed`, `..._Unscoped_EmptyWritePatterns_Allowed` still pass). Lint 0 issues.

## ⚠️ Bigger, SEPARATE finding — NOT fixed here (needs a decision)

`pushNotes`, `hideNotes`, `uploadNoteAsset`, `commitNotes` (`graph/schema.resolvers.go:2665-2723`) accept a shortapitoken via `checkapikey.Resolve` and enforce **no write scope at all** — a scoped token can `pushNotes` anything, bypassing `write_patterns` entirely. This is a wider hole than the one fixed here and needs its own decision: deny scoped tokens on these mutations, or enforce write_patterns on them. Flagging for review, not fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)