### PR TITLE
fix(security): confine scoped tokens on pushNotes/hideNotes/uploadNoteAsset/commitNotes

### DIFF
--- a/internal/appreq/request.go
+++ b/internal/appreq/request.go
@@ -296,6 +296,19 @@ func Scoped(ctx context.Context) bool {
 	return req.WebhookScoped
 }
 
+// ErrScopedToken is returned by RequireUnscoped for scoped-token requests.
+var ErrScopedToken = errors.New("operation not available to scoped tokens; use updateNotes within the token's write scope")
+
+// RequireUnscoped fails closed for scoped-token requests on operations that
+// have no per-path write scoping (pushNotes, hideNotes, commitNotes): a
+// shortapitoken must not reach the full-vault infra/sync lane.
+func RequireUnscoped(ctx context.Context) error {
+	if Scoped(ctx) {
+		return ErrScopedToken
+	}
+	return nil
+}
+
 // WebhookWritePatterns returns the write-scope globs stamped on the request
 // by a shortapitoken delivery. Empty/nil means unscoped (no enforcement).
 func WebhookWritePatterns(ctx context.Context) []string {

--- a/internal/case/commitnotes/resolve.go
+++ b/internal/case/commitnotes/resolve.go
@@ -3,6 +3,7 @@ package commitnotes
 import (
 	"context"
 	"fmt"
+	"trip2g/internal/appreq"
 	"trip2g/internal/graph/model"
 	appmodel "trip2g/internal/model"
 )
@@ -41,6 +42,12 @@ func buildUpdatedNotes(nvs *appmodel.NoteViews, pathIDs []int64, publicURL strin
 }
 
 func Resolve(ctx context.Context, env Env) (Payload, error) {
+	// commitNotes has no path input, so per-path scoping is undefined — scoped
+	// tokens are denied outright.
+	if err := appreq.RequireUnscoped(ctx); err != nil {
+		return &model.ErrorPayload{Message: err.Error()}, nil //nolint:nilerr // authorization denial returned as payload, not as error.
+	}
+
 	pathIDs, err := env.ListUncommittedPaths(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list uncommitted paths: %w", err)

--- a/internal/case/commitnotes/resolve_test.go
+++ b/internal/case/commitnotes/resolve_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"trip2g/internal/appreq"
 	"trip2g/internal/case/commitnotes"
 	"trip2g/internal/graph/model"
 	appmodel "trip2g/internal/model"
@@ -57,4 +58,57 @@ func TestResolve_Updated(t *testing.T) {
 	require.NotNil(t, payload.Updated[0].URL)
 	require.Equal(t, "https://site.com/commit-note", *payload.Updated[0].URL)
 	require.Empty(t, payload.Updated[0].Warnings)
+}
+
+// TestResolve_ScopedToken pins the scope guard: commitNotes has no path input,
+// so per-path scoping is undefined — a scoped shortapitoken must be denied
+// outright; unscoped full API keys keep working.
+func TestResolve_ScopedToken(t *testing.T) {
+	tests := []struct {
+		name       string
+		ctx        context.Context
+		wantDenied bool
+	}{
+		{
+			name: "scoped token denied",
+			ctx: appreq.NewContext(context.Background(), &appreq.Request{
+				WebhookScoped:        true,
+				WebhookDeliveryKind:  "cron",
+				WebhookWritePatterns: []string{"notes/**"},
+			}),
+			wantDenied: true,
+		},
+		{
+			name:       "unscoped key allowed",
+			ctx:        context.Background(),
+			wantDenied: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := &EnvMock{
+				ListUncommittedPathsFunc: func(_ context.Context) ([]int64, error) { return nil, nil },
+				PrepareLatestNotesFunc: func(_ context.Context, _ bool) (*appmodel.NoteViews, error) {
+					return appmodel.NewNoteViews(), nil
+				},
+				HandleLatestNotesAfterSaveFunc: func(_ context.Context, _ []int64) error { return nil },
+				ClearUncommittedPathsFunc:      func(_ context.Context) error { return nil },
+				PublicURLFunc:                  func() string { return "" },
+			}
+
+			result, err := commitnotes.Resolve(tt.ctx, env)
+			require.NoError(t, err)
+
+			if tt.wantDenied {
+				ep, ok := result.(*model.ErrorPayload)
+				require.True(t, ok, "expected *ErrorPayload for scoped token, got %T", result)
+				require.Contains(t, ep.Message, "scoped token")
+				require.Empty(t, env.ListUncommittedPathsCalls(), "commit must not proceed for scoped tokens")
+				return
+			}
+			require.IsType(t, &model.CommitNotesPayload{}, result)
+			require.Len(t, env.ClearUncommittedPathsCalls(), 1)
+		})
+	}
 }

--- a/internal/case/hidenotes/resolve.go
+++ b/internal/case/hidenotes/resolve.go
@@ -25,6 +25,12 @@ type Input = model.HideNotesInput
 type Payload = model.HideNotesOrErrorPayload
 
 func Resolve(ctx context.Context, env Env, input Input) (Payload, error) {
+	// hideNotes is a bulk-hide infra mutation with no per-path scoping — scoped
+	// tokens are denied outright (updateNotes' hide change is the scoped path).
+	if err := appreq.RequireUnscoped(ctx); err != nil {
+		return &model.ErrorPayload{Message: err.Error()}, nil //nolint:nilerr // authorization denial returned as payload, not as error.
+	}
+
 	// Collect note info before hiding (notes may be removed from NoteViews after reload).
 	nvs := env.LatestNoteViews()
 	var webhookChanges []handlenotewebhooks.NoteChange

--- a/internal/case/hidenotes/resolve_test.go
+++ b/internal/case/hidenotes/resolve_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"testing"
+	"trip2g/internal/appreq"
 	"trip2g/internal/db"
 	"trip2g/internal/graph/model"
 	"trip2g/internal/logger"
@@ -179,6 +180,51 @@ func TestResolve(t *testing.T) {
 				require.True(t, ok, "env should be a mock for callback tests")
 				tt.afterCallback(t, mockEnv)
 			}
+		})
+	}
+}
+
+// TestResolve_ScopedToken pins the scope guard: hideNotes is a bulk-hide infra
+// mutation that never consults write_patterns, so a scoped shortapitoken must
+// be denied outright; unscoped full API keys keep working.
+func TestResolve_ScopedToken(t *testing.T) {
+	tests := []struct {
+		name       string
+		ctx        context.Context
+		wantDenied bool
+	}{
+		{
+			name: "scoped token denied",
+			ctx: appreq.NewContext(context.Background(), &appreq.Request{
+				WebhookScoped:        true,
+				WebhookDeliveryKind:  "change",
+				WebhookWritePatterns: []string{"notes/**"},
+			}),
+			wantDenied: true,
+		},
+		{
+			name:       "unscoped key allowed",
+			ctx:        context.Background(),
+			wantDenied: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := newTestEnv(func(_ context.Context, _ db.HideNotePathParams) error { return nil })
+
+			result, err := Resolve(tt.ctx, env, model.HideNotesInput{Paths: []string{"note.md"}})
+			require.NoError(t, err)
+
+			if tt.wantDenied {
+				ep, ok := result.(*model.ErrorPayload)
+				require.True(t, ok, "expected *ErrorPayload for scoped token, got %T", result)
+				require.Contains(t, ep.Message, "scoped token")
+				require.Empty(t, env.HideNotePathCalls(), "HideNotePath must not be reached for scoped tokens")
+				return
+			}
+			require.IsType(t, &model.HideNotesPayload{}, result)
+			require.Len(t, env.HideNotePathCalls(), 1)
 		})
 	}
 }

