### PR TITLE
test(onboarding-vault): make ?name endpoint tests hermetic (green CI)

### DIFF
--- a/cmd/server/misc.go
+++ b/cmd/server/misc.go
@@ -11,6 +11,7 @@ import (
 	"trip2g/internal/db"
 	"trip2g/internal/model"
 	"trip2g/internal/openai"
+	onboardingvault "trip2g/onboarding-vault"
 
 	"github.com/oklog/ulid/v2"
 )
@@ -149,6 +150,10 @@ func (a *app) GenerateAPIKey() string {
 	}
 
 	return string(result)
+}
+
+func (a *app) OnboardingVaultZip() []byte {
+	return onboardingvault.ZipData
 }
 
 func (a *app) GenerateGitToken() string {

--- a/internal/case/downloadonboardingvault/endpoint.go
+++ b/internal/case/downloadonboardingvault/endpoint.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"trip2g/internal/appreq"
-	onboardingvault "trip2g/onboarding-vault"
 
 	"github.com/valyala/fasthttp"
 )
@@ -16,7 +15,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 	env := req.Env.(Env)
 	ctx := req.Req
 
-	if len(onboardingvault.ZipData) == 0 {
+	if len(env.OnboardingVaultZip()) == 0 {
 		ctx.SetStatusCode(http.StatusNotFound)
 		return nil, nil
 	}

--- a/internal/case/downloadonboardingvault/endpoint_test.go
+++ b/internal/case/downloadonboardingvault/endpoint_test.go
@@ -40,6 +40,18 @@ func zipRoots(t *testing.T, zipData []byte) map[string]bool {
 	return roots
 }
 
+// A build without the vault archive reports 404 instead of serving junk.
+func TestEndpoint_MissingVaultReturns404(t *testing.T) {
+	env := &mockEnv{publicURL: "https://example.com", vaultZip: []byte{}}
+	req := adminRequest(env, "/_system/onboarding-vault?name=secondbrain")
+
+	_, err := (&Endpoint{}).Handle(req)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusNotFound, req.Req.Response.StatusCode())
+	require.Empty(t, req.Req.Response.Header.Peek("Content-Disposition"))
+}
+
 func TestEndpoint_NameSetsFilenameAndRoot(t *testing.T) {
 	env := &mockEnv{publicURL: "https://example.com"}
 	req := adminRequest(env, "/_system/onboarding-vault?enable_admin_graphql&name=secondbrain")

--- a/internal/case/downloadonboardingvault/resolve.go
+++ b/internal/case/downloadonboardingvault/resolve.go
@@ -14,8 +14,6 @@ import (
 	"regexp"
 	"strings"
 
-	onboardingvault "trip2g/onboarding-vault"
-
 	"trip2g/internal/appreq"
 	"trip2g/internal/db"
 	"trip2g/internal/model"
@@ -28,6 +26,9 @@ type Env interface {
 	SetApiKeyMcpAdminTools(ctx context.Context, arg db.SetApiKeyMcpAdminToolsParams) error
 	LatestNoteViews() *model.NoteViews
 	PublicURL() string
+	// OnboardingVaultZip returns the vault template archive, empty when the
+	// vault was not built into this binary.
+	OnboardingVaultZip() []byte
 }
 
 const oldPrefix = "onboarding-vault/"
@@ -226,7 +227,7 @@ func Resolve(ctx context.Context, env Env, userID int, enableAdminGraphQL bool, 
 	newPrefix := vaultName + "/"
 
 	// Read embedded ZIP and modify files, replacing {{publicUrl}} placeholder.
-	modifiedZip, err := modifyZipFiles(onboardingvault.ZipData, replacements, publicURL, newPrefix)
+	modifiedZip, err := modifyZipFiles(env.OnboardingVaultZip(), replacements, publicURL, newPrefix)
 	if err != nil {
 		return nil, fmt.Errorf("failed to modify zip: %w", err)
 	}

--- a/internal/case/downloadonboardingvault/resolve_test.go
+++ b/internal/case/downloadonboardingvault/resolve_test.go
@@ -19,8 +19,49 @@ import (
 
 type mockEnv struct {
 	publicURL string
+	// vaultZip overrides the fixture archive; set to []byte{} to simulate a
+	// build without the onboarding vault.
+	vaultZip []byte
 
 	setAdminToolsCalls []db.SetApiKeyMcpAdminToolsParams
+}
+
+// testVaultZip builds a minimal vault archive in memory, so tests never
+// depend on the generated onboarding-vault/vault.zip release artifact.
+func testVaultZip() []byte {
+	var buf bytes.Buffer
+	writer := zip.NewWriter(&buf)
+
+	files := []struct{ name, content string }{
+		{oldPrefix + "_index.md", "# Welcome\n\n{{publicUrl}}\n"},
+		{oldPrefix + ".obsidian/app.json", "{}"},
+	}
+
+	for _, file := range files {
+		w, err := writer.Create(file.name)
+		if err != nil {
+			panic(err)
+		}
+
+		_, err = w.Write([]byte(file.content))
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	err := writer.Close()
+	if err != nil {
+		panic(err)
+	}
+
+	return buf.Bytes()
+}
+
+func (m *mockEnv) OnboardingVaultZip() []byte {
+	if m.vaultZip == nil {
+		return testVaultZip()
+	}
+	return m.vaultZip
 }
 
 func (m *mockEnv) GenerateAPIKey() string {


### PR DESCRIPTION
The `test` CI job was RED on main: `downloadonboardingvault` `TestEndpoint_*` (the `?name` feature, #244) returned 404 for every case, and `TestResolve_*` hit "not a valid zip file".

## Root cause
Not a missing build step. Under `-tags dev` (which CI uses), `onboarding-vault/embed_dev.go` reads `onboarding-vault/vault.zip` via `os.ReadFile` — **cwd-relative**. A Go test binary's cwd is the package dir, so the read fails and `ZipData` is nil → the endpoint's `len(ZipData)==0` guard 404s before `?name`/validation ever runs. Passed locally only because the run was without `-tags dev` (real `//go:embed`).

## Fix (hermetic)
Move the vault-zip source behind the use case's `Env` interface (`OnboardingVaultZip() []byte`, the repo's standard seam). Tests inject a tiny in-memory fixture zip; the app keeps returning the real embedded/dev-loaded bytes (`cmd/server/misc.go`) — production unchanged. Added `TestEndpoint_MissingVaultReturns404` so the 404 guard stays covered. No assertion weakened.

## Verified
Reproduced the CI condition (no `vault.zip` present): all tests FAIL (404) before, PASS after. Full `go test -tags dev ./...` → exit 0. Build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)