### PR TITLE
fix(db): correct Sheduled/Telegarm typos in publish note query names

### DIFF
--- a/internal/case/cronjob/sendscheduledtelegrampublishposts/resolve.go
+++ b/internal/case/cronjob/sendscheduledtelegrampublishposts/resolve.go
@@ -13,12 +13,12 @@ type Env interface {
 	LatestNoteViews() *model.NoteViews
 
 	// Bot publishing
-	ListSheduledTelegarmPublishNoteIDs(ctx context.Context) ([]int64, error)
+	ListScheduledTelegramPublishNoteIDs(ctx context.Context) ([]int64, error)
 	EnqueueSendTelegramPost(ctx context.Context, params model.SendTelegramPublishPostParams) error
 	EnqueueUpdateTelegramPost(ctx context.Context, notePathID int64) error
 
 	// Account publishing
-	ListSheduledTelegarmAccountPublishNoteIDs(ctx context.Context) ([]int64, error)
+	ListScheduledTelegramAccountPublishNoteIDs(ctx context.Context) ([]int64, error)
 	EnqueueSendTelegramAccountPost(ctx context.Context, params model.SendTelegramPublishPostParams) error
 	EnqueueUpdateTelegramAccountPost(ctx context.Context, notePathID int64) error
 }
@@ -64,7 +64,7 @@ func enqueueBotJobs(ctx context.Context, env Env) ([]ResultPost, error) {
 	return enqueueJobs(ctx, env, jobConfig{
 		logPrefix:     "sendscheduledtelegrampublishposts:bot:",
 		postType:      "bot",
-		listIDs:       env.ListSheduledTelegarmPublishNoteIDs,
+		listIDs:       env.ListScheduledTelegramPublishNoteIDs,
 		enqueueSend:   env.EnqueueSendTelegramPost,
 		enqueueUpdate: env.EnqueueUpdateTelegramPost,
 	})
@@ -74,7 +74,7 @@ func enqueueAccountJobs(ctx context.Context, env Env) ([]ResultPost, error) {
 	return enqueueJobs(ctx, env, jobConfig{
 		logPrefix:     "sendscheduledtelegrampublishposts:account:",
 		postType:      "account",
-		listIDs:       env.ListSheduledTelegarmAccountPublishNoteIDs,
+		listIDs:       env.ListScheduledTelegramAccountPublishNoteIDs,
 		enqueueSend:   env.EnqueueSendTelegramAccountPost,
 		enqueueUpdate: env.EnqueueUpdateTelegramAccountPost,
 	})

--- a/internal/db/queries.read.sql.go
+++ b/internal/db/queries.read.sql.go
@@ -5459,6 +5459,82 @@ func (q *Queries) ListOIDCCredentials(ctx context.Context) ([]OidcCredential, er
 	return items, nil
 }
 
+const listScheduledTelegramAccountPublishNoteIDs = `-- name: ListScheduledTelegramAccountPublishNoteIDs :many
+select distinct n.note_path_id
+  from telegram_publish_notes n
+  join note_paths p on n.note_path_id = p.id
+  -- the note must be tagged with at least one account chat
+  join telegram_publish_note_tags nt on n.note_path_id = nt.note_path_id
+  join telegram_publish_account_chats ac on nt.tag_id = ac.tag_id
+  join telegram_accounts a on ac.account_id = a.id
+  where p.hidden_by is null
+   and publish_at <= datetime('now')
+   and published_at is null
+   and last_error is null
+   and a.enabled = 1
+ order by n.publish_at, n.note_path_id
+`
+
+func (q *Queries) ListScheduledTelegramAccountPublishNoteIDs(ctx context.Context) ([]int64, error) {
+	rows, err := q.db.QueryContext(ctx, listScheduledTelegramAccountPublishNoteIDs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []int64
+	for rows.Next() {
+		var note_path_id int64
+		if err := rows.Scan(&note_path_id); err != nil {
+			return nil, err
+		}
+		items = append(items, note_path_id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listScheduledTelegramPublishNoteIDs = `-- name: ListScheduledTelegramPublishNoteIDs :many
+select n.note_path_id
+  from telegram_publish_notes n
+  join note_paths p on n.note_path_id = p.id
+  -- the note must be tagged with at least one bot chat
+  join telegram_publish_note_tags nt on n.note_path_id = nt.note_path_id
+  join telegram_publish_chats pc on nt.tag_id = pc.tag_id
+  where p.hidden_by is null
+   and publish_at <= datetime('now')
+   and published_at is null
+   and last_error is null
+ order by n.publish_at, n.note_path_id
+`
+
+func (q *Queries) ListScheduledTelegramPublishNoteIDs(ctx context.Context) ([]int64, error) {
+	rows, err := q.db.QueryContext(ctx, listScheduledTelegramPublishNoteIDs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []int64
+	for rows.Next() {
+		var note_path_id int64
+		if err := rows.Scan(&note_path_id); err != nil {
+			return nil, err
+		}
+		items = append(items, note_path_id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listSecretKeys = `-- name: ListSecretKeys :many
 select key from secrets where key like ? order by key
 `
@@ -5476,82 +5552,6 @@ func (q *Queries) ListSecretKeys(ctx context.Context, key string) ([]string, err
 			return nil, err
 		}
 		items = append(items, key)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listSheduledTelegarmAccountPublishNoteIDs = `-- name: ListSheduledTelegarmAccountPublishNoteIDs :many
-select distinct n.note_path_id
-  from telegram_publish_notes n
-  join note_paths p on n.note_path_id = p.id
-  -- the note must be tagged with at least one account chat
-  join telegram_publish_note_tags nt on n.note_path_id = nt.note_path_id
-  join telegram_publish_account_chats ac on nt.tag_id = ac.tag_id
-  join telegram_accounts a on ac.account_id = a.id
-  where p.hidden_by is null
-   and publish_at <= datetime('now')
-   and published_at is null
-   and last_error is null
-   and a.enabled = 1
- order by n.publish_at, n.note_path_id
-`
-
-func (q *Queries) ListSheduledTelegarmAccountPublishNoteIDs(ctx context.Context) ([]int64, error) {
-	rows, err := q.db.QueryContext(ctx, listSheduledTelegarmAccountPublishNoteIDs)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []int64
-	for rows.Next() {
-		var note_path_id int64
-		if err := rows.Scan(&note_path_id); err != nil {
-			return nil, err
-		}
-		items = append(items, note_path_id)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listSheduledTelegarmPublishNoteIDs = `-- name: ListSheduledTelegarmPublishNoteIDs :many
-select n.note_path_id
-  from telegram_publish_notes n
-  join note_paths p on n.note_path_id = p.id
-  -- the note must be tagged with at least one bot chat
-  join telegram_publish_note_tags nt on n.note_path_id = nt.note_path_id
-  join telegram_publish_chats pc on nt.tag_id = pc.tag_id
-  where p.hidden_by is null
-   and publish_at <= datetime('now')
-   and published_at is null
-   and last_error is null
- order by n.publish_at, n.note_path_id
-`
-
-func (q *Queries) ListSheduledTelegarmPublishNoteIDs(ctx context.Context) ([]int64, error) {
-	rows, err := q.db.QueryContext(ctx, listSheduledTelegarmPublishNoteIDs)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []int64
-	for rows.Next() {
-		var note_path_id int64
-		if err := rows.Scan(&note_path_id); err != nil {
-			return nil, err
-		}
-		items = append(items, note_path_id)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err

--- a/internal/db/telegram_publish_notes_test.go
+++ b/internal/db/telegram_publish_notes_test.go
@@ -137,7 +137,7 @@ func TestListAllTelegramPublishNotes(t *testing.T) {
 	})
 
 	t.Run("ListScheduledTelegramPublishNoteIDs_critical_bug_test", func(t *testing.T) {
-		noteIDs, err = queries.ListSheduledTelegarmPublishNoteIDs(ctx)
+		noteIDs, err = queries.ListScheduledTelegramPublishNoteIDs(ctx)
 		require.NoError(t, err)
 
 		// Should ONLY return path1 (publish_at has passed - ready to send)

--- a/queries.read.sql
+++ b/queries.read.sql
@@ -959,7 +959,7 @@ select t.*
  where nt.note_path_id = ?
  order by t.label;
 
--- name: ListSheduledTelegarmPublishNoteIDs :many
+-- name: ListScheduledTelegramPublishNoteIDs :many
 select n.note_path_id
   from telegram_publish_notes n
   join note_paths p on n.note_path_id = p.id
@@ -972,7 +972,7 @@ select n.note_path_id
    and last_error is null
  order by n.publish_at, n.note_path_id;
 
--- name: ListSheduledTelegarmAccountPublishNoteIDs :many
+-- name: ListScheduledTelegramAccountPublishNoteIDs :many
 select distinct n.note_path_id
   from telegram_publish_notes n
   join note_paths p on n.note_path_id = p.id


### PR DESCRIPTION
Renames two sqlc query names that carried typos since introduction:

- `ListSheduledTelegarmPublishNoteIDs` → `ListScheduledTelegramPublishNoteIDs`
- `ListSheduledTelegarmAccountPublishNoteIDs` → `ListScheduledTelegramAccountPublishNoteIDs`

Both select scheduled notes for Telegram publishing (bot path and user-account path), filtering on `last_error is null`.

Pure rename — no behaviour change. `queries.read.sql.go` is regenerated via `make sqlc`; its diff is larger than the rename alone because sqlc re-sorts queries alphabetically and `ListScheduled…` now sorts before `ListSecretKeys`. Verified content-preserving: normalising the rename and sorting non-empty lines gives an identical checksum before and after.

`go build ./...` and `go test ./internal/db/... ./internal/case/cronjob/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)