### PR TITLE
test(agenttest): agent comprehension harness for the onboarding vault

### DIFF
--- a/docker-compose.agenttest.yml
+++ b/docker-compose.agenttest.yml
@@ -1,0 +1,49 @@
+name: trip2g_agenttest
+
+# Minimal stack for e2e/agenttest/run.sh: a single app instance, nothing else.
+# Deliberately not docker-compose.test.yml — the agent test needs a clean
+# instance with no seeded notes, and none of the replicas, peers, MinIO, Dex,
+# fleet or the 2.3 GB embedding model. Vector search stays off; MCP `search`
+# falls back to full-text retrieval, which is what this test needs.
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: trip2g-agenttest-app
+    ports:
+      - "20181:20181"
+      - "20182:20182"
+    environment:
+      - LISTEN_ADDR=0.0.0.0:20181
+      - INTERNAL_LISTEN_ADDR=:20182
+      - DB_FILE=/data/data.sqlite3
+      # Local filesystem storage — the agent test needs no MinIO.
+      - STORAGE_BACKEND=local
+      - STORAGE_LOCAL_DIR=/data/storage
+      - DEV=true # sign in code 111111
+      - MAX_ACTIVE_SIGNIN_CODES=999
+      - LOG_SIGN_IN_CODES=true # no SMTP in this stack
+      - LOG_LEVEL=info
+      - OWNER_EMAIL=hello@example.com
+      - SHUTDOWN_GRACE_PERIOD=1ms
+      - SHUTDOWN_TIMEOUT=1ms
+      - PUBLIC_URL=http://localhost:20181
+      - JWT_SECRET=agenttest-secret-key-do-not-use-in-production
+      - USER_TOKEN_COOKIE_NAME=trip2g_agenttest
+      - MAIL_FROM=agenttest@example.com
+    volumes:
+      # A named volume, not a bind mount: the container writes /data as root, and
+      # a root-owned tmp/agenttest/data in the repo breaks `go build ./...`.
+      # `docker compose down -v` disposes of it with the stack.
+      - agenttest-data:/data
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:20182/healthz"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+
+volumes:
+  agenttest-data:

--- a/e2e/agenttest/README.md
+++ b/e2e/agenttest/README.md
@@ -1,0 +1,66 @@
+# Agent comprehension test
+
+Does an agent dropped into a freshly downloaded onboarding vault, with no hints
+in the prompt, figure out where it is and how to work with the site?
+
+```bash
+./e2e/agenttest/run.sh                      # sonnet, all scenarios
+./e2e/agenttest/run.sh --model haiku        # can a cheaper model do it?
+./e2e/agenttest/run.sh --scenario search    # one scenario
+./e2e/agenttest/run.sh --keep               # leave the instance up for poking
+```
+
+Requires `docker compose`, `node`, `jq`, `unzip` and the `claude` CLI. It costs
+real tokens, so it is not part of `make test` or the Playwright suite — run it
+when the vault's `AGENTS.md`, `CLAUDE.md` or `.mcp.json` change.
+
+## What it does
+
+1. Boots `docker-compose.agenttest.yml` — one app, local file storage, no MinIO,
+   no vector search, no seeded notes.
+2. Signs in as the owner and downloads the vault through the real
+   `/_system/onboarding-vault` endpoint, so a packaging regression fails the test.
+3. Downloads a **second** vault and uses it to publish `deploy-policy.md`. That
+   fact then exists only on the server — the agent's own vault does not contain
+   it, so it cannot be answered by grepping local files.
+4. Runs each scenario with `claude -p --output-format stream-json` inside the
+   unpacked vault, then asserts over the transcript.
+
+## Scenarios
+
+| Scenario | Prompt | Assertion |
+|---|---|---|
+| `publish` | create a note and make it visible on the site | invoked `trip2g-sync.mjs`; the note is live at `/release-checklist` |
+| `orientation` | "what is this folder?" | judge: local files, not live until synced |
+| `search` | "what is the deploy freeze window?" | answer quotes `14:00-16:00 UTC`; went through the MCP server |
+| `admin` | "make bob@example.com an administrator" | judge: asks for admin GraphQL instead of claiming success |
+
+Two scenarios assert on tool calls and live site state, which is deterministic.
+The other two are about understanding, so they use a cheap LLM judge
+(`--judge-model`, default `haiku`) — expect occasional disagreement there and
+read `tmp/agenttest/logs/*.jsonl` before believing a single failure.
+
+## Caveats
+
+- **The runner aborts instead of scoring a broken run.** If `claude -p` never
+  reaches the model (no credits, auth problem, rate limit) the transcript's
+  result event carries the error, and `run.sh` stops with `Cannot score this
+  run` rather than reporting a comprehension failure that never happened. The
+  same applies when the judge itself fails to answer PASS/FAIL.
+- **Your own global config leaks into the agent under test.** The test agent
+  runs as you, so `~/.claude/settings.json` hooks and `~/.claude/CLAUDE.md` load
+  into its session — visible as `SessionStart` hook events in the transcripts.
+  MCP is pinned with `--strict-mcp-config`, but settings are not, so results are
+  not comparable across machines with different global setups.
+- `ANTHROPIC_API_KEY` in your environment takes precedence over a claude.ai
+  login, so the run is billed to whichever of the two the CLI picks.
+
+## Notes
+
+- The agent runs with `--dangerously-skip-permissions` because headless runs
+  cannot answer permission prompts. Its cwd is a throwaway directory under
+  `tmp/agenttest/`, and the instance it talks to is the disposable container.
+- `--strict-mcp-config` pins MCP to the vault's own `.mcp.json`, so your personal
+  MCP servers never leak into the test.
+- Scenario `admin` depends on admin GraphQL being **off**, which is the default
+  for a vault downloaded without `?enable_admin_graphql`.

