### PR TITLE
fix(test-sync-cli): tolerate the demo vault's deliberately broken layout

### DIFF
--- a/scripts/test-sync-cli.sh
+++ b/scripts/test-sync-cli.sh
@@ -103,6 +103,25 @@ log_section() {
     echo -e "${YELLOW}════════════════════════════════════════════════════════════${NC}"
 }
 
+# docs/demo intentionally ships _layouts/broken-layout.html with a Jet parse
+# error, rendered by broken_layout_test.md to prove layout errors surface to
+# admins rather than silently breaking a page. Since #260 the CLI exits
+# non-zero on any CRITICAL warning, which aborts this suite on its very first
+# sync. That one fixture is tolerated here; a CRITICAL from anything else still
+# fails the run.
+EXPECTED_CRITICAL_PATHS='broken_layout_test.md _layouts/broken-layout.html'
+
+# Reads CLI output on stdin. Succeeds only when at least one CRITICAL was
+# reported and every one of them belongs to an expected fixture path.
+only_expected_criticals() {
+    sed 's/\x1b\[[0-9;]*m//g' | awk -v expected="$EXPECTED_CRITICAL_PATHS" '
+        BEGIN { split(expected, e, " "); for (i in e) ok[e[i]] = 1 }
+        /^  [^ ]/ { path = $0; sub(/^  /, "", path) }
+        /^    \[CRITICAL\]/ { seen++; if (!(path in ok)) unexpected++ }
+        END { exit (seen > 0 && unexpected == 0) ? 0 : 1 }
+    '
+}
+
 # Compare or update golden snapshot for a sync-updates file
 assert_sync_snapshot() {
     local out_file="$1"
@@ -139,8 +158,13 @@ sync_vault() {
 
     log_info "Syncing $(basename $vault)... (→ $out_file)"
     cd "$OBSIDIAN_SYNC_DIR"
-    local sync_exit=0
-    npx tsx src/sync/cli/cmd.ts --folder "$vault" --api-key "$API_KEY" --api-url "$ENDPOINT" --two-way --updated-output "$out_file" $extra_args 2>&1 || sync_exit=$?
+    local sync_exit=0 output
+    output=$(npx tsx src/sync/cli/cmd.ts --folder "$vault" --api-key "$API_KEY" --api-url "$ENDPOINT" --two-way --updated-output "$out_file" $extra_args 2>&1) || sync_exit=$?
+    printf '%s\n' "$output"
+    if [ "$sync_exit" -ne 0 ] && printf '%s\n' "$output" | only_expected_criticals; then
+        log_info "Tolerated expected CRITICAL from the deliberately broken demo layout"
+        sync_exit=0
+    fi
     assert_sync_snapshot "$out_file"
     return $sync_exit
 }
@@ -153,8 +177,11 @@ sync_vault_quiet() {
     local out_file="$SYNC_UPDATES_DIR/$(printf '%02d' $SYNC_STEP)-$(basename $vault).json"
 
     cd "$OBSIDIAN_SYNC_DIR"
-    local sync_exit=0
-    npx tsx src/sync/cli/cmd.ts --folder "$vault" --api-key "$API_KEY" --api-url "$ENDPOINT" --two-way --updated-output "$out_file" $extra_args > /dev/null 2>&1 || sync_exit=$?
+    local sync_exit=0 output
+    output=$(npx tsx src/sync/cli/cmd.ts --folder "$vault" --api-key "$API_KEY" --api-url "$ENDPOINT" --two-way --updated-output "$out_file" $extra_args 2>&1) || sync_exit=$?
+    if [ "$sync_exit" -ne 0 ] && printf '%s\n' "$output" | only_expected_criticals; then
+        sync_exit=0
+    fi
     assert_sync_snapshot "$out_file"
     return $sync_exit
 }


### PR DESCRIPTION
`./scripts/test-sync-cli.sh` has been unable to complete since 18 July.

`docs/demo/_layouts/broken-layout.html` contains `{{ some_unclosed_tag` on purpose — `broken_layout_test.md` renders it to prove layout errors surface to admins instead of silently breaking a page. Both have shipped in the demo vault for a long time.

Then #260 (`afced2cf`, 18 Jul) made the sync CLI exit non-zero on any `CRITICAL` warning, and layout parse errors are `CRITICAL`. Combined with `set -e` and `sync_vault` returning the CLI's exit code, the suite now dies on its very first sync.

The visible symptom is misleading:

```
📎 Published:
💾 Saved to tmp/sync-updates/01-testvault0.json
❌ Critical warnings detected, aborting.
✓ Snapshot match: 01-testvault0.json
✗ CLI sync tests failed
```

The sync succeeded and the snapshot matched — the run failed *after* that, on the fixture. Worth noting because it looks like stale snapshots: `testdata/sync-updates/` holds 18 goldens (last regenerated 7 Jul, `c3d6727b`) but only `01` is ever produced now. The other 17 aren't stale, they're unreachable.

This tolerates that one fixture and nothing else. `only_expected_criticals` parses the CLI's grouped output, associates each `[CRITICAL]` line with its file, and lets the run continue only when every critical belongs to `broken_layout_test.md` or `_layouts/broken-layout.html`. A critical from any other file — or the known one plus a new one — still fails the run, so the signal #260 added is preserved.

**Verification.** The matcher is unit-checked against the exact output format `cmd.ts` prints (`  <path>` then `    [LEVEL] <message>`, ANSI included):

| input | result |
|---|---|
| only the known broken layout | tolerate |
| known layout by its `_layouts/` path | tolerate |
| a different note goes critical | fail run |
| known critical + a new one | fail run |

I could **not** run the suite end to end — it needs `--api-key` and a server on `:8081`, which isn't up here. So the tolerance path is verified against the CLI's print format, not against a live run. If the server attributes the warning to some third path, the run will still fail and the output will name it — a one-line addition to `EXPECTED_CRITICAL_PATHS`.

Once it completes, the 17 never-exercised snapshots get compared for the first time since July; anything that genuinely drifted can be refreshed with `./scripts/test-sync-cli.sh -k <key> --update-snapshots`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)