### PR TITLE
fix(layoutloader): drop the @did self-literal check

### DIFF
--- a/internal/layoutloader/self_literal.go
+++ b/internal/layoutloader/self_literal.go
@@ -23,42 +23,33 @@ func derivePlaceholderIDs(sourceID string) (string, string) {
 }
 
 // scanSelfLiteral scans a component's PRE-expansion source for literal occurrences
-// of its own expanded @lid/@did names. Such literals silently break the rename
-// guarantee: the placeholders are optional, so a hardcoded "mesh-bar" survives a
-// file rename while "@did" would follow it. Escaped @@lid/@@did stay literal in the
-// raw source (they read "@@lid"), so they never match the expanded name.
+// of its own expanded @lid name. Such literals silently break the rename
+// guarantee: the placeholder is optional, so a hardcoded "mesh_bar" survives a
+// file rename while "@lid" would follow it. Escaped @@lid stays literal in the
+// raw source (it reads "@@lid"), so it never matches the expanded name.
+//
+// @did is deliberately NOT checked. A dash id is an ordinary word in HTML, so
+// every layout named after an element flagged its own markup — "/rss.html"
+// warned about the RSS root element `<rss version="2.0">`, and table/main/nav
+// layouts would do the same. The placeholder itself still expands as before.
 //
 // Rules:
-//   - Only the file's OWN lid/did. Referencing another component's expanded name
+//   - Only the file's OWN lid. Referencing another component's expanded name
 //     (e.g. index.html yielding mesh_bar()) is correct composition, never flagged.
-//   - JS/CSS strings are in scope: querySelector('.mesh-bar__nav') is exactly the
-//     drift to catch — the expansion is textual everywhere.
-//   - did matches with a BEM/CSS boundary so "mesh-bar" does not match inside
-//     "mesh-barometer".
 //   - lid matches only call/definition forms so "mesh_art" does not match inside
 //     "mesh_article".
-//   - Matches inside an HTML comment are skipped: comment prose (e.g. "the
-//     kanban app") isn't an identifier, it's English text that happens to
-//     contain the word.
-//   - Matches inside an absolute URL (scheme://...) are skipped: the URL names
-//     an external artifact (e.g. a release asset in another repo) whose name
-//     must not track this file's name.
-var (
-	htmlCommentRe = regexp.MustCompile(`<!--[\s\S]*?-->`)
-	absoluteURLRe = regexp.MustCompile(`\b[a-zA-Z][a-zA-Z0-9+.-]*://[^\s'"<>()]+`)
-)
+//   - Matches inside an HTML comment are skipped: usage documented in a comment
+//     is prose, not a real call site.
+var htmlCommentRe = regexp.MustCompile(`<!--[\s\S]*?-->`)
 
 // byteRange is a [start, end) byte offset range within scanned content.
 type byteRange struct{ start, end int }
 
 // skipRanges computes byte ranges that self-literal matches should ignore:
-// HTML comments and absolute URL tokens (see scanSelfLiteral's Rules).
+// HTML comments (see scanSelfLiteral's Rules).
 func skipRanges(content string) []byteRange {
 	var ranges []byteRange
 	for _, m := range htmlCommentRe.FindAllStringIndex(content, -1) {
-		ranges = append(ranges, byteRange{m[0], m[1]})
-	}
-	for _, m := range absoluteURLRe.FindAllStringIndex(content, -1) {
 		ranges = append(ranges, byteRange{m[0], m[1]})
 	}
 	return ranges
@@ -74,79 +65,49 @@ func inSkipRange(ranges []byteRange, pos int) bool {
 }
 
 func scanSelfLiteral(content, sourceID string) []model.NoteWarning {
-	lid, did := derivePlaceholderIDs(sourceID)
-	if lid == "" && did == "" {
+	lid, _ := derivePlaceholderIDs(sourceID)
+	if lid == "" {
 		return nil
 	}
 
-	type hit struct {
-		line int
-		kind string // "@lid" or "@did"
-		text string
-	}
-	var hits []hit
-
+	var lines []int
 	skip := skipRanges(content)
 
-	addHits := func(re *regexp.Regexp, kind, text string) {
+	addHits := func(re *regexp.Regexp) {
 		for _, m := range re.FindAllStringSubmatchIndex(content, -1) {
 			start := m[2]
 			if start < 0 || inSkipRange(skip, start) {
 				continue
 			}
-			line := 1 + strings.Count(content[:start], "\n")
-			hits = append(hits, hit{line: line, kind: kind, text: text})
+			lines = append(lines, 1+strings.Count(content[:start], "\n"))
 		}
 	}
 
-	if did != "" {
-		// non-word (or start) before; BEM/CSS boundary (or end) after.
-		didRe := regexp.MustCompile(`(?:^|[^\w])(` + regexp.QuoteMeta(did) + `)(?:__|--|[\s'"` + "`" + `.#:\[)\{,;]|$)`)
-		addHits(didRe, "@did", did)
-	}
+	q := regexp.QuoteMeta(lid)
+	// <lid>_ru( — RU variant call/definition (checked first so the _ru form wins).
+	addHits(regexp.MustCompile(`(?:^|[^\w])(` + q + `)_ru\(`))
+	// <lid>( — call or block definition.
+	addHits(regexp.MustCompile(`(?:^|[^\w])(` + q + `)\(`))
+	// _style_<lid> — the paired CSS block, boundary (or end) after.
+	addHits(regexp.MustCompile(`_style_(` + q + `)(?:[^\w]|$)`))
+	// yield <lid> — a yield reference, boundary (or end) after.
+	addHits(regexp.MustCompile(`yield\s+(` + q + `)(?:[^\w]|$)`))
 
-	if lid != "" {
-		q := regexp.QuoteMeta(lid)
-		// <lid>_ru( — RU variant call/definition (checked first so the _ru form wins).
-		addHits(regexp.MustCompile(`(?:^|[^\w])(`+q+`)_ru\(`), "@lid", lid)
-		// <lid>( — call or block definition.
-		addHits(regexp.MustCompile(`(?:^|[^\w])(`+q+`)\(`), "@lid", lid)
-		// _style_<lid> — the paired CSS block, boundary (or end) after.
-		addHits(regexp.MustCompile(`_style_(`+q+`)(?:[^\w]|$)`), "@lid", lid)
-		// yield <lid> — a yield reference, boundary (or end) after.
-		addHits(regexp.MustCompile(`yield\s+(`+q+`)(?:[^\w]|$)`), "@lid", lid)
-	}
-
-	if len(hits) == 0 {
+	if len(lines) == 0 {
 		return nil
 	}
 
-	// Dedupe by (line, kind): one warning per line per placeholder kind.
-	seen := make(map[string]struct{})
-	unique := hits[:0]
-	for _, h := range hits {
-		key := h.kind + ":" + strconv.Itoa(h.line)
-		if _, ok := seen[key]; ok {
+	// One warning per line, however many literals it holds.
+	sort.Ints(lines)
+	warnings := make([]model.NoteWarning, 0, len(lines))
+	for i, line := range lines {
+		if i > 0 && line == lines[i-1] {
 			continue
 		}
-		seen[key] = struct{}{}
-		unique = append(unique, h)
-	}
-
-	sort.Slice(unique, func(i, j int) bool {
-		if unique[i].line != unique[j].line {
-			return unique[i].line < unique[j].line
-		}
-		return unique[i].kind < unique[j].kind
-	})
-
-	warnings := make([]model.NoteWarning, 0, len(unique))
-	for _, h := range unique {
 		warnings = append(warnings, model.NoteWarning{
 			Level: model.NoteWarningWarning,
-			Message: "layout " + sourceID + " line " + strconv.Itoa(h.line) +
-				`: literal "` + h.text + `" matches this file's ` + h.kind +
-				`; replace with ` + h.kind + " so renames keep working",
+			Message: "layout " + sourceID + " line " + strconv.Itoa(line) +
+				`: literal "` + lid + `" matches this file's @lid; replace with @lid so renames keep working`,
 		})
 	}
 	return warnings

--- a/internal/layoutloader/self_literal_test.go
+++ b/internal/layoutloader/self_literal_test.go
@@ -39,55 +39,33 @@ func warnLines(t *testing.T, ws []model.NoteWarning, kind string) []string {
 	return out
 }
 
-func TestScanSelfLiteral_DidInCSSAndJS(t *testing.T) {
-	// bar.html style: @did placeholders are fine, but a hardcoded mesh-bar class
-	// (here in a JS querySelector string) is the drift to catch.
+func TestScanSelfLiteral_DidNotFlagged(t *testing.T) {
+	// The @did check is gone: a dash id is just a word, and layouts named after an
+	// HTML element (rss, table, main) matched their own tags. A hardcoded BEM class
+	// no longer warns — @lid is the only self-literal still tracked.
 	src := "line1\n" +
 		`.@did__nav { color: red; }` + "\n" +
-		`document.querySelector('.mesh-bar__nav')` + "\n"
+		`document.querySelector('.mesh-bar__nav')` + "\n" +
+		`a .mesh-bar { }` + "\n" +
+		`b .mesh-bar--mod { }` + "\n"
 	ws := scanSelfLiteral(src, "/mesh/bar")
-	require.Len(t, ws, 1)
-	require.Contains(t, ws[0].Message, "line 3")
-	require.Contains(t, ws[0].Message, `literal "mesh-bar"`)
-	require.Contains(t, ws[0].Message, "this file's @did")
-	require.Equal(t, model.NoteWarningWarning, ws[0].Level)
+	require.Empty(t, ws)
 }
 
-func TestScanSelfLiteral_EscapedPlaceholderNotFlagged(t *testing.T) {
-	// @@did is an escape that stays literal "@did" in the raw source, so it never
-	// matches the expanded "mesh-bar". Even when the expanded literal appears on the
-	// SAME line elsewhere, only the true literal is flagged.
-	src := `<div class="@did__x @@did">` + "\n" +
-		`<div class="@did__y mesh-bar__z @@did">` + "\n"
-	ws := scanSelfLiteral(src, "/mesh/bar")
-	// Only line 2 has a real literal (mesh-bar__z); the @@did escapes are ignored.
-	require.Len(t, ws, 1)
-	require.Contains(t, ws[0].Message, "line 2")
+func TestScanSelfLiteral_XMLRootElementNotFlagged(t *testing.T) {
+	// The onboarding vault's _layouts/rss.html: <rss> is the RSS 2.0 root element,
+	// not a reference to the layout's own name.
+	src := `<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">` + "\n" +
+		`</rss>` + "\n"
+	ws := scanSelfLiteral(src, "/rss.html")
+	require.Empty(t, ws)
 }
 
 func TestScanSelfLiteral_OtherComponentNotFlagged(t *testing.T) {
 	// index.html composing other components by their expanded names is correct.
-	src := `{{ yield mesh_bar() }}` + "\n" +
-		`<div class="mesh-bar__nav"></div>` + "\n"
+	src := `{{ yield mesh_bar() }}` + "\n"
 	ws := scanSelfLiteral(src, "/mesh/index")
 	require.Empty(t, ws)
-}
-
-func TestScanSelfLiteral_DidWordBoundary(t *testing.T) {
-	// mesh-bar must not match inside mesh-barometer.
-	src := `.mesh-barometer { x: 1 }` + "\n"
-	ws := scanSelfLiteral(src, "/mesh/bar")
-	require.Empty(t, ws)
-}
-
-func TestScanSelfLiteral_DidBoundaryVariants(t *testing.T) {
-	src := `a .mesh-bar { }` + "\n" + // whitespace after
-		`b .mesh-bar__el { }` + "\n" + // __ suffix
-		`c .mesh-bar--mod { }` + "\n" + // -- suffix
-		`d "mesh-bar"` + "\n" + // quote after
-		`e mesh-bar` + "\n" // end of line
-	ws := scanSelfLiteral(src, "/mesh/bar")
-	require.Len(t, warnLines(t, ws, "@did"), 5)
 }
 
 func TestScanSelfLiteral_LidCallForms(t *testing.T) {
@@ -109,49 +87,23 @@ func TestScanSelfLiteral_LidWordBoundary(t *testing.T) {
 
 func TestScanSelfLiteral_DedupePerLine(t *testing.T) {
 	// Two literals on one line collapse to a single warning for that line/kind.
-	src := `<a class="mesh-bar__x mesh-bar__y">` + "\n"
+	src := `{{ block mesh_bar() }}{{ yield mesh_bar() }}` + "\n"
 	ws := scanSelfLiteral(src, "/mesh/bar")
 	require.Len(t, ws, 1)
 }
 
 func TestScanSelfLiteral_HTMLCommentNotFlagged(t *testing.T) {
-	// English prose inside an HTML comment is not an identifier reference.
-	src := `<!-- Mount point for the React kanban app -->` + "\n"
+	// Usage documented in a comment is prose, not a real call site.
+	src := `<!-- Render with {{ yield kanban() }} from any note. -->` + "\n"
 	ws := scanSelfLiteral(src, "/kanban")
 	require.Empty(t, ws)
 }
 
-func TestScanSelfLiteral_AbsoluteURLNotFlagged(t *testing.T) {
-	// kanban.js is the fixed release-asset name of a separate upstream repo;
-	// it must not be flagged as if it should track this layout's own name.
-	src := `<script src="https://github.com/trip2g/kanban_template/releases/latest/download/kanban.js"></script>` + "\n"
+func TestScanSelfLiteral_RealViolationStillCaughtNearComments(t *testing.T) {
+	src := `<!-- Render with {{ yield kanban() }} from any note. -->` + "\n" +
+		`{{ block kanban() }}` + "\n"
 	ws := scanSelfLiteral(src, "/kanban")
-	require.Empty(t, ws)
-}
-
-func TestScanSelfLiteral_RealViolationStillCaughtNearCommentsAndURLs(t *testing.T) {
-	src := `<!-- Mount point for the React kanban app -->` + "\n" +
-		`document.querySelector('.kanban__nav')` + "\n" +
-		`.kanban { color: red; }` + "\n"
-	ws := scanSelfLiteral(src, "/kanban")
-	require.Len(t, warnLines(t, ws, "@did"), 2)
-}
-
-func TestScanSelfLiteral_BEMCompoundStillNotFlagged(t *testing.T) {
-	// "kanban-header-right" — single dash, not a BEM boundary — must stay clean.
-	src := `.kanban-header-right { display: flex; }` + "\n"
-	ws := scanSelfLiteral(src, "/kanban")
-	require.Empty(t, ws)
-}
-
-func TestScanSelfLiteral_URLCarveOutScopedToToken(t *testing.T) {
-	// The URL carve-out must apply to the URL token only, not blank out the
-	// whole line: a real violation sharing a line with a URL is still caught.
-	src := `<script src="https://github.com/trip2g/kanban_template/releases/latest/download/kanban.js"></script><div class="kanban"></div>` + "\n"
-	ws := scanSelfLiteral(src, "/kanban")
-	require.Len(t, ws, 1)
-	require.Contains(t, ws[0].Message, "line 1")
-	require.Contains(t, ws[0].Message, "this file's @did")
+	require.Len(t, warnLines(t, ws, "@lid"), 1)
 }
 
 func TestScanSelfLiteral_Clean(t *testing.T) {
@@ -166,14 +118,14 @@ func TestLoad_SurfacesSelfLiteralWarning(t *testing.T) {
 	sources := []model.LayoutSourceFile{{
 		ID:      "/mesh/bar",
 		Path:    "_layouts/mesh/bar.html",
-		Content: `{{ block @lid() }}<div class="mesh-bar__nav"></div>{{ end }}`,
+		Content: `{{ block mesh_bar() }}<div class="@did__nav"></div>{{ end }}`,
 	}}
 	env := &testEnv{logger: &logger.TestLogger{}}
 	layouts, err := Load(env, sources, Options{})
 	require.NoError(t, err)
 	got := layouts.Map["/mesh/bar"].Warnings
 	require.NotEmpty(t, got)
-	require.Contains(t, got[0].Message, `literal "mesh-bar"`)
+	require.Contains(t, got[0].Message, `literal "mesh_bar"`)
 }
 
 func TestLoadPreview_SelfLiteralWarning(t *testing.T) {
@@ -184,13 +136,13 @@ func TestLoadPreview_SelfLiteralWarning(t *testing.T) {
 	main := model.LayoutSourceFile{
 		ID:      "/mesh/bar",
 		Path:    "_layouts/mesh/bar.html",
-		Content: `{{ block @lid() }}<div class="mesh-bar__nav"></div>{{ end }}`,
+		Content: `{{ block mesh_bar() }}<div class="@did__nav"></div>{{ end }}`,
 	}
 	_, warnings := layouts.LoadPreview(main, nil)
 
 	var found bool
 	for _, w := range warnings {
-		if strings.Contains(w, `literal "mesh-bar"`) {
+		if strings.Contains(w, `literal "mesh_bar"`) {
 			found = true
 		}
 	}


### PR DESCRIPTION
The onboarding vault ships `_layouts/rss.html`, and every sync of it produced:

```
layout /rss.html line 1: literal "rss" matches this file's @did; replace with @did so renames keep working
```

That's the RSS 2.0 root element `<rss version="2.0">`, not a reference to the layout's own name — and taking the advice would emit `<mysite-feed>` and break the feed.

The false positive isn't specific to rss. `@did` expands the layout's path to a dash id, which in HTML is just an ordinary word, so **any layout named after an element flags its own markup**: `table.html` on `<table …>`, `main.html`, `nav.html`, `header.html`, `article.html`, `section.html`, `form.html`.

Removed the `@did` branch of `scanSelfLiteral`; `@lid` (Jet block names, matched only in call/definition forms) is unaffected and still catches the drift it was built for. The `@did` placeholder itself expands exactly as before — `docs/en/user/bem.md` stays accurate, and the `.@did__x` classes throughout `docs/_layouts/mesh/*.html` keep working.

Two follow-on cleanups, both consequences of the removal:

- the absolute-URL carve-out in `skipRanges` only existed because a did could match inside a URL (`…/download/kanban.js` for a `/kanban` layout). No `@lid` form can appear there, so it's gone along with its two tests.
- with one placeholder kind left, the per-kind dedupe key and sort collapse to "one warning per line".

Reproduced against the real `onboarding-vault/_layouts/rss.html` before and after: one warning → zero. `go build ./...` and the full `go test ./internal/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)