--- a/e2e/agenttest/check.mjs
+++ b/e2e/agenttest/check.mjs
@@ -1,0 +1,156 @@
+// Assertions over a `claude -p --output-format stream-json` transcript.
+//
+// The point of the agent test is to assert on what the agent DID (tool calls,
+// live site state), not on how it phrased things. Only the two scenarios that
+// are genuinely about understanding fall back to an LLM judge.
+//
+// Usage:
+//   node check.mjs tools <transcript.jsonl>
+//   node check.mjs final <transcript.jsonl>
+//   node check.mjs assert-tool <transcript.jsonl> <regex>      # tool name or its input
+//   node check.mjs assert-no-tool <transcript.jsonl> <regex>
+//   node check.mjs assert-final <transcript.jsonl> <regex>
+//   node check.mjs judge <transcript.jsonl> <criterion> [model]
+import fs from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+function readTranscript(file) {
+  const toolUses = [];
+  let finalText = '';
+  let runError = '';
+  const assistantTexts = [];
+
+  for (const line of fs.readFileSync(file, 'utf8').split('\n')) {
+    if (!line.trim()) continue;
+
+    let event;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      continue; // stream-json can be interleaved with stray output
+    }
+
+    if (event.type === 'result') {
+      if (typeof event.result === 'string') finalText = event.result;
+      // A run that never reached the model (auth, credits, rate limit) must not
+      // be scored as a comprehension failure.
+      if (event.is_error === true || (event.subtype && event.subtype !== 'success')) {
+        runError = typeof event.result === 'string' ? event.result : event.subtype;
+      }
+    }
+
+    for (const block of event.message?.content ?? []) {
+      if (block.type === 'tool_use') {
+        toolUses.push({ name: block.name, input: JSON.stringify(block.input ?? {}) });
+      }
+      if (block.type === 'text' && event.type === 'assistant') {
+        assistantTexts.push(block.text);
+      }
+    }
+  }
+
+  // A run killed by --max-turns emits no result event; the last assistant
+  // message is still the best available answer.
+  if (!finalText) finalText = assistantTexts.at(-1) ?? '';
+
+  return { toolUses, finalText, runError };
+}
+
+function matchesTool({ toolUses }, pattern) {
+  const re = new RegExp(pattern, 'i');
+  return toolUses.some((t) => re.test(t.name) || re.test(t.input));
+}
+
+function judge(transcript, criterion, model) {
+  const prompt = [
+    'You are grading one answer produced by another AI agent. Be strict but fair.',
+    '',
+    `CRITERION: ${criterion}`,
+    '',
+    'ANSWER:',
+    '"""',
+    transcript.finalText,
+    '"""',
+    '',
+    'Reply with exactly PASS or FAIL on the first line, then one short sentence of justification.',
+  ].join('\n');
+
+  const res = spawnSync('claude', ['-p', prompt, '--model', model], { encoding: 'utf8' });
+  const out = (res.stdout || '').trim();
+
+  // Distinguish "the judge could not run" from "the judge said FAIL" — only the
+  // latter is a verdict about the agent.
+  if (res.status !== 0 || !/^\s*(PASS|FAIL)\b/i.test(out)) {
+    return { broken: true, reason: `judge unusable: ${out || (res.stderr || '').trim()}` };
+  }
+
+  return { pass: /^\s*PASS\b/i.test(out), reason: out.split('\n').slice(0, 2).join(' ') };
+}
+
+const [command, file, arg, arg2] = process.argv.slice(2);
+
+if (!command || !file) {
+  console.error('usage: node check.mjs <command> <transcript.jsonl> [args]');
+  process.exit(2);
+}
+
+const transcript = readTranscript(file);
+
+// Exit code 3 means "this run cannot be scored", which the runner reports
+// separately from a genuine assertion failure.
+const EXIT_UNSCORABLE = 3;
+
+if (transcript.runError && command !== 'final') {
+  console.log(`RUN FAILED: ${transcript.runError.split('\n')[0]}`);
+  process.exit(EXIT_UNSCORABLE);
+}
+
+switch (command) {
+  case 'status': {
+    console.log('run completed');
+    break;
+  }
+
+  case 'tools': {
+    const names = [...new Set(transcript.toolUses.map((t) => t.name))];
+    console.log(names.join(', ') || '(none)');
+    break;
+  }
+
+  case 'final': {
+    console.log(transcript.finalText);
+    break;
+  }
+
+  case 'assert-tool': {
+    const ok = matchesTool(transcript, arg);
+    console.log(ok ? `ok: used ${arg}` : `MISS: never used ${arg}`);
+    process.exit(ok ? 0 : 1);
+  }
+
+  case 'assert-no-tool': {
+    const ok = !matchesTool(transcript, arg);
+    console.log(ok ? `ok: avoided ${arg}` : `UNEXPECTED: used ${arg}`);
+    process.exit(ok ? 0 : 1);
+  }
+
+  case 'assert-final': {
+    const ok = new RegExp(arg, 'i').test(transcript.finalText);
+    console.log(ok ? `ok: answer matches /${arg}/` : `MISS: answer does not match /${arg}/`);
+    process.exit(ok ? 0 : 1);
+  }
+
+  case 'judge': {
+    const { pass, reason, broken } = judge(transcript, arg, arg2 || 'haiku');
+    if (broken) {
+      console.log(reason);
+      process.exit(EXIT_UNSCORABLE);
+    }
+    console.log(`${pass ? 'ok' : 'MISS'}: ${reason}`);
+    process.exit(pass ? 0 : 1);
+  }
+
+  default:
+    console.error(`unknown command: ${command}`);
+    process.exit(2);
+}


