### PR TITLE
fix(validation): check an email's format, not its MX record

### DIFF
--- a/internal/case/admin/createhatlink/resolve.go
+++ b/internal/case/admin/createhatlink/resolve.go
@@ -36,8 +36,12 @@ type Input = model.CreateHatLinkInput
 type Payload = model.CreateHatLinkOrErrorPayload
 
 func validateRequest(r *Input) *model.ErrorPayload {
+	// EmailFormat, not Email: is.Email resolves the domain's MX record, so this
+	// resolver blocks on DNS and refuses a well-formed address whose domain
+	// accepts no mail. Nothing is ever mailed here — the minted URL is handed
+	// to its holder — so the address has to be well-formed, not deliverable.
 	errPayload := model.NewOzzoError(ozzo.ValidateStruct(r,
-		ozzo.Field(&r.Email, ozzo.Required, is.Email),
+		ozzo.Field(&r.Email, ozzo.Required, is.EmailFormat),
 	))
 	if errPayload != nil {
 		return errPayload

--- a/internal/case/admin/createhatlink/resolve_test.go
+++ b/internal/case/admin/createhatlink/resolve_test.go
@@ -118,6 +118,13 @@ func TestResolve(t *testing.T) {
 			wantTTL: 60 * time.Minute,
 		},
 		{
+			name:    "an address whose domain accepts no mail is minted anyway",
+			env:     newEnv(),
+			input:   model.CreateHatLinkInput{Email: "owner@local.invalid"},
+			want:    &model.CreateHatLinkPayload{URL: "https://example.com/_system/hat?token=jwt-token"},
+			wantTTL: 5 * time.Minute,
+		},
+		{
 			name:  "invalid email is a validation error",
 			env:   newEnv(),
 			input: model.CreateHatLinkInput{Email: "not-an-email"},

--- a/internal/case/admin/createuser/resolve.go
+++ b/internal/case/admin/createuser/resolve.go
@@ -21,9 +21,12 @@ type Env interface {
 type Input = model.CreateUserInput
 type Payload = model.CreateUserOrErrorPayload
 
+// EmailFormat, not Email: is.Email resolves the domain's MX record. Nothing is
+// mailed from here — an admin is recording an address — so the check would only
+// make the mutation depend on DNS and refuse a domain that accepts no mail.
 func validateRequest(r *Input) *model.ErrorPayload {
 	return model.NewOzzoError(ozzo.ValidateStruct(r,
-		ozzo.Field(&r.Email, ozzo.Required, is.Email),
+		ozzo.Field(&r.Email, ozzo.Required, is.EmailFormat),
 	))
 }
 

--- a/internal/case/admin/createuser/resolve_test.go
+++ b/internal/case/admin/createuser/resolve_test.go
@@ -131,6 +131,38 @@ func TestResolve(t *testing.T) {
 			},
 		},
 		{
+			name: "an address whose domain accepts no mail is created anyway",
+			env: &envMock{
+				CurrentAdminUserTokenFunc: func(ctx context.Context) (*usertoken.Data, error) {
+					return &usertoken.Data{ID: 1, Role: "admin"}, nil
+				},
+				UserByEmailFunc: func(ctx context.Context, lower string) (db.User, error) {
+					return db.User{}, sql.ErrNoRows
+				},
+				InsertUserWithEmailFunc: func(ctx context.Context, arg db.InsertUserWithEmailParams) (db.User, error) {
+					return db.User{
+						ID:         124,
+						Email:      ptr.To(arg.Email),
+						CreatedVia: arg.CreatedVia,
+					}, nil
+				},
+			},
+			args: args{
+				ctx: context.Background(),
+				input: model.CreateUserInput{
+					Email: "owner@local.invalid",
+				},
+			},
+			want: &model.CreateUserPayload{
+				User: &db.User{
+					ID:         124,
+					Email:      ptr.To("owner@local.invalid"),
+					CreatedVia: "admin",
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "validation error - invalid email",
 			env: &envMock{
 				CurrentAdminUserTokenFunc: func(ctx context.Context) (*usertoken.Data, error) {

--- a/internal/case/admin/updateuser/resolve.go
+++ b/internal/case/admin/updateuser/resolve.go
@@ -22,10 +22,13 @@ type Env interface {
 type Input = model.UpdateUserInput
 type Payload = model.UpdateUserOrErrorPayload
 
+// EmailFormat, not Email: is.Email resolves the domain's MX record. Nothing is
+// mailed from here — an admin is correcting an address — so the check would only
+// make the mutation depend on DNS and refuse a domain that accepts no mail.
 func validateRequest(r *Input) *model.ErrorPayload {
 	return model.NewOzzoError(ozzo.ValidateStruct(r,
 		ozzo.Field(&r.ID, ozzo.Required),
-		ozzo.Field(&r.Email, ozzo.When(r.Email != nil, is.Email)),
+		ozzo.Field(&r.Email, ozzo.When(r.Email != nil, is.EmailFormat)),
 	))
 }
 

--- a/internal/case/admin/updateuser/resolve_test.go
+++ b/internal/case/admin/updateuser/resolve_test.go
@@ -190,6 +190,37 @@ func TestResolve(t *testing.T) {
 			},
 		},
 		{
+			name: "an address whose domain accepts no mail is stored anyway",
+			env: &envMock{
+				CurrentAdminUserTokenFunc: func(ctx context.Context) (*usertoken.Data, error) {
+					return &usertoken.Data{ID: 1, Role: "admin"}, nil
+				},
+				UserByIDFunc: func(ctx context.Context, id int64) (db.User, error) {
+					return db.User{ID: id, Email: ptr.To("old@example.com")}, nil
+				},
+				UserByEmailFunc: func(ctx context.Context, lower string) (db.User, error) {
+					return db.User{}, sql.ErrNoRows
+				},
+				UpdateUserFunc: func(ctx context.Context, arg db.UpdateUserParams) (db.User, error) {
+					return db.User{ID: arg.ID, Email: arg.Email}, nil
+				},
+			},
+			args: args{
+				ctx: context.Background(),
+				input: model.UpdateUserInput{
+					ID:    123,
+					Email: ptr.To("owner-legacy@local.invalid"),
+				},
+			},
+			want: &model.UpdateUserPayload{
+				User: &db.User{
+					ID:    123,
+					Email: ptr.To("owner-legacy@local.invalid"),
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "validation error - invalid email",
 			env: &envMock{
 				CurrentAdminUserTokenFunc: func(ctx context.Context) (*usertoken.Data, error) {


### PR DESCRIPTION
Three admin-side resolvers validate `email` with ozzo's `is.Email`, which is `govalidator.IsExistingEmail` — it resolves the domain's MX record over DNS. None of the three sends mail:

| resolver | what it does with the address |
|---|---|
| `createHatLink` | puts it in a link handed to its holder |
| `admin.createUser` | writes a row |
| `admin.updateUser` | writes a row |

Two consequences. A well-formed address whose domain accepts no mail is refused with `must be a valid email address`, so a deployment cannot record an address it never intends to mail. And every call makes a DNS query inside the resolver, which means an instance running in a closed network with no outbound DNS cannot mint a sign-in link or edit a user at all, whatever the address. The three packages' own tests spend 20s in those lookups; with this change they run in 4ms.

`is.EmailFormat` is the same syntactic check without the lookup. `not-an-email` and an empty address are still refused, with the same messages. Each package gains a test that a well-formed address in a domain that accepts no mail is accepted.

Three call sites keep `is.Email` and are untouched: `requestEmailSignIn` is the only one that actually enqueues mail, and `signInByEmail` / `createEmailWaitListRequest` sit on public endpoints where changing validation is a product decision rather than a bug fix. Neither of those two mails anything either, so the same argument applies to them — worth a separate look.