### PR TITLE
fix(onboarding-vault): ship AGENTS.md and CLAUDE.md in the downloaded vault

### DIFF
--- a/internal/case/downloadonboardingvault/resolve_test.go
+++ b/internal/case/downloadonboardingvault/resolve_test.go
@@ -34,6 +34,7 @@ func testVaultZip() []byte {
 
 	files := []struct{ name, content string }{
 		{oldPrefix + "_index.md", "# Welcome\n\n{{publicUrl}}\n"},
+		{oldPrefix + "AGENTS.md", "# Agent context\n\n{{publicUrl}}/_system/git\n"},
 		{oldPrefix + ".obsidian/app.json", "{}"},
 	}
 
@@ -115,6 +116,39 @@ func TestResolve_IndexMDContainsPublicURL(t *testing.T) {
 	require.NotEmpty(t, indexContent, "_index.md should exist in zip")
 	require.Contains(t, indexContent, "https://example.com", "_index.md should contain publicURL")
 	require.NotContains(t, indexContent, "{{publicUrl}}", "_index.md should not contain placeholder")
+}
+
+// AGENTS.md is the agent's only entry point into the vault: it must ship and
+// point at the real instance.
+func TestResolve_AgentsMDContainsPublicURL(t *testing.T) {
+	env := &mockEnv{publicURL: "https://example.com"}
+
+	zipData, err := Resolve(context.Background(), env, 1, false, "example.com")
+	require.NoError(t, err)
+
+	reader, err := zip.NewReader(bytes.NewReader(zipData), int64(len(zipData)))
+	require.NoError(t, err)
+
+	var agentsContent string
+	for _, file := range reader.File {
+		if file.Name != "example.com/AGENTS.md" {
+			continue
+		}
+
+		rc, openErr := file.Open()
+		require.NoError(t, openErr)
+
+		content, readErr := io.ReadAll(rc)
+		rc.Close()
+		require.NoError(t, readErr)
+
+		agentsContent = string(content)
+		break
+	}
+
+	require.NotEmpty(t, agentsContent, "AGENTS.md should exist in zip")
+	require.Contains(t, agentsContent, "https://example.com")
+	require.NotContains(t, agentsContent, "{{publicUrl}}")
 }
 
 func TestResolve_EnableAdminGraphQL(t *testing.T) {

--- a/onboarding-vault/AGENTS.md
+++ b/onboarding-vault/AGENTS.md
@@ -4,7 +4,13 @@ subgraph: private
 
 # Agent context
 
-Publishing platform: Obsidian vault → website. Sync via Obsidian plugin, CLI, or Git.
+## Where you are
+
+This folder is a **local Obsidian vault** — plain Markdown files on disk — paired with a live trip2g site at {{publicUrl}}. The files here are what you edit; the site is what readers see. Three things follow from that:
+
+- **Nothing is live until you sync.** Editing a file changes nothing on the site; publishing is an explicit step — see [Sync](#sync). The same files are also open in Obsidian on the user's machine, so treat them as shared state.
+- **Synced notes become searchable.** Published notes are indexed for vector search (RAG) through the `my-trip2g-instance` MCP server — `search` → `note_html`. A note you never synced does not exist for it.
+- **Managing the site needs the user's consent.** Admin GraphQL is off by default. If a task requires it (subgraphs, API keys, settings), ask the user to enable it — see [Enable admin GraphQL](#enable-admin-graphql). Check whether you already have it by looking for the introspection tool on `my-trip2g-instance`; don't assume.
 
 ## Quick start (for an agent)
 
@@ -143,7 +149,7 @@ Full guide: search `trip2g-docs-public-hub` for **Git Access**.
 
 ## Enable admin GraphQL
 
-To manage the site via agent, enable **"Execute admin GraphQL"** for your API key:
+Managing the site (subgraphs, keys, settings) requires **"Execute admin GraphQL"** on the API key. It is off unless the user turned it on at download time — an agent cannot grant it to itself, so ask the user to open the link below:
 
 [Open API key settings]({{publicUrl}}/admin#!nav=integrations/integrations_nav=apikeys/id=key1) → Enable Admin GraphQL
 

--- a/onboarding-vault/AGENTS.md
+++ b/onboarding-vault/AGENTS.md
@@ -8,7 +8,7 @@ Publishing platform: Obsidian vault → website. Sync via Obsidian plugin, CLI, 
 
 ## Quick start (for an agent)
 
-- **Publish / first sync:** run `node .obsidian/plugins/trip2g/trip2g-sync.mjs --folder .` from the vault root — every note becomes a page; `_index.md` is the homepage.
+- **Publish / first sync:** run `node .obsidian/plugins/trip2g/trip2g-sync.mjs --folder .` from the vault root — no flags or credentials needed, they are read from `.obsidian/plugins/trip2g/data.json`. Every note becomes a page; `_index.md` is the homepage.
 - **Edit content:** notes are plain Markdown files in this folder; edit them, then sync.
 - **Manage the site:** call admin GraphQL / search via the `my-trip2g-instance` MCP server (`.mcp.json`).
 

--- a/onboarding-vault/CLAUDE.md
+++ b/onboarding-vault/CLAUDE.md
@@ -1,0 +1,15 @@
+---
+subgraph: private
+---
+
+# trip2g vault
+
+This vault's agent guide lives in `AGENTS.md`, at the vault root. Read it first — it covers the publishing model, the sync CLI, git access, and the MCP tools configured in `.mcp.json`.
+
+Publish everything you changed:
+
+```bash
+node .obsidian/plugins/trip2g/trip2g-sync.mjs --folder .
+```
+
+Run it from the vault root — credentials are read automatically from `.obsidian/plugins/trip2g/data.json`.

--- a/onboarding-vault/generate.sh
+++ b/onboarding-vault/generate.sh
@@ -30,14 +30,16 @@ vault_dir = repo_root / "onboarding-vault"
 out_zip   = vault_dir / "vault.zip"
 
 EXCLUDE = {
-    vault_dir / "embed.go",
     vault_dir / "generate.sh",
     vault_dir / "vault.zip",
     vault_dir / ".obsidian" / "workspace.json",
     # data.json contains real credentials — never bundle
     vault_dir / ".obsidian" / "plugins" / "trip2g" / "data.json",
-    vault_dir / "AGENTS.md",
 }
+
+# Directories that may appear inside the vault while working on the repo but
+# are not vault content.
+EXCLUDE_DIRS = {".omc", ".git", "node_modules"}
 
 FIXED_DATE = (2024, 1, 1, 0, 0, 0)
 
@@ -45,7 +47,11 @@ entries = sorted(vault_dir.rglob("*"))
 
 with zipfile.ZipFile(out_zip, "w", compression=zipfile.ZIP_DEFLATED) as zf:
     for path in entries:
-        if path in EXCLUDE:
+        # Go sources (embed.go, embed_dev.go, tests) are build machinery and
+        # must not land in the user's Obsidian vault.
+        if path in EXCLUDE or path.suffix == ".go":
+            continue
+        if EXCLUDE_DIRS & set(path.relative_to(vault_dir).parts):
             continue
         rel = path.relative_to(repo_root)
         hidden = 0x02 if path.name.startswith(".") else 0   # FILE_ATTRIBUTE_HIDDEN for dotfiles (Windows)

--- a/onboarding-vault/vault_test.go
+++ b/onboarding-vault/vault_test.go
@@ -1,0 +1,51 @@
+package onboardingvault
+
+import (
+	"archive/zip"
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestZipContents guards the packaging rules of generate.sh: the agent guide
+// and the sync CLI must ship, build machinery and credentials must not.
+func TestZipContents(t *testing.T) {
+	if len(ZipData) == 0 {
+		t.Skip("vault.zip not built — run go generate ./onboarding-vault/...")
+	}
+
+	reader, err := zip.NewReader(bytes.NewReader(ZipData), int64(len(ZipData)))
+	require.NoError(t, err)
+
+	names := make(map[string]bool, len(reader.File))
+	for _, file := range reader.File {
+		names[file.Name] = true
+	}
+
+	required := []string{
+		"onboarding-vault/AGENTS.md",
+		"onboarding-vault/CLAUDE.md",
+		"onboarding-vault/.obsidian/plugins/trip2g/trip2g-sync.mjs",
+		"onboarding-vault/.obsidian/plugins/trip2g/main.js",
+		"onboarding-vault/.obsidian/community-plugins.json",
+	}
+	for _, name := range required {
+		require.True(t, names[name], "%s must be bundled", name)
+	}
+
+	forbidden := []string{
+		"onboarding-vault/generate.sh",
+		"onboarding-vault/vault.zip",
+		// data.json is written per download with real credentials
+		"onboarding-vault/.obsidian/plugins/trip2g/data.json",
+	}
+	for _, name := range forbidden {
+		require.False(t, names[name], "%s must not be bundled", name)
+	}
+
+	for name := range names {
+		require.False(t, strings.HasSuffix(name, ".go"), "build machinery %s must not be bundled", name)
+	}
+}


### PR DESCRIPTION
## Problem

An agent unpacking the onboarding vault has no idea how to sync — it never sees the sync instructions.

`generate.sh` explicitly excluded `AGENTS.md` from `vault.zip`, so the downloaded vault shipped **zero** agent instructions. The only guide left in the archive was a stale `CLAUDE.md` that pointed at the (absent) `AGENTS.md`, and that file no longer exists in the working tree either — so the next regeneration would have dropped even the dangling pointer.

Side effect: the `{{publicUrl}}` substitution for `AGENTS.md` in `downloadonboardingvault/resolve.go` was dead code, since the file was never in the archive.

## Changes

- `generate.sh`: stop excluding `AGENTS.md`; exclude all `*.go` (build machinery) instead of listing `embed.go` by hand, and skip `.omc`/`.git`/`node_modules` — a stray `.omc/state/sessions/...` was leaking into the archive.
- Restore `onboarding-vault/CLAUDE.md` so Claude Code auto-loads a pointer to `AGENTS.md` plus the one-line sync command.
- `AGENTS.md` quick start now states that credentials come from `.obsidian/plugins/trip2g/data.json` — no flags needed.

## Tests

- `onboarding-vault/vault_test.go` (new): asserts the archive ships `AGENTS.md`, `CLAUDE.md` and the sync CLI, and never ships `*.go`, `generate.sh` or the credential `data.json`. Red before the fix.
- `resolve_test.go`: covers the previously untested `AGENTS.md` `{{publicUrl}}` substitution.

Verified end-to-end: unpacked the regenerated zip, dropped in a `data.json`, and `node .obsidian/plugins/trip2g/trip2g-sync.mjs --folder . --dry-run` picked up the credentials and classified all 10 notes with no flags.