### PR TITLE
feat(markdownv2): render Obsidian callouts on the Telegram path

### DIFF
--- a/internal/markdownv2/html_converter.go
+++ b/internal/markdownv2/html_converter.go
@@ -6,8 +6,11 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"trip2g/internal/mdloader/callout"
 	"trip2g/internal/mdloader/highlight"
 	"trip2g/internal/model"
+	"unicode"
+	"unicode/utf8"
 
 	enclavecore "github.com/quailyquaily/goldmark-enclave/core"
 	"github.com/yuin/goldmark/ast"
@@ -204,6 +207,9 @@ func (c *HTMLConverter) renderNode(n ast.Node, src []byte, entering bool, res *C
 	case *ast.Blockquote:
 		c.renderBlockquote(n, entering)
 
+	case *callout.Node:
+		c.renderCallout(node, entering)
+
 	case *ast.Link:
 		if entering {
 			c.Write(fmt.Sprintf(`<a href="%s">`, html.EscapeString(string(node.Destination))))
@@ -284,10 +290,58 @@ func (c *HTMLConverter) renderBlockquote(n ast.Node, entering bool) {
 
 	// Blockquote ending with || means Telegram expandable quote
 	if inner, ok := strings.CutSuffix(content, "||"); ok {
-		c.Write(fmt.Sprintf(`<blockquote expandable>%s</blockquote>`, inner))
+		c.writeQuote(inner, true)
+	} else {
+		c.writeQuote(content, false)
+	}
+}
+
+// renderCallout renders an Obsidian callout as a blockquote with a bold title
+// line, collecting the body in its own buffer like renderBlockquote does.
+// A collapsed callout (`[!type]-`) maps to an expandable quote: Telegram shows
+// its first line — the title — and hides the body behind an expand control.
+func (c *HTMLConverter) renderCallout(node *callout.Node, entering bool) {
+	if entering {
+		// The parser builds a fresh node, so HasBlankPreviousLines is always
+		// false here; separate from preceding content by what was written.
+		if cur := c.currentBuffer(); cur != "" && !strings.HasSuffix(cur, "\n\n") {
+			c.Write("\n\n")
+		}
+		c.pushBuffer()
+		return
+	}
+
+	body := strings.TrimSpace(c.popBuffer())
+
+	title := node.Title
+	if title == "" {
+		title = capitalize(node.CalloutType)
+	}
+
+	content := fmt.Sprintf("<b>%s</b>", html.EscapeString(title))
+	if body != "" {
+		content += "\n" + body
+	}
+
+	c.writeQuote(content, node.Foldable && !node.Expanded)
+}
+
+// writeQuote wraps content into a Telegram blockquote, expandable or not.
+func (c *HTMLConverter) writeQuote(content string, expandable bool) {
+	if expandable {
+		c.Write(fmt.Sprintf(`<blockquote expandable>%s</blockquote>`, content))
 	} else {
 		c.Write(fmt.Sprintf(`<blockquote>%s</blockquote>`, content))
 	}
+}
+
+// capitalize upper-cases the first rune of s, matching the web callout renderer.
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	r, size := utf8.DecodeRuneInString(s)
+	return string(unicode.ToUpper(r)) + s[size:]
 }
 
 // renderCustomEmoji renders a Telegram custom emoji, or warns on an unsupported

--- a/internal/markdownv2/html_converter_test.go
+++ b/internal/markdownv2/html_converter_test.go
@@ -343,6 +343,191 @@ title: "Test"
 	}
 }
 
