### PR TITLE
feat(layouts): coalesce() helper + fix dynamic asset() in mesh hero video

### DIFF
--- a/docs/_layouts/mesh/hero.html
+++ b/docs/_layouts/mesh/hero.html
@@ -66,8 +66,13 @@
     {{yield mesh_button(label=docs_label, href="/"+lang+"/user", modifier="@did__cta")}}
   </div>
   <div class="@did__video">
-    <video controls preload="none" playsinline poster="{{ asset("demo-"+lang+"-poster.jpg") }}">
-      <source src="{{ asset("demo-"+lang+".mp4") }}" type="video/mp4">
+    {* asset() only registers static string literals; build a map so both
+       variants are discovered/uploaded, then pick one by lang at runtime,
+       falling back to en for any unexpected lang *}
+    {{ posters := map("en", asset("demo-en-poster.jpg"), "ru", asset("demo-ru-poster.jpg")) }}
+    {{ videos := map("en", asset("demo-en.mp4"), "ru", asset("demo-ru.mp4")) }}
+    <video controls preload="none" playsinline poster="{{ coalesce(posters[lang], posters["en"]) }}">
+      <source src="{{ coalesce(videos[lang], videos["en"]) }}" type="video/mp4">
     </video>
   </div>
 </section>

--- a/internal/layoutloader/coalesce_test.go
+++ b/internal/layoutloader/coalesce_test.go
@@ -1,0 +1,71 @@
+package layoutloader
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+	"trip2g/internal/logger"
+	"trip2g/internal/model"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoalesceRender(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"first arg valid returned", `{{ coalesce("a", "b") }}`, "a"},
+		{"first empty skipped, second returned", `{{ coalesce("", "b") }}`, "b"},
+		{"all empty falls back to last", `{{ coalesce("", "") }}`, ""},
+		{"map hit returned", `{{ m := map("en", "x", "ru", "y") }}{{ coalesce(m["ru"], m["en"]) }}`, "y"},
+		{"map miss falls back", `{{ m := map("en", "x") }}{{ coalesce(m["ru"], m["en"]) }}`, "x"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sources := []model.LayoutSourceFile{{
+				ID:      "/page",
+				Path:    "_layouts/page.html",
+				Content: tt.content,
+			}}
+
+			layouts, err := Load(&testEnv{logger: &logger.TestLogger{}}, sources, Options{})
+			require.NoError(t, err)
+
+			var buf bytes.Buffer
+			err = layouts.Map["/page"].View.Execute(&buf, nil, nil)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, buf.String())
+		})
+	}
+}
+
+func TestIsEmptyValue(t *testing.T) {
+	var nilPtr *string
+	s := "x"
+
+	tests := []struct {
+		name string
+		v    reflect.Value
+		want bool
+	}{
+		{"invalid value", reflect.Value{}, true},
+		{"empty string", reflect.ValueOf(""), true},
+		{"non-empty string", reflect.ValueOf("x"), false},
+		{"nil pointer", reflect.ValueOf(nilPtr), true},
+		{"non-nil pointer", reflect.ValueOf(&s), false},
+		{"empty slice", reflect.ValueOf([]string{}), true},
+		{"non-empty slice", reflect.ValueOf([]string{"a"}), false},
+		{"empty map", reflect.ValueOf(map[string]string{}), true},
+		{"non-empty map", reflect.ValueOf(map[string]string{"a": "b"}), false},
+		{"nil interface", reflect.ValueOf([]interface{}{nil}).Index(0), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isEmptyValue(tt.v))
+		})
+	}
+}

--- a/internal/layoutloader/loader.go
+++ b/internal/layoutloader/loader.go
@@ -566,6 +566,21 @@ func (jl *jetLoader) load(source model.LayoutSourceFile) (view *jet.Template, pa
 		return reflect.ValueOf(fmt.Sprintf("%T: %+v\nmethods: %v", iface, iface, methods))
 	})
 
+	// coalesce returns the first argument that is set and non-empty, else the last
+	// argument. Useful for value fallback since Jet's `||` is boolean, not
+	// value-coalescing: coalesce(videos[lang], videos["en"]).
+	views.AddGlobalFunc("coalesce", func(a jet.Arguments) reflect.Value {
+		a.RequireNumOfArguments("coalesce", 1, -1)
+		n := a.NumOfArguments()
+		for i := range n {
+			v := a.Get(i)
+			if v.IsValid() && !isEmptyValue(v) {
+				return v
+			}
+		}
+		return a.Get(n - 1)
+	})
+
 	// yield_blocks is registered with a mutable slice pointer so the second pass
 	// can populate block names after all templates are parsed.
 	blockNames := make([]string, 0)
@@ -586,6 +601,29 @@ func (jl *jetLoader) load(source model.LayoutSourceFile) (view *jet.Template, pa
 	}
 
 	return view, ""
+}
+
+// isEmptyValue reports whether v should be treated as "not set" by coalesce:
+// invalid values (e.g. a map index miss), nil pointers/interfaces, empty
+// strings, and zero-length slices/maps.
+func isEmptyValue(v reflect.Value) bool {
+	if !v.IsValid() {
+		return true
+	}
+	if v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			return true
+		}
+		v = v.Elem()
+	}
+	switch v.Kind() { //nolint:exhaustive // only pointer/string/slice/map have a meaningful empty; all other kinds are never empty
+	case reflect.Ptr:
+		return v.IsNil()
+	case reflect.String, reflect.Slice, reflect.Map:
+		return v.Len() == 0
+	default:
+		return false
+	}
 }
 
 type assetFinder struct {


### PR DESCRIPTION
## Problem
The mesh landing hero embedded the demo video via a DYNAMIC `asset()` argument:
```jet
<source src="{{ asset("demo-"+lang+".mp4") }}">
```
`asset()` is resolved by a static AST scan (`assetFinder`) that only registers string LITERALS, so `demo-en.mp4`/`demo-ru.mp4` were never registered, and at runtime `asset()` silently fell back to the bare filename, giving a relative `demo-en.mp4` that 404s. The video never plays on trip2g.com.

## Fix
- Build a static map so both variants are registered/uploaded, then pick one by `lang` at runtime (no dynamic `asset()` call remains):
  ```jet
  {{ videos := map("en", asset("demo-en.mp4"), "ru", asset("demo-ru.mp4")) }}
  <source src="{{ coalesce(videos[lang], videos["en"]) }}">
  ```
- Add a `coalesce(...)` Jet global helper (`internal/layoutloader/loader.go`) that returns the first set + non-empty argument, else the last. Jet's `||` is boolean, not value-coalescing, so this fills the gap. A map-index miss evaluates to an invalid `reflect.Value`, which `coalesce` skips (verified against jet v6 source + a render test).

## Tests
- `internal/layoutloader/coalesce_test.go`: end-to-end render tests through the real `jet.Set` (literal-first, fallback, all-empty, map-hit, map-miss fallback) + direct `isEmptyValue` table tests. 15/15 subtests pass; `go build`/`go vet`/full package suite clean.
- Live-verified on the dev instance: `<source>` now renders `src="/_system/assets/.../demo-en.mp4"` (a resolved asset URL).

## Deploy note
`coalesce()` is a new binary-side function, so this must be deployed before the updated `hero.html` renders on prod (otherwise `coalesce` is undefined there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)