### PR TITLE
fix(rendernotepage): never derive meta description from a closed note body

### DIFF
--- a/internal/case/rendernotepage/meta_description.go
+++ b/internal/case/rendernotepage/meta_description.go
@@ -14,8 +14,15 @@ const metaDescriptionMaxLen = 155
 // deriveMetaDescription builds a fallback SEO meta description from a note's
 // first paragraph when it declares no explicit description:. Returns "" when
 // nothing usable can be extracted.
+//
+// Only a note whose body is already anonymous-visible may be summarized this
+// way: the description lands in the <head> of every render, including the
+// paywall and sign-in wall pages, which are served before access is granted.
+// A closed note therefore gets a description only from explicit frontmatter —
+// no explicit description means no description, and nothing but the title
+// (shown on the wall by design) leaves the note.
 func deriveMetaDescription(note *model.NoteView) string {
-	if note == nil || note.PartialRenderer == nil {
+	if note == nil || note.PartialRenderer == nil || !note.IsAnonymouslyReadable() {
 		return ""
 	}
 	intro := note.PartialRenderer.Introduce()

--- a/internal/case/rendernotepage/meta_description_test.go
+++ b/internal/case/rendernotepage/meta_description_test.go
@@ -31,15 +31,36 @@ func TestDeriveMetaDescription(t *testing.T) {
 	})
 
 	t.Run("strips html and collapses whitespace", func(t *testing.T) {
-		note := &model.NoteView{PartialRenderer: introPartialRenderer{
+		note := &model.NoteView{Free: true, PartialRenderer: introPartialRenderer{
 			intro: model.NoteViewSection{ContentHTML: "<p>Hello   <strong>world</strong>\nagain</p>"},
 		}}
 		require.Equal(t, "Hello world again", deriveMetaDescription(note))
 	})
 
+	// The derived description reaches the <head> of the paywall / sign-in wall
+	// pages too, so a note that is not anonymous-visible must never be summarized
+	// from its body.
+	t.Run("non-free note yields nothing", func(t *testing.T) {
+		note := &model.NoteView{PartialRenderer: introPartialRenderer{
+			intro: model.NoteViewSection{ContentHTML: "<p>Paid content</p>"},
+		}}
+		require.Empty(t, deriveMetaDescription(note))
+	})
+
+	t.Run("require_signin subgraph yields nothing", func(t *testing.T) {
+		note := &model.NoteView{
+			Free:      true,
+			Subgraphs: map[string]*model.NoteSubgraph{"members": {RequireSignin: true}},
+			PartialRenderer: introPartialRenderer{
+				intro: model.NoteViewSection{ContentHTML: "<p>Members only</p>"},
+			},
+		}
+		require.Empty(t, deriveMetaDescription(note))
+	})
+
 	t.Run("truncates to about 155 chars with ellipsis on word boundary", func(t *testing.T) {
 		long := strings.Repeat("word ", 60) // 300 chars
-		note := &model.NoteView{PartialRenderer: introPartialRenderer{
+		note := &model.NoteView{Free: true, PartialRenderer: introPartialRenderer{
 			intro: model.NoteViewSection{ContentHTML: "<p>" + long + "</p>"},
 		}}
 		got := deriveMetaDescription(note)

--- a/internal/case/rendernotepage/paywall_meta_test.go
+++ b/internal/case/rendernotepage/paywall_meta_test.go
@@ -1,0 +1,101 @@
+package rendernotepage_test
+
+import (
+	"strings"
+	"testing"
+
+	"trip2g/internal/model"
+
+	"github.com/stretchr/testify/require"
+)
+
+// leakPartialRenderer feeds deriveMetaDescription a first paragraph with a
+// recognizable marker, the way the real markdown renderer would.
+type leakPartialRenderer struct {
+	intro string
+}
+
+func (r leakPartialRenderer) Sections(int) []model.NoteViewSection  { return nil }
+func (r leakPartialRenderer) Section(string) *model.NoteViewSection { return nil }
+func (r leakPartialRenderer) Introduce() model.NoteViewSection {
+	return model.NoteViewSection{ContentHTML: "<p>" + r.intro + "</p>"}
+}
+func (r leakPartialRenderer) HeadingBlocks(int) []model.NoteViewSection { return nil }
+func (r leakPartialRenderer) FirstList() *model.NoteViewList            { return nil }
+func (r leakPartialRenderer) Lists() []model.NoteViewList               { return nil }
+func (r leakPartialRenderer) FirstImageURL() string                     { return "" }
+
+const secretIntro = "SECRET-INTRO-MARKER the closed body starts right here"
+
+// TestPaywalledNoteBodyNeverLeaksIntoMeta pins the fix for a content leak: the
+// meta description is derived from the note's first paragraph, and it was built
+// before the paywall / sign-in wall branch ran — so an anonymous GET of a closed
+// note answered 200 with that paragraph in <meta name="description">, in
+// og:description and once more through OGTagsSorted. The title is shown on
+// purpose; the body is not.
+func TestPaywalledNoteBodyNeverLeaksIntoMeta(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(note *model.NoteView)
+	}{
+		{
+			name:  "paywall (non-free note)",
+			setup: func(note *model.NoteView) { note.Free = false },
+		},
+		{
+			name: "sign-in wall (require_signin subgraph)",
+			setup: func(note *model.NoteView) {
+				note.Subgraphs = map[string]*model.NoteSubgraph{
+					"members": {Name: "members", RequireSignin: true},
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			note, views := cacheTestNote()
+			note.PartialRenderer = leakPartialRenderer{intro: secretIntro}
+			tc.setup(note)
+			env, _, _ := cacheTestEnv(views, nil)
+
+			ctx := newReqCtx(reqOpts{})
+			runHandle(t, env, ctx, nil)
+
+			html := string(body(t, ctx))
+			require.NotContains(t, html, secretIntro,
+				"closed note body must not reach an anonymous reader")
+			require.Contains(t, html, note.Title, "the title is shown on purpose")
+		})
+	}
+
+	t.Run("explicit description is still published", func(t *testing.T) {
+		note, views := cacheTestNote()
+		note.Free = false
+		note.PartialRenderer = leakPartialRenderer{intro: secretIntro}
+		note.Description = ptrTo("Teaser written for the paywall page")
+		env, _, _ := cacheTestEnv(views, nil)
+
+		ctx := newReqCtx(reqOpts{})
+		runHandle(t, env, ctx, nil)
+
+		html := string(body(t, ctx))
+		require.NotContains(t, html, secretIntro)
+		require.Contains(t, html, "Teaser written for the paywall page")
+	})
+
+	t.Run("free note still gets a derived description", func(t *testing.T) {
+		note, views := cacheTestNote()
+		note.PartialRenderer = leakPartialRenderer{intro: secretIntro}
+		env, _, _ := cacheTestEnv(views, nil)
+
+		ctx := newReqCtx(reqOpts{})
+		runHandle(t, env, ctx, nil)
+
+		html := string(body(t, ctx))
+		require.Equal(t, 3, strings.Count(html, secretIntro),
+			"public note: meta description, og:description and the twitter/og pass")
+	})
+}
+
+func ptrTo[T any](v T) *T { return &v }


### PR DESCRIPTION
## Problem

`endpoint.go` builds the meta description and OG tags right after `Resolve` (line 66-82), before the paywall / sign-in wall branch runs. With no explicit `description:` in frontmatter, `deriveMetaDescription` summarizes the note's **first paragraph** — so an anonymous GET of a closed note answered `200` with that paragraph in the page three times:

```html
<meta name="description" content="SECRET-INTRO-MARKER the closed body starts right here">
<meta property="og:description" content="SECRET-INTRO-MARKER …">   <!-- layout slot -->
<meta property="og:description" content="SECRET-INTRO-MARKER …">   <!-- OGTagsSorted() -->
```

Both the paywall (`free: false`) and the sign-in wall (`require_signin` subgraph) paths were affected. The wall page itself renders only the title and the explicit description — that part was fine.

## Fix

All three occurrences grow from one root, so the gate goes into `deriveMetaDescription` itself: derive from the body only when the note is already anonymous-visible (`NoteView.IsAnonymouslyReadable()` — the same static gate the anonymous render path uses: `free`, no `require_signin` subgraph, not `.html`).

A closed note now gets a description only from explicit frontmatter; no explicit description means no description. Public notes keep their derived SEO description unchanged, and the title stays on the wall page by design.

## Tests

- `paywall_meta_test.go` — HTTP-level reproduction through `Endpoint.Handle`: a non-free / require-signin note with a marker in its first paragraph must not put that marker anywhere in the response; explicit `description` is still published; a free note still emits the derived description in all three slots.
- `meta_description_test.go` — unit gate: non-free and `require_signin` notes derive nothing.

Red before the change, green after; full `go test ./internal/...` passes.