--- a/internal/case/pushnotes/resolve.go
+++ b/internal/case/pushnotes/resolve.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"trip2g/internal/appreq"
 	"trip2g/internal/graph/model"
 	"trip2g/internal/logger"
 
@@ -38,6 +39,12 @@ var allowedContentTypes = map[string]struct{}{ //nolint:gochecknoglobals // it's
 }
 
 func Resolve(ctx context.Context, env Env, input model.PushNotesInput) (model.PushNotesOrErrorPayload, error) {
+	// pushNotes is the full-vault sync lane with no per-path scoping — scoped
+	// tokens are denied outright.
+	if err := appreq.RequireUnscoped(ctx); err != nil {
+		return &model.ErrorPayload{Message: err.Error()}, nil //nolint:nilerr // authorization denial returned as payload, not as error.
+	}
+
 	log := logger.WithPrefix(env.Logger(), "pushNotes:")
 
 	// Check storage limits before writing.

--- a/internal/case/pushnotes/resolve_test.go
+++ b/internal/case/pushnotes/resolve_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"trip2g/internal/appreq"
 	"trip2g/internal/case/pushnotes"
 	"trip2g/internal/graph/model"
 	"trip2g/internal/logger"
@@ -517,4 +518,53 @@ func TestResolve_AssetURLAbsolutization(t *testing.T) {
 		require.Len(t, payload.Updated, 1)
 		require.Equal(t, "https://cdn.other.com/image.png", payload.Updated[0].Assets[0].URL)
 	})
