### PR TITLE
feat(admin/debug): render-all page - iframe smoke-test of every admin route

### DIFF
--- a/assets/ui/admin/cronjob/catalog/catalog.view.ts
+++ b/assets/ui/admin/cronjob/catalog/catalog.view.ts
@@ -2,6 +2,7 @@ namespace $.$$ {
 	export class $trip2g_admin_cronjob_catalog extends $.$trip2g_admin_cronjob_catalog {
 		@$mol_mem
 		data( reset?: null ) {
+			if( this.$.$mol_state_arg.value( 'test_fail' ) ) throw new Error( 'test_fail: emulated cronjob catalog failure' )
 			const res = $trip2g_admin_cronjob_catalog_list()
 
 			return $trip2g_graphql_make_map( res.admin.allCronJobs.nodes )

--- a/assets/ui/admin/debug/renderall/renderall.view.css.ts
+++ b/assets/ui/admin/debug/renderall/renderall.view.css.ts
@@ -1,0 +1,56 @@
+namespace $ {
+	const { rem, per } = $mol_style_unit
+
+	$mol_style_define( $trip2g_admin_debug_renderall, {
+
+		Stats: {
+			padding: rem( .5 ),
+			color: $mol_theme.shade,
+		},
+
+		Grid: {
+			display: 'flex',
+			flex: {
+				wrap: 'wrap',
+			},
+			gap: rem( .5 ),
+			padding: rem( .5 ),
+		},
+
+		Cell: {
+			display: 'flex',
+			flex: {
+				direction: 'column',
+				grow: 1,
+				basis: rem( 30 ),
+			},
+			border: {
+				radius: '4px',
+			},
+			background: {
+				color: $mol_theme.card,
+			},
+		},
+
+		Cell_head: {
+			display: 'flex',
+			justifyContent: 'space-between',
+			alignItems: 'center',
+			padding: rem( .25 ),
+		},
+
+		Cell_status: {
+			padding: $mol_gap.text,
+			color: $mol_theme.shade,
+		},
+
+		Frame: {
+			width: per( 100 ),
+			height: rem( 30 ),
+			background: {
+				color: $mol_theme.back,
+			},
+		},
+
+	} )
+}

--- a/assets/ui/admin/debug/renderall/renderall.view.tree
+++ b/assets/ui/admin/debug/renderall/renderall.view.tree
@@ -1,0 +1,32 @@
+$trip2g_admin_debug_renderall $mol_page
+	title @ \Render All Pages
+	close_icon null $mol_view
+	tools /
+		<= Test_fail $mol_check_box
+			title @ \Emulate failures
+			checked? <=> test_fail? false
+		<= Scan $mol_button_minor
+			title @ \Scan errors
+			click? <=> scan? null
+		<= close_icon
+	App $trip2g_admin_app
+	body /
+		<= Stats $mol_view
+			sub /
+				<= stats \
+		<= Grid $mol_view
+			sub <= cells /$mol_view
+	Cell*0 $mol_view
+		sub /
+			<= Cell_head* $mol_view
+				sub /
+					<= Cell_link* $mol_link
+						target \_blank
+						uri <= route_uri* \
+						sub /
+							<= route_label* \
+					<= Cell_status* $mol_view
+						sub /
+							<= cell_status* \
+			<= Frame* $mol_frame
+				uri <= route_uri* \

--- a/assets/ui/admin/debug/renderall/renderall.view.tree.locale=ru.json
+++ b/assets/ui/admin/debug/renderall/renderall.view.tree.locale=ru.json
@@ -1,0 +1,5 @@
+{
+	"$trip2g_admin_debug_renderall_title": "Рендер всех страниц",
+	"$trip2g_admin_debug_renderall_Scan_title": "Проверить ошибки",
+	"$trip2g_admin_debug_renderall_Test_fail_title": "Эмуляция ошибок"
+}

--- a/assets/ui/admin/debug/renderall/renderall.view.ts
+++ b/assets/ui/admin/debug/renderall/renderall.view.ts
@@ -1,0 +1,251 @@
+namespace $.$$ {
+
+	type RenderAllRoute = {
+		id: string
+		label: string
+		uri: string
+		depth: number
+	}
+
+	const MAX_DEPTH = 2       // list -> show/new (1) -> edit (2)
+	const PER_SOURCE_CAP = 3  // record/action links taken from a single iframe
+	const MAX_PASSES = 4      // auto rescans while new routes keep appearing
+	const RESCAN_DELAY = 1500 // ms to let freshly added iframes load before rescanning
+
+	/**
+	 * Migration smoke-test page: derives every list-level admin route from the
+	 * nav catalog and renders each in an iframe, so opening this page fires every
+	 * list query. Scan then reads the internals of the already-loaded iframes,
+	 * discovers deeper route links (show / new / edit) that the catalogs render
+	 * for their records, and appends iframes for those too - bounded by depth and
+	 * a per-iframe cap so it does not explode. Errors are collected from
+	 * [mol_view_error] across all iframes, discovered ones included.
+	 */
+	export class $trip2g_admin_debug_renderall extends $.$trip2g_admin_debug_renderall {
+
+		base() {
+			return this.$.$mol_dom_context.document.location.pathname
+		}
+
+		@ $mol_mem
+		test_fail( next?: boolean ): boolean {
+			if( next === undefined ) {
+				return this.$.$mol_state_arg.value( 'test_fail' ) ? true : false
+			}
+			this.$.$mol_state_arg.value( 'test_fail', next ? '1' : null )
+			return next
+		}
+
+		@ $mol_mem
+		derived(): readonly RenderAllRoute[] {
+			const routes: RenderAllRoute[] = []
+			const base = this.base()
+
+			const walk = ( view: $mol_view, args: Record< string, string >, labels: string[], depth: number ) => {
+
+				// skip self to avoid recursive iframes
+				if( view.constructor === this.constructor ) return
+
+				// recurse the static nav levels only (app -> menu groups);
+				// deeper catalogs are data-driven record lists whose spreads()
+				// fetch data - the leaf iframe fires that query itself
+				if( depth < 2 && view instanceof $mol_book2_catalog ) {
+					const ids = Object.keys( view.spreads() )
+					if( ids.length ) {
+						for( const id of ids ) walk(
+							view.Spread( id ),
+							{ ... args, [ view.param() ]: id },
+							[ ... labels, String( view.spread_title( id ) ) ],
+							depth + 1,
+						)
+						return
+					}
+				}
+
+				const query = Object.entries( args )
+					.map( ( [ key, val ] ) => `${ key }=${ encodeURIComponent( val ) }` )
+					.join( '/' )
+
+				routes.push( {
+					id: query,
+					label: labels.join( ' / ' ),
+					uri: `${ base }#!${ query }`,
+					depth: 0,
+				} )
+
+			}
+
+			walk( this.App(), {}, [], 0 )
+			return routes
+		}
+
+		@ $mol_mem
+		discovered( next?: readonly RenderAllRoute[] ): readonly RenderAllRoute[] {
+			return next ?? []
+		}
+
+		@ $mol_mem
+		routes(): readonly RenderAllRoute[] {
+			const seen = new Set< string >()
+			const all: RenderAllRoute[] = []
+			for( const route of [ ... this.derived(), ... this.discovered() ] ) {
+				if( seen.has( route.id ) ) continue
+				seen.add( route.id )
+				all.push( route )
+			}
+			return all
+		}
+
+		route( id: string ) {
+			return this.routes().find( route => route.id === id )!
+		}
+
+		@ $mol_mem
+		override cells() {
+			return this.routes().map( route => this.Cell( route.id ) )
+		}
+
+		override stats() {
+			const derived = this.derived().length
+			const discovered = this.routes().length - derived
+			const note = this.scan_note()
+			return `${ this.routes().length } routes (${ derived } list + ${ discovered } discovered)${ note ? ` - ${ note }` : '' }`
+		}
+
+		@ $mol_mem
+		scan_note( next = '' ): string {
+			return next
+		}
+
+		override route_uri( id: string ) {
+			const uri = this.route( id ).uri
+			if( !this.test_fail() ) return uri
+			return `${ uri }/test_fail=1`
+		}
+
+		override route_label( id: string ) {
+			return this.route( id ).label
+		}
+
+		@ $mol_mem_key
+		override cell_status( id: string, next = '' ): string {
+			return next
+		}
+
+		frame_status( id: string ) {
+			const frame = this.Frame( id ).dom_node() as HTMLIFrameElement
+			try {
+
+				const doc = frame.contentDocument
+				if( !doc || !doc.body ) return 'no document'
+
+				const errors = [ ... doc.querySelectorAll( '[mol_view_error]' ) ]
+					.map( el => el.getAttribute( 'mol_view_error' )! )
+					.filter( error => error !== 'Promise' )
+				if( errors.length ) return `errors ${ errors.length }: ${ [ ... new Set( errors ) ].join( ', ' ) }`
+
+				const pending = doc.querySelectorAll( '[mol_view_error="Promise"]' ).length
+				if( pending ) return `loading (${ pending })`
+
+				return 'ok'
+
+			} catch( error ) {
+				return 'inaccessible'
+			}
+		}
+
+		parse_args( query: string ): Record< string, string > {
+			const args: Record< string, string > = {}
+			for( const chunk of query.split( '/' ) ) {
+				if( !chunk ) continue
+				const parts = chunk.split( '=' ).map( decodeURIComponent )
+				args[ parts.shift()! ] = parts.join( '=' )
+			}
+			return args
+		}
+
+		hash_of( href: string ): string {
+			const marker = href.indexOf( '#!' )
+			return marker < 0 ? '' : href.slice( marker + 2 )
+		}
+
+		// A drill-down route keeps every arg of its source and adds at least one
+		// more (row -> id, action -> id=new, show -> edit), so lateral menu links
+		// (sibling spreads) and upward nav links are ignored.
+		is_drilldown( source: Record< string, string >, candidate: Record< string, string > ) {
+			for( const key in source ) {
+				if( candidate[ key ] !== source[ key ] ) return false
+			}
+			return Object.keys( candidate ).length > Object.keys( source ).length
+		}
+
+		discover() {
+			const base = this.base()
+			const existing = new Set( this.routes().map( route => route.id ) )
+			const found: RenderAllRoute[] = []
+			let capped = 0
+
+			for( const route of this.routes() ) {
+				if( route.depth >= MAX_DEPTH ) continue
+
+				const frame = this.Frame( route.id ).dom_node() as HTMLIFrameElement
+				let doc: Document | null = null
+				try { doc = frame.contentDocument } catch( error ) { continue }
+				if( !doc || !doc.body ) continue
+
+				const source = this.parse_args( route.id )
+				let taken = 0
+
+				for( const anchor of [ ... doc.querySelectorAll( 'a[href]' ) ] as HTMLAnchorElement[] ) {
+					const hash = this.hash_of( anchor.getAttribute( 'href' ) || anchor.href )
+					if( !hash || existing.has( hash ) ) continue
+					if( found.some( route => route.id === hash ) ) continue
+
+					const candidate = this.parse_args( hash )
+					if( !this.is_drilldown( source, candidate ) ) continue
+
+					if( taken >= PER_SOURCE_CAP ) { capped += 1; break }
+
+					const added = Object.keys( candidate )
+						.filter( key => source[ key ] === undefined )
+						.map( key => `${ key }=${ candidate[ key ] }` )
+						.join( ' ' )
+
+					found.push( {
+						id: hash,
+						label: `${ route.label } / ${ added }`,
+						uri: `${ base }#!${ hash }`,
+						depth: route.depth + 1,
+					} )
+					taken += 1
+				}
+			}
+
+			if( found.length ) this.discovered( [ ... this.discovered(), ... found ] )
+			return { added: found.length, capped }
+		}
+
+		scan_pass( pass: number ) {
+			const result = this.discover()
+
+			for( const route of this.routes() ) {
+				this.cell_status( route.id, this.frame_status( route.id ) )
+			}
+
+			this.scan_note( `pass ${ pass + 1 }: +${ result.added } discovered${ result.capped ? `, ${ result.capped } iframe(s) capped at ${ PER_SOURCE_CAP }` : '' }` )
+
+			if( result.added > 0 && pass + 1 < MAX_PASSES ) {
+				new this.$.$mol_after_timeout( RESCAN_DELAY, () => this.scan_pass( pass + 1 ) )
+			}
+
+			return this.routes().length
+		}
+
+		override scan( next?: Event | null ) {
+			this.scan_pass( 0 )
+			return null
+		}
+
+	}
+
+}

--- a/assets/ui/admin/healthchecks/healthchecks.view.ts
+++ b/assets/ui/admin/healthchecks/healthchecks.view.ts
@@ -2,6 +2,7 @@ namespace $.$$ {
 	export class $trip2g_admin_healthchecks extends $.$trip2g_admin_healthchecks {
 		@$mol_mem
 		data() {
+			if (this.$.$mol_state_arg.value('test_fail')) throw new Error('test_fail: emulated healthchecks failure')
 			const res = $trip2g_admin_healthchecks_list()
 			return $trip2g_graphql_make_map(res.admin.healthChecks);
 		}

--- a/assets/ui/admin/menu/system/system.view.tree
+++ b/assets/ui/admin/menu/system/system.view.tree
@@ -22,3 +22,5 @@ $trip2g_admin_menu_system $trip2g_admin_catalog
 			close_icon <= Spread_close
 		cronwebhooks <= ListCronWebhooks $trip2g_admin_cronwebhook_catalog
 			close_icon <= Spread_close
+		renderall <= RenderAll $trip2g_admin_debug_renderall
+			close_icon <= Spread_close

--- a/e2e/renderall.spec.js
+++ b/e2e/renderall.spec.js
@@ -1,0 +1,151 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+
+/**
+ * Render-all smoke test.
+ *
+ * The admin render-all page derives every list-level admin route from the nav
+ * catalog and renders each in a same-origin iframe. A component that fails to
+ * render exposes a [mol_view_error] attribute in its iframe document.
+ *
+ * This spec exercises the built-in fault emulation:
+ *  1. clean load  -> zero render errors across all admin routes
+ *  2. emulate on  -> exactly two routes fail (cronjob catalog + healthchecks)
+ *  3. emulate off -> back to zero errors
+ *
+ * Ground truth is the [mol_view_error] attribute (value != 'Promise', which
+ * only marks a still-loading view), not the render-all cell status text.
+ */
+
+const RENDERALL_URI = '/admin#!nav=system/system_nav=renderall';
+
+/**
+ * Sign in as admin (hello@example.com, dev code 111111) via GraphQL. The
+ * signInByEmail mutation sets the session cookie on the page's context, which
+ * authorizes subsequent /admin navigation. Cookie based so it does not depend
+ * on the homepage rendering a sign-in widget (the marketing landing does not).
+ */
+async function signInAdmin(page) {
+  const requestCode = await page.request.post('/_system/graphql', {
+    data: {
+      query: `mutation ($input: RequestEmailSignInCodeInput!) {
+        requestEmailSignInCode(input: $input) {
+          ... on RequestEmailSignInCodePayload { success }
+          ... on ErrorPayload { message }
+        }
+      }`,
+      variables: { input: { email: 'hello@example.com' } },
+    },
+  });
+  expect(requestCode.ok(), 'requestEmailSignInCode HTTP ok').toBeTruthy();
+
+  const signIn = await page.request.post('/_system/graphql', {
+    data: {
+      query: `mutation ($input: SignInByEmailInput!) {
+        signInByEmail(input: $input) {
+          ... on SignInPayload { token }
+          ... on ErrorPayload { message }
+        }
+      }`,
+      variables: { input: { email: 'hello@example.com', code: '111111' } },
+    },
+  });
+  expect(signIn.ok(), 'signInByEmail HTTP ok').toBeTruthy();
+  const body = await signIn.json();
+  expect(body.data?.signInByEmail?.token, `sign in failed: ${JSON.stringify(body)}`).toBeTruthy();
+}
+
+/** Collect iframes whose document carries a real (non-loading) render error. */
+async function errorFrames(page) {
+  return await page.evaluate(() => {
+    const out = [];
+    for (const f of Array.from(document.querySelectorAll('iframe'))) {
+      let doc;
+      try { doc = f.contentDocument; } catch { continue; }
+      if (!doc || !doc.body) continue;
+      const errors = Array.from(doc.querySelectorAll('[mol_view_error]'))
+        .map(el => el.getAttribute('mol_view_error'))
+        .filter(v => v !== 'Promise');
+      if (errors.length) {
+        out.push({
+          src: f.getAttribute('src') || '',
+          errors: [...new Set(errors)],
+          text: (doc.body.innerText || '').replace(/\s+/g, ' ').trim(),
+        });
+      }
+    }
+    return out;
+  });
+}
+
+/** Wait until every iframe src matches the expected test_fail marker state. */
+async function waitFramesMarked(page, shouldContain) {
+  await expect.poll(async () => {
+    return await page.evaluate((want) => {
+      const iframes = Array.from(document.querySelectorAll('iframe'));
+      if (!iframes.length) return false;
+      return iframes.every(f => ((f.getAttribute('src') || '').includes('test_fail=1')) === want);
+    }, shouldContain);
+  }, { timeout: 30_000, intervals: [500, 1000, 2000] }).toBe(true);
+}
+
+/** Wait until no iframe is still loading a view (no mol_view_error="Promise"). */
+async function waitFramesSettled(page) {
+  await expect.poll(async () => {
+    return await page.evaluate(() => {
+      const iframes = Array.from(document.querySelectorAll('iframe'));
+      if (!iframes.length) return -1;
+      let pending = 0;
+      for (const f of iframes) {
+        let doc;
+        try { doc = f.contentDocument; } catch { continue; }
+        if (!doc || !doc.body) { pending++; continue; }
+        pending += doc.querySelectorAll('[mol_view_error="Promise"]').length;
+      }
+      return pending;
+    });
+  }, { timeout: 60_000, intervals: [1000, 2000, 3000] }).toBe(0);
+}
+
+test.describe.serial('Render All smoke test', () => {
+  test('clean load then fault emulation across admin routes', async ({ page }) => {
+    test.setTimeout(240_000);
+
+    await signInAdmin(page);
+
+    // 1. Clean load: every admin route renders without error.
+    await page.goto(RENDERALL_URI);
+    await page.waitForSelector('iframe', { timeout: 30_000 });
+    await waitFramesMarked(page, false);
+    await waitFramesSettled(page);
+
+    const clean = await errorFrames(page);
+    expect(clean, `expected a clean render, got: ${JSON.stringify(clean)}`).toHaveLength(0);
+
+    // 2. Emulate failures: toggle the checkbox on.
+    await page.getByText('Emulate failures').click();
+    await waitFramesMarked(page, true);
+    await waitFramesSettled(page);
+
+    await expect.poll(async () => (await errorFrames(page)).length, { timeout: 60_000 }).toBe(2);
+
+    const faulted = await errorFrames(page);
+    expect(faulted).toHaveLength(2);
+
+    const cron = faulted.find(f => f.src.includes('system_nav=cronjobs'));
+    const health = faulted.find(f => f.src.includes('system_nav=healthchecks'));
+    expect(cron, `cronjob catalog route not flagged: ${JSON.stringify(faulted)}`).toBeTruthy();
+    expect(health, `healthchecks route not flagged: ${JSON.stringify(faulted)}`).toBeTruthy();
+    expect(cron.src).toContain('test_fail=1');
+    expect(health.src).toContain('test_fail=1');
+    expect(cron.text).toContain('test_fail: emulated cronjob catalog failure');
+    expect(health.text).toContain('test_fail: emulated healthchecks failure');
+
+    // 3. Clean again: toggle the checkbox off.
+    await page.getByText('Emulate failures').click();
+    await waitFramesMarked(page, false);
+    await waitFramesSettled(page);
+
+    await expect.poll(async () => (await errorFrames(page)).length, { timeout: 60_000 }).toBe(0);
+  });
+});

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -552,6 +552,15 @@ if [ "${ENABLE_TG}" = "1" ]; then
   go run ./cmd/tge2e -db tmp/data/test.sqlite3 -snapshots testdata/telegram/step1 check
 fi
 
+# Run render-all smoke test (admin routes + fault emulation)
+echo ""
+echo "🧪 Running render-all smoke test (admin routes + fault emulation)..."
+npx playwright test e2e/renderall.spec.js || {
+  echo -e "${RED}✗ Render-all E2E tests failed${NC}"
+  exit 1
+}
+echo -e "${GREEN}✓ Render-all E2E tests passed${NC}"
+
 # Run bidirectional federation E2E tests
 echo ""
 echo "🔗 Running bidirectional federation E2E tests..."


### PR DESCRIPTION
## What
An admin debug page that renders every list-level admin route in a same-origin iframe grid, as a migration/health smoke-test: opening it fires every admin query at once and surfaces any broken component.

- **Route derivation**: walks the nav catalog for all list routes; each renders in a `$mol_frame`.
- **Recursive discovery**: `Scan` reads loaded iframes for deeper route links (show / new / edit) and adds iframes for them, bounded by depth + a per-source cap (proven live: 39 list routes cascaded to 176 with show/new/edit reached).
- **Error scan**: reports per-cell status from each iframe's `[mol_view_error]`.
- **Built-in `test_fail` toggle** ("Emulate failures" checkbox): sets a `test_fail` arg propagated into every iframe src; two components (cronjob catalog + healthchecks) throw a guarded emulated failure only when it is set (zero effect in normal use). Lets the smoke-test self-verify that the scan catches broken pages.
- Localized title/scan/checkbox (en default + ru).

## Test
`e2e/renderall.spec.js` (wired into `scripts/test-e2e.sh`): signs in, asserts a clean render (0 errors), toggles emulation on (asserts exactly the 2 seeded routes fail), toggles off (back to 0). Verified live: baseline 0 / on 2 / off 0.

## Live proof
Fault-injection confirmed the iframe error-detection works: a broken component surfaces `[mol_view_error]` in its cell, caught by the scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)