### PR TITLE
fix(assets): serve chrome and system-note assets anonymously

### DIFF
--- a/internal/assetindex/assetindex.go
+++ b/internal/assetindex/assetindex.go
@@ -47,7 +47,8 @@ type Key struct {
 // Ownership describes who may read an asset.
 type Ownership struct {
 	// Public is true when the asset is reachable anonymously: referenced by a
-	// layout or by at least one publicly readable note.
+	// layout, by site chrome, or by at least one note that is anonymously
+	// readable (see publiclyServable).
 	Public bool
 	// Notes are the live notes referencing this exact (hash, fileName); a
 	// signed-in user may read the asset if they can read at least one of them.
@@ -111,7 +112,7 @@ func build(env Env) map[Key]*Ownership {
 				k := Key{Hash: ar.Hash, FileName: ar.FileName}
 				e := entry(k)
 				e.Notes = append(e.Notes, nv)
-				if nv.IsPubliclyReadable() {
+				if publiclyServable(nv) {
 					e.Public = true
 				}
 			}
@@ -128,4 +129,20 @@ func build(env Env) map[Key]*Ownership {
 	}
 
 	return byKey
+}
+
+// publiclyServable reports whether nv referencing an asset is enough to serve
+// that asset anonymously.
+//
+// The question is "can this note's bytes reach a requester with no session",
+// not "may this note be listed" — those diverge for system notes, which are
+// hidden from every listing yet render their content into public pages. The
+// site logo lives in _header.md: gating on listability (IsPubliclyReadable)
+// answered 401 for the very asset every anonymous page embeds.
+//
+// Chrome counts even when it is not free: the template renders _header and
+// _footer for anonymous visitors without consulting their `free` flag, so
+// their assets are in public HTML either way.
+func publiclyServable(nv *model.NoteView) bool {
+	return nv.IsAnonymouslyReadable() || nv.IsSiteChrome()
 }

--- a/internal/assetindex/assetindex_test.go
+++ b/internal/assetindex/assetindex_test.go
@@ -77,6 +77,55 @@ func TestAssetOwnership_SharedAssetPublicIfAnyOwnerIsFree(t *testing.T) {
 	require.Len(t, own.Notes, 2)
 }
 
+// TestAssetOwnership_FreeSystemNoteIsPublic pins the fix for a 401 on the site
+// logo: system notes are hidden from listings but their content renders inside
+// public pages, so publicness must follow anonymous readability, not
+// listability.
+func TestAssetOwnership_FreeSystemNoteIsPublic(t *testing.T) {
+	idx := assetindex.New(&testEnv{nvs: views(noteWithAsset("_header.md", "img.png", true))})
+
+	own, ok := idx.AssetOwnership("h1", "img.png")
+	require.True(t, ok)
+	require.True(t, own.Public, "a free system note must make its assets anonymously servable")
+}
+
+// TestAssetOwnership_ChromeNoteIsPublicWithoutFree covers chrome that carries
+// no frontmatter at all (the shipped onboarding vault's _header.md): the page
+// template renders _header/_footer for anonymous visitors without consulting
+// `free`, so their assets are in public HTML regardless.
+func TestAssetOwnership_ChromeNoteIsPublicWithoutFree(t *testing.T) {
+	idx := assetindex.New(&testEnv{nvs: views(noteWithAsset("ru/_header.md", "img.png", false))})
+
+	own, ok := idx.AssetOwnership("h1", "img.png")
+	require.True(t, ok)
+	require.True(t, own.Public, "chrome renders anonymously, so its assets must be servable")
+}
+
+// TestAssetOwnership_PaidSystemNoteStaysPrivate keeps the widening bounded: a
+// system note that is neither free nor chrome must not leak its assets.
+func TestAssetOwnership_PaidSystemNoteStaysPrivate(t *testing.T) {
+	idx := assetindex.New(&testEnv{nvs: views(noteWithAsset("_mcp_instructions.md", "img.png", false))})
+
+	own, ok := idx.AssetOwnership("h1", "img.png")
+	require.True(t, ok)
+	require.False(t, own.Public, "a paid system note must keep its assets private")
+}
+
+// TestAssetOwnership_SigninWalledChromeIsStillPublic documents the one place
+// the chrome carve-out outranks a gate that stops content notes: the sign-in
+// wall page is itself wrapped in site chrome, so a guest who is refused the
+// note still receives the header markup — and must be able to load the logo
+// in it. Gating here would only produce a broken image on the wall page.
+func TestAssetOwnership_SigninWalledChromeIsStillPublic(t *testing.T) {
+	note := noteWithAsset("_footer.md", "img.png", true)
+	note.Subgraphs = map[string]*model.NoteSubgraph{"members": {RequireSignin: true}}
+	idx := assetindex.New(&testEnv{nvs: views(note)})
+
+	own, ok := idx.AssetOwnership("h1", "img.png")
+	require.True(t, ok)
+	require.True(t, own.Public)
+}
+
 func TestAssetOwnership_LayoutAssetIsPublic(t *testing.T) {
 	env := &testEnv{
 		nvs: views(),

--- a/internal/case/serveasset/resolve_test.go
+++ b/internal/case/serveasset/resolve_test.go
@@ -415,3 +415,39 @@ func TestHandle_SharedHashDifferentFileName_PrivateRowNotLeakedViaPublicSibling(
 	require.Equal(t, http.StatusUnauthorized, ctx.Response.StatusCode(),
 		"a private row must not inherit publicness from a same-hash sibling row")
 }
+
+// indexEnv is the assetindex.Env half of the wiring, so the test below runs the
+// real index rather than a canned Ownership.
+type indexEnv struct{ nvs *model.NoteViews }
+
+func (e *indexEnv) LiveNoteViews() *model.NoteViews { return e.nvs }
+func (e *indexEnv) Layouts() *model.Layouts         { return nil }
+func (e *indexEnv) AssetIndexGeneration() uint64    { return 1 }
+
+// TestHandle_SiteLogoInHeaderNote_AnonymousGets200 is the end-to-end pin for
+// the production 401 on the site logo: docs/_header.md is a system note, so
+// gating asset publicness on listability (IsPubliclyReadable) made every
+// anonymous visitor fail to load the logo that every page embeds. Wires the
+// real assetindex so a regression in either half is caught here.
+func TestHandle_SiteLogoInHeaderNote_AnonymousGets200(t *testing.T) {
+	logo := db.NoteAsset{ID: 9, FileName: "logo.svg", Sha256Hash: testHash, Size: int64(len(testBody))}
+	header := &model.NoteView{
+		Path: "_header.md",
+		Free: true,
+		AssetReplaces: map[string]*model.NoteAssetReplace{
+			"logo.svg": {ID: 9, Hash: testHash, FileName: "logo.svg"},
+		},
+	}
+	idx := assetindex.New(&indexEnv{nvs: &model.NoteViews{List: []*model.NoteView{header}}})
+
+	env := newEnv(envOpts{rows: []db.NoteAsset{logo}})
+	env.AssetOwnershipFunc = idx.AssetOwnership
+
+	ctx, handled := doRequest(t, env, reqOpts{path: model.NoteAssetURLPath(testHash, "logo.svg")})
+
+	require.True(t, handled)
+	require.Equal(t, http.StatusOK, ctx.Response.StatusCode())
+	require.Equal(t, "public, max-age=31536000, immutable", string(ctx.Response.Header.Peek("Cache-Control")))
+	require.Equal(t, testBody, body(ctx))
+	require.Empty(t, env.CanReadNoteCalls(), "chrome assets must not need a session")
+}

--- a/internal/model/note.go
+++ b/internal/model/note.go
@@ -1503,15 +1503,43 @@ func (n *NoteView) IsSystem() bool {
 	return len(p) > 0 && p[0] == '_' || strings.Contains(p, "/_")
 }
 
-// IsPubliclyReadable reports whether a note may be exposed through an
-// unauthenticated endpoint. Such endpoints (RSS, template feeds) have no user
-// context, so they must honor the same static gates as anonymous page rendering
-// rather than relying on Free alone.
-func (n *NoteView) IsPubliclyReadable() bool {
+// IsSiteChrome reports whether the note is site chrome — the _header/_footer
+// notes the page template wraps every note in (see defaulttemplate.HeaderRef).
+// Chrome renders for anonymous visitors regardless of its own `free` flag or
+// subgraph gates — even the sign-in wall page is wrapped in it — so the markup
+// it contributes, and the assets in it (e.g. the site logo), are public by
+// construction. Matched by name in any folder, mirroring how chrome
+// is resolved per language/section (docs/_header.md, docs/ru/_header.md).
+// A note wired as chrome under some other name is not matched here; it has to
+// carry free: true for its assets to be treated as public.
+func (n *NoteView) IsSiteChrome() bool {
+	if n == nil {
+		return false
+	}
+	base := filepath.ToSlash(n.Path)
+	if i := strings.LastIndexByte(base, '/'); i >= 0 {
+		base = base[i+1:]
+	}
+	base = strings.TrimSuffix(base, ".md")
+	return base == "_header" || base == "_footer"
+}
+
+// IsAnonymouslyReadable reports whether the note's content may reach a
+// requester with no session — the same static gates anonymous page rendering
+// applies (canreadnote falls back to Free for a nil token; .html files are
+// never user content; a require_signin subgraph stops guests at the sign-in
+// wall).
+//
+// System notes pass this gate. They are never served as their own page, but
+// their rendered content ships inside public pages as chrome (_header,
+// _footer) or transclusion, so the bytes behind them — assets included — are
+// already anonymous-visible. Being *listed* by an unauthenticated endpoint is
+// a stricter question; use IsPubliclyReadable for that.
+func (n *NoteView) IsAnonymouslyReadable() bool {
 	if n == nil || !n.Free {
 		return false
 	}
-	if strings.HasSuffix(n.Path, ".html") || n.IsSystem() {
+	if strings.HasSuffix(n.Path, ".html") {
 		return false
 	}
 	for _, subgraph := range n.Subgraphs {
@@ -1520,4 +1548,13 @@ func (n *NoteView) IsPubliclyReadable() bool {
 		}
 	}
 	return true
+}
+
+// IsPubliclyReadable reports whether a note may be exposed as an item through
+// an unauthenticated endpoint. Such endpoints (RSS, template feeds) have no
+// user context, so they must honor the same static gates as anonymous page
+// rendering rather than relying on Free alone, plus one more: system notes are
+// hidden from every listing.
+func (n *NoteView) IsPubliclyReadable() bool {
+	return n.IsAnonymouslyReadable() && !n.IsSystem()
 }

--- a/internal/model/note_test.go
+++ b/internal/model/note_test.go
@@ -807,6 +807,62 @@ func TestNoteView_IsSystem(t *testing.T) {
 	}
 }
 
+func TestNoteView_IsSiteChrome(t *testing.T) {
+	cases := []struct {
+		path   string
+		expect bool
+	}{
+		{"_header.md", true},
+		{"_footer.md", true},
+		{"ru/_header.md", true},
+		{"docs/ru/_footer.md", true},
+		{"_layouts/_header.html", false}, // a layout, not a chrome note
+		{"_index.md", false},
+		{"_header_old.md", false},
+		{"header.md", false},
+		{"docs/note.md", false},
+	}
+
+	for _, c := range cases {
+		n := &NoteView{Path: c.path}
+		require.Equal(t, c.expect, n.IsSiteChrome(), "path: %s", c.path)
+	}
+
+	require.False(t, (*NoteView)(nil).IsSiteChrome())
+}
+
+// TestNoteView_IsAnonymouslyReadableVsPubliclyReadable pins the split the
+// asset route depends on: a free system note's content reaches anonymous
+// visitors (it renders as chrome inside public pages) even though it must
+// never appear as an item in a listing.
+func TestNoteView_IsAnonymouslyReadableVsPubliclyReadable(t *testing.T) {
+	header := &NoteView{Path: "_header.md", Free: true}
+	require.True(t, header.IsAnonymouslyReadable())
+	require.False(t, header.IsPubliclyReadable(), "system notes stay out of listings")
+
+	post := &NoteView{Path: "post.md", Free: true}
+	require.True(t, post.IsAnonymouslyReadable())
+	require.True(t, post.IsPubliclyReadable())
+
+	paid := &NoteView{Path: "post.md"}
+	require.False(t, paid.IsAnonymouslyReadable())
+	require.False(t, paid.IsPubliclyReadable())
+
+	tmpl := &NoteView{Path: "_layouts/base.html", Free: true}
+	require.False(t, tmpl.IsAnonymouslyReadable(), ".html files are never user content")
+
+	walled := &NoteView{
+		Path:      "post.md",
+		Free:      true,
+		Subgraphs: map[string]*NoteSubgraph{"members": {RequireSignin: true}},
+	}
+	require.False(t, walled.IsAnonymouslyReadable())
+	require.False(t, walled.IsPubliclyReadable())
+
+	require.False(t, (*NoteView)(nil).IsAnonymouslyReadable())
+	require.False(t, (*NoteView)(nil).IsPubliclyReadable(), "nil must not panic through IsSystem")
+}
+
 func TestResolveFullURL(t *testing.T) {
 	const publicURL = "https://main.example.com"
 


### PR DESCRIPTION
## The bug

https://trip2g.com/docs — the site logo is a broken image. `GET /_system/assets/1e9e5f1d…/logo.svg` → **401 Unauthorized** for anyone without a session.

The logo lives in `docs/_header.md` (`![[logo.svg|250]]`). `serveasset` decides anonymous-vs-gated from `assetindex`, which marked an asset public only when an owning note passed `NoteView.IsPubliclyReadable()` — and that predicate excludes system notes (`IsSystem()`, path component starting with `_`). Every `_header.md` is a system note, so the logo fell through to `enforceAccess`, which requires a session.

Signed-in admins load it fine, which is why it stayed invisible from the inside. It broke when #228 moved assets off presigned URLs onto `/_system/assets`.

Measured on production: crawled all 405 sitemap URLs, collected 44 distinct asset URLs — exactly one 401s, `logo.svg`. Landing-page assets are unaffected because they live in `_layouts` and take the layout branch of the index.

## The fix

`IsPubliclyReadable` answers *"may this note be listed by an unauthenticated endpoint"* (RSS, template feeds). Asset serving asks a different question: *"can these bytes reach a requester with no session"*. Those diverge precisely at system notes, which are hidden from listings yet render their content into public pages.

- `NoteView.IsAnonymouslyReadable()` — the shared gates: `free`, not `.html`, no `require_signin` subgraph. No system-note exclusion.
- `NoteView.IsPubliclyReadable()` — now `IsAnonymouslyReadable() && !IsSystem()`. Unchanged behavior for its existing callers (RSS/feed queries).
- `assetindex` uses `publiclyServable(nv) = nv.IsAnonymouslyReadable() || nv.IsSiteChrome()`.

The chrome carve-out covers a second landmine that had not fired yet. `docs/ru/_header.md` has no frontmatter (not `free`) and survives only because its logo is byte-identical to the English header's; the shipped `onboarding-vault/_header.md` has no frontmatter either, so any new user adding a logo to their header would get the same 401. The page template renders `_header`/`_footer` for anonymous visitors without consulting `free` — verified live: `/ru/agent` emits `<img src="/_system/assets/…/logo.svg">` from a non-free header note — and even the sign-in wall page is wrapped in chrome. So chrome assets are in public HTML regardless, and gating them only yields a broken image.

Bounded deliberately: a non-chrome system note that is not free stays private (test), and chrome wired under a custom name via `header:` frontmatter still needs `free: true`. Reproducing defaulttemplate's full header precedence (frontmatter → layout-section glob → `_header` fallback) inside the index would duplicate exactly the logic whose drift caused this bug.

## Tests

Four new tests, all verified to fail without the fix:

- `assetindex`: free system note is public; chrome without `free` is public; paid non-chrome system note stays private; sign-in-walled chrome is still public (documents why).
- `serveasset`: end-to-end through the real `assetindex` — a `_header.md` logo returns 200 with immutable caching to an anonymous request, no `CanReadNote` call.
- `model`: `IsSiteChrome` table, and the `IsAnonymouslyReadable` vs `IsPubliclyReadable` split including nil-receiver safety.

`go test ./...` green, `golangci-lint` clean on the touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)