+}
+
+// TestResolve_ScopedToken pins the scope guard: pushNotes is the infra/sync
+// lane (full-vault push) with no per-path scoping, so a scoped shortapitoken
+// must be denied outright; unscoped full API keys keep working.
+func TestResolve_ScopedToken(t *testing.T) {
+	mockLogger := &logger.TestLogger{}
+
+	tests := []struct {
+		name       string
+		ctx        context.Context
+		wantDenied bool
+	}{
+		{
+			name: "scoped token denied",
+			ctx: appreq.NewContext(context.Background(), &appreq.Request{
+				WebhookScoped:        true,
+				WebhookDeliveryKind:  "change",
+				WebhookWritePatterns: []string{"notes/**"},
+			}),
+			wantDenied: true,
+		},
+		{
+			name:       "unscoped key allowed",
+			ctx:        context.Background(),
+			wantDenied: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := newEnvMock(mockLogger)
+			env.LatestNoteViewsFunc = appmodel.NewNoteViews
+			env.LayoutsFunc = func() *appmodel.Layouts {
+				return &appmodel.Layouts{Map: map[string]appmodel.Layout{}}
+			}
+
+			result, err := pushnotes.Resolve(tt.ctx, env, model.PushNotesInput{})
+			require.NoError(t, err)
+
+			if tt.wantDenied {
+				ep, ok := result.(*model.ErrorPayload)
+				require.True(t, ok, "expected *ErrorPayload for scoped token, got %T", result)
+				require.Contains(t, ep.Message, "scoped token")
+				return
+			}
+			require.IsType(t, &model.PushNotesPayload{}, result)
+		})
+	}
 }