+// A blockquote ending with || is a Telegram expandable quote. Callouts share the
+// same emit path, so this pins the existing behaviour.
+func TestHTMLBlockquoteExpandable(t *testing.T) {
+	tests := []struct {
+		name     string
+		markdown string
+		expected string
+	}{
+		{
+			name:     "multiline quote ending with ||",
+			markdown: "> spoiler quote\n> hidden||",
+			expected: "<blockquote expandable>spoiler quote\nhidden</blockquote>",
+		},
+		{
+			name:     "single line quote ending with ||",
+			markdown: "> hidden||",
+			expected: "<blockquote expandable>hidden</blockquote>",
+		},
+		{
+			name:     "quote without || stays plain",
+			markdown: "> visible",
+			expected: "<blockquote>visible</blockquote>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mdOptions := mdloader.Options{
+				Sources: []mdloader.SourceFile{{
+					Content: []byte(`---
+free: true
+title: "Test"
+---
+` + tt.markdown),
+				}},
+				Log:     &logger.TestLogger{},
+				Version: "latest",
+			}
+
+			nvs, err := mdloader.Load(mdOptions)
+			require.NoError(t, err)
+
+			convertor := markdownv2.HTMLConverter{}
+			res := convertor.Process(nvs.List[0])
+
+			require.Empty(t, res.Warnings)
+			require.Equal(t, tt.expected, res.Content)
+		})
+	}
+}
+
+// Obsidian callouts become Telegram blockquotes with a bold title line.
+// The fold marker decides expandability: `-` (collapsed) -> <blockquote expandable>,
+// `+` and no marker -> plain <blockquote>.
+// Regression: callouts used to be dropped entirely, body included, with an
+// "unexpected markdown node: Callout" warning — hence require.Empty on warnings.
+func TestHTMLCallout(t *testing.T) {
+	tests := []struct {
+		name     string
+		markdown string
+		expected string
+	}{
+		{
+			name:     "callout with custom title",
+			markdown: "> [!note] My Title\n> body line",
+			expected: "<blockquote><b>My Title</b>\nbody line</blockquote>",
+		},
+		{
+			name:     "non-ascii type capitalizes by rune, not byte",
+			markdown: "> [!заметка]\n> body line",
+			expected: "<blockquote><b>Заметка</b>\nbody line</blockquote>",
+		},
+		{
+			name:     "callout without title falls back to capitalized type",
+			markdown: "> [!warning]\n> body line",
+			expected: "<blockquote><b>Warning</b>\nbody line</blockquote>",
+		},
+		{
+			name:     "collapsed callout is expandable",
+			markdown: "> [!tip]- Collapsed\n> hidden body",
+			expected: "<blockquote expandable><b>Collapsed</b>\nhidden body</blockquote>",
+		},
+		{
+			name:     "collapsed callout without title",
+			markdown: "> [!warning]-\n> hidden body",
+			expected: "<blockquote expandable><b>Warning</b>\nhidden body</blockquote>",
+		},
+		{
+			name:     "expanded callout is a plain quote",
+			markdown: "> [!tip]+ Expanded\n> shown body",
+			expected: "<blockquote><b>Expanded</b>\nshown body</blockquote>",
+		},
+		{
+			name:     "uppercase type keeps the title verbatim",
+			markdown: "> [!NOTE] Upper\n> b",
+			expected: "<blockquote><b>Upper</b>\nb</blockquote>",
+		},
+		{
+			name:     "inline formatting in body survives",
+			markdown: "> [!note] Inline\n> some **bold**, a [link](https://example.com) and `code`",
+			expected: "<blockquote><b>Inline</b>\nsome <b>bold</b>, a <a href=\"https://example.com\">link</a> and <code>code</code></blockquote>",
+		},
+		{
+			name:     "multiple paragraphs in body",
+			markdown: "> [!note] T\n> p1\n>\n> p2",
+			expected: "<blockquote><b>T</b>\np1\n\np2</blockquote>",
+		},
+		{
+			name:     "list in body",
+			markdown: "> [!note] T\n> steps:\n> - one\n> - two",
+			expected: "<blockquote><b>T</b>\nsteps:\n- one\n- two</blockquote>",
+		},
+		{
+			name:     "code block in body",
+			markdown: "> [!note] T\n> ```\n> x\n> ```",
+			expected: "<blockquote><b>T</b>\n<pre>x</pre></blockquote>",
+		},
+		{
+			name:     "nested blockquote in body",
+			markdown: "> [!note] T\n> > inner",
+			expected: "<blockquote><b>T</b>\n<blockquote>inner</blockquote></blockquote>",
+		},
+		{
+			name:     "callout between paragraphs",
+			markdown: "before\n\n> [!note] T\n> body\n\nafter",
+			expected: "before\n\n<blockquote><b>T</b>\nbody</blockquote>\n\nafter",
+		},
+		{
+			name:     "callout right after a paragraph keeps a blank line separator",
+			markdown: "before\n> [!note] T\n> body",
+			expected: "before\n\n<blockquote><b>T</b>\nbody</blockquote>",
+		},
+		{
+			name:     "empty callout renders the title only",
+			markdown: "> [!note]",
+			expected: "<blockquote><b>Note</b></blockquote>",
+		},
+		{
+			name:     "unknown type with title",
+			markdown: "> [!gallery] Photo Wall\n> body",
+			expected: "<blockquote><b>Photo Wall</b>\nbody</blockquote>",
+		},
+		{
+			name:     "unknown type without title",
+			markdown: "> [!gallery]\n> body",
+			expected: "<blockquote><b>Gallery</b>\nbody</blockquote>",
+		},
+		{
+			name:     "title is html-escaped",
+			markdown: "> [!note] Title with <b>&</b>\n> body",
+			expected: "<blockquote><b>Title with &lt;b&gt;&amp;&lt;/b&gt;</b>\nbody</blockquote>",
+		},
+		{
+			name:     "plain blockquote is not a callout",
+			markdown: "> plain quote\n> not a callout",
+			expected: "<blockquote>plain quote\nnot a callout</blockquote>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mdOptions := mdloader.Options{
+				Sources: []mdloader.SourceFile{{
+					Content: []byte(`---
+free: true
+title: "Test"
+---
+` + tt.markdown),
+				}},
+				Log:     &logger.TestLogger{},
+				Version: "latest",
+			}
+
+			nvs, err := mdloader.Load(mdOptions)
+			require.NoError(t, err)
+
+			convertor := markdownv2.HTMLConverter{}
+			res := convertor.Process(nvs.List[0])
+
+			require.Empty(t, res.Warnings, "callout must not warn as an unexpected node")
+			require.Equal(t, tt.expected, res.Content)
+		})
+	}
+}
+
 func TestHTMLWikilinks(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/internal/mdloader/callout/callout_test.go
+++ b/internal/mdloader/callout/callout_test.go
@@ -3,6 +3,7 @@ package callout_test
 import (
 	"bytes"
 	"testing"
+	"unicode/utf8"
 
 	"trip2g/internal/mdloader/callout"
 
@@ -123,6 +124,14 @@ func TestCaseInsensitiveType(t *testing.T) {
 	require.Contains(t, html, `class="callout callout--note"`)
 	// Default title capitalizes the lowercased type.
 	require.Contains(t, html, "Note")
+}
+
+func TestNonASCIITypeTitle(t *testing.T) {
+	html := render(t, "> [!заметка]\n> body\n")
+
+	// Default title capitalizes the first rune, not the first byte.
+	require.Contains(t, html, "Заметка")
+	require.True(t, utf8.ValidString(html))
 }
 
 func TestMultiLineBody(t *testing.T) {

--- a/internal/mdloader/callout/renderer.go
+++ b/internal/mdloader/callout/renderer.go
@@ -1,7 +1,8 @@
 package callout
 
 import (
-	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/renderer"
@@ -128,5 +129,6 @@ func capitalize(s string) string {
 	if s == "" {
 		return s
 	}
-	return strings.ToUpper(s[:1]) + s[1:]
+	r, size := utf8.DecodeRuneInString(s)
+	return string(unicode.ToUpper(r)) + s[size:]
 }


### PR DESCRIPTION
Obsidian callouts are currently dropped **entirely** when publishing to Telegram — title, icon and full body. `html_converter.go` had no `case *callout.Node:`, so the node fell to `default:` and returned `ast.WalkSkipChildren`, taking its children with it. Every callout in every published post is invisible today.

The navigation bot failed differently and worse: its catch-all `UnknownNodeHandler` suppressed both the warning and the skip, so the body leaked into surrounding prose — `before\n> [!note] T\n> body` rendered as `beforebody`. It inherits this fix for free, since `default:` is no longer reached for callouts.

## Mapping

Obsidian's fold markers are already parsed into `Foldable`/`Expanded`, and the web renderer has always mapped them onto `<details open>` / `<details>` / `<div>`. The Telegram equivalent:

| Obsidian | Telegram |
|---|---|
| `> [!x]-` (collapsed) | `<blockquote expandable>` |
| `> [!x]+`, `> [!x]` | `<blockquote>` |
| title, or capitalized type | bold first line inside the quote |

The `expandable` emit is shared with `renderBlockquote` rather than duplicated. The `\|\|`-suffix convention stays quote-only — callout expandability comes from the fold marker.

## Separate commit: a UTF-8 bug in shipped code

`capitalize` sliced the first *byte*, so `> [!заметка]` produced invalid UTF-8 (`�\xb7аметка`). The web renderer carried the same defect — its comment says "first rune" while the code slices a byte — so this is live on the site today, not just in the new path. Fixed in both via `utf8.DecodeRuneInString`, with regression tests in both packages.

## Verified against the live API

Two risks flagged during review were checked against a real bot rather than the docs, which state that entities cannot nest:

- `<pre>` inside `<blockquote>` — **accepted, both entities intact** (`blockquote len=19` + `pre len=9`). No risk delta for code inside a callout.
- `<blockquote>` inside `<blockquote>` — **silently flattened**, not rejected. A callout inside a quote loses its frame; the text survives and no error is returned.

## Known limitation, deliberately not fixed here

A callout nested inside another callout leaks its literal `[!tip] Inner` marker to the reader. The cause is `WalkSkipChildren` in the shared transformer (`mdloader/callout/parser.go`), which never converts inner callouts — changing it would alter the website's output too. Filed separately.

`go build ./...` and `go test ./internal/...` pass with zero failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)