### PR TITLE
fix(hat): admin-minted sign-in links no longer provision users or grant admin

### DIFF
--- a/assets/ui/gql/schema.graphql.ts
+++ b/assets/ui/gql/schema.graphql.ts
@@ -2304,9 +2304,9 @@ export type CreateGoogleOAuthCredentialsPayload = {
 };
 
 export type CreateHatLinkInput = {
-  adminEnter?: InputMaybe<Scalars['Boolean']['input']>;
   email: Scalars['String']['input'];
   expiresInMinutes?: InputMaybe<Scalars['Int']['input']>;
+  redirectUrl?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type CreateHatLinkOrErrorPayload = CreateHatLinkPayload | ErrorPayload;

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -85,7 +85,7 @@ func (a *app) startServer() { //nolint:gocognit // server startup wiring
 		// in the address bar. A bad/expired token is logged and falls through so
 		// it never breaks the return page.
 		if hatAuthToken := string(ctx.QueryArgs().Peek("hat")); hatAuthToken != "" {
-			if hatErr := signinbyhat.Resolve(ctx, a, hatAuthToken); hatErr != nil {
+			if _, hatErr := signinbyhat.Resolve(ctx, a, hatAuthToken); hatErr != nil {
 				a.log.Warn("failed to resolve hot auth token", "error", hatErr)
 			} else if parsedURL, parseErr := url.Parse(string(ctx.Request.Header.RequestURI())); parseErr != nil {
 				a.log.Warn("failed to parse URL after hat sign-in", "error", parseErr)

--- a/e2e/hat-link.spec.js
+++ b/e2e/hat-link.spec.js
@@ -1,0 +1,91 @@
+// @ts-check
+/**
+ * E2E tests for admin-minted sign-in links (`createHatLink` → `/_system/hat`).
+ *
+ * The link is a way in for someone who already exists. It must not create the
+ * account it names, and it must not grant a role — provisioning belongs to the
+ * callers that hold the JWT secret (the login-link CLI and the fleet), not to
+ * the admin API.
+ */
+import { test, expect } from '@playwright/test';
+import { graphqlSignIn, USER_TOKEN_COOKIE_NAME } from './helpers/auth.js';
+
+const APP_URL = process.env.APP_URL || 'http://localhost:8081';
+
+const CREATE_HAT_LINK = `
+  mutation CreateHatLink($input: CreateHatLinkInput!) {
+    admin {
+      data: createHatLink(input: $input) {
+        __typename
+        ... on CreateHatLinkPayload { url }
+        ... on ErrorPayload { message byFields { name value } }
+      }
+    }
+  }
+`;
+
+async function createHatLink(request, cookie, input) {
+  const res = await request.post(`${APP_URL}/_system/graphql`, {
+    headers: { 'Content-Type': 'application/json', Cookie: cookie },
+    data: { query: CREATE_HAT_LINK, variables: { input } },
+  });
+  expect(res.ok()).toBeTruthy();
+
+  const body = await res.json();
+  expect(body.errors).toBeUndefined();
+
+  return body.data.admin.data;
+}
+
+test.describe('admin-minted sign-in link', () => {
+  let cookie;
+
+  test.beforeAll(async ({ request }) => {
+    const jwt = await graphqlSignIn(request);
+    cookie = `${USER_TOKEN_COOKIE_NAME}=${jwt}`;
+  });
+
+  test('a link for an unknown address is refused and creates nobody', async ({ request }) => {
+    const email = `nobody-${Date.now()}@example.com`;
+    const link = await createHatLink(request, cookie, { email });
+    expect(link.__typename).toBe('CreateHatLinkPayload');
+
+    const res = await request.get(link.url, { maxRedirects: 0 });
+    expect(res.status()).toBe(401);
+    expect(await res.text()).toContain('no user with email');
+
+    // Redeeming it twice must stay refused: a first exchange that quietly
+    // created the account would make the second one succeed.
+    const again = await request.get(link.url, { maxRedirects: 0 });
+    expect(again.status()).toBe(401);
+  });
+
+  test('a link for an existing user signs in and lands on its redirect', async ({ request }) => {
+    const link = await createHatLink(request, cookie, {
+      email: 'hello@example.com',
+      redirectUrl: '/admin/users',
+    });
+    expect(link.__typename).toBe('CreateHatLinkPayload');
+
+    const res = await request.get(link.url, { maxRedirects: 0 });
+    expect(res.status()).toBe(302);
+    expect(res.headers()['location']).toBe('/admin/users');
+  });
+
+  test('a link with no redirect lands on the site root', async ({ request }) => {
+    const link = await createHatLink(request, cookie, { email: 'hello@example.com' });
+
+    const res = await request.get(link.url, { maxRedirects: 0 });
+    expect(res.status()).toBe(302);
+    expect(res.headers()['location']).toBe('/');
+  });
+
+  test('an off-site redirect is refused at mint time', async ({ request }) => {
+    for (const redirectUrl of ['//evil.example.com/', 'https://evil.example.com/']) {
+      const result = await createHatLink(request, cookie, { email: 'hello@example.com', redirectUrl });
+
+      expect(result.__typename).toBe('ErrorPayload');
+      expect(result.byFields.map((f) => f.name)).toContain('redirectUrl');
+    }
+  });
+});

--- a/internal/case/admin/createhatlink/resolve.go
+++ b/internal/case/admin/createhatlink/resolve.go
@@ -47,6 +47,13 @@ func validateRequest(r *Input) *model.ErrorPayload {
 		return model.NewFieldError("expiresInMinutes", fmt.Sprintf("must be between 1 and %d", maxExpiryMinutes))
 	}
 
+	// A path on this site and nothing else. "//host" is a scheme-relative URL a
+	// browser follows off-site, so the link would sign someone in here and land
+	// them somewhere we do not control.
+	if r.RedirectURL != nil && (!strings.HasPrefix(*r.RedirectURL, "/") || strings.HasPrefix(*r.RedirectURL, "//")) {
+		return model.NewFieldError("redirectUrl", "must be a path on this site, starting with a single /")
+	}
+
 	return nil
 }
 
@@ -72,11 +79,18 @@ func Resolve(ctx context.Context, env Env, input Input) (Payload, error) {
 	}
 	expiresIn := time.Duration(minutes) * time.Minute
 
-	adminEnter := input.AdminEnter != nil && *input.AdminEnter
+	redirect := "/"
+	if input.RedirectURL != nil {
+		redirect = *input.RedirectURL
+	}
 
+	// No AdminEnter here on purpose: this link is a way in for someone who
+	// already exists, and provisioning belongs to the callers that hold the JWT
+	// secret. An admin who wants a new admin creates the user and grants the
+	// role, both of which are their own operations with their own audit entries.
 	hatToken, err := env.GenerateHotAuthTokenWithTTL(ctx, appmodel.HotAuthToken{
-		Email:      input.Email,
-		AdminEnter: adminEnter,
+		Email:    input.Email,
+		Redirect: redirect,
 	}, expiresIn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to mint hot auth token: %w", err)
@@ -86,7 +100,7 @@ func Resolve(ctx context.Context, env Env, input Input) (Payload, error) {
 	env.AuditLogger().Info("create hat link",
 		"actorUserID", token.ID,
 		"email", input.Email,
-		"adminEnter", adminEnter,
+		"redirectUrl", redirect,
 		"expiresInMinutes", minutes,
 	)
 

--- a/internal/case/admin/createhatlink/resolve_test.go
+++ b/internal/case/admin/createhatlink/resolve_test.go
@@ -68,30 +68,46 @@ func TestResolve(t *testing.T) {
 			afterCallback: func(t *testing.T, mockEnv *envMock) {
 				require.Len(t, mockEnv.CurrentAdminUserTokenCalls(), 1)
 				require.Len(t, mockEnv.GenerateHotAuthTokenWithTTLCalls(), 1)
-				require.Equal(t, appmodel.HotAuthToken{Email: "owner@example.com"},
+				require.Equal(t, appmodel.HotAuthToken{Email: "owner@example.com", Redirect: "/"},
 					mockEnv.GenerateHotAuthTokenWithTTLCalls()[0].Data)
 			},
 		},
 		{
-			name:    "adminEnter true is carried into the token",
+			name:    "the link never provisions, whoever asks for it",
 			env:     newEnv(),
-			input:   model.CreateHatLinkInput{Email: "owner@example.com", AdminEnter: ptr(true)},
+			input:   model.CreateHatLinkInput{Email: "owner@example.com"},
 			want:    &model.CreateHatLinkPayload{URL: "https://example.com/_system/hat?token=jwt-token"},
 			wantTTL: 5 * time.Minute,
 			afterCallback: func(t *testing.T, mockEnv *envMock) {
-				require.Equal(t, appmodel.HotAuthToken{Email: "owner@example.com", AdminEnter: true},
+				require.False(t, mockEnv.GenerateHotAuthTokenWithTTLCalls()[0].Data.AdminEnter,
+					"the admin API minted a token that creates a user and grants admin")
+			},
+		},
+		{
+			name:    "a redirect is carried into the token",
+			env:     newEnv(),
+			input:   model.CreateHatLinkInput{Email: "owner@example.com", RedirectURL: ptr("/admin/users")},
+			want:    &model.CreateHatLinkPayload{URL: "https://example.com/_system/hat?token=jwt-token"},
+			wantTTL: 5 * time.Minute,
+			afterCallback: func(t *testing.T, mockEnv *envMock) {
+				require.Equal(t, appmodel.HotAuthToken{Email: "owner@example.com", Redirect: "/admin/users"},
 					mockEnv.GenerateHotAuthTokenWithTTLCalls()[0].Data)
 			},
 		},
 		{
-			name:    "adminEnter false keeps the user non-admin",
-			env:     newEnv(),
-			input:   model.CreateHatLinkInput{Email: "owner@example.com", AdminEnter: ptr(false)},
-			want:    &model.CreateHatLinkPayload{URL: "https://example.com/_system/hat?token=jwt-token"},
-			wantTTL: 5 * time.Minute,
-			afterCallback: func(t *testing.T, mockEnv *envMock) {
-				require.Equal(t, appmodel.HotAuthToken{Email: "owner@example.com", AdminEnter: false},
-					mockEnv.GenerateHotAuthTokenWithTTLCalls()[0].Data)
+			name:  "an off-site redirect is a validation error",
+			env:   newEnv(),
+			input: model.CreateHatLinkInput{Email: "owner@example.com", RedirectURL: ptr("//evil.example.com/")},
+			want: &model.ErrorPayload{
+				ByFields: []model.FieldMessage{{Name: "redirectUrl", Value: "must be a path on this site, starting with a single /"}},
+			},
+		},
+		{
+			name:  "an absolute redirect is a validation error",
+			env:   newEnv(),
+			input: model.CreateHatLinkInput{Email: "owner@example.com", RedirectURL: ptr("https://evil.example.com/")},
+			want: &model.ErrorPayload{
+				ByFields: []model.FieldMessage{{Name: "redirectUrl", Value: "must be a path on this site, starting with a single /"}},
 			},
 		},
 		{
@@ -234,8 +250,8 @@ func TestResolve_AuditsWithoutLeakingTheLink(t *testing.T) {
 	env.AuditLoggerFunc = func() logger.Logger { return recorder }
 
 	got, err := createhatlink.Resolve(context.Background(), env, model.CreateHatLinkInput{
-		Email:      "owner@example.com",
-		AdminEnter: ptr(true),
+		Email:       "owner@example.com",
+		RedirectURL: ptr("/admin/users"),
 	})
 	require.NoError(t, err)
 	require.IsType(t, &model.CreateHatLinkPayload{}, got)
@@ -246,7 +262,7 @@ func TestResolve_AuditsWithoutLeakingTheLink(t *testing.T) {
 	require.NotContains(t, entry.args, "https://example.com/_system/hat?token=jwt-token")
 	require.Contains(t, entry.args, "owner@example.com")
 	require.Contains(t, entry.args, 42)
-	require.Contains(t, entry.args, true)
+	require.Contains(t, entry.args, "/admin/users")
 }
 
 type logEntry struct {

--- a/internal/case/signinbyhat/endpoint.go
+++ b/internal/case/signinbyhat/endpoint.go
@@ -36,7 +36,7 @@ func (e *Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 		return nil, nil
 	}
 
-	err := Resolve(req.Req, req.Env.(Env), token)
+	redirect, err := Resolve(req.Req, req.Env.(Env), token)
 	if err != nil {
 		req.Req.SetStatusCode(http.StatusUnauthorized)
 		req.Req.SetBodyString(fmt.Sprintf("authentication failed: %v", err))
@@ -44,7 +44,7 @@ func (e *Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 	}
 
 	req.Req.SetStatusCode(http.StatusFound)
-	req.Req.Response.Header.Set("Location", "/")
+	req.Req.Response.Header.Set("Location", location(redirect, "/"))
 	return nil, nil
 }
 
@@ -71,7 +71,7 @@ func (e *GetEndpoint) Handle(req *appreq.Request) (interface{}, error) {
 		return nil, nil
 	}
 
-	err := Resolve(req.Req, req.Env.(Env), token)
+	redirect, err := Resolve(req.Req, req.Env.(Env), token)
 	if err != nil {
 		req.Req.SetStatusCode(http.StatusUnauthorized)
 		req.Req.SetBodyString(fmt.Sprintf("authentication failed: %v", err))
@@ -79,50 +79,66 @@ func (e *GetEndpoint) Handle(req *appreq.Request) (interface{}, error) {
 	}
 
 	req.Req.SetStatusCode(http.StatusFound)
-	req.Req.Response.Header.Set("Location", "/admin")
+	req.Req.Response.Header.Set("Location", location(redirect, "/admin"))
 	return nil, nil
 }
 
-func Resolve(ctx context.Context, env Env, token string) error {
-	// Parse and validate JWT token.
-	hotAuthToken, err := env.ParseHotAuthToken(ctx, token)
-	if err != nil {
-		return fmt.Errorf("failed to parse token: %w", err)
+// The redirect rides the signed token, so it cannot be steered by whoever opens
+// the link; a link that names none keeps the endpoint's own default.
+func location(redirect, fallback string) string {
+	if redirect == "" {
+		return fallback
 	}
 
-	// Get or create user.
+	return redirect
+}
+
+// Resolve signs the token's subject in and reports where to send the browser;
+// an empty redirect leaves the caller's own default.
+//
+// Only a provisioning token creates the user or touches roles. An ordinary
+// sign-in link is a way in for someone who already exists, so an unknown
+// address is refused rather than silently becoming an account.
+func Resolve(ctx context.Context, env Env, token string) (string, error) {
+	hotAuthToken, err := env.ParseHotAuthToken(ctx, token)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse token: %w", err)
+	}
+
 	user, err := env.UserByEmail(ctx, hotAuthToken.Email)
 	if err != nil {
-		if db.IsNoFound(err) {
-			// User doesn't exist, create new user.
-			params := db.InsertUserWithEmailParams{
-				Email:      hotAuthToken.Email,
-				CreatedVia: "hot_auth_token",
-			}
-			user, err = env.InsertUserWithEmail(ctx, params)
-			if err != nil {
-				return fmt.Errorf("failed to create user: %w", err)
-			}
-		} else {
-			return fmt.Errorf("failed to get user: %w", err)
+		if !db.IsNoFound(err) {
+			return "", fmt.Errorf("failed to get user: %w", err)
+		}
+
+		if !hotAuthToken.AdminEnter {
+			return "", fmt.Errorf("no user with email %s", hotAuthToken.Email)
+		}
+
+		params := db.InsertUserWithEmailParams{
+			Email:      hotAuthToken.Email,
+			CreatedVia: "hot_auth_token",
+		}
+
+		user, err = env.InsertUserWithEmail(ctx, params)
+		if err != nil {
+			return "", fmt.Errorf("failed to create user: %w", err)
 		}
 	}
 
-	// If AdminEnter flag is set, ensure user is admin.
 	if hotAuthToken.AdminEnter {
 		err = ensureUserIsAdmin(ctx, env, user.ID)
 		if err != nil {
-			return err
+			return "", err
 		}
 	}
 
-	// Create session and set cookie.
 	_, err = env.SetupUserToken(ctx, user.ID)
 	if err != nil {
-		return fmt.Errorf("failed to create session: %w", err)
+		return "", fmt.Errorf("failed to create session: %w", err)
 	}
 
-	return nil
+	return hotAuthToken.Redirect, nil
 }
 
 func ensureUserIsAdmin(ctx context.Context, env Env, userID int64) error {

--- a/internal/case/signinbyhat/resolve_test.go
+++ b/internal/case/signinbyhat/resolve_test.go
@@ -68,7 +68,7 @@ func TestResolve_InvalidToken(t *testing.T) {
 		parseErr: errors.New("invalid signature"),
 	}
 
-	err := signinbyhat.Resolve(context.Background(), env, "bad-token")
+	_, err := signinbyhat.Resolve(context.Background(), env, "bad-token")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to parse token")
 }
@@ -84,7 +84,7 @@ func TestResolve_ExistingUser_NotAdmin(t *testing.T) {
 		userErr: nil,
 	}
 
-	err := signinbyhat.Resolve(context.Background(), env, "valid-token")
+	_, err := signinbyhat.Resolve(context.Background(), env, "valid-token")
 	require.NoError(t, err)
 }
 
@@ -99,24 +99,24 @@ func TestResolve_ExistingUser_AlreadyAdmin(t *testing.T) {
 		admin: db.Admin{UserID: 456},
 	}
 
-	err := signinbyhat.Resolve(context.Background(), env, "valid-token")
+	_, err := signinbyhat.Resolve(context.Background(), env, "valid-token")
 	require.NoError(t, err)
 }
 
-func TestResolve_NewUser_NotAdmin(t *testing.T) {
+func TestResolve_UnknownUser_WithoutAdminEnter_IsRefused(t *testing.T) {
 	email := "newuser@example.com"
 	env := &mockEnv{
 		hotAuthToken: &model.HotAuthToken{
 			Email:      email,
 			AdminEnter: false,
 		},
-		userErr:    sql.ErrNoRows,
-		createUser: db.User{ID: 999, Email: &email},
+		userErr: sql.ErrNoRows,
 	}
 
-	err := signinbyhat.Resolve(context.Background(), env, "valid-token")
-	require.NoError(t, err)
-	require.Equal(t, email, *env.createUser.Email)
+	_, err := signinbyhat.Resolve(context.Background(), env, "valid-token")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no user with email")
+	require.Nil(t, env.createUser.Email, "an ordinary sign-in link created an account")
 }
 
 func TestResolve_NewUser_MakeAdmin(t *testing.T) {
@@ -132,7 +132,7 @@ func TestResolve_NewUser_MakeAdmin(t *testing.T) {
 		createAdmin: db.Admin{UserID: 111},
 	}
 
-	err := signinbyhat.Resolve(context.Background(), env, "valid-token")
+	_, err := signinbyhat.Resolve(context.Background(), env, "valid-token")
 	require.NoError(t, err)
 	require.Equal(t, email, *env.createUser.Email)
 	require.Equal(t, int64(111), env.createAdmin.UserID)
@@ -150,7 +150,7 @@ func TestResolve_ExistingUser_UpgradeToAdmin(t *testing.T) {
 		createAdmin: db.Admin{UserID: 333},
 	}
 
-	err := signinbyhat.Resolve(context.Background(), env, "valid-token")
+	_, err := signinbyhat.Resolve(context.Background(), env, "valid-token")
 	require.NoError(t, err)
 	require.Equal(t, int64(333), env.createAdmin.UserID)
 }
@@ -159,13 +159,13 @@ func TestResolve_CreateUserFails(t *testing.T) {
 	env := &mockEnv{
 		hotAuthToken: &model.HotAuthToken{
 			Email:      "newuser@example.com",
-			AdminEnter: false,
+			AdminEnter: true,
 		},
 		userErr:       sql.ErrNoRows,
 		createUserErr: errors.New("database error"),
 	}
 
-	err := signinbyhat.Resolve(context.Background(), env, "valid-token")
+	_, err := signinbyhat.Resolve(context.Background(), env, "valid-token")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to create user")
 }
@@ -182,7 +182,7 @@ func TestResolve_MakeAdminFails(t *testing.T) {
 		createAdminErr: errors.New("admin insert failed"),
 	}
 
-	err := signinbyhat.Resolve(context.Background(), env, "valid-token")
+	_, err := signinbyhat.Resolve(context.Background(), env, "valid-token")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to make user admin")
 }
@@ -198,7 +198,31 @@ func TestResolve_SetupTokenFails(t *testing.T) {
 		setupTokenErr: errors.New("cookie error"),
 	}
 
-	err := signinbyhat.Resolve(context.Background(), env, "valid-token")
+	_, err := signinbyhat.Resolve(context.Background(), env, "valid-token")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to create session")
+}
+
+func TestResolve_ReturnsTheRedirectTheTokenCarries(t *testing.T) {
+	email := "user@example.com"
+	env := &mockEnv{
+		hotAuthToken: &model.HotAuthToken{Email: email, Redirect: "/admin/users"},
+		user:         db.User{ID: 777, Email: &email},
+	}
+
+	redirect, err := signinbyhat.Resolve(context.Background(), env, "valid-token")
+	require.NoError(t, err)
+	require.Equal(t, "/admin/users", redirect)
+}
+
+func TestResolve_ReturnsNoRedirectWhenTheTokenNamesNone(t *testing.T) {
+	email := "user@example.com"
+	env := &mockEnv{
+		hotAuthToken: &model.HotAuthToken{Email: email},
+		user:         db.User{ID: 888, Email: &email},
+	}
+
+	redirect, err := signinbyhat.Resolve(context.Background(), env, "valid-token")
+	require.NoError(t, err)
+	require.Empty(t, redirect)
 }

--- a/internal/graph/generated/generated.go
+++ b/internal/graph/generated/generated.go
@@ -3428,8 +3428,8 @@ union DeleteAdminOrErrorPayload = DeleteAdminPayload | ErrorPayload
 
 input CreateHatLinkInput {
   email: String!
-  # Land as admin instead of a plain signed-in user. Defaults to false.
-  adminEnter: Boolean
+  # Where the link lands. A path on this site, defaults to /.
+  redirectUrl: String
   # Link lifetime, 1..60 minutes. Defaults to 5.
   expiresInMinutes: Int
 }
@@ -47291,7 +47291,7 @@ func (ec *executionContext) unmarshalInputCreateHatLinkInput(ctx context.Context
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"email", "adminEnter", "expiresInMinutes"}
+	fieldsInOrder := [...]string{"email", "redirectUrl", "expiresInMinutes"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -47305,13 +47305,13 @@ func (ec *executionContext) unmarshalInputCreateHatLinkInput(ctx context.Context
 				return it, err
 			}
 			it.Email = data
-		case "adminEnter":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("adminEnter"))
-			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+		case "redirectUrl":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("redirectUrl"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.AdminEnter = data
+			it.RedirectURL = data
 		case "expiresInMinutes":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("expiresInMinutes"))
 			data, err := ec.unmarshalOInt2ᚖint32(ctx, v)

--- a/internal/graph/model/models_gen.go
+++ b/internal/graph/model/models_gen.go
@@ -1249,9 +1249,9 @@ type CreateGoogleOAuthCredentialsPayload struct {
 func (CreateGoogleOAuthCredentialsPayload) IsCreateGoogleOAuthCredentialsOrErrorPayload() {}
 
 type CreateHatLinkInput struct {
-	Email            string `json:"email"`
-	AdminEnter       *bool  `json:"adminEnter,omitempty"`
-	ExpiresInMinutes *int32 `json:"expiresInMinutes,omitempty"`
+	Email            string  `json:"email"`
+	RedirectURL      *string `json:"redirectUrl,omitempty"`
+	ExpiresInMinutes *int32  `json:"expiresInMinutes,omitempty"`
 }
 
 type CreateHatLinkPayload struct {

--- a/internal/graph/schema.graphqls
+++ b/internal/graph/schema.graphqls
@@ -2260,8 +2260,8 @@ union DeleteAdminOrErrorPayload = DeleteAdminPayload | ErrorPayload
 
 input CreateHatLinkInput {
   email: String!
-  # Land as admin instead of a plain signed-in user. Defaults to false.
-  adminEnter: Boolean
+  # Where the link lands. A path on this site, defaults to /.
+  redirectUrl: String
   # Link lifetime, 1..60 minutes. Defaults to 5.
   expiresInMinutes: Int
 }

--- a/internal/model/hot_auth_token.go
+++ b/internal/model/hot_auth_token.go
@@ -1,6 +1,13 @@
 package model
 
 type HotAuthToken struct {
-	Email      string `json:"e"`
-	AdminEnter bool   `json:"ae,omitempty"`
+	Email string `json:"e"`
+	// Provisioning: creates the user if missing and makes them admin. Only for
+	// fleet logic — the fleet and the login-link CLI mint it in-process from the
+	// JWT secret, to reach an instance nobody can sign in to yet. The admin API
+	// cannot ask for it.
+	AdminEnter bool `json:"ae,omitempty"`
+	// Where the exchange sends the browser. Empty keeps each endpoint's own
+	// default.
+	Redirect string `json:"r,omitempty"`
 }


### PR DESCRIPTION
A sign-in link minted through the admin API could create the account it named and make that account an admin. Both happened silently, at redemption, and neither was the point of the link.

## What happened

`/_system/hat` did three things in a row: look the user up by the email in the token, **create them if missing**, and — if the token carried `AdminEnter` — grant admin. `createHatLink` exposed `adminEnter` as an ordinary input field defaulting to false, so a caller that simply forgot it produced a working link whose holder landed as a plain user, while a caller that passed it turned any address into an admin.

The failure mode is quiet in both directions: forget the field and the link signs someone in with no rights (the admin UI renders, every GraphQL call answers `unauthorized`); pass it and an arbitrary address becomes an administrator with no separate action to audit.

## What this changes

**The mutation cannot provision.** `adminEnter` is gone from `CreateHatLinkInput`. The token it mints never carries `AdminEnter`, so the link is a way in for someone who already exists — nothing more.

**An unknown address is refused, not created.** Only a provisioning token may create the user:

```go
if !hotAuthToken.AdminEnter {
    return "", fmt.Errorf("no user with email %s", hotAuthToken.Email)
}
```

**`AdminEnter` stays for the bootstrap path**, which is the only place it was ever needed: the `login-link` CLI and the fleet mint it in-process from the JWT secret, to reach an instance nobody can sign in to yet. Provisioning now requires that secret rather than an admin session — the fleet is unaffected, since it never used this mutation.

An admin who wants a new admin creates the user and grants the role. Both are existing operations that leave their own audit entries, which minting a link never did.

## Also: `redirectUrl`

Optional on the mutation, defaulting to `/`, so a link can land where it is useful. It travels **inside the signed token**, not on the query string, so it cannot be steered by whoever opens the link, and it is validated at mint time as a path on this site — `//host` and absolute URLs are rejected, since a scheme-relative URL would sign someone in here and land them somewhere else.

Endpoints keep their own defaults when a token names no redirect, so existing links behave exactly as before.

## Breaking

`adminEnter` is removed from `CreateHatLinkInput`. Callers passing it will get a schema error. The admin UI never sent it.

## Tests

`e2e/hat-link.spec.js` is new — there was no end-to-end coverage of this flow at all, which is part of why it drifted. It pins that an unknown address is refused **twice in a row**, since a first exchange that quietly created the account would let the second succeed.

Unit tests updated for both cases, including the redirect being carried and off-site redirects refused.

`go build ./...`, `go test ./...` and `make lint` (0 issues) all pass locally.