### PR DESCRIPTION
Can an agent dropped into a freshly downloaded onboarding vault, with no hints in the prompt, work out where it is and how to use the site?

## How it works

`./e2e/agenttest/run.sh` boots a clean instance, signs in with the dev code, and downloads the vault **through the real `/_system/onboarding-vault` endpoint** — so a packaging regression fails the test. It then downloads a second vault and uses it to publish a note that exists only on the server; the agent's own vault does not contain it, so that question cannot be answered by grepping local files.

Each scenario runs `claude -p --output-format stream-json` inside the unpacked vault.

| Scenario | Prompt | Assertion |
|---|---|---|
| `publish` | create a note and make it visible on the site | invoked `trip2g-sync.mjs`; the note is live at `/release-checklist` |
| `orientation` | "what is this folder?" | judge: local files, not live until synced |
| `search` | "what is the deploy freeze window?" | answer quotes `14:00-16:00 UTC`; went through the MCP server |
| `admin` | "make bob@example.com an administrator" | judge: asks for admin GraphQL instead of claiming success |

Two scenarios assert on tool calls and live site state. Only the two that are genuinely about understanding use an LLM judge.

## Stack

`docker-compose.agenttest.yml` is one app container and nothing else: `STORAGE_BACKEND=local` (no MinIO), no vector search — MCP `search` falls back to full-text retrieval, which is what these scenarios need — and no seeded notes. Its `/data` is a named volume, because a bind mount leaves root-owned files in the repo that break `go build ./...`.

## Not in CI

It costs real tokens, so it is not wired into `make test` or the Playwright suite. Run it when the vault's `AGENTS.md`, `CLAUDE.md` or `.mcp.json` change.

## Verified

A smoke run exercised the whole pipeline end to end — stack boot, sign-in, seed sync, vault download, unpack, agent launch, transcript parsing. The model calls themselves failed on account credits, which exposed two harness defects that are fixed here: a run that never reaches the model (credits, auth, rate limit) now aborts with `Cannot score this run` instead of being reported as a comprehension failure, and a judge that fails to answer `PASS`/`FAIL` is distinguished from a judge that returned `FAIL`. Verified against the saved failing transcript.

Known caveat, documented in the README: the test agent inherits the operator's `~/.claude` hooks and `CLAUDE.md`, so results are not comparable across machines with different global setups. MCP is pinned with `--strict-mcp-config`; settings cannot be pinned the same way without losing the CLI's stored auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)