### PR TITLE
fix(auth): log sign-in code when SMTP unconfigured instead of blocking dev login

### DIFF
--- a/cmd/server/email.go
+++ b/cmd/server/email.go
@@ -112,7 +112,10 @@ func (a *app) SendMail(_ context.Context, data model.Mail) error {
 }
 
 func (a *app) LogSignInCodes() bool {
-	return a.config.LogSignInCodes
+	// Without SMTP the code can't be emailed, so log it server-side instead:
+	// this keeps dev and unconfigured/bootstrap sign-in working. An explicit
+	// LogSignInCodes flag forces logging even when SMTP is configured.
+	return a.config.LogSignInCodes || a.config.SMTPHost == ""
 }
 
 func (a *app) SMTPHost() string {

--- a/internal/case/backjob/sendsignincode/resolve.go
+++ b/internal/case/backjob/sendsignincode/resolve.go
@@ -25,7 +25,7 @@ func Resolve(ctx context.Context, env Env, task Params) error {
 	env.Logger().Info("Sending sign-in code", "email", task.Email)
 
 	if env.LogSignInCodes() {
-		env.Logger().Warn("sign-in code (LOG_SIGN_IN_CODES enabled — insecure, for bootstrap only)",
+		env.Logger().Warn("sign-in code logged (no SMTP or LogSignInCodes enabled) — insecure, for dev/bootstrap only",
 			"email", task.Email, "code", task.Code)
 	}
 

--- a/internal/case/requestemailsignin/mocks_test.go
+++ b/internal/case/requestemailsignin/mocks_test.go
@@ -31,14 +31,8 @@ var _ Env = &EnvMock{}
 //			IncrementAndCheckSigninCounterFunc: func() bool {
 //				panic("mock out the IncrementAndCheckSigninCounter method")
 //			},
-//			LogSignInCodesFunc: func() bool {
-//				panic("mock out the LogSignInCodes method")
-//			},
 //			MaxActiveSignInCodesFunc: func() int64 {
 //				panic("mock out the MaxActiveSignInCodes method")
-//			},
-//			SMTPHostFunc: func() string {
-//				panic("mock out the SMTPHost method")
 //			},
 //			TryToAutoRegisterUserFunc: func(ctx context.Context, email string) (*db.User, error) {
 //				panic("mock out the TryToAutoRegisterUser method")
@@ -74,14 +68,8 @@ type EnvMock struct {
 	// IncrementAndCheckSigninCounterFunc mocks the IncrementAndCheckSigninCounter method.
 	IncrementAndCheckSigninCounterFunc func() bool
 
-	// LogSignInCodesFunc mocks the LogSignInCodes method.
-	LogSignInCodesFunc func() bool
-
 	// MaxActiveSignInCodesFunc mocks the MaxActiveSignInCodes method.
 	MaxActiveSignInCodesFunc func() int64
-
-	// SMTPHostFunc mocks the SMTPHost method.
-	SMTPHostFunc func() string
 
 	// TryToAutoRegisterUserFunc mocks the TryToAutoRegisterUser method.
 	TryToAutoRegisterUserFunc func(ctx context.Context, email string) (*db.User, error)
@@ -126,14 +114,8 @@ type EnvMock struct {
 		// IncrementAndCheckSigninCounter holds details about calls to the IncrementAndCheckSigninCounter method.
 		IncrementAndCheckSigninCounter []struct {
 		}
-		// LogSignInCodes holds details about calls to the LogSignInCodes method.
-		LogSignInCodes []struct {
-		}
 		// MaxActiveSignInCodes holds details about calls to the MaxActiveSignInCodes method.
 		MaxActiveSignInCodes []struct {
-		}
-		// SMTPHost holds details about calls to the SMTPHost method.
-		SMTPHost []struct {
 		}
 		// TryToAutoRegisterUser holds details about calls to the TryToAutoRegisterUser method.
 		TryToAutoRegisterUser []struct {
@@ -173,9 +155,7 @@ type EnvMock struct {
 	lockCreateSignInCode               sync.RWMutex
 	lockEnqueueRequestSignInEmail      sync.RWMutex
 	lockIncrementAndCheckSigninCounter sync.RWMutex
-	lockLogSignInCodes                 sync.RWMutex
 	lockMaxActiveSignInCodes           sync.RWMutex
-	lockSMTPHost                       sync.RWMutex
 	lockTryToAutoRegisterUser          sync.RWMutex
 	lockTurnstileSiteKey               sync.RWMutex
 	lockUserBanByUserID                sync.RWMutex
@@ -322,33 +302,6 @@ func (mock *EnvMock) IncrementAndCheckSigninCounterCalls() []struct {
 	return calls
 }
 
-// LogSignInCodes calls LogSignInCodesFunc.
-func (mock *EnvMock) LogSignInCodes() bool {
-	if mock.LogSignInCodesFunc == nil {
-		panic("EnvMock.LogSignInCodesFunc: method is nil but Env.LogSignInCodes was just called")
-	}
-	callInfo := struct {
-	}{}
-	mock.lockLogSignInCodes.Lock()
-	mock.calls.LogSignInCodes = append(mock.calls.LogSignInCodes, callInfo)
-	mock.lockLogSignInCodes.Unlock()
-	return mock.LogSignInCodesFunc()
-}
-
-// LogSignInCodesCalls gets all the calls that were made to LogSignInCodes.
-// Check the length with:
-//
-//	len(mockedEnv.LogSignInCodesCalls())
-func (mock *EnvMock) LogSignInCodesCalls() []struct {
-} {
-	var calls []struct {
-	}
-	mock.lockLogSignInCodes.RLock()
-	calls = mock.calls.LogSignInCodes
-	mock.lockLogSignInCodes.RUnlock()
-	return calls
-}
-
 // MaxActiveSignInCodes calls MaxActiveSignInCodesFunc.
 func (mock *EnvMock) MaxActiveSignInCodes() int64 {
 	if mock.MaxActiveSignInCodesFunc == nil {
@@ -373,33 +326,6 @@ func (mock *EnvMock) MaxActiveSignInCodesCalls() []struct {
 	mock.lockMaxActiveSignInCodes.RLock()
 	calls = mock.calls.MaxActiveSignInCodes
 	mock.lockMaxActiveSignInCodes.RUnlock()
-	return calls
-}
-
-// SMTPHost calls SMTPHostFunc.
-func (mock *EnvMock) SMTPHost() string {
-	if mock.SMTPHostFunc == nil {
-		panic("EnvMock.SMTPHostFunc: method is nil but Env.SMTPHost was just called")
-	}
-	callInfo := struct {
-	}{}
-	mock.lockSMTPHost.Lock()
-	mock.calls.SMTPHost = append(mock.calls.SMTPHost, callInfo)
-	mock.lockSMTPHost.Unlock()
-	return mock.SMTPHostFunc()
-}
-
-// SMTPHostCalls gets all the calls that were made to SMTPHost.
-// Check the length with:
-//
-//	len(mockedEnv.SMTPHostCalls())
-func (mock *EnvMock) SMTPHostCalls() []struct {
-} {
-	var calls []struct {
-	}
-	mock.lockSMTPHost.RLock()
-	calls = mock.calls.SMTPHost
-	mock.lockSMTPHost.RUnlock()
 	return calls
 }
 

--- a/internal/case/requestemailsignin/resolve.go
+++ b/internal/case/requestemailsignin/resolve.go
@@ -20,8 +20,6 @@ type Env interface {
 	CreateSignInCode(ctx context.Context, userID int64) (string, error)
 	UserBanByUserID(ctx context.Context, userID int64) (*db.UserBan, error)
 	MaxActiveSignInCodes() int64
-	SMTPHost() string
-	LogSignInCodes() bool
 
 	// patreon, boosty, etc
 	TryToAutoRegisterUser(ctx context.Context, email string) (*db.User, error)
@@ -65,12 +63,6 @@ func Resolve(ctx context.Context, env Env, input Input, remoteIP string) (model.
 		if env.IncrementAndCheckSigninCounter() {
 			return &model.RequestCaptchaPayload{SiteKey: siteKey}, nil
 		}
-	}
-
-	if env.SMTPHost() == "" && !env.LogSignInCodes() {
-		return &model.ErrorPayload{
-			Message: "Email delivery isn't configured on this server, so no code can be sent. Sign in with Google or GitHub instead, or ask the site admin.",
-		}, nil
 	}
 
 	user, err := env.UserByEmail(ctx, input.Email)

--- a/internal/case/requestemailsignin/resolve_test.go
+++ b/internal/case/requestemailsignin/resolve_test.go
@@ -29,8 +29,6 @@ func fullFlowEnv(siteKey string) *EnvMock {
 			return 0, nil
 		},
 		MaxActiveSignInCodesFunc: func() int64 { return 3 },
-		SMTPHostFunc:             func() string { return "smtp.example.com" },
-		LogSignInCodesFunc:       func() bool { return false },
 		CreateSignInCodeFunc: func(_ context.Context, _ int64) (string, error) {
 			return "ABC123", nil
 		},
@@ -162,56 +160,4 @@ func TestMaxActiveSignInCodes_AtLimitRejected(t *testing.T) {
 	require.True(t, ok, "count == limit must return ErrorPayload, got %T", result)
 	require.Equal(t, "too_many_sign_in_codes", errPayload.Message)
 	require.Empty(t, env.CreateSignInCodeCalls(), "must not create a code once the limit is reached")
-}
-
-// TestNoSMTP_LogSignInCodesDisabled_ReturnsError verifies that when no SMTP is
-// configured and code logging is disabled, no code can ever be delivered, so
-// Resolve returns an ErrorPayload without creating or queueing a code.
-func TestNoSMTP_LogSignInCodesDisabled_ReturnsError(t *testing.T) {
-	env := fullFlowEnv("")
-	env.SMTPHostFunc = func() string { return "" }
-	env.LogSignInCodesFunc = func() bool { return false }
-
-	result, err := Resolve(context.Background(), env, Input{Email: "user@example.com"}, "")
-	require.NoError(t, err)
-
-	errPayload, ok := result.(*model.ErrorPayload)
-	require.True(t, ok, "expected ErrorPayload, got %T", result)
-	require.Equal(
-		t,
-		"Email delivery isn't configured on this server, so no code can be sent. Sign in with Google or GitHub instead, or ask the site admin.",
-		errPayload.Message,
-	)
-	require.Empty(t, env.EnqueueRequestSignInEmailCalls(), "must not queue a code that can't be delivered")
-}
-
-// TestNoSMTP_LogSignInCodesEnabled_ProceedsNormally verifies that when SMTP is
-// not configured but code logging is enabled, the code is still logged
-// server-side, so Resolve proceeds to the normal success path.
-func TestNoSMTP_LogSignInCodesEnabled_ProceedsNormally(t *testing.T) {
-	env := fullFlowEnv("")
-	env.SMTPHostFunc = func() string { return "" }
-	env.LogSignInCodesFunc = func() bool { return true }
-
-	result, err := Resolve(context.Background(), env, Input{Email: "user@example.com"}, "")
-	require.NoError(t, err)
-
-	payload, ok := result.(*model.RequestEmailSignInCodePayload)
-	require.True(t, ok, "expected RequestEmailSignInCodePayload, got %T", result)
-	require.True(t, payload.Success)
-}
-
-// TestSMTPConfigured_ProceedsNormally verifies that when SMTP is configured,
-// the normal success path is unaffected regardless of LogSignInCodes.
-func TestSMTPConfigured_ProceedsNormally(t *testing.T) {
-	env := fullFlowEnv("")
-	env.SMTPHostFunc = func() string { return "smtp.example.com" }
-	env.LogSignInCodesFunc = func() bool { return false }
-
-	result, err := Resolve(context.Background(), env, Input{Email: "user@example.com"}, "")
-	require.NoError(t, err)
-
-	payload, ok := result.(*model.RequestEmailSignInCodePayload)
-	require.True(t, ok, "expected RequestEmailSignInCodePayload, got %T", result)
-	require.True(t, payload.Success)
 }


### PR DESCRIPTION
## Problem
With no SMTP configured (local dev, fresh self-hosted), requesting an email sign-in code returned an error ("Email delivery isn't configured...") and never generated a code, so login was impossible. Dev mode already issues a fixed code (`DevSignInCode` + `DevSignInBypass`), but the guard blocked reaching the code-entry step.

Also a code smell: the `requestemailsignin` business case knew about email transport (`SMTPHost()`, `LogSignInCodes()`).

## Fix
- Remove the transport-aware guard and `SMTPHost()`/`LogSignInCodes()` from `requestemailsignin.Env`; the business case no longer knows about email transport.
- Put the policy in one cmd/server accessor: `LogSignInCodes()` returns true when there is no SMTP host, so the existing `sendsignincode` job logs the code server-side. Dev and unconfigured/bootstrap sign-in work with no error.
- Drop three obsolete guard tests; regenerate the moq mock.

## Verify
- `go build` + `go test ./internal/case/requestemailsignin/... ./internal/case/backjob/sendsignincode/...` green; `make lint` clean.
- Live check on the running dev instance: `requestEmailSignInCode` for a non-existent email now returns `not_found` (flow proceeds past the removed guard) instead of the old "Email delivery isn't configured" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)