--- a/internal/case/updatenotes/resolve.go
+++ b/internal/case/updatenotes/resolve.go
@@ -10,7 +10,6 @@ import (
 	pathpkg "path"
 	"strings"
 
-	"trip2g/internal/appreq"
 	"trip2g/internal/db"
 	"trip2g/internal/graph/model"
 	appmodel "trip2g/internal/model"
@@ -57,20 +56,7 @@ func normalizeNotePath(p string) string {
 }
 
 func webhookWriteDenied(ctx context.Context, path string) *model.ErrorPayload {
-	wp := appreq.WebhookWritePatterns(ctx)
-	// Scoped-token requests (shortapitoken): deny-all when write_patterns is
-	// empty, and deny on no-match when non-empty. Keyed off Scoped — the flag
-	// every shortapitoken carries — not off DeliveryKind, which is an optional
-	// claim: a scoped token minted without it must not fall through to the
-	// legacy allow-all. DeliveryKind kept as a defensive second signal.
-	// Unscoped/admin requests keep the legacy behaviour: empty = allow all.
-	if appreq.Scoped(ctx) || appreq.WebhookDeliveryKind(ctx) != "" {
-		if len(wp) == 0 || !webhookutil.MatchesAny(path, wp) {
-			return &model.ErrorPayload{Message: "write denied for path: " + path}
-		}
-		return nil
-	}
-	if len(wp) > 0 && !webhookutil.MatchesAny(path, wp) {
+	if webhookutil.WriteScopeDenied(ctx, path) {
 		return &model.ErrorPayload{Message: "write denied for path: " + path}
 	}
 	return nil

--- a/internal/case/uploadnoteasset/mocks_test.go
+++ b/internal/case/uploadnoteasset/mocks_test.go
@@ -47,6 +47,9 @@ var _ uploadnoteasset.Env = &EnvMock{}
 //			NoteVersionAssetPathsFunc: func(ctx context.Context, id int64) (map[string]struct{}, error) {
 //				panic("mock out the NoteVersionAssetPaths method")
 //			},
+//			NoteVersionByIDFunc: func(ctx context.Context, id int64) (db.NoteVersionByIDRow, error) {
+//				panic("mock out the NoteVersionByID method")
+//			},
 //			PrepareLatestNotesFunc: func(ctx context.Context, partial bool) (*appmodel.NoteViews, error) {
 //				panic("mock out the PrepareLatestNotes method")
 //			},
@@ -86,6 +89,9 @@ type EnvMock struct {
 
 	// NoteVersionAssetPathsFunc mocks the NoteVersionAssetPaths method.
 	NoteVersionAssetPathsFunc func(ctx context.Context, id int64) (map[string]struct{}, error)
+
+	// NoteVersionByIDFunc mocks the NoteVersionByID method.
+	NoteVersionByIDFunc func(ctx context.Context, id int64) (db.NoteVersionByIDRow, error)
 
 	// PrepareLatestNotesFunc mocks the PrepareLatestNotes method.
 	PrepareLatestNotesFunc func(ctx context.Context, partial bool) (*appmodel.NoteViews, error)
@@ -150,6 +156,13 @@ type EnvMock struct {
 			// ID is the id argument value.
 			ID int64
 		}
+		// NoteVersionByID holds details about calls to the NoteVersionByID method.
+		NoteVersionByID []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ID is the id argument value.
+			ID int64
+		}
 		// PrepareLatestNotes holds details about calls to the PrepareLatestNotes method.
 		PrepareLatestNotes []struct {
 			// Ctx is the ctx argument value.
@@ -182,6 +195,7 @@ type EnvMock struct {
 	lockNoteAssetByPathAndHash sync.RWMutex
 	lockNoteAssetExists        sync.RWMutex
 	lockNoteVersionAssetPaths  sync.RWMutex
+	lockNoteVersionByID        sync.RWMutex
 	lockPrepareLatestNotes     sync.RWMutex
 	lockPutAssetObject         sync.RWMutex
 	lockUpsertNoteVersionAsset sync.RWMutex
@@ -463,6 +477,42 @@ func (mock *EnvMock) NoteVersionAssetPathsCalls() []struct {
 	mock.lockNoteVersionAssetPaths.RLock()
 	calls = mock.calls.NoteVersionAssetPaths
 	mock.lockNoteVersionAssetPaths.RUnlock()
+	return calls
+}
+
+// NoteVersionByID calls NoteVersionByIDFunc.
+func (mock *EnvMock) NoteVersionByID(ctx context.Context, id int64) (db.NoteVersionByIDRow, error) {
+	if mock.NoteVersionByIDFunc == nil {
+		panic("EnvMock.NoteVersionByIDFunc: method is nil but Env.NoteVersionByID was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+		ID  int64
+	}{
+		Ctx: ctx,
+		ID:  id,
+	}
+	mock.lockNoteVersionByID.Lock()
+	mock.calls.NoteVersionByID = append(mock.calls.NoteVersionByID, callInfo)
+	mock.lockNoteVersionByID.Unlock()
+	return mock.NoteVersionByIDFunc(ctx, id)
+}
+
+// NoteVersionByIDCalls gets all the calls that were made to NoteVersionByID.
+// Check the length with:
+//
+//	len(mockedEnv.NoteVersionByIDCalls())
+func (mock *EnvMock) NoteVersionByIDCalls() []struct {
+	Ctx context.Context
+	ID  int64
+} {
+	var calls []struct {
+		Ctx context.Context
+		ID  int64
+	}
+	mock.lockNoteVersionByID.RLock()
+	calls = mock.calls.NoteVersionByID
+	mock.lockNoteVersionByID.RUnlock()
 	return calls
 }
 

--- a/internal/case/uploadnoteasset/resolve.go
+++ b/internal/case/uploadnoteasset/resolve.go
@@ -9,11 +9,13 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"trip2g/internal/appreq"
 	"trip2g/internal/db"
 	"trip2g/internal/graph/model"
 	"trip2g/internal/logger"
 	appmodel "trip2g/internal/model"
 	"trip2g/internal/translit"
+	"trip2g/internal/webhookutil"
 )
 
 type Env interface {
@@ -26,6 +28,7 @@ type Env interface {
 	NoteAssetByPathAndHash(ctx context.Context, arg db.NoteAssetByPathAndHashParams) (db.NoteAsset, error)
 	NoteAssetExists(ctx context.Context, asset db.NoteAsset) (bool, error)
 	NoteVersionAssetPaths(ctx context.Context, id int64) (map[string]struct{}, error)
+	NoteVersionByID(ctx context.Context, id int64) (db.NoteVersionByIDRow, error)
 	PrepareLatestNotes(ctx context.Context, partial bool) (*appmodel.NoteViews, error)
 	CheckStorageLimits(ctx context.Context, additionalAssetBytes int64) (string, error)
 }
@@ -36,7 +39,36 @@ var reUnsafeChars = regexp.MustCompile(`[^a-zA-Z0-9_.-]`)
 type Input = model.UploadNoteAssetInput
 type Payload = model.UploadNoteAssetOrErrorPayload
 
+// scopedWriteDenied enforces write_patterns for scoped-token requests: noteID
+// (a note VERSION id) must resolve to a note path within the token's write
+// scope, matched with the same matcher updateNotes uses. Returns a non-nil
+// payload when the upload must be rejected.
+func scopedWriteDenied(ctx context.Context, env Env, noteID int64) (*model.ErrorPayload, error) {
+	if !appreq.Scoped(ctx) {
+		return nil, nil
+	}
+	row, err := env.NoteVersionByID(ctx, noteID)
+	if err != nil {
+		if db.IsNoFound(err) {
+			return &model.ErrorPayload{Message: fmt.Sprintf("note version not found: %d", noteID)}, nil
+		}
+		return nil, fmt.Errorf("failed to resolve note version %d: %w", noteID, err)
+	}
+	if webhookutil.WriteScopeDenied(ctx, row.Path) {
+		return &model.ErrorPayload{Message: "write denied for path: " + row.Path}, nil
+	}
+	return nil, nil
+}
+
 func Resolve(ctx context.Context, env Env, input Input) (Payload, error) {
+	denied, deniedErr := scopedWriteDenied(ctx, env, input.NoteID)
+	if deniedErr != nil {
+		return nil, deniedErr
+	}
+	if denied != nil {
+		return denied, nil
+	}
+
 	// Step 1: Validation
 	assetPaths, err := env.NoteVersionAssetPaths(ctx, input.NoteID)
 	if err != nil {

--- a/internal/case/uploadnoteasset/resolve_test.go
+++ b/internal/case/uploadnoteasset/resolve_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"io"
 	"testing"
+	"trip2g/internal/appreq"
 	"trip2g/internal/case/uploadnoteasset"
 	"trip2g/internal/db"
 	"trip2g/internal/graph/model"
@@ -31,6 +32,7 @@ type Env interface {
 	NoteAssetByPathAndHash(ctx context.Context, arg db.NoteAssetByPathAndHashParams) (db.NoteAsset, error)
 	NoteAssetExists(ctx context.Context, asset db.NoteAsset) (bool, error)
 	NoteVersionAssetPaths(ctx context.Context, id int64) (map[string]struct{}, error)
+	NoteVersionByID(ctx context.Context, id int64) (db.NoteVersionByIDRow, error)
 	PrepareLatestNotes(ctx context.Context, partial bool) (*appmodel.NoteViews, error)
 	CheckStorageLimits(ctx context.Context, additionalAssetBytes int64) (string, error)
 }
@@ -424,6 +426,116 @@ func TestResolve(t *testing.T) {
 			if tt.validate != nil {
 				tt.validate(t, payload, env)
 			}
+		})
+	}
+}
+
+// TestResolve_ScopedToken pins write-scope enforcement for uploadNoteAsset:
+// a scoped shortapitoken may attach assets only to notes whose path matches
+// its write_patterns (same matcher as updateNotes); unscoped requests skip
+// the note-path lookup entirely.
+func TestResolve_ScopedToken(t *testing.T) {
+	testContent := []byte("asset bytes")
+	testHash := calcHash(testContent)
+
+	makeInput := func() model.UploadNoteAssetInput {
+		return model.UploadNoteAssetInput{
+			NoteID:       42,
+			Path:         "images/pic.png",
+			AbsolutePath: "/abs/images/pic.png",
+			Sha256Hash:   testHash,
+			File: graphql.Upload{
+				File:     bytes.NewReader(testContent),
+				Filename: "pic.png",
+				Size:     int64(len(testContent)),
+			},
+		}
+	}
+
+	// makeEnv returns mocks for the asset-reuse happy path (existing asset,
+	// object present, link upserted). notePath is what NoteVersionByID reports
+	// for version 42; leave NoteVersionByIDFunc nil to assert it is not called.
+	makeEnv := func(notePath string) *EnvMock {
+		env := &EnvMock{
+			LoggerFunc: func() logger.Logger { return &logger.TestLogger{} },
+			NoteVersionAssetPathsFunc: func(_ context.Context, _ int64) (map[string]struct{}, error) {
+				return map[string]struct{}{"images/pic.png": {}}, nil
+			},
+			NoteAssetByPathAndHashFunc: func(_ context.Context, _ db.NoteAssetByPathAndHashParams) (db.NoteAsset, error) {
+				return db.NoteAsset{ID: 1}, nil
+			},
+			NoteAssetExistsFunc: func(_ context.Context, _ db.NoteAsset) (bool, error) { return true, nil },
+			UpsertNoteVersionAssetFunc: func(_ context.Context, _ db.UpsertNoteVersionAssetParams) error {
+				return nil
+			},
+			PrepareLatestNotesFunc: func(_ context.Context, _ bool) (*appmodel.NoteViews, error) {
+				return &appmodel.NoteViews{}, nil
+			},
+		}
+		if notePath != "" {
+			env.NoteVersionByIDFunc = func(_ context.Context, id int64) (db.NoteVersionByIDRow, error) {
+				require.Equal(t, int64(42), id)
+				return db.NoteVersionByIDRow{VersionID: id, Path: notePath}, nil
+			}
+		}
+		return env
+	}
+
+	scopedCtx := func(patterns []string) context.Context {
+		return appreq.NewContext(context.Background(), &appreq.Request{
+			WebhookScoped:        true,
+			WebhookDeliveryKind:  "change",
+			WebhookWritePatterns: patterns,
+		})
+	}
+
+	tests := []struct {
+		name       string
+		ctx        context.Context
+		notePath   string // "" = NoteVersionByID must not be called
+		wantDenied bool
+	}{
+		{
+			name:     "scoped token with matching pattern allowed",
+			ctx:      scopedCtx([]string{"notes/**"}),
+			notePath: "notes/todo.md",
+		},
+		{
+			name:       "scoped token with non-matching pattern denied",
+			ctx:        scopedCtx([]string{"notes/**"}),
+			notePath:   "secrets/private.md",
+			wantDenied: true,
+		},
+		{
+			name:       "scoped token with empty patterns denied",
+			ctx:        scopedCtx([]string{}),
+			notePath:   "notes/todo.md",
+			wantDenied: true,
+		},
+		{
+			name:     "unscoped request allowed without path lookup",
+			ctx:      context.Background(),
+			notePath: "", // NoteVersionByIDFunc stays nil — a call would panic
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := makeEnv(tt.notePath)
+
+			result, err := uploadnoteasset.Resolve(tt.ctx, env, makeInput())
+			require.NoError(t, err)
+
+			if tt.wantDenied {
+				ep, ok := result.(*model.ErrorPayload)
+				require.True(t, ok, "expected *ErrorPayload (write denied), got %T", result)
+				require.Contains(t, ep.Message, "write denied for path: "+tt.notePath)
+				require.Empty(t, env.UpsertNoteVersionAssetCalls(), "denied upload must not link the asset")
+				require.Empty(t, env.NoteVersionAssetPathsCalls(), "denied upload must not proceed to validation")
+				return
+			}
+			require.IsType(t, &model.UploadNoteAssetPayload{}, result)
+			require.Len(t, env.UpsertNoteVersionAssetCalls(), 1)
 		})
 	}
 }

--- a/internal/webhookutil/writescope.go
+++ b/internal/webhookutil/writescope.go
@@ -1,0 +1,22 @@
+package webhookutil
+
+import (
+	"context"
+
+	"trip2g/internal/appreq"
+)
+
+// WriteScopeDenied reports whether writing path is denied by the request's
+// webhook write scope. Scoped-token requests: empty write_patterns means
+// deny-all, non-empty denies on no-match. Keyed off Scoped — the flag every
+// shortapitoken carries — not off DeliveryKind, which is an optional claim: a
+// scoped token minted without it must not fall through to the legacy allow-all.
+// Unscoped/admin requests keep the legacy behaviour: empty means allow-all.
+// path must be the canonical slash-less note path.
+func WriteScopeDenied(ctx context.Context, path string) bool {
+	wp := appreq.WebhookWritePatterns(ctx)
+	if appreq.Scoped(ctx) || appreq.WebhookDeliveryKind(ctx) != "" {
+		return len(wp) == 0 || !MatchesAny(path, wp)
+	}
+	return len(wp) > 0 && !MatchesAny(path, wp)
+}


### PR DESCRIPTION
Follow-up to #247. `checkapikey.Resolve` accepts a shortapitoken as a virtual ApiKey, but only `updateNotes` enforced its write scope. The other four write mutations ignored `write_patterns` entirely, letting a scoped token write outside its scope.

## Fix (hybrid, owner-decided)
- **Deny** scoped tokens on `pushNotes`, `hideNotes`, `commitNotes` — the infra/sync lane (full-vault push, bulk hide, commit-all). `commitNotes` has no path input, so per-path scoping is undefined; deny is the only coherent answer. Shared guard `appreq.RequireUnscoped(ctx)`.
- **Scope** `uploadNoteAsset` (not deny) — a scoped bot legitimately attaches media (e.g. a Telegram voice note) to a note in its scope. Resolves `noteId → note path` (`NoteVersionByID`) and checks it against `write_patterns`.
- **Shared matcher** — extracted #247's exact logic into `webhookutil.WriteScopeDenied`, keyed off `appreq.Scoped(ctx) || DeliveryKind != ""` (a scoped token minted without a delivery kind must not fall through to legacy allow-all). `updateNotes` now delegates to it — behavior pinned by #247's own tests (green after rebase).

## Fleet safety
The scoped agent lane (`internal/fleet/remotekb.go`) uses ONLY `UpdateNotesScoped`; `commitNotes` exists only for the full-API-key obsidian-plugin batch flow. Denying the three does not break agents (verified).

## Verified
TDD RED proven first; `go test` green across pushnotes/hidenotes/commitnotes/uploadnoteasset/updatenotes/checkapikey/webhookutil; `go build -tags dev` OK. Rebased onto merged #247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)