### PR TITLE
fix(rendernotepage): answer 401/403 for closed notes instead of 200

### DIFF
--- a/internal/case/rendernotepage/endpoint.go
+++ b/internal/case/rendernotepage/endpoint.go
@@ -134,6 +134,7 @@ func (e Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 			// Sign-in wall: render auth form instead of content
 			layoutParams.MetaRobots = "noindex, nofollow"
 			ctx.Response.Header.Set("Cache-Control", "no-store")
+			ctx.SetStatusCode(wallStatusCode(resp))
 
 			dtCtx := buildDefaultTemplateCtx(req, layoutParams, resp, env)
 			dtCtx.SigninWallError = &defaulttemplate.SigninWallError{
@@ -146,6 +147,8 @@ func (e Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 		var paywallErr *PaywallError
 		if errors.As(err, &paywallErr) {
 			layoutParams.MetaRobots = "noindex, nofollow"
+			ctx.Response.Header.Set("Cache-Control", "no-store")
+			ctx.SetStatusCode(wallStatusCode(resp))
 
 			dtCtx := buildDefaultTemplateCtx(req, layoutParams, resp, env)
 			dtCtx.PaywallError = &defaulttemplate.PaywallError{
@@ -242,6 +245,18 @@ func handleContentTypeNote(ctx *fasthttp.RequestCtx, env Env, resp *Response, la
 	}
 	ctx.SetBodyString(mdchunk.StripFrontmatter(string(resp.Note.Content)))
 	return true, nil
+}
+
+// wallStatusCode maps a sign-in wall / paywall render onto the HTTP status that
+// describes it, so a client learns the note was withheld without parsing the
+// HTML: 401 while nobody is signed in, 403 once a signed-in viewer is simply
+// not entitled to this note. The wall page is served as the response body in
+// both cases.
+func wallStatusCode(resp *Response) int {
+	if resp == nil || resp.UserToken == nil {
+		return http.StatusUnauthorized
+	}
+	return http.StatusForbidden
 }
 
 func unsupportedFileExt(path string) string {

--- a/internal/case/rendernotepage/wall_status_test.go
+++ b/internal/case/rendernotepage/wall_status_test.go
@@ -1,0 +1,97 @@
+package rendernotepage_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"trip2g/internal/model"
+	"trip2g/internal/usertoken"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A closed note used to answer 200 OK with the wall page, so a client had to
+// parse the HTML to tell "here is the note" from "you cannot read this note".
+// The wall pages still render in full — only the status line changes:
+//
+//	401 — nobody is signed in (sign-in wall, or paywall hit anonymously)
+//	403 — signed in, but this viewer has no access to the note
+//
+// Cache-Control: no-store and noindex, nofollow stay on both walls.
+func TestWallPagesAnswerWithAccessStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      func(note *model.NoteView)
+		token      *usertoken.Data
+		canRead    bool
+		wantStatus int
+		wantMarker string
+	}{
+		{
+			name:       "anonymous + non-free note -> 401",
+			setup:      func(note *model.NoteView) { note.Free = false },
+			wantStatus: http.StatusUnauthorized,
+			wantMarker: "paywall",
+		},
+		{
+			name: "anonymous + require_signin subgraph -> 401",
+			setup: func(note *model.NoteView) {
+				note.Subgraphs = map[string]*model.NoteSubgraph{
+					"members": {Name: "members", RequireSignin: true},
+				}
+			},
+			wantStatus: http.StatusUnauthorized,
+			wantMarker: "signinwall",
+		},
+		{
+			name:       "signed in without access -> 403",
+			token:      &usertoken.Data{ID: 1, Role: "user"},
+			canRead:    false,
+			wantStatus: http.StatusForbidden,
+			wantMarker: "paywall",
+		},
+		{
+			name:       "signed in with access -> 200",
+			token:      &usertoken.Data{ID: 1, Role: "user"},
+			canRead:    true,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "anonymous + free note -> 200",
+			canRead:    true,
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			note, views := cacheTestNote()
+			if tt.setup != nil {
+				tt.setup(note)
+			}
+			env, _, _ := cacheTestEnv(views, nil)
+			env.CanReadNoteFunc = func(context.Context, *model.NoteView) (bool, error) {
+				return tt.canRead, nil
+			}
+
+			ctx := newReqCtx(reqOpts{})
+			runHandle(t, env, ctx, tt.token)
+
+			require.Equal(t, tt.wantStatus, ctx.Response.StatusCode())
+
+			if tt.wantStatus == http.StatusOK {
+				require.NotEqual(t, "no-store", string(ctx.Response.Header.Peek("Cache-Control")))
+				return
+			}
+
+			require.Equal(t, "no-store", string(ctx.Response.Header.Peek("Cache-Control")),
+				"a closed page must never be stored")
+
+			html := string(body(t, ctx))
+			require.Contains(t, html, `name="robots" content="noindex, nofollow"`)
+			require.Contains(t, html, tt.wantMarker, "the wall page itself is still rendered")
+			require.NotContains(t, html, "<h1>Test</h1>", "the note body stays hidden")
+		})
+	}
+}


### PR DESCRIPTION
## Problem

A GET of a closed note answered **200 OK** with the paywall / sign-in wall page. The status line said "here is the note" while the body said "you cannot read this note", so any client — monitoring, an agent, a link checker — had to parse the HTML (`id="paywall"`) to learn the note was actually withheld.

## Fix

`rendernotepage.Resolve` already distinguishes the two wall cases; the endpoint rendered both without touching the status code (still the 200 preset at the top of `Handle`). It now sets the status that matches the access state:

| Case | Status |
|---|---|
| Note readable | `200 OK` |
| Nobody signed in (sign-in wall, or paywall hit anonymously) | `401 Unauthorized` |
| Signed in, but not entitled to this note | `403 Forbidden` |
| Note does not exist | `404 Not Found` (unchanged) |

The wall page is still rendered in full as the response body, so the sign-in form and the offers UI are unaffected — only the status line changes.

`Cache-Control: no-store` was set on the sign-in wall but **not** on the paywall; it is now on both. `noindex, nofollow` stays on both.

402 Payment Required was considered for the paid case and skipped: 401/403 describe access control more precisely and are far better supported by clients.

## Notes

- The page cache is unaffected — wall pages never reach it (`cacheDecision` and the early fast path each gate on `Free` / `RequireSignin` / `CanReadNote` independently), and `fillPageCache` already refuses any non-200 response.
- One behavior change worth knowing: link unfurlers that require a 2xx will no longer render a preview card for a shared paid note. The OG tags are still emitted on the wall page, so unfurlers that follow the body regardless are fine.

## Tests

`wall_status_test.go` drives the real endpoint over all five states (anonymous non-free, anonymous `require_signin`, signed-in-without-access, signed-in-with-access, anonymous free), asserting status, `Cache-Control`, `noindex, nofollow`, that the wall page still renders, and that the note body stays hidden. Written red first (all three wall cases returned 200), then fixed.

`go test ./...` passes.