### PR TITLE
fix(mcp): UTF-8 chunking, federated argument loss, expand quality

### DIFF
--- a/docs/demo/_mcp_wiki.md
+++ b/docs/demo/_mcp_wiki.md
@@ -9,6 +9,16 @@ You are a wiki assistant. Answer questions based on the knowledge base.
 
 ## Workflow
 
-1. Run `search(query)` to find relevant notes
-2. Open the best match with `note_html(pid=...)`
-3. Synthesize a concise answer with source links
+1. `search(query)` — content words from the question, not a full sentence.
+2. `note_html(path=<result.note_path>, toc_path=<match.toc_path>)` — read the
+   matched section. Copy both values verbatim from the search result.
+3. Synthesize a concise answer and cite the `url` of every note you used.
+
+## Reading less
+
+- `note_html(path=..., match_id=<match.match_id>)` returns just the chunk around
+  a hit — the cheapest read there is when the match is a single passage.
+- `expand(path=...)` walks a note's table of contents level by level. Use it when
+  a `toc_path` misses, instead of falling back to reading the whole note.
+- Whole-note reads are the last resort: one section is ~300 tokens, a full note
+  is 3,000+.

--- a/internal/case/mcp/endpoint.go
+++ b/internal/case/mcp/endpoint.go
@@ -401,10 +401,10 @@ Send POST requests with a JSON-RPC 2.0 body and these headers:
 
 Public access: no token required for open knowledge bases.
 
-Authentication (required for private/subscriber-only content):
-  Authorization: Bearer t2g_<your-token>
-  ?token=t2g_<your-token>
-  X-API-Key: <your-api-key>
+Authentication (required for private/subscriber-only content), any one of:
+  header       Authorization: Bearer t2g_<your-token>
+  query param  ?token=t2g_<your-token>
+  header       X-API-Key: <your-api-key>
 
 Get a personal token: your account → Tokens → Generate token.
 
@@ -431,11 +431,20 @@ Client config (Claude Desktop / Claude Code / Cursor / Copilot / Gemini CLI):
     }
   }
 
+Tools:
+  search, note_html, expand, similar — search this base and read it, whole notes
+    or one section at a time (toc_path), or one chunk (match_id).
+  federated_search, federated_note_html, federated_expand, federated_similar,
+    federated_instructions — the same against a connected peer base, addressed by
+    kb_id; nested bases are addressed <hub>/<base>.
+
 Extend MCP via note frontmatter:
   mcp_method: <name>    — expose a note as an MCP tool; the note's content becomes
                           the tool's response.
-  mcp_method: initialize — default method shown when an agent requests tool info.
-                           Override which note handles it via ?method=<note-path>.
+  mcp_method: initialize — the note whose content is returned in the instructions
+                           field of the initialize response. This does not
+                           override the JSON-RPC initialize method itself. Pick a
+                           different note with ?method=<note-path>.
 Read more in the docs.
 
 Docs: https://trip2g.com/en/user/mcp

--- a/internal/case/mcp/endpoint_dispatch_test.go
+++ b/internal/case/mcp/endpoint_dispatch_test.go
@@ -176,7 +176,7 @@ func TestPersonalTokenAdminSeesAllKBNotes(t *testing.T) {
 	env.FederationClientFunc = func(_ context.Context, kbID string) (appmodel.Federation, error) {
 		federationQueriedKBIDs = append(federationQueriedKBIDs, kbID)
 		return &federationMock{
-			searchFunc: func(_ context.Context, params appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+			searchFunc: func(_ context.Context, params appmodel.MCPSearchParams) (appmodel.FederationResult, error) {
 				return appmodel.FederationResult{Content: []appmodel.FederationContent{{Type: "text", Text: "ok"}}}, nil
 			},
 		}, nil
@@ -224,7 +224,7 @@ func TestPersonalTokenNonAdminKBNoteFiltered(t *testing.T) {
 	env.FederationClientFunc = func(_ context.Context, kbID string) (appmodel.Federation, error) {
 		queriedKBIDs = append(queriedKBIDs, kbID)
 		return &federationMock{
-			searchFunc: func(_ context.Context, _ appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+			searchFunc: func(_ context.Context, _ appmodel.MCPSearchParams) (appmodel.FederationResult, error) {
 				return appmodel.FederationResult{Content: []appmodel.FederationContent{{Type: "text", Text: "ok"}}}, nil
 			},
 		}, nil
@@ -356,7 +356,7 @@ func TestFederationPathDepthEarlyReject(t *testing.T) {
 		env.FederationMaxDepthFunc = func() int { return maxDepth }
 		env.FederationClientFunc = func(context.Context, string) (appmodel.Federation, error) {
 			*outboundCalls++
-			ok := func(context.Context, appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+			ok := func(context.Context, appmodel.MCPSearchParams) (appmodel.FederationResult, error) {
 				return appmodel.FederationResult{Content: []appmodel.FederationContent{{Type: "text", Text: "ok"}}}, nil
 			}
 			return &federationMock{searchFunc: ok, federatedSearchFunc: ok}, nil

--- a/internal/case/mcp/endpoint_golden_test.go
+++ b/internal/case/mcp/endpoint_golden_test.go
@@ -276,6 +276,16 @@ func goldenEnv() *EnvMock {
 			{Text: "2", Level: 2, ID: "two"},
 		},
 	}
+	// A tool note without the leading-underscore naming convention: the
+	// path-based system-note rule misses it, so it used to surface in search.
+	toolNote := &appmodel.NoteView{
+		Path:      "instructions.md",
+		PathID:    21,
+		Title:     "Instructions",
+		Permalink: "/instructions",
+		MCPMethod: "instructions",
+		Content:   []byte("---\nmcp_method: instructions\n---\n\nBase instructions."),
+	}
 	private := &appmodel.NoteView{
 		Path:      "private.md",
 		PathID:    11,
@@ -315,7 +325,7 @@ func goldenEnv() *EnvMock {
 		MCPFederationKBID:  "peer",
 	}
 
-	notes := []*appmodel.NoteView{doc, aphorisms, private, initNote, guide, codeReview, privateTool, peer}
+	notes := []*appmodel.NoteView{doc, aphorisms, toolNote, private, initNote, guide, codeReview, privateTool, peer}
 	views := appmodel.NewNoteViews()
 	views.List = notes
 	for _, n := range notes {
@@ -326,12 +336,20 @@ func goldenEnv() *EnvMock {
 	}
 	views.MCPFederationNotes = []*appmodel.MCPFederationNote{appmodel.NewMCPFederationNote(peer)}
 
-	searchHits := []appmodel.SearchResult{{
-		NoteView:           doc,
-		URL:                doc.Permalink,
-		Score:              0.9,
-		HighlightedContent: []string{"alpha body"},
-	}}
+	searchHits := []appmodel.SearchResult{
+		{
+			NoteView:           doc,
+			URL:                doc.Permalink,
+			Score:              0.9,
+			HighlightedContent: []string{"alpha body"},
+		},
+		{
+			NoteView:           toolNote,
+			URL:                toolNote.Permalink,
+			Score:              0.4,
+			HighlightedContent: []string{"Base instructions."},
+		},
+	}
 
 	return &EnvMock{
 		LatestNoteViewsFunc:  func() *appmodel.NoteViews { return views },

--- a/internal/case/mcp/endpoint_golden_test.go
+++ b/internal/case/mcp/endpoint_golden_test.go
@@ -211,11 +211,11 @@ func normalizeGolden(body []byte) string {
 // goldenFedClient is a fixed federation peer: deterministic content, no network.
 type goldenFedClient struct{ appmodel.Federation }
 
-func (goldenFedClient) Search(context.Context, appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+func (goldenFedClient) Search(context.Context, appmodel.MCPSearchParams) (appmodel.FederationResult, error) {
 	return goldenFedResult("peer search hit"), nil
 }
 
-func (goldenFedClient) FederatedSearch(context.Context, appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+func (goldenFedClient) FederatedSearch(context.Context, appmodel.MCPSearchParams) (appmodel.FederationResult, error) {
 	return goldenFedResult("peer federated search hit"), nil
 }
 
@@ -223,7 +223,7 @@ func (goldenFedClient) Instructions(context.Context) (appmodel.FederationResult,
 	return goldenFedResult("peer instructions"), nil
 }
 
-func (goldenFedClient) FederatedInstructions(context.Context, appmodel.FederationInstructionsParams) (appmodel.FederationResult, error) {
+func (goldenFedClient) FederatedInstructions(context.Context, appmodel.MCPInstructionsParams) (appmodel.FederationResult, error) {
 	return goldenFedResult("peer federated instructions"), nil
 }
 

--- a/internal/case/mcp/endpoint_golden_test.go
+++ b/internal/case/mcp/endpoint_golden_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"html/template"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -95,6 +96,8 @@ func goldenCases() []goldenCase {
 		{name: "call_expand_root", body: call(5, "expand", `{"path":"doc.md"}`)},
 		{name: "call_expand_section", body: call(5, "expand", `{"path":"doc.md","toc_path":["Beta"]}`)},
 		{name: "call_expand_no_selector", body: call(5, "expand", `{}`)},
+		{name: "call_expand_leading_h1", body: call(5, "expand", `{"path":"aphorisms.md"}`)},
+		{name: "call_note_html_h1_shortened_toc_path", body: call(5, "note_html", `{"path":"aphorisms.md","toc_path":["1"]}`)},
 
 		{name: "call_federated_search", body: call(6, "federated_search", `{"query":"alpha"}`)},
 		{name: "call_federated_search_by_kb", body: call(6, "federated_search", `{"query":"alpha","kb_id":"peer"}`)},
@@ -253,6 +256,26 @@ func goldenEnv() *EnvMock {
 			{Text: "Beta", Level: 2, ID: "beta"},
 		},
 	}
+	// Mirrors the real load pipeline for a note that opens with an H1: HasH1 is
+	// set, the H1 heads the Headings list, and its data-header div wraps the
+	// rest of the document. Aphoristic section titles pin the short-heading
+	// previews at the same time.
+	aphorisms := &appmodel.NoteView{
+		Path:      "aphorisms.md",
+		PathID:    20,
+		Title:     "Книга 10",
+		Permalink: "/aphorisms",
+		HasH1:     true,
+		HTML: template.HTML(`<div data-header="Книга 10" data-level="1"><h1 id="kniga">Книга 10</h1>` +
+			`<div data-header="1" data-level="2"><h2 id="one">1</h2><p>Душа моя, ужели ты никогда не будешь доброй и простой?</p></div>` +
+			`<div data-header="2" data-level="2"><h2 id="two">2</h2><p>Замечай, чего требует твоя природа.</p></div></div>`),
+		Content: []byte("# Книга 10\n\n## 1\n\nДуша моя.\n\n## 2\n\nЗамечай.\n"),
+		Headings: appmodel.NoteViewHeadings{
+			{Text: "Книга 10", Level: 1, ID: "kniga"},
+			{Text: "1", Level: 2, ID: "one"},
+			{Text: "2", Level: 2, ID: "two"},
+		},
+	}
 	private := &appmodel.NoteView{
 		Path:      "private.md",
 		PathID:    11,
@@ -292,7 +315,7 @@ func goldenEnv() *EnvMock {
 		MCPFederationKBID:  "peer",
 	}
 
-	notes := []*appmodel.NoteView{doc, private, initNote, guide, codeReview, privateTool, peer}
+	notes := []*appmodel.NoteView{doc, aphorisms, private, initNote, guide, codeReview, privateTool, peer}
 	views := appmodel.NewNoteViews()
 	views.List = notes
 	for _, n := range notes {

--- a/internal/case/mcp/federated_graphql_ext_test.go
+++ b/internal/case/mcp/federated_graphql_ext_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"trip2g/internal/case/mcp"
 	"trip2g/internal/metrics"
@@ -15,10 +16,10 @@ import (
 // federationGraphQLMock extends federationMock with a working GraphQLRequest.
 type federationGraphQLMock struct {
 	federationMock
-	graphqlFunc func(ctx context.Context, params appmodel.FederationGraphQLParams) (appmodel.FederationResult, error)
+	graphqlFunc func(ctx context.Context, params appmodel.MCPGraphQLParams) (appmodel.FederationResult, error)
 }
 
-func (m *federationGraphQLMock) GraphQLRequest(ctx context.Context, params appmodel.FederationGraphQLParams) (appmodel.FederationResult, error) {
+func (m *federationGraphQLMock) GraphQLRequest(ctx context.Context, params appmodel.MCPGraphQLParams) (appmodel.FederationResult, error) {
 	if m.graphqlFunc == nil {
 		panic("unexpected GraphQLRequest call")
 	}
@@ -37,6 +38,7 @@ func buildFedGQLEnvMock(t *testing.T, federatedEnabled bool, clientFactory func(
 	nvs.MCPFederationNotes = []*appmodel.MCPFederationNote{appmodel.NewMCPFederationNote(kbNote)}
 
 	return &EnvMock{
+		FederatedFanoutTimeoutFunc:  func() time.Duration { return 2 * time.Second },
 		LatestNoteViewsFunc:         func() *appmodel.NoteViews { return nvs },
 		CanReadNoteFunc:             func(_ context.Context, _ *appmodel.NoteView) (bool, error) { return true, nil },
 		FederationClientFunc:        clientFactory,
@@ -134,11 +136,11 @@ func TestGraphQLRequest_FedAuthFlagOff_MethodNotFound(t *testing.T) {
 // TestFederatedGraphQLRequest_SenderForwardsViaClient: flag on + valid query →
 // callFederatedSingleKB invoked, client.GraphQLRequest called with correct KBID/query/variables.
 func TestFederatedGraphQLRequest_SenderForwardsViaClient(t *testing.T) {
-	var gotParams appmodel.FederationGraphQLParams
+	var gotParams appmodel.MCPGraphQLParams
 	clientCalled := false
 
 	federation := &federationGraphQLMock{
-		graphqlFunc: func(_ context.Context, params appmodel.FederationGraphQLParams) (appmodel.FederationResult, error) {
+		graphqlFunc: func(_ context.Context, params appmodel.MCPGraphQLParams) (appmodel.FederationResult, error) {
 			clientCalled = true
 			gotParams = params
 			return appmodel.FederationResult{

--- a/internal/case/mcp/federated_instructions_test.go
+++ b/internal/case/mcp/federated_instructions_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"trip2g/internal/case/mcp"
 	"trip2g/internal/fedinstr"
@@ -53,9 +54,10 @@ func TestFederatedInstructionsDirectPeer(t *testing.T) {
 		},
 	}
 	env := &EnvMock{
-		MCPMetricsFunc:      func() *metrics.MCPMetrics { return nil },
-		LatestNoteViewsFunc: func() *appmodel.NoteViews { return nvs },
-		CanReadNoteFunc:     func(context.Context, *appmodel.NoteView) (bool, error) { return true, nil },
+		FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+		MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+		LatestNoteViewsFunc:        func() *appmodel.NoteViews { return nvs },
+		CanReadNoteFunc:            func(context.Context, *appmodel.NoteView) (bool, error) { return true, nil },
 		FederationClientFunc: func(_ context.Context, kbID string) (appmodel.Federation, error) {
 			require.Equal(t, "bob", kbID)
 			return federation, nil
@@ -75,7 +77,7 @@ func TestFederatedInstructionsNestedForwards(t *testing.T) {
 	cache := fedinstr.New()
 	var gotKBID string
 	federation := &federationMock{
-		federatedInstructionsFunc: func(_ context.Context, params appmodel.FederationInstructionsParams) (appmodel.FederationResult, error) {
+		federatedInstructionsFunc: func(_ context.Context, params appmodel.MCPInstructionsParams) (appmodel.FederationResult, error) {
 			gotKBID = params.KBID
 			return appmodel.FederationResult{
 				Content: []appmodel.FederationContent{{Type: "text", Text: "nietzsche's guidance"}},
@@ -83,9 +85,10 @@ func TestFederatedInstructionsNestedForwards(t *testing.T) {
 		},
 	}
 	env := &EnvMock{
-		MCPMetricsFunc:      func() *metrics.MCPMetrics { return nil },
-		LatestNoteViewsFunc: func() *appmodel.NoteViews { return nvs },
-		CanReadNoteFunc:     func(context.Context, *appmodel.NoteView) (bool, error) { return true, nil },
+		FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+		MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+		LatestNoteViewsFunc:        func() *appmodel.NoteViews { return nvs },
+		CanReadNoteFunc:            func(context.Context, *appmodel.NoteView) (bool, error) { return true, nil },
 		FederationClientFunc: func(_ context.Context, kbID string) (appmodel.Federation, error) {
 			require.Equal(t, "bob", kbID)
 			return federation, nil
@@ -107,6 +110,7 @@ func TestFederatedInstructionsRespectsMaxDepth(t *testing.T) {
 	cache := fedinstr.New()
 	federation := &federationMock{} // must never be called: depth is rejected up front
 	env := &EnvMock{
+		FederatedFanoutTimeoutFunc:      func() time.Duration { return 2 * time.Second },
 		MCPMetricsFunc:                  func() *metrics.MCPMetrics { return nil },
 		LatestNoteViewsFunc:             func() *appmodel.NoteViews { return nvs },
 		CanReadNoteFunc:                 func(context.Context, *appmodel.NoteView) (bool, error) { return true, nil },
@@ -135,6 +139,7 @@ func TestFederatedInstructionsCacheHitSkipsForward(t *testing.T) {
 		},
 	}
 	env := &EnvMock{
+		FederatedFanoutTimeoutFunc:      func() time.Duration { return 2 * time.Second },
 		MCPMetricsFunc:                  func() *metrics.MCPMetrics { return nil },
 		LatestNoteViewsFunc:             func() *appmodel.NoteViews { return nvs },
 		CanReadNoteFunc:                 func(context.Context, *appmodel.NoteView) (bool, error) { return true, nil },
@@ -163,6 +168,7 @@ func TestFederatedInstructionsCacheConcurrent(t *testing.T) {
 		},
 	}
 	env := &EnvMock{
+		FederatedFanoutTimeoutFunc:      func() time.Duration { return 2 * time.Second },
 		MCPMetricsFunc:                  func() *metrics.MCPMetrics { return nil },
 		LatestNoteViewsFunc:             func() *appmodel.NoteViews { return nvs },
 		CanReadNoteFunc:                 func(context.Context, *appmodel.NoteView) (bool, error) { return true, nil },
@@ -196,6 +202,7 @@ func TestFederatedInstructionsUnknownKBID(t *testing.T) {
 	nvs := fedInstrNoteViews()
 	cache := fedinstr.New()
 	env := &EnvMock{
+		FederatedFanoutTimeoutFunc:      func() time.Duration { return 2 * time.Second },
 		MCPMetricsFunc:                  func() *metrics.MCPMetrics { return nil },
 		LatestNoteViewsFunc:             func() *appmodel.NoteViews { return nvs },
 		CanReadNoteFunc:                 func(context.Context, *appmodel.NoteView) (bool, error) { return true, nil },
@@ -211,7 +218,8 @@ func TestFederatedInstructionsUnknownKBID(t *testing.T) {
 }
 
 func TestFederatedInstructionsRequiresKBID(t *testing.T) {
-	env := &EnvMock{MCPMetricsFunc: func() *metrics.MCPMetrics { return nil }}
+	env := &EnvMock{
+		FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second }, MCPMetricsFunc: func() *metrics.MCPMetrics { return nil }}
 	resp := callFederatedInstructions(t, env, `{}`)
 	require.NotNil(t, resp.Error)
 	require.Equal(t, mcp.ErrCodeInvalidParams, resp.Error.Code)

--- a/internal/case/mcp/federation_fanout_test.go
+++ b/internal/case/mcp/federation_fanout_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type fanoutSearchFn = func(context.Context, appmodel.FederationSearchParams) (appmodel.FederationResult, error)
+type fanoutSearchFn = func(context.Context, appmodel.MCPSearchParams) (appmodel.FederationResult, error)
 
 // fanoutEnv builds an env with n federation KB notes (kb1..kbn, registration
 // order) whose clients answer Search via searchFunc, plus the fan-out knobs.
@@ -80,7 +80,7 @@ func TestFederatedSearchBlindFanoutCapsPeersAndReportsSkipped(t *testing.T) {
 	var mu sync.Mutex
 	queried := map[string]bool{}
 	env := fanoutEnv(5, 3, 5, time.Second, func(kbID string) fanoutSearchFn {
-		return func(_ context.Context, _ appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+		return func(_ context.Context, _ appmodel.MCPSearchParams) (appmodel.FederationResult, error) {
 			mu.Lock()
 			queried[kbID] = true
 			mu.Unlock()
@@ -110,7 +110,7 @@ func TestFederatedSearchBlindFanoutCapsPeersAndReportsSkipped(t *testing.T) {
 func TestFederatedSearchFanoutConcurrencyBounded(t *testing.T) {
 	var inflight, peak atomic.Int64
 	env := fanoutEnv(6, 10, 2, 5*time.Second, func(kbID string) fanoutSearchFn {
-		return func(_ context.Context, _ appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+		return func(_ context.Context, _ appmodel.MCPSearchParams) (appmodel.FederationResult, error) {
 			cur := inflight.Add(1)
 			for {
 				old := peak.Load()
@@ -136,7 +136,7 @@ func TestFederatedSearchHungPeerTimesOutOthersReturn(t *testing.T) {
 	hung := make(chan struct{})
 	t.Cleanup(func() { close(hung) })
 	env := fanoutEnv(3, 10, 5, 100*time.Millisecond, func(kbID string) fanoutSearchFn {
-		return func(_ context.Context, _ appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+		return func(_ context.Context, _ appmodel.MCPSearchParams) (appmodel.FederationResult, error) {
 			if kbID == "kb2" {
 				<-hung
 				return appmodel.FederationResult{}, context.Canceled
@@ -165,7 +165,7 @@ func TestFederatedSearchExplicitKBIDsIgnoreFanoutLimit(t *testing.T) {
 	var mu sync.Mutex
 	queried := map[string]bool{}
 	env := fanoutEnv(5, 2, 5, time.Second, func(kbID string) fanoutSearchFn {
-		return func(_ context.Context, _ appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+		return func(_ context.Context, _ appmodel.MCPSearchParams) (appmodel.FederationResult, error) {
 			mu.Lock()
 			queried[kbID] = true
 			mu.Unlock()

--- a/internal/case/mcp/federation_handlers.go
+++ b/internal/case/mcp/federation_handlers.go
@@ -10,7 +10,7 @@ import (
 )
 
 func handleFederatedSearch(ctx context.Context, env Env, id any, argsRaw json.RawMessage) Response {
-	args, errResp := unmarshalArgs[FederatedSearchArguments](argsRaw, id, "federated_search")
+	args, errResp := unmarshalArgs[model.MCPSearchParams](argsRaw, id, "federated_search")
 	if errResp != nil {
 		return *errResp
 	}
@@ -41,7 +41,7 @@ func handleFederatedSearch(ctx context.Context, env Env, id any, argsRaw json.Ra
 		}
 		results := fanout(ctx, env, selected, env.FederatedFanoutConcurrency(), env.FederatedFanoutTimeout(),
 			func(ctx context.Context, client model.Federation) (model.FederationResult, error) {
-				return client.Search(ctx, model.FederationSearchParams{Query: args.Query})
+				return client.Search(ctx, forwarded(*args))
 			})
 		m := metricsFromContext(ctx)
 		touched := 0
@@ -67,7 +67,7 @@ func handleFederatedSearch(ctx context.Context, env Env, id any, argsRaw json.Ra
 		metricsFromContext(ctx).RecordFederatedRequest(federatedStatus(err))
 		return errorResponse(id, ErrCodeInternal, err.Error())
 	}
-	params := model.FederationSearchParams{Query: args.Query}
+	params := forwarded(*args)
 	var result model.FederationResult
 	if rest == "" {
 		result, err = client.Search(ctx, params)
@@ -148,7 +148,7 @@ func federatedSingleKBResult(
 // tools. Results are cached per full kb_id path so repeat calls (and
 // already-visited routes) are served without re-forwarding.
 func handleFederatedInstructions(ctx context.Context, env Env, id any, argsRaw json.RawMessage) Response {
-	args, errResp := unmarshalArgs[FederatedInstructionsArguments](argsRaw, id, "federated_instructions")
+	args, errResp := unmarshalArgs[model.MCPInstructionsParams](argsRaw, id, "federated_instructions")
 	if errResp != nil {
 		return *errResp
 	}
@@ -165,7 +165,7 @@ func handleFederatedInstructions(ctx context.Context, env Env, id any, argsRaw j
 			if rest == "" {
 				return client.Instructions(ctx)
 			}
-			return client.FederatedInstructions(ctx, model.FederationInstructionsParams{KBID: rest})
+			return client.FederatedInstructions(ctx, model.MCPInstructionsParams{KBID: rest})
 		})
 	if errResp != nil {
 		return *errResp
@@ -175,20 +175,14 @@ func handleFederatedInstructions(ctx context.Context, env Env, id any, argsRaw j
 }
 
 func handleFederatedSimilar(ctx context.Context, env Env, id any, argsRaw json.RawMessage) Response {
-	args, errResp := unmarshalArgs[FederatedSimilarArguments](argsRaw, id, "federated_similar")
+	args, errResp := unmarshalArgs[model.MCPSimilarParams](argsRaw, id, "federated_similar")
 	if errResp != nil {
 		return *errResp
 	}
 	if args.KBID == "" {
 		return errorResponse(id, ErrCodeInvalidParams, "kb_id is required")
 	}
-	params := model.FederationSimilarParams{
-		PID:    args.PID,
-		NoteID: args.NoteID,
-		Path:   args.Path,
-		Href:   args.Href,
-		Limit:  args.Limit,
-	}
+	params := forwarded(*args)
 	return callFederatedSingleKB(ctx, env, id, args.KBID, func(client model.Federation, rest string) (model.FederationResult, error) {
 		if rest == "" {
 			return client.Similar(ctx, params)
@@ -199,20 +193,14 @@ func handleFederatedSimilar(ctx context.Context, env Env, id any, argsRaw json.R
 }
 
 func handleFederatedNoteHTML(ctx context.Context, env Env, id any, argsRaw json.RawMessage) Response {
-	args, errResp := unmarshalArgs[FederatedNoteHTMLArguments](argsRaw, id, "federated_note_html")
+	args, errResp := unmarshalArgs[model.MCPNoteHTMLParams](argsRaw, id, "federated_note_html")
 	if errResp != nil {
 		return *errResp
 	}
 	if args.KBID == "" {
 		return errorResponse(id, ErrCodeInvalidParams, "kb_id is required")
 	}
-	params := model.FederationNoteHTMLParams{
-		PID:     args.PID.Value,
-		NoteID:  args.NoteID,
-		Path:    args.Path,
-		Href:    args.Href,
-		MatchID: args.MatchID,
-	}
+	params := forwarded(*args)
 	return callFederatedSingleKB(ctx, env, id, args.KBID, func(client model.Federation, rest string) (model.FederationResult, error) {
 		if rest == "" {
 			return client.NoteHTML(ctx, params)
@@ -223,20 +211,14 @@ func handleFederatedNoteHTML(ctx context.Context, env Env, id any, argsRaw json.
 }
 
 func handleFederatedExpand(ctx context.Context, env Env, id any, argsRaw json.RawMessage) Response {
-	args, errResp := unmarshalArgs[FederatedExpandArguments](argsRaw, id, "federated_expand")
+	args, errResp := unmarshalArgs[model.MCPExpandParams](argsRaw, id, "federated_expand")
 	if errResp != nil {
 		return *errResp
 	}
 	if args.KBID == "" {
 		return errorResponse(id, ErrCodeInvalidParams, "kb_id is required")
 	}
-	params := model.FederationExpandParams{
-		PID:     args.PID,
-		NoteID:  args.NoteID,
-		Path:    args.Path,
-		Href:    args.Href,
-		TocPath: args.TocPath,
-	}
+	params := forwarded(*args)
 	return callFederatedSingleKB(ctx, env, id, args.KBID, func(client model.Federation, rest string) (model.FederationResult, error) {
 		if rest == "" {
 			return client.Expand(ctx, params)
@@ -267,7 +249,7 @@ func handleFederatedGraphQLRequest(ctx context.Context, env Env, id any, argsRaw
 	}
 
 	return callFederatedSingleKB(ctx, env, id, args.KBID, func(client model.Federation, rest string) (model.FederationResult, error) {
-		return client.GraphQLRequest(ctx, model.FederationGraphQLParams{KBID: rest, Query: args.Query, Variables: args.Variables})
+		return client.GraphQLRequest(ctx, model.MCPGraphQLParams{KBID: rest, Query: args.Query, Variables: args.Variables})
 	})
 }
 
@@ -314,4 +296,24 @@ func federationNotConfiguredResponse(id any, kbID string) Response {
 		Message: message,
 	}
 	return successResponse(id, structuredToolResult(message, payload))
+}
+
+// forwarded strips the hub's routing token from a federated call's arguments so
+// the rest of them — limit, detail_limit, toc_path, match_id, the note id —
+// reach the peer verbatim. The hub and the peer share one params type per tool,
+// so nothing can be dropped by forgetting to copy a field.
+func forwarded[T interface {
+	model.MCPSearchParams | model.MCPSimilarParams | model.MCPNoteHTMLParams | model.MCPExpandParams
+}](args T) T {
+	switch p := any(&args).(type) {
+	case *model.MCPSearchParams:
+		p.KBID, p.KBIDs = "", nil
+	case *model.MCPSimilarParams:
+		p.KBID = ""
+	case *model.MCPNoteHTMLParams:
+		p.KBID = ""
+	case *model.MCPExpandParams:
+		p.KBID = ""
+	}
+	return args
 }

--- a/internal/case/mcp/federation_handlers.go
+++ b/internal/case/mcp/federation_handlers.go
@@ -126,20 +126,21 @@ func federatedSingleKBResult(
 		resp := federationNotConfiguredResponse(id, kbID)
 		return model.FederationResult{}, &resp
 	}
-	client, err := env.FederationClient(ctx, kb.ID)
-	if err != nil {
-		// A client that can't be built is still a failed outbound attempt,
-		// same as on the fan-out path.
-		metricsFromContext(ctx).RecordFederatedRequest(federatedStatus(err))
-		resp := errorResponse(id, ErrCodeInternal, err.Error())
-		return model.FederationResult{}, &resp
-	}
-	result, err := call(client, rest)
+	// Bound the hop like the fan-out path does. Without a deadline a peer that
+	// accepts the connection and never answers leaves the agent waiting on a
+	// tool that never returns, which is worse for it than a fast failure.
+	result, err := callPeer(ctx, env, kb.ID, env.FederatedFanoutTimeout(),
+		func(ctx context.Context, client model.Federation) (model.FederationResult, error) {
+			return call(client, rest)
+		})
 	metricsFromContext(ctx).RecordFederatedRequest(federatedStatus(err))
 	if err != nil {
 		resp := errorResponse(id, ErrCodeInternal, err.Error())
 		return model.FederationResult{}, &resp
 	}
+	// A peer answering "not configured" names the kb_id in its own frame; the
+	// caller must see it in theirs, same as on the fan-out path.
+	rewriteFederatedResponse(kb.ID, &result)
 	return result, nil
 }
 

--- a/internal/case/mcp/federation_handlers_test.go
+++ b/internal/case/mcp/federation_handlers_test.go
@@ -438,10 +438,20 @@ func TestFederatedSingleKBCallTimesOut(t *testing.T) {
 	nvs := appmodel.NewNoteViews()
 	nvs.MCPFederationNotes = []*appmodel.MCPFederationNote{appmodel.NewMCPFederationNote(kbNote)}
 
+	const peerSilence = 3 * time.Second
 	federation := &federationMock{
 		noteHTMLFunc: func(ctx context.Context, _ appmodel.MCPNoteHTMLParams) (appmodel.FederationResult, error) {
-			<-ctx.Done() // a peer that never answers
-			return appmodel.FederationResult{}, ctx.Err()
+			// A peer that accepts the call and sits on it. The upper bound only
+			// keeps the test from hanging when the hop is unbounded; the hop's
+			// own deadline is an order of magnitude shorter.
+			select {
+			case <-ctx.Done():
+				return appmodel.FederationResult{}, ctx.Err()
+			case <-time.After(peerSilence):
+				return appmodel.FederationResult{
+					Content: []appmodel.FederationContent{{Type: "text", Text: "too late"}},
+				}, nil
+			}
 		},
 	}
 	env := &EnvMock{
@@ -463,15 +473,9 @@ func TestFederatedSingleKBCallTimesOut(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	done := make(chan mcp.Response, 1)
-	go func() {
-		done <- callMCP(t, env, mcp.Request{JSONRPC: "2.0", Method: "tools/call", Params: paramsJSON, ID: 1})
-	}()
+	start := time.Now()
+	resp := callMCP(t, env, mcp.Request{JSONRPC: "2.0", Method: "tools/call", Params: paramsJSON, ID: 1})
 
-	select {
-	case resp := <-done:
-		require.NotNil(t, resp.Error, "an unanswered peer must surface as an error, not a result")
-	case <-time.After(5 * time.Second):
-		t.Fatal("federated_note_html did not return: the single-KB hop is unbounded")
-	}
+	require.NotNil(t, resp.Error, "an unanswered peer must surface as an error, not a result")
+	require.Less(t, time.Since(start), peerSilence, "the hop must give up on its own deadline")
 }

--- a/internal/case/mcp/federation_handlers_test.go
+++ b/internal/case/mcp/federation_handlers_test.go
@@ -424,3 +424,54 @@ func TestFederatedCallsForwardEveryArgument(t *testing.T) {
 	call("federated_similar", `{"kb_id":"nietzsche","path":"a.md","limit":3}`)
 	require.Equal(t, 3, similar.Limit)
 }
+
+// TestFederatedSingleKBCallTimesOut pins the deadline on the single-KB hop. Only
+// the fan-out path was bounded, so a peer that accepted the connection and never
+// answered left the agent waiting on a tool that never returned — worse for it
+// than a fast failure.
+func TestFederatedSingleKBCallTimesOut(t *testing.T) {
+	kbNote := &appmodel.NoteView{
+		PathID:             17,
+		MCPFederationKBURL: "https://bob.example/_system/mcp",
+		MCPFederationKBID:  "nietzsche",
+	}
+	nvs := appmodel.NewNoteViews()
+	nvs.MCPFederationNotes = []*appmodel.MCPFederationNote{appmodel.NewMCPFederationNote(kbNote)}
+
+	federation := &federationMock{
+		noteHTMLFunc: func(ctx context.Context, _ appmodel.MCPNoteHTMLParams) (appmodel.FederationResult, error) {
+			<-ctx.Done() // a peer that never answers
+			return appmodel.FederationResult{}, ctx.Err()
+		},
+	}
+	env := &EnvMock{
+		FederationMaxDepthFunc:     func() int { return 3 },
+		FederatedFanoutTimeoutFunc: func() time.Duration { return 50 * time.Millisecond },
+		MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+		LatestNoteViewsFunc:        func() *appmodel.NoteViews { return nvs },
+		CanReadNoteFunc: func(_ context.Context, _ *appmodel.NoteView) (bool, error) {
+			return true, nil
+		},
+		FederationClientFunc: func(_ context.Context, _ string) (appmodel.Federation, error) {
+			return federation, nil
+		},
+	}
+
+	paramsJSON, err := json.Marshal(mcp.CallToolParams{
+		Name:      "federated_note_html",
+		Arguments: json.RawMessage(`{"kb_id":"nietzsche","path":"a.md"}`),
+	})
+	require.NoError(t, err)
+
+	done := make(chan mcp.Response, 1)
+	go func() {
+		done <- callMCP(t, env, mcp.Request{JSONRPC: "2.0", Method: "tools/call", Params: paramsJSON, ID: 1})
+	}()
+
+	select {
+	case resp := <-done:
+		require.NotNil(t, resp.Error, "an unanswered peer must surface as an error, not a result")
+	case <-time.After(5 * time.Second):
+		t.Fatal("federated_note_html did not return: the single-KB hop is unbounded")
+	}
+}

--- a/internal/case/mcp/federation_handlers_test.go
+++ b/internal/case/mcp/federation_handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"trip2g/internal/case/mcp"
 	"trip2g/internal/metrics"
@@ -13,61 +14,65 @@ import (
 )
 
 type federationMock struct {
-	searchFunc          func(ctx context.Context, params appmodel.FederationSearchParams) (appmodel.FederationResult, error)
-	federatedSearchFunc func(ctx context.Context, params appmodel.FederationSearchParams) (appmodel.FederationResult, error)
-	noteHTMLFunc        func(ctx context.Context, params appmodel.FederationNoteHTMLParams) (appmodel.FederationResult, error)
-	expandFunc          func(ctx context.Context, params appmodel.FederationExpandParams) (appmodel.FederationResult, error)
-	federatedExpandFunc func(ctx context.Context, params appmodel.FederationExpandParams) (appmodel.FederationResult, error)
+	searchFunc          func(ctx context.Context, params appmodel.MCPSearchParams) (appmodel.FederationResult, error)
+	federatedSearchFunc func(ctx context.Context, params appmodel.MCPSearchParams) (appmodel.FederationResult, error)
+	noteHTMLFunc        func(ctx context.Context, params appmodel.MCPNoteHTMLParams) (appmodel.FederationResult, error)
+	similarFunc         func(ctx context.Context, params appmodel.MCPSimilarParams) (appmodel.FederationResult, error)
+	expandFunc          func(ctx context.Context, params appmodel.MCPExpandParams) (appmodel.FederationResult, error)
+	federatedExpandFunc func(ctx context.Context, params appmodel.MCPExpandParams) (appmodel.FederationResult, error)
 
 	instructionsFunc          func(ctx context.Context) (appmodel.FederationResult, error)
-	federatedInstructionsFunc func(ctx context.Context, params appmodel.FederationInstructionsParams) (appmodel.FederationResult, error)
+	federatedInstructionsFunc func(ctx context.Context, params appmodel.MCPInstructionsParams) (appmodel.FederationResult, error)
 }
 
-func (m *federationMock) Search(ctx context.Context, params appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+func (m *federationMock) Search(ctx context.Context, params appmodel.MCPSearchParams) (appmodel.FederationResult, error) {
 	if m.searchFunc == nil {
 		panic("unexpected Search call")
 	}
 	return m.searchFunc(ctx, params)
 }
 
-func (m *federationMock) Similar(ctx context.Context, params appmodel.FederationSimilarParams) (appmodel.FederationResult, error) {
-	panic("unexpected Similar call")
+func (m *federationMock) Similar(ctx context.Context, params appmodel.MCPSimilarParams) (appmodel.FederationResult, error) {
+	if m.similarFunc == nil {
+		panic("unexpected Similar call")
+	}
+	return m.similarFunc(ctx, params)
 }
 
-func (m *federationMock) NoteHTML(ctx context.Context, params appmodel.FederationNoteHTMLParams) (appmodel.FederationResult, error) {
+func (m *federationMock) NoteHTML(ctx context.Context, params appmodel.MCPNoteHTMLParams) (appmodel.FederationResult, error) {
 	if m.noteHTMLFunc == nil {
 		panic("unexpected NoteHTML call")
 	}
 	return m.noteHTMLFunc(ctx, params)
 }
 
-func (m *federationMock) FederatedSearch(ctx context.Context, params appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+func (m *federationMock) FederatedSearch(ctx context.Context, params appmodel.MCPSearchParams) (appmodel.FederationResult, error) {
 	if m.federatedSearchFunc == nil {
 		panic("unexpected FederatedSearch call")
 	}
 	return m.federatedSearchFunc(ctx, params)
 }
 
-func (m *federationMock) FederatedSimilar(ctx context.Context, params appmodel.FederationSimilarParams) (appmodel.FederationResult, error) {
+func (m *federationMock) FederatedSimilar(ctx context.Context, params appmodel.MCPSimilarParams) (appmodel.FederationResult, error) {
 	panic("unexpected FederatedSimilar call")
 }
 
-func (m *federationMock) FederatedNoteHTML(ctx context.Context, params appmodel.FederationNoteHTMLParams) (appmodel.FederationResult, error) {
+func (m *federationMock) FederatedNoteHTML(ctx context.Context, params appmodel.MCPNoteHTMLParams) (appmodel.FederationResult, error) {
 	panic("unexpected FederatedNoteHTML call")
 }
 
-func (m *federationMock) GraphQLRequest(ctx context.Context, params appmodel.FederationGraphQLParams) (appmodel.FederationResult, error) {
+func (m *federationMock) GraphQLRequest(ctx context.Context, params appmodel.MCPGraphQLParams) (appmodel.FederationResult, error) {
 	panic("unexpected GraphQLRequest call")
 }
 
-func (m *federationMock) Expand(ctx context.Context, params appmodel.FederationExpandParams) (appmodel.FederationResult, error) {
+func (m *federationMock) Expand(ctx context.Context, params appmodel.MCPExpandParams) (appmodel.FederationResult, error) {
 	if m.expandFunc == nil {
 		panic("unexpected Expand call")
 	}
 	return m.expandFunc(ctx, params)
 }
 
-func (m *federationMock) FederatedExpand(ctx context.Context, params appmodel.FederationExpandParams) (appmodel.FederationResult, error) {
+func (m *federationMock) FederatedExpand(ctx context.Context, params appmodel.MCPExpandParams) (appmodel.FederationResult, error) {
 	if m.federatedExpandFunc == nil {
 		panic("unexpected FederatedExpand call")
 	}
@@ -81,7 +86,7 @@ func (m *federationMock) Instructions(ctx context.Context) (appmodel.FederationR
 	return m.instructionsFunc(ctx)
 }
 
-func (m *federationMock) FederatedInstructions(ctx context.Context, params appmodel.FederationInstructionsParams) (appmodel.FederationResult, error) {
+func (m *federationMock) FederatedInstructions(ctx context.Context, params appmodel.MCPInstructionsParams) (appmodel.FederationResult, error) {
 	if m.federatedInstructionsFunc == nil {
 		panic("unexpected FederatedInstructions call")
 	}
@@ -99,7 +104,7 @@ func TestFederatedSearchUsesMockedFederationClient(t *testing.T) {
 
 	var gotQuery string
 	federation := &federationMock{
-		searchFunc: func(ctx context.Context, params appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+		searchFunc: func(ctx context.Context, params appmodel.MCPSearchParams) (appmodel.FederationResult, error) {
 			gotQuery = params.Query
 			return appmodel.FederationResult{
 				Content:           []appmodel.FederationContent{{Type: "text", Text: "remote bob"}},
@@ -108,7 +113,8 @@ func TestFederatedSearchUsesMockedFederationClient(t *testing.T) {
 		},
 	}
 	env := &EnvMock{
-		MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
+		FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+		MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
 		LatestNoteViewsFunc: func() *appmodel.NoteViews {
 			return nvs
 		},
@@ -155,9 +161,9 @@ func TestFederatedNoteHTMLToleratesStringPID(t *testing.T) {
 	nvs := appmodel.NewNoteViews()
 	nvs.MCPFederationNotes = []*appmodel.MCPFederationNote{appmodel.NewMCPFederationNote(kbNote)}
 
-	var gotParams appmodel.FederationNoteHTMLParams
+	var gotParams appmodel.MCPNoteHTMLParams
 	federation := &federationMock{
-		noteHTMLFunc: func(ctx context.Context, params appmodel.FederationNoteHTMLParams) (appmodel.FederationResult, error) {
+		noteHTMLFunc: func(ctx context.Context, params appmodel.MCPNoteHTMLParams) (appmodel.FederationResult, error) {
 			gotParams = params
 			return appmodel.FederationResult{
 				Content: []appmodel.FederationContent{{Type: "text", Text: "remote note body"}},
@@ -165,7 +171,8 @@ func TestFederatedNoteHTMLToleratesStringPID(t *testing.T) {
 		},
 	}
 	env := &EnvMock{
-		MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
+		FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+		MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
 		LatestNoteViewsFunc: func() *appmodel.NoteViews {
 			return nvs
 		},
@@ -193,7 +200,7 @@ func TestFederatedNoteHTMLToleratesStringPID(t *testing.T) {
 	result := resp.Result.(mcp.CallToolResult)
 	require.Equal(t, "remote note body", result.Content[0].Text)
 	require.Equal(t, "concepts/volya-k-vlasti.md", gotParams.Path)
-	require.Zero(t, gotParams.PID)
+	require.Zero(t, gotParams.PID.Value)
 }
 
 func TestFederatedNoteHTMLForwardsMatchIDOnly(t *testing.T) {
@@ -208,9 +215,9 @@ func TestFederatedNoteHTMLForwardsMatchIDOnly(t *testing.T) {
 	nvs := appmodel.NewNoteViews()
 	nvs.MCPFederationNotes = []*appmodel.MCPFederationNote{appmodel.NewMCPFederationNote(kbNote)}
 
-	var gotParams appmodel.FederationNoteHTMLParams
+	var gotParams appmodel.MCPNoteHTMLParams
 	federation := &federationMock{
-		noteHTMLFunc: func(ctx context.Context, params appmodel.FederationNoteHTMLParams) (appmodel.FederationResult, error) {
+		noteHTMLFunc: func(ctx context.Context, params appmodel.MCPNoteHTMLParams) (appmodel.FederationResult, error) {
 			gotParams = params
 			return appmodel.FederationResult{
 				Content: []appmodel.FederationContent{{Type: "text", Text: "focused chunk"}},
@@ -218,7 +225,8 @@ func TestFederatedNoteHTMLForwardsMatchIDOnly(t *testing.T) {
 		},
 	}
 	env := &EnvMock{
-		MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
+		FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+		MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
 		LatestNoteViewsFunc: func() *appmodel.NoteViews {
 			return nvs
 		},
@@ -260,7 +268,7 @@ func TestFederatedSearchDelegatesNestedKBID(t *testing.T) {
 
 	var gotKBID string
 	federation := &federationMock{
-		federatedSearchFunc: func(ctx context.Context, params appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+		federatedSearchFunc: func(ctx context.Context, params appmodel.MCPSearchParams) (appmodel.FederationResult, error) {
 			gotKBID = params.KBID
 			return appmodel.FederationResult{
 				Content: []appmodel.FederationContent{{Type: "text", Text: "remote nested"}},
@@ -268,7 +276,8 @@ func TestFederatedSearchDelegatesNestedKBID(t *testing.T) {
 		},
 	}
 	env := &EnvMock{
-		MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
+		FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+		MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
 		LatestNoteViewsFunc: func() *appmodel.NoteViews {
 			return nvs
 		},
@@ -311,7 +320,7 @@ func TestFederatedExpandUsesMockedFederationClient(t *testing.T) {
 
 	var gotPath []string
 	federation := &federationMock{
-		expandFunc: func(_ context.Context, params appmodel.FederationExpandParams) (appmodel.FederationResult, error) {
+		expandFunc: func(_ context.Context, params appmodel.MCPExpandParams) (appmodel.FederationResult, error) {
 			gotPath = params.TocPath
 			return appmodel.FederationResult{
 				Content:           []appmodel.FederationContent{{Type: "text", Text: "remote children"}},
@@ -320,8 +329,9 @@ func TestFederatedExpandUsesMockedFederationClient(t *testing.T) {
 		},
 	}
 	env := &EnvMock{
-		MCPMetricsFunc:      func() *metrics.MCPMetrics { return nil },
-		LatestNoteViewsFunc: func() *appmodel.NoteViews { return nvs },
+		FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+		MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+		LatestNoteViewsFunc:        func() *appmodel.NoteViews { return nvs },
 		CanReadNoteFunc: func(_ context.Context, _ *appmodel.NoteView) (bool, error) {
 			return true, nil
 		},
@@ -348,4 +358,69 @@ func TestFederatedExpandUsesMockedFederationClient(t *testing.T) {
 	result := resp.Result.(mcp.CallToolResult)
 	require.Equal(t, "remote children", result.Content[0].Text)
 	require.JSONEq(t, `{"children":[{"title":"Sub"}]}`, string(result.StructuredContent.(json.RawMessage)))
+}
+
+// TestFederatedCallsForwardEveryArgument pins the class of bug that made the
+// hub advertise arguments it then dropped: limit and detail_limit never reached
+// a peer's search, and toc_path was absent from federated_note_html entirely,
+// so a remote read always returned the whole note instead of one section.
+func TestFederatedCallsForwardEveryArgument(t *testing.T) {
+	kbNote := &appmodel.NoteView{
+		PathID:             17,
+		MCPFederationKBURL: "https://bob.example/_system/mcp",
+		MCPFederationKBID:  "nietzsche",
+	}
+	nvs := appmodel.NewNoteViews()
+	nvs.MCPFederationNotes = []*appmodel.MCPFederationNote{appmodel.NewMCPFederationNote(kbNote)}
+
+	ok := appmodel.FederationResult{Content: []appmodel.FederationContent{{Type: "text", Text: "ok"}}}
+
+	var search appmodel.MCPSearchParams
+	var noteHTML appmodel.MCPNoteHTMLParams
+	var similar appmodel.MCPSimilarParams
+	federation := &federationMock{
+		searchFunc: func(_ context.Context, p appmodel.MCPSearchParams) (appmodel.FederationResult, error) {
+			search = p
+			return ok, nil
+		},
+		noteHTMLFunc: func(_ context.Context, p appmodel.MCPNoteHTMLParams) (appmodel.FederationResult, error) {
+			noteHTML = p
+			return ok, nil
+		},
+		similarFunc: func(_ context.Context, p appmodel.MCPSimilarParams) (appmodel.FederationResult, error) {
+			similar = p
+			return ok, nil
+		},
+	}
+	env := &EnvMock{
+		FederationMaxDepthFunc:     func() int { return 3 },
+		FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+		MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+		LatestNoteViewsFunc:        func() *appmodel.NoteViews { return nvs },
+		CanReadNoteFunc: func(_ context.Context, _ *appmodel.NoteView) (bool, error) {
+			return true, nil
+		},
+		FederationClientFunc: func(_ context.Context, _ string) (appmodel.Federation, error) {
+			return federation, nil
+		},
+	}
+
+	call := func(name, args string) {
+		t.Helper()
+		paramsJSON, err := json.Marshal(mcp.CallToolParams{Name: name, Arguments: json.RawMessage(args)})
+		require.NoError(t, err)
+		resp := callMCP(t, env, mcp.Request{JSONRPC: "2.0", Method: "tools/call", Params: paramsJSON, ID: 1})
+		require.Nil(t, resp.Error)
+	}
+
+	call("federated_search", `{"kb_id":"nietzsche","query":"воля","limit":2,"detail_limit":1}`)
+	require.Equal(t, 2, search.Limit)
+	require.Equal(t, 1, search.DetailLimit)
+	require.Empty(t, search.KBID, "the hub's routing token must not travel to the peer")
+
+	call("federated_note_html", `{"kb_id":"nietzsche","path":"a.md","toc_path":["Глава 1","Введение"]}`)
+	require.Equal(t, []string{"Глава 1", "Введение"}, noteHTML.TocPath)
+
+	call("federated_similar", `{"kb_id":"nietzsche","path":"a.md","limit":3}`)
+	require.Equal(t, 3, similar.Limit)
 }

--- a/internal/case/mcp/federation_helpers_test.go
+++ b/internal/case/mcp/federation_helpers_test.go
@@ -106,7 +106,8 @@ func TestVerifyInboundSentinels(t *testing.T) {
 	})
 
 	t.Run("bad signature", func(t *testing.T) {
-		_, _, err := verifyInbound(context.Background(), federationVerifyEnvMock{ //nolint:govet // err in closure shadows outer test err intentionally
+		_, _, err := verifyInbound(context.Background(), federationVerifyEnvMock{
+			//nolint:govet // err in closure shadows outer test err intentionally
 			secret:   db.FederationSecret{Kid: "alice", SecretCrypt: []byte("other-secret")},
 			secretOK: true,
 		}, valid)
@@ -138,7 +139,8 @@ func TestVerifyInboundSentinels(t *testing.T) {
 	})
 
 	t.Run("revoked", func(t *testing.T) {
-		_, _, err := verifyInbound(context.Background(), federationVerifyEnvMock{ //nolint:govet // err in closure shadows outer test err intentionally
+		_, _, err := verifyInbound(context.Background(), federationVerifyEnvMock{
+			//nolint:govet // err in closure shadows outer test err intentionally
 			secret:   db.FederationSecret{Kid: "alice", SecretCrypt: secret, RevokedAt: &now},
 			secretOK: true,
 		}, valid)

--- a/internal/case/mcp/federation_helpers_test.go
+++ b/internal/case/mcp/federation_helpers_test.go
@@ -106,8 +106,7 @@ func TestVerifyInboundSentinels(t *testing.T) {
 	})
 
 	t.Run("bad signature", func(t *testing.T) {
-		_, _, err := verifyInbound(context.Background(), federationVerifyEnvMock{
-			//nolint:govet // err in closure shadows outer test err intentionally
+		_, _, err := verifyInbound(context.Background(), federationVerifyEnvMock{ //nolint:govet // err in closure shadows outer test err intentionally
 			secret:   db.FederationSecret{Kid: "alice", SecretCrypt: []byte("other-secret")},
 			secretOK: true,
 		}, valid)
@@ -139,8 +138,7 @@ func TestVerifyInboundSentinels(t *testing.T) {
 	})
 
 	t.Run("revoked", func(t *testing.T) {
-		_, _, err := verifyInbound(context.Background(), federationVerifyEnvMock{
-			//nolint:govet // err in closure shadows outer test err intentionally
+		_, _, err := verifyInbound(context.Background(), federationVerifyEnvMock{ //nolint:govet // err in closure shadows outer test err intentionally
 			secret:   db.FederationSecret{Kid: "alice", SecretCrypt: secret, RevokedAt: &now},
 			secretOK: true,
 		}, valid)

--- a/internal/case/mcp/federation_hoprewrite_test.go
+++ b/internal/case/mcp/federation_hoprewrite_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"trip2g/internal/case/mcp"
 	"trip2g/internal/metrics"
@@ -23,8 +24,9 @@ func singlePeerEnv(kbID string, fed *federationMock) *EnvMock {
 	nvs := appmodel.NewNoteViews()
 	nvs.MCPFederationNotes = []*appmodel.MCPFederationNote{appmodel.NewMCPFederationNote(note)}
 	return &EnvMock{
-		MCPMetricsFunc:      func() *metrics.MCPMetrics { return nil },
-		LatestNoteViewsFunc: func() *appmodel.NoteViews { return nvs },
+		FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+		MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+		LatestNoteViewsFunc:        func() *appmodel.NoteViews { return nvs },
 		CanReadNoteFunc: func(context.Context, *appmodel.NoteView) (bool, error) {
 			return true, nil
 		},
@@ -50,7 +52,7 @@ func fedSingleSearchPayload(t *testing.T, result mcp.CallToolResult) mcp.SearchR
 func TestFederatedSearchPrefixesNestedKBID(t *testing.T) {
 	var gotKBID string
 	fed := &federationMock{
-		federatedSearchFunc: func(_ context.Context, params appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+		federatedSearchFunc: func(_ context.Context, params appmodel.MCPSearchParams) (appmodel.FederationResult, error) {
 			gotKBID = params.KBID
 			// The philosophers hub already stamped its child segment on the way up.
 			return appmodel.FederationResult{
@@ -73,7 +75,7 @@ func TestFederatedSearchPrefixesNestedKBID(t *testing.T) {
 // kb_id yet. Composed with the outer hop this is what accrues to the full path.
 func TestFederatedSearchStampsMiddleHopSegment(t *testing.T) {
 	fed := &federationMock{
-		searchFunc: func(context.Context, appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+		searchFunc: func(context.Context, appmodel.MCPSearchParams) (appmodel.FederationResult, error) {
 			// A leaf base answers over its own notes: no kb_id yet.
 			return appmodel.FederationResult{
 				Content:           []appmodel.FederationContent{{Type: "text", Text: "leaf"}},
@@ -93,7 +95,7 @@ func TestFederatedSearchStampsMiddleHopSegment(t *testing.T) {
 // Blind fan-out results keep the correct per-base kb_id for each direct peer.
 func TestFederatedSearchFanoutStampsPerBaseKBID(t *testing.T) {
 	env := fanoutEnv(2, 10, 5, 0, func(kbID string) fanoutSearchFn {
-		return func(context.Context, appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+		return func(context.Context, appmodel.MCPSearchParams) (appmodel.FederationResult, error) {
 			return appmodel.FederationResult{
 				Content:           []appmodel.FederationContent{{Type: "text", Text: "hit " + kbID}},
 				StructuredContent: json.RawMessage(`{"results":[{"title":"` + kbID + `"}]}`),
@@ -119,7 +121,7 @@ func TestFederatedSearchFanoutStampsPerBaseKBID(t *testing.T) {
 // prefixes its child segment so the suggested address is the caller's full path.
 func TestFederatedSearchComposedNotConfiguredHint(t *testing.T) {
 	fed := &federationMock{
-		federatedSearchFunc: func(context.Context, appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+		federatedSearchFunc: func(context.Context, appmodel.MCPSearchParams) (appmodel.FederationResult, error) {
 			return appmodel.FederationResult{
 				Content:           []appmodel.FederationContent{{Type: "text", Text: "not configured"}},
 				StructuredContent: json.RawMessage(`{"status":"federation_not_configured","kb_id":"ghost"}`),

--- a/internal/case/mcp/metrics_flow_test.go
+++ b/internal/case/mcp/metrics_flow_test.go
@@ -92,7 +92,7 @@ func withFederationEnv(env *EnvMock) {
 	env.LatestNoteViewsFunc = func() *appmodel.NoteViews { return nvs }
 	env.FederationClientFunc = func(_ context.Context, _ string) (appmodel.Federation, error) {
 		return &federationMock{
-			searchFunc: func(_ context.Context, _ appmodel.FederationSearchParams) (appmodel.FederationResult, error) {
+			searchFunc: func(_ context.Context, _ appmodel.MCPSearchParams) (appmodel.FederationResult, error) {
 				return appmodel.FederationResult{Content: []appmodel.FederationContent{{Type: "text", Text: "remote"}}}, nil
 			},
 		}, nil

--- a/internal/case/mcp/rerank_test.go
+++ b/internal/case/mcp/rerank_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -72,7 +73,8 @@ func searchRerankEnv(t *testing.T, feats features.Features, embURL string) *EnvM
 	noteB := &appmodel.NoteView{Path: "b.md", PathID: 2, Title: "B", Permalink: "/b"}
 
 	return &EnvMock{
-		MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
+		FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+		MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
 		SearchLiveNotesFunc: func(string) ([]appmodel.SearchResult, error) {
 			return []appmodel.SearchResult{
 				{NoteView: noteA, URL: noteA.Permalink, Score: 2.0, HighlightedContent: []string{"alpha"}},

--- a/internal/case/mcp/resolve.go
+++ b/internal/case/mcp/resolve.go
@@ -243,7 +243,7 @@ func resolveSearchLimits(log logger.Logger, limit, detailLimit int) (int, int) {
 func handleSearch(ctx context.Context, env Env, id any, argsRaw json.RawMessage) Response {
 	log := logger.WithPrefix(env.Logger(), "mcp:handleSearch")
 
-	args, errResp := unmarshalArgs[SearchArguments](argsRaw, id, "search")
+	args, errResp := unmarshalArgs[model.MCPSearchParams](argsRaw, id, "search")
 	if errResp != nil {
 		return *errResp
 	}
@@ -573,12 +573,12 @@ func noteKind(note *model.NoteView) string {
 func handleSimilar(ctx context.Context, env Env, id any, argsRaw json.RawMessage) Response {
 	log := logger.WithPrefix(env.Logger(), "mcp:handleSimilar")
 
-	args, errResp := unmarshalArgs[SimilarArguments](argsRaw, id, "similar")
+	args, errResp := unmarshalArgs[model.MCPSimilarParams](argsRaw, id, "similar")
 	if errResp != nil {
 		return *errResp
 	}
 
-	if args.Path == "" && args.Href == "" && args.PID == 0 && args.NoteID == 0 {
+	if args.Path == "" && args.Href == "" && args.PID.IsZero() && args.NoteID.IsZero() {
 		return errorResponse(id, ErrCodeInvalidParams, "one of pid, note_id, path, or href is required")
 	}
 
@@ -636,10 +636,10 @@ func handleSimilar(ctx context.Context, env Env, id any, argsRaw json.RawMessage
 	return successResponse(id, structuredToolResult(sb.String(), buildSimilarPayload(sourceNote, results, env.NoteURL)))
 }
 
-func resolveSimilarReference(noteViews *model.NoteViews, args SimilarArguments) *model.NoteView {
-	id := args.PID
+func resolveSimilarReference(noteViews *model.NoteViews, args model.MCPSimilarParams) *model.NoteView {
+	id := args.PID.Value
 	if id == 0 {
-		id = args.NoteID
+		id = args.NoteID.Value
 	}
 	if id != 0 {
 		return noteViews.GetByPathID(id)
@@ -679,7 +679,7 @@ func buildSimilarPayload(sourceNote *model.NoteView, results []graphmodel.Simila
 func handleNoteHTML(ctx context.Context, env Env, id any, argsRaw json.RawMessage) Response {
 	log := logger.WithPrefix(env.Logger(), "mcp:handleNoteHTML")
 
-	args, errResp := unmarshalArgs[NoteHTMLArguments](argsRaw, id, "note_html")
+	args, errResp := unmarshalArgs[model.MCPNoteHTMLParams](argsRaw, id, "note_html")
 	if errResp != nil {
 		return *errResp
 	}
@@ -762,21 +762,21 @@ func topLevelSectionsNudge(note *model.NoteView) string {
 func handleExpand(ctx context.Context, env Env, id any, argsRaw json.RawMessage) Response {
 	log := logger.WithPrefix(env.Logger(), "mcp:handleExpand")
 
-	args, errResp := unmarshalArgs[ExpandArguments](argsRaw, id, "expand")
+	args, errResp := unmarshalArgs[model.MCPExpandParams](argsRaw, id, "expand")
 	if errResp != nil {
 		return *errResp
 	}
 
-	if args.Path == "" && args.Href == "" && args.PID == 0 && args.NoteID == 0 {
+	if args.Path == "" && args.Href == "" && args.PID.IsZero() && args.NoteID.IsZero() {
 		return errorResponse(id, ErrCodeInvalidParams, "one of pid, note_id, path, or href is required")
 	}
 
 	noteViews := env.LatestNoteViews()
-	note := resolveNoteReference(noteViews, NoteHTMLArguments{
+	note := resolveNoteReference(noteViews, model.MCPNoteHTMLParams{
 		Path:   args.Path,
 		Href:   args.Href,
-		PID:    PID{Value: args.PID},
-		NoteID: PID{Value: args.NoteID},
+		PID:    args.PID,
+		NoteID: args.NoteID,
 	})
 	if note == nil {
 		log.Warn("note not found", "path", args.Path, "href", args.Href, "pid", args.PID, "note_id", args.NoteID)
@@ -867,7 +867,7 @@ func parseChunkMatchID(matchID string) (int64, int, bool) {
 	return pathID, chunkIndex, true
 }
 
-func resolveNoteReference(noteViews *model.NoteViews, args NoteHTMLArguments) *model.NoteView {
+func resolveNoteReference(noteViews *model.NoteViews, args model.MCPNoteHTMLParams) *model.NoteView {
 	id := args.PID.Value
 	if id == 0 {
 		id = args.NoteID.Value

--- a/internal/case/mcp/resolve.go
+++ b/internal/case/mcp/resolve.go
@@ -748,7 +748,7 @@ func handleNoteHTML(ctx context.Context, env Env, id any, argsRaw json.RawMessag
 // topLevelSectionsNudge is the cheap (~30 token) expand-shaped hint returned on
 // a pointer miss instead of the full note.
 func topLevelSectionsNudge(note *model.NoteView) string {
-	children := tocChildren(note.Headings, nil)
+	children := tocChildren(note, nil)
 	if len(children) == 0 {
 		return "the note has no sections; call note_html without toc_path to read the whole note"
 	}
@@ -792,7 +792,7 @@ func handleExpand(ctx context.Context, env Env, id any, argsRaw json.RawMessage)
 		return errorResponse(id, ErrCodeInvalidParams, "Note not found")
 	}
 
-	children := tocChildren(note.Headings, args.TocPath)
+	children := tocChildren(note, args.TocPath)
 	payload := ExpandPayload{
 		NoteID:   note.PathID,
 		NotePath: note.Path,
@@ -821,7 +821,11 @@ func expandSummary(note *model.NoteView, parentPath []string, children []TOCNode
 		if c.HasChildren {
 			marker = " (has subsections)"
 		}
-		fmt.Fprintf(&sb, "- %s%s\n", c.Title, marker)
+		preview := ""
+		if c.Preview != "" {
+			preview = " — " + c.Preview
+		}
+		fmt.Fprintf(&sb, "- %s%s%s\n", c.Title, marker, preview)
 	}
 	return sb.String()
 }

--- a/internal/case/mcp/resolve.go
+++ b/internal/case/mcp/resolve.go
@@ -311,6 +311,13 @@ func filterSearchResults(ctx context.Context, env Env, results []model.SearchRes
 		if r.NoteView.IsSystem() || r.NoteView.ExcludeSearch {
 			continue
 		}
+		// A note registered as a tool is server infrastructure: an agent gets
+		// its body from initialize or from calling the tool, so it is noise in
+		// results. The rule above only catches it when the vault happens to
+		// name it with a leading underscore.
+		if r.NoteView.MCPMethod != "" {
+			continue
+		}
 
 		ok, err := canReadMCPNote(ctx, env, r.NoteView)
 		if err != nil {

--- a/internal/case/mcp/resolve_entrypoint_test.go
+++ b/internal/case/mcp/resolve_entrypoint_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"trip2g/internal/case/mcp"
 	"trip2g/internal/logger"
@@ -30,6 +31,7 @@ func TestResolveEntryPoint(t *testing.T) {
 		views.PathMap[note.Path] = note
 
 		return &EnvMock{
+			FederatedFanoutTimeoutFunc:  func() time.Duration { return 2 * time.Second },
 			MCPMetricsFunc:              func() *metrics.MCPMetrics { return nil },
 			LoggerFunc:                  func() logger.Logger { return &logger.DummyLogger{} },
 			LatestNoteViewsFunc:         func() *appmodel.NoteViews { return views },

--- a/internal/case/mcp/resolve_test.go
+++ b/internal/case/mcp/resolve_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"trip2g/internal/case/mcp"
 	"trip2g/internal/features"
@@ -22,8 +23,9 @@ type Env interface {
 func TestResolve(t *testing.T) {
 	t.Run("initialize returns server info", func(t *testing.T) {
 		env := &EnvMock{
-			MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+			FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+			MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+			SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					List:    []*appmodel.NoteView{},
@@ -60,8 +62,9 @@ func TestResolve(t *testing.T) {
 		}
 
 		env := &EnvMock{
-			MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+			FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+			MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+			SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					List:    []*appmodel.NoteView{note},
@@ -112,8 +115,9 @@ soul_profile:
 		}
 
 		env := &EnvMock{
-			MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+			FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+			MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+			SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					List:    []*appmodel.NoteView{note},
@@ -144,8 +148,9 @@ soul_profile:
 
 	t.Run("tools/list returns static tools", func(t *testing.T) {
 		env := &EnvMock{
-			MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+			FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+			MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+			SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					List:    []*appmodel.NoteView{},
@@ -195,8 +200,9 @@ soul_profile:
 		}
 
 		env := &EnvMock{
-			MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+			FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+			MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+			SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					List:    []*appmodel.NoteView{note},
@@ -255,8 +261,9 @@ soul_profile:
 			Content:        []byte("RU instructions"),
 		}
 		env := &EnvMock{
-			MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+			FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+			MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+			SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{List: []*appmodel.NoteView{en, ru}, PathMap: map[string]*appmodel.NoteView{}}
 			},
@@ -281,7 +288,8 @@ soul_profile:
 	})
 
 	t.Run("method not found returns error", func(t *testing.T) {
-		env := &EnvMock{MCPMetricsFunc: func() *metrics.MCPMetrics { return nil }}
+		env := &EnvMock{
+			FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second }, MCPMetricsFunc: func() *metrics.MCPMetrics { return nil }}
 
 		req := mcp.Request{
 			JSONRPC: "2.0",
@@ -298,8 +306,9 @@ soul_profile:
 
 	t.Run("invalid call params returns error", func(t *testing.T) {
 		env := &EnvMock{
-			MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+			FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+			MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+			SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					List:    []*appmodel.NoteView{},
@@ -329,7 +338,8 @@ soul_profile:
 	// A notification carries no id and gets no JSON-RPC response at all: the
 	// transport answers 202 Accepted with an empty body, per the MCP spec.
 	t.Run("notifications/initialized returns no response body", func(t *testing.T) {
-		env := &EnvMock{MCPMetricsFunc: func() *metrics.MCPMetrics { return nil }}
+		env := &EnvMock{
+			FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second }, MCPMetricsFunc: func() *metrics.MCPMetrics { return nil }}
 
 		// A notification carries no id, so none is sent here.
 		req := mcp.Request{
@@ -353,8 +363,9 @@ func TestSearchReturnsStructuredContent(t *testing.T) {
 	}
 
 	env := &EnvMock{
-		MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-		SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+		FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+		MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+		SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 		SearchLiveNotesFunc: func(query string) ([]appmodel.SearchResult, error) {
 			return []appmodel.SearchResult{{
 				NoteView:           note,
@@ -432,8 +443,9 @@ func TestExpandReturnsDirectChildren(t *testing.T) {
 	}
 
 	env := &EnvMock{
-		MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-		SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+		FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+		MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+		SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 		LatestNoteViewsFunc: func() *appmodel.NoteViews {
 			return &appmodel.NoteViews{
 				List:    []*appmodel.NoteView{note},
@@ -489,8 +501,9 @@ func TestSearchMarksFederationKBNotes(t *testing.T) {
 	}
 
 	env := &EnvMock{
-		MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-		SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+		FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+		MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+		SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 		SearchLiveNotesFunc: func(query string) ([]appmodel.SearchResult, error) {
 			return []appmodel.SearchResult{{
 				NoteView:           note,
@@ -561,8 +574,9 @@ func TestSearchHidesInaccessibleFederationKBNotes(t *testing.T) {
 	}
 
 	env := &EnvMock{
-		MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-		SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+		FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+		MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+		SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 		SearchLiveNotesFunc: func(query string) ([]appmodel.SearchResult, error) {
 			return []appmodel.SearchResult{
 				{NoteView: federationNote, URL: federationNote.Permalink, Score: 2},
@@ -627,8 +641,9 @@ func TestSearchHidesInaccessibleNotes(t *testing.T) {
 	}
 
 	env := &EnvMock{
-		MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-		SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+		FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+		MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+		SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 		SearchLiveNotesFunc: func(query string) ([]appmodel.SearchResult, error) {
 			return []appmodel.SearchResult{
 				{NoteView: privateNote, URL: privateNote.Permalink, Score: 2},
@@ -678,9 +693,10 @@ func TestSearchHidesInaccessibleNotes(t *testing.T) {
 
 func TestFederatedSearchWithoutKBNotesReturnsStructuredStatus(t *testing.T) {
 	env := &EnvMock{
-		MCPMetricsFunc:      func() *metrics.MCPMetrics { return nil },
-		SiteConfigFunc:      func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
-		LatestNoteViewsFunc: appmodel.NewNoteViews,
+		FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+		MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+		SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+		LatestNoteViewsFunc:        appmodel.NewNoteViews,
 		LoggerFunc: func() logger.Logger {
 			return &logger.DummyLogger{}
 		},
@@ -733,8 +749,9 @@ func TestSearchFiltersSystemAndExcludedNotes(t *testing.T) {
 	}
 
 	env := &EnvMock{
-		MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-		SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+		FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+		MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+		SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 		SearchLiveNotesFunc: func(query string) ([]appmodel.SearchResult, error) {
 			return []appmodel.SearchResult{
 				{NoteView: systemNote, URL: systemNote.Permalink, Score: 3},
@@ -795,8 +812,9 @@ func TestSearch_CustomDomainURL(t *testing.T) {
 	}
 
 	env := &EnvMock{
-		MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-		SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+		FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+		MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+		SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 		SearchLiveNotesFunc: func(query string) ([]appmodel.SearchResult, error) {
 			return []appmodel.SearchResult{{
 				NoteView: note,
@@ -854,8 +872,9 @@ func TestSearch_CustomDomainURL(t *testing.T) {
 
 func noteHTMLEnv(note *appmodel.NoteView) *EnvMock {
 	return &EnvMock{
-		MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-		SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+		FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+		MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+		SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 		LatestNoteViewsFunc: func() *appmodel.NoteViews {
 			noteViews := appmodel.NewNoteViews()
 			noteViews.RegisterNote(note)
@@ -878,8 +897,9 @@ func TestHandleNoteHtml(t *testing.T) {
 		}
 
 		env := &EnvMock{
-			MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+			FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+			MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+			SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					PathMap: map[string]*appmodel.NoteView{
@@ -926,8 +946,9 @@ func TestHandleNoteHtml(t *testing.T) {
 		}
 
 		env := &EnvMock{
-			MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+			FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+			MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+			SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				noteViews := appmodel.NewNoteViews()
 				noteViews.RegisterNote(note)
@@ -970,8 +991,9 @@ func TestHandleNoteHtml(t *testing.T) {
 		}
 
 		env := &EnvMock{
-			MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+			FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+			MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+			SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				noteViews := appmodel.NewNoteViews()
 				noteViews.RegisterNote(note)
@@ -1039,8 +1061,9 @@ func TestHandleNoteHtml(t *testing.T) {
 		}
 
 		env := &EnvMock{
-			MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+			FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+			MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+			SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				noteViews := appmodel.NewNoteViews()
 				noteViews.RegisterNote(note)
@@ -1146,8 +1169,9 @@ func TestHandleNoteHtml(t *testing.T) {
 		}
 
 		env := &EnvMock{
-			MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+			FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+			MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+			SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				noteViews := appmodel.NewNoteViews()
 				noteViews.RegisterNote(note)
@@ -1191,8 +1215,9 @@ func TestHandleNoteHtml(t *testing.T) {
 		}
 
 		env := &EnvMock{
-			MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+			FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+			MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+			SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				noteViews := appmodel.NewNoteViews()
 				noteViews.RegisterNote(note)
@@ -1238,8 +1263,9 @@ func TestHandleNoteHtml(t *testing.T) {
 		}
 
 		env := &EnvMock{
-			MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+			FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+			MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+			SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				noteViews := appmodel.NewNoteViews()
 				noteViews.RegisterNote(note)
@@ -1386,8 +1412,9 @@ func TestHandleNoteHtml(t *testing.T) {
 		}
 
 		env := &EnvMock{
-			MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+			FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+			MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+			SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				noteViews := appmodel.NewNoteViews()
 				noteViews.RegisterNote(note)
@@ -1419,8 +1446,9 @@ func TestHandleNoteHtml(t *testing.T) {
 
 	t.Run("returns error for non-existent note", func(t *testing.T) {
 		env := &EnvMock{
-			MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+			FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+			MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+			SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					PathMap: map[string]*appmodel.NoteView{},
@@ -1478,8 +1506,9 @@ func TestSimilarAcceptsPIDAndReturnsStructuredContent(t *testing.T) {
 	noteViews.List = []*appmodel.NoteView{sourceNote, similarNote}
 
 	env := &EnvMock{
-		MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-		SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+		FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+		MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+		SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 		FeaturesFunc: func() features.Features {
 			return features.Features{
 				VectorSearch: features.VectorSearchConfig{Enabled: true},
@@ -1543,8 +1572,9 @@ func TestStripFrontmatter(t *testing.T) {
 		}
 
 		env := &EnvMock{
-			MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+			FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+			MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+			SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					List: []*appmodel.NoteView{note},
@@ -1585,8 +1615,9 @@ func TestStripFrontmatter(t *testing.T) {
 		}
 
 		env := &EnvMock{
-			MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+			FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+			MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+			SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					List: []*appmodel.NoteView{note},
@@ -1627,8 +1658,9 @@ func TestStripFrontmatter(t *testing.T) {
 		}
 
 		env := &EnvMock{
-			MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+			FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+			MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+			SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					List: []*appmodel.NoteView{note},
@@ -1670,8 +1702,9 @@ func TestStripFrontmatter(t *testing.T) {
 		}
 
 		env := &EnvMock{
-			MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+			FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+			MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+			SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					List: []*appmodel.NoteView{note},
@@ -1710,8 +1743,9 @@ func TestStripFrontmatter(t *testing.T) {
 func TestHandleSimilarLimitValidation(t *testing.T) {
 	t.Run("uses default when limit is zero", func(t *testing.T) {
 		env := &EnvMock{
-			MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+			FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+			MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+			SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					PathMap: map[string]*appmodel.NoteView{
@@ -1762,8 +1796,9 @@ func TestHandleSimilarLimitValidation(t *testing.T) {
 
 	t.Run("caps limit at maximum", func(t *testing.T) {
 		env := &EnvMock{
-			MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-			SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+			FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+			MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+			SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 			LatestNoteViewsFunc: func() *appmodel.NoteViews {
 				return &appmodel.NoteViews{
 					PathMap: map[string]*appmodel.NoteView{
@@ -1827,8 +1862,9 @@ func makeSearchNote(pathID int64, path, title string) *appmodel.NoteView {
 func makeSearchEnv(t *testing.T, results []appmodel.SearchResult) *EnvMock {
 	t.Helper()
 	return &EnvMock{
-		MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
-		SiteConfigFunc: func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
+		FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+		MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
+		SiteConfigFunc:             func(context.Context) appmodel.SiteConfig { return appmodel.SiteConfig{} },
 		SearchLiveNotesFunc: func(query string) ([]appmodel.SearchResult, error) {
 			return results, nil
 		},

--- a/internal/case/mcp/search_corpus_test.go
+++ b/internal/case/mcp/search_corpus_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -37,7 +38,8 @@ func corpusEnv() *EnvMock {
 	live := &appmodel.NoteView{Path: "published.md", PathID: 2, Title: "Published", Permalink: "/published"}
 
 	return &EnvMock{
-		MCPMetricsFunc: func() *metrics.MCPMetrics { return nil },
+		FederatedFanoutTimeoutFunc: func() time.Duration { return 2 * time.Second },
+		MCPMetricsFunc:             func() *metrics.MCPMetrics { return nil },
 		SearchLatestNotesFunc: func(string) ([]appmodel.SearchResult, error) {
 			return []appmodel.SearchResult{{
 				NoteView: latest, URL: latest.Permalink, Score: 1,

--- a/internal/case/mcp/testdata/endpoint_golden.txt
+++ b/internal/case/mcp/testdata/endpoint_golden.txt
@@ -1482,6 +1482,7 @@ HTTP 200 application/json
       "results": [
         {
           "title": "Peer Note",
+          "kb_id": "peer",
           "note_id": 1,
           "note_path": "peer.md",
           "href": "/peer",

--- a/internal/case/mcp/testdata/endpoint_golden.txt
+++ b/internal/case/mcp/testdata/endpoint_golden.txt
@@ -218,6 +218,13 @@ HTTP 200 application/json
             "pid": {
               "type": "number",
               "description": "Non-negative integer (uint64) remote note id, copied verbatim from a federated_search result's note_id field. Not a path, slug, or match_id. Prefer path or match_id"
+            },
+            "toc_path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Breadcrumb path to a specific section, e.g. [\"Chapter 1\", \"Introduction\"]. Use toc_path from a federated_search match, or a child path from federated_expand. Without it the whole note comes back."
             }
           },
           "required": [
@@ -531,6 +538,13 @@ HTTP 200 application/json
             "pid": {
               "type": "number",
               "description": "Non-negative integer (uint64) remote note id, copied verbatim from a federated_search result's note_id field. Not a path, slug, or match_id. Prefer path or match_id"
+            },
+            "toc_path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Breadcrumb path to a specific section, e.g. [\"Chapter 1\", \"Introduction\"]. Use toc_path from a federated_search match, or a child path from federated_expand. Without it the whole note comes back."
             }
           },
           "required": [
@@ -886,6 +900,13 @@ HTTP 200 application/json
             "pid": {
               "type": "number",
               "description": "Non-negative integer (uint64) remote note id, copied verbatim from a federated_search result's note_id field. Not a path, slug, or match_id. Prefer path or match_id"
+            },
+            "toc_path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Breadcrumb path to a specific section, e.g. [\"Chapter 1\", \"Introduction\"]. Use toc_path from a federated_search match, or a child path from federated_expand. Without it the whole note comes back."
             }
           },
           "required": [
@@ -1162,7 +1183,7 @@ HTTP 200 application/json
   "id": 3,
   "error": {
     "code": -32602,
-    "message": "Invalid search arguments: json: cannot unmarshal number into Go struct field SearchArguments.query of type string"
+    "message": "Invalid search arguments: json: cannot unmarshal number into Go struct field MCPSearchParams.query of type string"
   }
 }
 
@@ -1741,6 +1762,13 @@ HTTP 200 application/json
             "pid": {
               "type": "number",
               "description": "Non-negative integer (uint64) remote note id, copied verbatim from a federated_search result's note_id field. Not a path, slug, or match_id. Prefer path or match_id"
+            },
+            "toc_path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Breadcrumb path to a specific section, e.g. [\"Chapter 1\", \"Introduction\"]. Use toc_path from a federated_search match, or a child path from federated_expand. Without it the whole note comes back."
             }
           },
           "required": [
@@ -2054,6 +2082,13 @@ HTTP 200 application/json
             "pid": {
               "type": "number",
               "description": "Non-negative integer (uint64) remote note id, copied verbatim from a federated_search result's note_id field. Not a path, slug, or match_id. Prefer path or match_id"
+            },
+            "toc_path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Breadcrumb path to a specific section, e.g. [\"Chapter 1\", \"Introduction\"]. Use toc_path from a federated_search match, or a child path from federated_expand. Without it the whole note comes back."
             }
           },
           "required": [
@@ -2378,6 +2413,13 @@ HTTP 200 application/json
             "pid": {
               "type": "number",
               "description": "Non-negative integer (uint64) remote note id, copied verbatim from a federated_search result's note_id field. Not a path, slug, or match_id. Prefer path or match_id"
+            },
+            "toc_path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Breadcrumb path to a specific section, e.g. [\"Chapter 1\", \"Introduction\"]. Use toc_path from a federated_search match, or a child path from federated_expand. Without it the whole note comes back."
             }
           },
           "required": [

--- a/internal/case/mcp/testdata/endpoint_golden.txt
+++ b/internal/case/mcp/testdata/endpoint_golden.txt
@@ -1369,6 +1369,60 @@ HTTP 200 application/json
   }
 }
 
+### call_expand_leading_h1
+HTTP 200 application/json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Книга 10 — \"top level\", 2 subsection(s):\n- 1 — Душа моя, ужели ты никогда не будешь доброй и простой?\n- 2 — Замечай, чего требует твоя природа.\n"
+      }
+    ],
+    "structuredContent": {
+      "note_id": 20,
+      "note_path": "aphorisms.md",
+      "children": [
+        {
+          "title": "1",
+          "level": 2,
+          "path": [
+            "1"
+          ],
+          "has_children": false,
+          "preview": "Душа моя, ужели ты никогда не будешь доброй и простой?"
+        },
+        {
+          "title": "2",
+          "level": 2,
+          "path": [
+            "2"
+          ],
+          "has_children": false,
+          "preview": "Замечай, чего требует твоя природа."
+        }
+      ]
+    }
+  }
+}
+
+### call_note_html_h1_shortened_toc_path
+HTTP 200 application/json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "\u003ch2 id=\"one\"\u003e1\u003c/h2\u003e\u003cp\u003eДуша моя, ужели ты никогда не будешь доброй и простой?\u003c/p\u003e"
+      }
+    ]
+  }
+}
+
 ### call_federated_search
 HTTP 200 application/json
 {

--- a/internal/case/mcp/testdata/endpoint_golden.txt
+++ b/internal/case/mcp/testdata/endpoint_golden.txt
@@ -311,6 +311,13 @@ HTTP 200 application/json
         "name": "guide"
       },
       {
+        "description": "Instructions",
+        "inputSchema": {
+          "type": "object"
+        },
+        "name": "instructions"
+      },
+      {
         "description": "Read a note. Canonical calls, copying fields verbatim from a search result: search(query) -> note_html(path=<result.note_path>) reads the whole note; search(query) -> note_html(match_id=<match.match_id>) reads just the focused chunk around a hit (cheaper, targeted); expand(path=<result.note_path>, toc_path=[...]) -> note_html(path=<result.note_path>, toc_path=[...]) reads one exact section. Only pass pid/note_id if you already copied that exact integer from a result's note_id field — never invent one. path is a string like \"concepts/x.md\"; match_id is \"p<pid>:c<chunk>\"; a value like \":\" or \"/hub/goethe.md\" is a PATH, not a note_id.",
         "inputSchema": {
           "type": "object",
@@ -667,6 +674,13 @@ HTTP 200 application/json
         "name": "guide"
       },
       {
+        "description": "Instructions",
+        "inputSchema": {
+          "type": "object"
+        },
+        "name": "instructions"
+      },
+      {
         "description": "Read a note. Canonical calls, copying fields verbatim from a search result: search(query) -> note_html(path=<result.note_path>) reads the whole note; search(query) -> note_html(match_id=<match.match_id>) reads just the focused chunk around a hit (cheaper, targeted); expand(path=<result.note_path>, toc_path=[...]) -> note_html(path=<result.note_path>, toc_path=[...]) reads one exact section. Only pass pid/note_id if you already copied that exact integer from a result's note_id field — never invent one. path is a string like \"concepts/x.md\"; match_id is \"p<pid>:c<chunk>\"; a value like \":\" or \"/hub/goethe.md\" is a PATH, not a note_id.",
         "inputSchema": {
           "type": "object",
@@ -991,6 +1005,13 @@ HTTP 200 application/json
           "type": "object"
         },
         "name": "guide"
+      },
+      {
+        "description": "Instructions",
+        "inputSchema": {
+          "type": "object"
+        },
+        "name": "instructions"
       },
       {
         "description": "Read a note. Canonical calls, copying fields verbatim from a search result: search(query) -> note_html(path=<result.note_path>) reads the whole note; search(query) -> note_html(match_id=<match.match_id>) reads just the focused chunk around a hit (cheaper, targeted); expand(path=<result.note_path>, toc_path=[...]) -> note_html(path=<result.note_path>, toc_path=[...]) reads one exact section. Only pass pid/note_id if you already copied that exact integer from a result's note_id field — never invent one. path is a string like \"concepts/x.md\"; match_id is \"p<pid>:c<chunk>\"; a value like \":\" or \"/hub/goethe.md\" is a PATH, not a note_id.",
@@ -1910,6 +1931,13 @@ HTTP 200 application/json
         "name": "guide"
       },
       {
+        "description": "Instructions",
+        "inputSchema": {
+          "type": "object"
+        },
+        "name": "instructions"
+      },
+      {
         "description": "Read a note. Canonical calls, copying fields verbatim from a search result: search(query) -> note_html(path=<result.note_path>) reads the whole note; search(query) -> note_html(match_id=<match.match_id>) reads just the focused chunk around a hit (cheaper, targeted); expand(path=<result.note_path>, toc_path=[...]) -> note_html(path=<result.note_path>, toc_path=[...]) reads one exact section. Only pass pid/note_id if you already copied that exact integer from a result's note_id field — never invent one. path is a string like \"concepts/x.md\"; match_id is \"p<pid>:c<chunk>\"; a value like \":\" or \"/hub/goethe.md\" is a PATH, not a note_id.",
         "inputSchema": {
           "type": "object",
@@ -2228,6 +2256,13 @@ HTTP 200 application/json
           "type": "object"
         },
         "name": "guide"
+      },
+      {
+        "description": "Instructions",
+        "inputSchema": {
+          "type": "object"
+        },
+        "name": "instructions"
       },
       {
         "description": "Read a note. Canonical calls, copying fields verbatim from a search result: search(query) -> note_html(path=<result.note_path>) reads the whole note; search(query) -> note_html(match_id=<match.match_id>) reads just the focused chunk around a hit (cheaper, targeted); expand(path=<result.note_path>, toc_path=[...]) -> note_html(path=<result.note_path>, toc_path=[...]) reads one exact section. Only pass pid/note_id if you already copied that exact integer from a result's note_id field — never invent one. path is a string like \"concepts/x.md\"; match_id is \"p<pid>:c<chunk>\"; a value like \":\" or \"/hub/goethe.md\" is a PATH, not a note_id.",
@@ -2559,6 +2594,13 @@ HTTP 200 application/json
           "type": "object"
         },
         "name": "guide"
+      },
+      {
+        "description": "Instructions",
+        "inputSchema": {
+          "type": "object"
+        },
+        "name": "instructions"
       },
       {
         "description": "Read a note. Canonical calls, copying fields verbatim from a search result: search(query) -> note_html(path=<result.note_path>) reads the whole note; search(query) -> note_html(match_id=<match.match_id>) reads just the focused chunk around a hit (cheaper, targeted); expand(path=<result.note_path>, toc_path=[...]) -> note_html(path=<result.note_path>, toc_path=[...]) reads one exact section. Only pass pid/note_id if you already copied that exact integer from a result's note_id field — never invent one. path is a string like \"concepts/x.md\"; match_id is \"p<pid>:c<chunk>\"; a value like \":\" or \"/hub/goethe.md\" is a PATH, not a note_id.",

--- a/internal/case/mcp/toc_expand_test.go
+++ b/internal/case/mcp/toc_expand_test.go
@@ -1,0 +1,126 @@
+package mcp
+
+import (
+	"html/template"
+	"strings"
+	"testing"
+
+	"trip2g/internal/model"
+
+	"github.com/stretchr/testify/require"
+)
+
+// noteWithLeadingH1 mirrors what the real load pipeline produces for a note that
+// opens with an H1: the H1 is in Headings at level 1 and wraps the rest of the
+// document in its own data-header div, while the template suppresses the visible
+// duplicate because NoteView.HasH1 is set.
+func noteWithLeadingH1() *model.NoteView {
+	return &model.NoteView{
+		Path:   "goethe.md",
+		PathID: 7,
+		Title:  "Goethe — Maxims and Reflections",
+		HasH1:  true,
+		Headings: model.NoteViewHeadings{
+			{Text: "Goethe — Maxims and Reflections", Level: 1, ID: "goethe"},
+			{Text: "Maxims", Level: 2, ID: "maxims"},
+			{Text: "Art", Level: 3, ID: "art"},
+			{Text: "Reflections", Level: 2, ID: "reflections"},
+		},
+		HTML: template.HTML(`<div data-header="Goethe — Maxims and Reflections" data-level="1"><h1>Goethe — Maxims and Reflections</h1>` +
+			`<div data-header="Maxims" data-level="2"><h2>Maxims</h2><p>maxims body</p>` +
+			`<div data-header="Art" data-level="3"><h3>Art</h3><p>art body</p></div></div>` +
+			`<div data-header="Reflections" data-level="2"><h2>Reflections</h2><p>reflections body</p></div></div>`),
+	}
+}
+
+func TestExpandDropsTheLeadingH1(t *testing.T) {
+	note := noteWithLeadingH1()
+
+	top := tocChildren(note, nil)
+	titles := make([]string, len(top))
+	for i, c := range top {
+		titles[i] = c.Title
+	}
+	require.Equal(t, []string{"Maxims", "Reflections"}, titles,
+		"the leading H1 is the title and is suppressed in the body, so it must not eat a level of navigation")
+
+	// The shortened path still resolves against the unchanged HTML.
+	require.NotEmpty(t, sectionHTMLByTocPath(string(note.HTML), []string{"Maxims"}))
+	require.Equal(t, []string{"Art"}, []string{tocChildren(note, []string{"Maxims"})[0].Title})
+}
+
+func TestExpandKeepsLaterH1s(t *testing.T) {
+	note := &model.NoteView{
+		Path:  "book.md",
+		Title: "Book",
+		HasH1: true,
+		Headings: model.NoteViewHeadings{
+			{Text: "Book", Level: 1},
+			{Text: "Part One", Level: 1},
+			{Text: "Part Two", Level: 1},
+		},
+		HTML: template.HTML(`<div data-header="Book" data-level="1"><h1>Book</h1>` +
+			`<div data-header="Part One" data-level="1"><h1>Part One</h1><p>one</p></div>` +
+			`<div data-header="Part Two" data-level="1"><h1>Part Two</h1><p>two</p></div></div>`),
+	}
+
+	top := tocChildren(note, nil)
+	require.Len(t, top, 2, "only the first H1 is the title; later ones are real sections")
+	require.Equal(t, "Part One", top[0].Title)
+	require.Equal(t, "Part Two", top[1].Title)
+}
+
+func TestExpandLeavesNotesWithoutLeadingH1Alone(t *testing.T) {
+	note := &model.NoteView{
+		Path:  "article.md",
+		Title: "Article",
+		Headings: model.NoteViewHeadings{
+			{Text: "Introduction", Level: 1},
+			{Text: "Details", Level: 1},
+		},
+		HTML: template.HTML(`<div data-header="Introduction" data-level="1"><h1>Introduction</h1><p>x</p></div>` +
+			`<div data-header="Details" data-level="1"><h1>Details</h1><p>y</p></div>`),
+	}
+
+	top := tocChildren(note, nil)
+	require.Len(t, top, 2)
+	require.Equal(t, "Introduction", top[0].Title)
+}
+
+func TestExpandPreviewsShortHeadings(t *testing.T) {
+	// An aphoristic corpus: 39 subsections titled "1", "2", ... carry no meaning
+	// on their own, so an agent has nothing to choose between when descending.
+	note := &model.NoteView{
+		Path:  "meditations.md",
+		Title: "Книга 10",
+		Headings: model.NoteViewHeadings{
+			{Text: "1", Level: 1},
+			{Text: "2", Level: 1},
+			{Text: "A heading long enough to stand on its own", Level: 1},
+		},
+		HTML: template.HTML(`<div data-header="1" data-level="1"><h1>1</h1><p>Душа моя, ужели ты никогда не будешь доброй и простой?</p></div>` +
+			`<div data-header="2" data-level="1"><h1>2</h1><p>Замечай, чего требует твоя природа.</p></div>` +
+			`<div data-header="A heading long enough to stand on its own" data-level="1"><h1>A heading long enough to stand on its own</h1><p>body</p></div>`),
+	}
+
+	top := tocChildren(note, nil)
+	require.Len(t, top, 3)
+	require.True(t, strings.HasPrefix(top[0].Preview, "Душа моя"), "got %q", top[0].Preview)
+	require.True(t, strings.HasPrefix(top[1].Preview, "Замечай"), "got %q", top[1].Preview)
+	require.Empty(t, top[2].Preview, "a heading that already reads on its own needs no preview")
+}
+
+func TestExpandPreviewCountsRunesNotBytes(t *testing.T) {
+	// "Книга 10" is 8 runes but 15 bytes: a byte-length threshold would call it
+	// long enough and skip the preview exactly where it is needed most.
+	note := &model.NoteView{
+		Path:     "b.md",
+		Title:    "Меди",
+		Headings: model.NoteViewHeadings{{Text: "Книга 10", Level: 1}},
+		HTML:     template.HTML(`<div data-header="Книга 10" data-level="1"><h1>Книга 10</h1><p>Первая строка книги.</p></div>`),
+	}
+
+	top := tocChildren(note, nil)
+	require.Len(t, top, 1)
+	require.NotEmpty(t, top[0].Preview)
+}

--- a/internal/case/mcp/toc_path.go
+++ b/internal/case/mcp/toc_path.go
@@ -24,6 +24,25 @@ type TOCItem struct {
 
 const htmlDivElement = "div"
 
+// navigableHeadings drops the leading H1 when the note opens with one: that H1
+// is the note's title and the template renders it in place of its own, so
+// leaving it in the TOC costs an agent a whole expand call on a single node
+// that only repeats the title. A second or later H1 is a real section and stays.
+//
+// Levels are left exactly as parsed. Renumbering them would mean reslicing
+// note.Headings, whose backing array is shared by every other reader of the
+// note cache.
+func navigableHeadings(note *model.NoteView) model.NoteViewHeadings {
+	if note == nil {
+		return nil
+	}
+	h := note.Headings
+	if note.HasH1 && len(h) > 0 && h[0].Level == 1 {
+		return h[1:]
+	}
+	return h
+}
+
 // buildNoteTOC builds a flat TOC list with full hierarchical paths from NoteViewHeadings.
 // Handles repeated heading names by including the full ancestor chain in Path.
 func buildNoteTOC(headings model.NoteViewHeadings) []TOCItem {
@@ -513,8 +532,8 @@ func firstSectionPath(noteHTML string) []string {
 // An empty parentPath returns the top-level sections. Each child reports whether it
 // has children of its own, so an agent can walk the tree level by level (expand)
 // without loading the note's content or its full flat TOC.
-func tocChildren(headings model.NoteViewHeadings, parentPath []string) []TOCNode {
-	all := buildNoteTOC(headings)
+func tocChildren(note *model.NoteView, parentPath []string) []TOCNode {
+	all := buildNoteTOC(navigableHeadings(note))
 	out := make([]TOCNode, 0)
 	for _, item := range all {
 		if len(item.Path) != len(parentPath)+1 || !tocPathHasPrefix(item.Path, parentPath) {
@@ -527,7 +546,71 @@ func tocChildren(headings model.NoteViewHeadings, parentPath []string) []TOCNode
 			HasChildren: tocHasDirectChild(all, item.Path),
 		})
 	}
+	addSectionPreviews(note, out)
 	return out
+}
+
+// shortHeadingRunes is the length below which a heading carries no meaning of
+// its own. Corpora of aphorisms number their sections ("1", "2", ... "39"), so
+// the TOC an agent navigates by is structurally correct and semantically empty.
+// Counted in runes: "Книга 10" is 8 runes but 15 bytes, and a byte threshold
+// would skip a preview exactly where it is needed.
+const shortHeadingRunes = 15
+
+// previewRunes caps a section preview. Enough to tell two aphorisms apart,
+// short enough that a 39-node TOC stays cheap to read.
+const previewRunes = 90
+
+// addSectionPreviews fills Preview on the children whose titles are too short to
+// choose between, with the opening words of the section's own text.
+func addSectionPreviews(note *model.NoteView, children []TOCNode) {
+	if note == nil || len(children) == 0 {
+		return
+	}
+	needed := false
+	for _, c := range children {
+		if utf8.RuneCountInString(c.Title) < shortHeadingRunes {
+			needed = true
+			break
+		}
+	}
+	if !needed {
+		return
+	}
+	doc, err := html.Parse(strings.NewReader(string(note.HTML)))
+	if err != nil {
+		return
+	}
+	for i := range children {
+		if utf8.RuneCountInString(children[i].Title) >= shortHeadingRunes {
+			continue
+		}
+		section := navigateSectionPath(doc, children[i].Path)
+		if section == nil {
+			continue
+		}
+		children[i].Preview = sectionPreview(section, children[i].Title)
+	}
+}
+
+// sectionPreview returns the opening words of a section's text, without the
+// heading the caller already has.
+func sectionPreview(section *html.Node, title string) string {
+	text := strings.TrimSpace(htmlNodeText(section))
+	text = strings.TrimSpace(strings.TrimPrefix(text, title))
+	text = strings.Join(strings.Fields(text), " ")
+	if text == "" {
+		return ""
+	}
+	runes := []rune(text)
+	if len(runes) <= previewRunes {
+		return text
+	}
+	cut := string(runes[:previewRunes])
+	if sp := strings.LastIndexByte(cut, ' '); sp > previewRunes/2 {
+		cut = cut[:sp]
+	}
+	return cut + "…"
 }
 
 // tocPathHasPrefix reports whether path starts with prefix.

--- a/internal/case/mcp/toc_path_test.go
+++ b/internal/case/mcp/toc_path_test.go
@@ -11,28 +11,28 @@ import (
 )
 
 func TestTocChildren(t *testing.T) {
-	headings := model.NoteViewHeadings{
+	note := &model.NoteView{Headings: model.NoteViewHeadings{
 		{Text: "Setup", Level: 1, ID: "setup"},
 		{Text: "Install", Level: 2, ID: "install"},
 		{Text: "Configure", Level: 2, ID: "configure"},
 		{Text: "Events", Level: 1, ID: "events"},
 		{Text: "Note changed", Level: 2, ID: "note_changed"},
-	}
+	}}
 
-	top := tocChildren(headings, nil)
+	top := tocChildren(note, nil)
 	require.Equal(t, []TOCNode{
 		{Title: "Setup", Level: 1, Path: []string{"Setup"}, HasChildren: true},
 		{Title: "Events", Level: 1, Path: []string{"Events"}, HasChildren: true},
 	}, top)
 
-	setup := tocChildren(headings, []string{"Setup"})
+	setup := tocChildren(note, []string{"Setup"})
 	require.Equal(t, []TOCNode{
 		{Title: "Install", Level: 2, Path: []string{"Setup", "Install"}, HasChildren: false},
 		{Title: "Configure", Level: 2, Path: []string{"Setup", "Configure"}, HasChildren: false},
 	}, setup)
 
-	require.Empty(t, tocChildren(headings, []string{"Setup", "Install"})) // leaf
-	require.Empty(t, tocChildren(headings, []string{"Nope"}))             // unknown path
+	require.Empty(t, tocChildren(note, []string{"Setup", "Install"})) // leaf
+	require.Empty(t, tocChildren(note, []string{"Nope"}))             // unknown path
 }
 
 // TestNormalizeForMatchBothPipelines verifies that the same logical text, when

--- a/internal/case/mcp/tools.go
+++ b/internal/case/mcp/tools.go
@@ -242,6 +242,11 @@ func staticTools(ctx context.Context, env Env) []Tool { //nolint:funlen // flat 
 						Type:        "string",
 						Description: "String chunk id of the form \"p<pid>:c<chunk>\", copied verbatim from a remote search match's match_id field; alone it is enough to resolve the note",
 					},
+					"toc_path": {
+						Type:        "array",
+						Description: "Breadcrumb path to a specific section, e.g. [\"Chapter 1\", \"Introduction\"]. Use toc_path from a federated_search match, or a child path from federated_expand. Without it the whole note comes back.",
+						Items:       &Property{Type: "string"},
+					},
 				},
 				Required: []string{"kb_id"},
 			},

--- a/internal/case/mcp/types.go
+++ b/internal/case/mcp/types.go
@@ -2,44 +2,9 @@ package mcp
 
 import (
 	"encoding/json"
-	"strconv"
-	"strings"
 
 	"trip2g/internal/model"
 )
-
-// PID is a note id that tolerates what models actually send: a JSON number,
-// a numeric string ("70"), or a non-numeric string like a chunk match_id
-// ("p36:c2") or a path. Non-numeric input parses to Value 0 with Raw kept for
-// error messages, so a valid path in the same call can still resolve instead
-// of the whole request failing on unmarshal.
-type PID struct {
-	Value int64
-	Raw   string
-}
-
-func (p *PID) UnmarshalJSON(b []byte) error {
-	s := strings.TrimSpace(string(b))
-	if s == "null" {
-		return nil
-	}
-	if strings.HasPrefix(s, `"`) {
-		var raw string
-		if err := json.Unmarshal(b, &raw); err != nil {
-			return err
-		}
-		p.Raw = raw
-		if v, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64); err == nil {
-			p.Value = v
-		}
-		return nil
-	}
-	return json.Unmarshal(b, &p.Value)
-}
-
-func (p PID) MarshalJSON() ([]byte, error) {
-	return json.Marshal(p.Value)
-}
 
 // JSON-RPC 2.0 types
 
@@ -102,53 +67,6 @@ type CallToolResult struct {
 type Content struct {
 	Type string `json:"type"`
 	Text string `json:"text"`
-}
-
-// Tool-specific argument types
-
-type SearchArguments struct {
-	Query       string `json:"query"`
-	Limit       int    `json:"limit,omitempty"`
-	DetailLimit int    `json:"detail_limit,omitempty"`
-}
-
-type FederatedSearchArguments struct {
-	Query       string   `json:"query"`
-	KBID        string   `json:"kb_id,omitempty"`
-	KBIDs       []string `json:"kb_ids,omitempty"`
-	Limit       int      `json:"limit,omitempty"`
-	DetailLimit int      `json:"detail_limit,omitempty"`
-}
-
-type FederatedSimilarArguments struct {
-	KBID   string `json:"kb_id"`
-	PID    int64  `json:"pid,omitempty"`
-	NoteID string `json:"note_id,omitempty"`
-	Path   string `json:"path,omitempty"`
-	Href   string `json:"href,omitempty"`
-	Limit  int    `json:"limit,omitempty"`
-}
-
-type FederatedNoteHTMLArguments struct {
-	KBID    string `json:"kb_id"`
-	PID     PID    `json:"pid,omitzero"`
-	NoteID  string `json:"note_id,omitempty"`
-	Path    string `json:"path,omitempty"`
-	Href    string `json:"href,omitempty"`
-	MatchID string `json:"match_id,omitempty"`
-}
-
-type FederatedInstructionsArguments struct {
-	KBID string `json:"kb_id"`
-}
-
-type FederatedExpandArguments struct {
-	KBID    string   `json:"kb_id"`
-	PID     int64    `json:"pid,omitempty"`
-	NoteID  string   `json:"note_id,omitempty"`
-	Path    string   `json:"path,omitempty"`
-	Href    string   `json:"href,omitempty"`
-	TocPath []string `json:"toc_path,omitempty"`
 }
 
 type FederationRef struct {
@@ -225,35 +143,9 @@ type SearchLink struct {
 	Href   string `json:"href"`
 }
 
-type SimilarArguments struct {
-	Path   string `json:"path,omitempty"`
-	Href   string `json:"href,omitempty"`
-	PID    int64  `json:"pid,omitempty"`
-	NoteID int64  `json:"note_id,omitempty"`
-	Limit  int    `json:"limit,omitempty"`
-}
-
 type SimilarResultPayload struct {
 	Source  SearchResultItem   `json:"source"`
 	Results []SearchResultItem `json:"results"`
-}
-
-type NoteHTMLArguments struct {
-	Path         string   `json:"path,omitempty"`
-	Href         string   `json:"href,omitempty"`
-	PID          PID      `json:"pid,omitzero"`
-	NoteID       PID      `json:"note_id,omitzero"`
-	MatchID      string   `json:"match_id,omitempty"`
-	ContextWords int      `json:"context_words,omitempty"`
-	TocPath      []string `json:"toc_path,omitempty"`
-}
-
-type ExpandArguments struct {
-	Path    string   `json:"path,omitempty"`
-	Href    string   `json:"href,omitempty"`
-	PID     int64    `json:"pid,omitempty"`
-	NoteID  int64    `json:"note_id,omitempty"`
-	TocPath []string `json:"toc_path,omitempty"`
 }
 
 // TOCNode is one node in a progressive-disclosure TOC walk: a direct child of the

--- a/internal/case/mcp/types.go
+++ b/internal/case/mcp/types.go
@@ -156,6 +156,9 @@ type TOCNode struct {
 	Level       int      `json:"level"`
 	Path        []string `json:"path"`
 	HasChildren bool     `json:"has_children"`
+	// Preview carries the section's opening words when the title is too short
+	// to choose by ("1", "2", ... in a corpus of aphorisms).
+	Preview string `json:"preview,omitempty"`
 }
 
 type ExpandPayload struct {

--- a/internal/case/mcp/types_test.go
+++ b/internal/case/mcp/types_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"trip2g/internal/model"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,7 +50,7 @@ func TestSearchResultItemFederationJSON(t *testing.T) {
 }
 
 func TestFederatedArgumentsJSON(t *testing.T) {
-	search := FederatedSearchArguments{
+	search := model.MCPSearchParams{
 		Query: "design notes",
 		KBID:  "bob",
 		KBIDs: []string{"bob", "github"},
@@ -58,12 +60,12 @@ func TestFederatedArgumentsJSON(t *testing.T) {
 	require.NoError(t, err)
 	require.JSONEq(t, `{"query":"design notes","kb_id":"bob","kb_ids":["bob","github"]}`, string(data))
 
-	similar := FederatedSimilarArguments{KBID: "bob", PID: 10, Limit: 3}
+	similar := model.MCPSimilarParams{KBID: "bob", PID: model.PID{Value: 10}, Limit: 3}
 	data, err = json.Marshal(similar)
 	require.NoError(t, err)
 	require.JSONEq(t, `{"kb_id":"bob","pid":10,"limit":3}`, string(data))
 
-	html := FederatedNoteHTMLArguments{KBID: "bob", MatchID: "m1"}
+	html := model.MCPNoteHTMLParams{KBID: "bob", MatchID: "m1"}
 	data, err = json.Marshal(html)
 	require.NoError(t, err)
 	require.JSONEq(t, `{"kb_id":"bob","match_id":"m1"}`, string(data))

--- a/internal/federation/client.go
+++ b/internal/federation/client.go
@@ -46,39 +46,39 @@ func NewClient(peer model.FederationPeer, http *fasthttp.Client, devMode bool) *
 	}
 }
 
-func (c *Client) Search(ctx context.Context, params model.FederationSearchParams) (model.FederationResult, error) {
+func (c *Client) Search(ctx context.Context, params model.MCPSearchParams) (model.FederationResult, error) {
 	return c.callTool(ctx, "search", params)
 }
 
-func (c *Client) Similar(ctx context.Context, params model.FederationSimilarParams) (model.FederationResult, error) {
+func (c *Client) Similar(ctx context.Context, params model.MCPSimilarParams) (model.FederationResult, error) {
 	return c.callTool(ctx, "similar", params)
 }
 
-func (c *Client) NoteHTML(ctx context.Context, params model.FederationNoteHTMLParams) (model.FederationResult, error) {
+func (c *Client) NoteHTML(ctx context.Context, params model.MCPNoteHTMLParams) (model.FederationResult, error) {
 	return c.callTool(ctx, "note_html", params)
 }
 
-func (c *Client) FederatedSearch(ctx context.Context, params model.FederationSearchParams) (model.FederationResult, error) {
+func (c *Client) FederatedSearch(ctx context.Context, params model.MCPSearchParams) (model.FederationResult, error) {
 	return c.callTool(ctx, "federated_search", params)
 }
 
-func (c *Client) FederatedSimilar(ctx context.Context, params model.FederationSimilarParams) (model.FederationResult, error) {
+func (c *Client) FederatedSimilar(ctx context.Context, params model.MCPSimilarParams) (model.FederationResult, error) {
 	return c.callTool(ctx, "federated_similar", params)
 }
 
-func (c *Client) FederatedNoteHTML(ctx context.Context, params model.FederationNoteHTMLParams) (model.FederationResult, error) {
+func (c *Client) FederatedNoteHTML(ctx context.Context, params model.MCPNoteHTMLParams) (model.FederationResult, error) {
 	return c.callTool(ctx, "federated_note_html", params)
 }
 
-func (c *Client) Expand(ctx context.Context, params model.FederationExpandParams) (model.FederationResult, error) {
+func (c *Client) Expand(ctx context.Context, params model.MCPExpandParams) (model.FederationResult, error) {
 	return c.callTool(ctx, "expand", params)
 }
 
-func (c *Client) FederatedExpand(ctx context.Context, params model.FederationExpandParams) (model.FederationResult, error) {
+func (c *Client) FederatedExpand(ctx context.Context, params model.MCPExpandParams) (model.FederationResult, error) {
 	return c.callTool(ctx, "federated_expand", params)
 }
 
-func (c *Client) GraphQLRequest(ctx context.Context, params model.FederationGraphQLParams) (model.FederationResult, error) {
+func (c *Client) GraphQLRequest(ctx context.Context, params model.MCPGraphQLParams) (model.FederationResult, error) {
 	return c.callTool(ctx, "graphql_request", params)
 }
 
@@ -86,7 +86,7 @@ func (c *Client) Instructions(ctx context.Context) (model.FederationResult, erro
 	return c.callTool(ctx, "instructions", nil)
 }
 
-func (c *Client) FederatedInstructions(ctx context.Context, params model.FederationInstructionsParams) (model.FederationResult, error) {
+func (c *Client) FederatedInstructions(ctx context.Context, params model.MCPInstructionsParams) (model.FederationResult, error) {
 	return c.callTool(ctx, "federated_instructions", params)
 }
 

--- a/internal/federation/client_test.go
+++ b/internal/federation/client_test.go
@@ -50,17 +50,17 @@ func TestClientCallsSixFederationTools(t *testing.T) {
 		Depth:  1,
 	}, &fasthttp.Client{}, false)
 
-	_, err := client.Search(context.Background(), model.FederationSearchParams{Query: "q"})
+	_, err := client.Search(context.Background(), model.MCPSearchParams{Query: "q"})
 	require.NoError(t, err)
-	_, err = client.Similar(context.Background(), model.FederationSimilarParams{PID: 1})
+	_, err = client.Similar(context.Background(), model.MCPSimilarParams{PID: model.PID{Value: 1}})
 	require.NoError(t, err)
-	_, err = client.NoteHTML(context.Background(), model.FederationNoteHTMLParams{PID: 1})
+	_, err = client.NoteHTML(context.Background(), model.MCPNoteHTMLParams{PID: model.PID{Value: 1}})
 	require.NoError(t, err)
-	_, err = client.FederatedSearch(context.Background(), model.FederationSearchParams{Query: "q", KBID: "deep"})
+	_, err = client.FederatedSearch(context.Background(), model.MCPSearchParams{Query: "q", KBID: "deep"})
 	require.NoError(t, err)
-	_, err = client.FederatedSimilar(context.Background(), model.FederationSimilarParams{KBID: "deep", PID: 1})
+	_, err = client.FederatedSimilar(context.Background(), model.MCPSimilarParams{KBID: "deep", PID: model.PID{Value: 1}})
 	require.NoError(t, err)
-	result, err := client.FederatedNoteHTML(context.Background(), model.FederationNoteHTMLParams{KBID: "deep", PID: 1})
+	result, err := client.FederatedNoteHTML(context.Background(), model.MCPNoteHTMLParams{KBID: "deep", PID: model.PID{Value: 1}})
 	require.NoError(t, err)
 
 	require.Equal(t, []string{

--- a/internal/mdchunk/chunk.go
+++ b/internal/mdchunk/chunk.go
@@ -1,6 +1,9 @@
 package mdchunk
 
-import "strings"
+import (
+	"strings"
+	"unicode/utf8"
+)
 
 const (
 	// Sizing is in ESTIMATED TOKENS (see estimateTokens), not characters: at
@@ -77,7 +80,14 @@ func Split(title string, rawContent []byte) []Chunk { //nolint:gocognit // inher
 		}
 		last := current[len(current)-1]
 		if len(last) > chunkOverlap {
-			return last[len(last)-chunkOverlap:]
+			// The window is sized in bytes, so it can land inside a multibyte
+			// rune; walk forward to the next boundary, otherwise every chunk
+			// after the first starts with a broken rune.
+			start := len(last) - chunkOverlap
+			for start < len(last) && !utf8.RuneStart(last[start]) {
+				start++
+			}
+			return last[start:]
 		}
 		return last
 	}

--- a/internal/mdchunk/chunk_test.go
+++ b/internal/mdchunk/chunk_test.go
@@ -3,6 +3,7 @@ package mdchunk
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestStripFrontmatter(t *testing.T) {
@@ -259,4 +260,36 @@ func firstLine(s string) string {
 		return s[:i]
 	}
 	return s
+}
+
+// TestSplitKeepsOverlapRuneAligned pins the overlap window to rune boundaries.
+// The tail of the previous block is prepended to the next chunk; slicing it by
+// byte offset cut a multibyte rune in half, so every affected chunk started with
+// U+FFFD (reported live as "�слепляет" and "� τίνων").
+func TestSplitKeepsOverlapRuneAligned(t *testing.T) {
+	tests := []struct {
+		name string
+		word string
+	}{
+		{"cyrillic", "ослепляет мысль "},
+		{"greek", "τίνων ἕνεκα "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Vary the trailing byte count so the 200-byte window lands mid-rune
+			// in at least some of the runs.
+			for pad := 0; pad < 4; pad++ {
+				body := "## Alpha\n\n" + strings.Repeat(tt.word, 60) + strings.Repeat("x", pad) +
+					"\n\n## Beta\n\n" + strings.Repeat(tt.word, 60)
+				for _, c := range Split("Заметка", []byte(body)) {
+					if !utf8.ValidString(c.Content) {
+						t.Errorf("pad=%d chunk %d is not valid UTF-8", pad, c.Index)
+					}
+					if strings.ContainsRune(c.Content, utf8.RuneError) {
+						t.Errorf("pad=%d chunk %d contains U+FFFD: %.20q", pad, c.Index, c.Content)
+					}
+				}
+			}
+		})
+	}
 }

--- a/internal/mdchunk/chunk_test.go
+++ b/internal/mdchunk/chunk_test.go
@@ -278,7 +278,7 @@ func TestSplitKeepsOverlapRuneAligned(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Vary the trailing byte count so the 200-byte window lands mid-rune
 			// in at least some of the runs.
-			for pad := 0; pad < 4; pad++ {
+			for pad := range 4 {
 				body := "## Alpha\n\n" + strings.Repeat(tt.word, 60) + strings.Repeat("x", pad) +
 					"\n\n## Beta\n\n" + strings.Repeat(tt.word, 60)
 				for _, c := range Split("Заметка", []byte(body)) {

--- a/internal/model/federation.go
+++ b/internal/model/federation.go
@@ -8,17 +8,17 @@ import (
 )
 
 type Federation interface {
-	Search(ctx context.Context, params FederationSearchParams) (FederationResult, error)
-	Similar(ctx context.Context, params FederationSimilarParams) (FederationResult, error)
-	NoteHTML(ctx context.Context, params FederationNoteHTMLParams) (FederationResult, error)
-	FederatedSearch(ctx context.Context, params FederationSearchParams) (FederationResult, error)
-	FederatedSimilar(ctx context.Context, params FederationSimilarParams) (FederationResult, error)
-	FederatedNoteHTML(ctx context.Context, params FederationNoteHTMLParams) (FederationResult, error)
-	Expand(ctx context.Context, params FederationExpandParams) (FederationResult, error)
-	FederatedExpand(ctx context.Context, params FederationExpandParams) (FederationResult, error)
-	GraphQLRequest(ctx context.Context, params FederationGraphQLParams) (FederationResult, error)
+	Search(ctx context.Context, params MCPSearchParams) (FederationResult, error)
+	Similar(ctx context.Context, params MCPSimilarParams) (FederationResult, error)
+	NoteHTML(ctx context.Context, params MCPNoteHTMLParams) (FederationResult, error)
+	FederatedSearch(ctx context.Context, params MCPSearchParams) (FederationResult, error)
+	FederatedSimilar(ctx context.Context, params MCPSimilarParams) (FederationResult, error)
+	FederatedNoteHTML(ctx context.Context, params MCPNoteHTMLParams) (FederationResult, error)
+	Expand(ctx context.Context, params MCPExpandParams) (FederationResult, error)
+	FederatedExpand(ctx context.Context, params MCPExpandParams) (FederationResult, error)
+	GraphQLRequest(ctx context.Context, params MCPGraphQLParams) (FederationResult, error)
 	Instructions(ctx context.Context) (FederationResult, error)
-	FederatedInstructions(ctx context.Context, params FederationInstructionsParams) (FederationResult, error)
+	FederatedInstructions(ctx context.Context, params MCPInstructionsParams) (FederationResult, error)
 }
 
 type FederationClientFactory interface {
@@ -32,50 +32,6 @@ type FederationPeer struct {
 	Secret []byte
 	Issuer string
 	Depth  int
-}
-
-type FederationSearchParams struct {
-	Query string   `json:"query"`
-	KBID  string   `json:"kb_id,omitempty"`
-	KBIDs []string `json:"kb_ids,omitempty"`
-}
-
-type FederationSimilarParams struct {
-	KBID   string `json:"kb_id,omitempty"`
-	PID    int64  `json:"pid,omitempty"`
-	NoteID string `json:"note_id,omitempty"`
-	Path   string `json:"path,omitempty"`
-	Href   string `json:"href,omitempty"`
-	Limit  int    `json:"limit,omitempty"`
-}
-
-type FederationInstructionsParams struct {
-	KBID string `json:"kb_id,omitempty"`
-}
-
-type FederationGraphQLParams struct {
-	KBID      string         `json:"kb_id,omitempty"`
-	Query     string         `json:"query"`
-	Variables map[string]any `json:"variables,omitempty"`
-}
-
-type FederationNoteHTMLParams struct {
-	KBID         string `json:"kb_id,omitempty"`
-	PID          int64  `json:"pid,omitempty"`
-	NoteID       string `json:"note_id,omitempty"`
-	Path         string `json:"path,omitempty"`
-	Href         string `json:"href,omitempty"`
-	MatchID      string `json:"match_id,omitempty"`
-	ContextWords int    `json:"context_words,omitempty"`
-}
-
-type FederationExpandParams struct {
-	KBID    string   `json:"kb_id,omitempty"`
-	PID     int64    `json:"pid,omitempty"`
-	NoteID  string   `json:"note_id,omitempty"`
-	Path    string   `json:"path,omitempty"`
-	Href    string   `json:"href,omitempty"`
-	TocPath []string `json:"toc_path,omitempty"`
 }
 
 type FederationResult struct {

--- a/internal/model/federation_easyjson.go
+++ b/internal/model/federation_easyjson.go
@@ -17,244 +17,7 @@ var (
 	_ easyjson.Marshaler
 )
 
-func easyjson7b3c8c57DecodeTrip2gInternalModel(in *jlexer.Lexer, out *FederationSimilarParams) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "kb_id":
-			out.KBID = string(in.String())
-		case "pid":
-			out.PID = int64(in.Int64())
-		case "note_id":
-			out.NoteID = string(in.String())
-		case "path":
-			out.Path = string(in.String())
-		case "href":
-			out.Href = string(in.String())
-		case "limit":
-			out.Limit = int(in.Int())
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson7b3c8c57EncodeTrip2gInternalModel(out *jwriter.Writer, in FederationSimilarParams) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	if in.KBID != "" {
-		const prefix string = ",\"kb_id\":"
-		first = false
-		out.RawString(prefix[1:])
-		out.String(string(in.KBID))
-	}
-	if in.PID != 0 {
-		const prefix string = ",\"pid\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Int64(int64(in.PID))
-	}
-	if in.NoteID != "" {
-		const prefix string = ",\"note_id\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.NoteID))
-	}
-	if in.Path != "" {
-		const prefix string = ",\"path\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Path))
-	}
-	if in.Href != "" {
-		const prefix string = ",\"href\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Href))
-	}
-	if in.Limit != 0 {
-		const prefix string = ",\"limit\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Int(int(in.Limit))
-	}
-	out.RawByte('}')
-}
-
-// MarshalJSON supports json.Marshaler interface
-func (v FederationSimilarParams) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjson7b3c8c57EncodeTrip2gInternalModel(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v FederationSimilarParams) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson7b3c8c57EncodeTrip2gInternalModel(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *FederationSimilarParams) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjson7b3c8c57DecodeTrip2gInternalModel(&r, v)
-	return r.Error()
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *FederationSimilarParams) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson7b3c8c57DecodeTrip2gInternalModel(l, v)
-}
-func easyjson7b3c8c57DecodeTrip2gInternalModel1(in *jlexer.Lexer, out *FederationSearchParams) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "query":
-			out.Query = string(in.String())
-		case "kb_id":
-			out.KBID = string(in.String())
-		case "kb_ids":
-			if in.IsNull() {
-				in.Skip()
-				out.KBIDs = nil
-			} else {
-				in.Delim('[')
-				if out.KBIDs == nil {
-					if !in.IsDelim(']') {
-						out.KBIDs = make([]string, 0, 4)
-					} else {
-						out.KBIDs = []string{}
-					}
-				} else {
-					out.KBIDs = (out.KBIDs)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v1 string
-					v1 = string(in.String())
-					out.KBIDs = append(out.KBIDs, v1)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson7b3c8c57EncodeTrip2gInternalModel1(out *jwriter.Writer, in FederationSearchParams) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"query\":"
-		out.RawString(prefix[1:])
-		out.String(string(in.Query))
-	}
-	if in.KBID != "" {
-		const prefix string = ",\"kb_id\":"
-		out.RawString(prefix)
-		out.String(string(in.KBID))
-	}
-	if len(in.KBIDs) != 0 {
-		const prefix string = ",\"kb_ids\":"
-		out.RawString(prefix)
-		{
-			out.RawByte('[')
-			for v2, v3 := range in.KBIDs {
-				if v2 > 0 {
-					out.RawByte(',')
-				}
-				out.String(string(v3))
-			}
-			out.RawByte(']')
-		}
-	}
-	out.RawByte('}')
-}
-
-// MarshalJSON supports json.Marshaler interface
-func (v FederationSearchParams) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjson7b3c8c57EncodeTrip2gInternalModel1(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v FederationSearchParams) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson7b3c8c57EncodeTrip2gInternalModel1(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *FederationSearchParams) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjson7b3c8c57DecodeTrip2gInternalModel1(&r, v)
-	return r.Error()
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *FederationSearchParams) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson7b3c8c57DecodeTrip2gInternalModel1(l, v)
-}
-func easyjson7b3c8c57DecodeTrip2gInternalModel2(in *jlexer.Lexer, out *FederationResult) {
+func easyjson7b3c8c57DecodeTrip2gInternalModel(in *jlexer.Lexer, out *FederationResult) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -289,9 +52,9 @@ func easyjson7b3c8c57DecodeTrip2gInternalModel2(in *jlexer.Lexer, out *Federatio
 					out.Content = (out.Content)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v4 FederationContent
-					(v4).UnmarshalEasyJSON(in)
-					out.Content = append(out.Content, v4)
+					var v1 FederationContent
+					(v1).UnmarshalEasyJSON(in)
+					out.Content = append(out.Content, v1)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -312,7 +75,7 @@ func easyjson7b3c8c57DecodeTrip2gInternalModel2(in *jlexer.Lexer, out *Federatio
 		in.Consumed()
 	}
 }
-func easyjson7b3c8c57EncodeTrip2gInternalModel2(out *jwriter.Writer, in FederationResult) {
+func easyjson7b3c8c57EncodeTrip2gInternalModel(out *jwriter.Writer, in FederationResult) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -323,11 +86,11 @@ func easyjson7b3c8c57EncodeTrip2gInternalModel2(out *jwriter.Writer, in Federati
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v5, v6 := range in.Content {
-				if v5 > 0 {
+			for v2, v3 := range in.Content {
+				if v2 > 0 {
 					out.RawByte(',')
 				}
-				(v6).MarshalEasyJSON(out)
+				(v3).MarshalEasyJSON(out)
 			}
 			out.RawByte(']')
 		}
@@ -348,27 +111,27 @@ func easyjson7b3c8c57EncodeTrip2gInternalModel2(out *jwriter.Writer, in Federati
 // MarshalJSON supports json.Marshaler interface
 func (v FederationResult) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson7b3c8c57EncodeTrip2gInternalModel2(&w, v)
+	easyjson7b3c8c57EncodeTrip2gInternalModel(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v FederationResult) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson7b3c8c57EncodeTrip2gInternalModel2(w, v)
+	easyjson7b3c8c57EncodeTrip2gInternalModel(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *FederationResult) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson7b3c8c57DecodeTrip2gInternalModel2(&r, v)
+	easyjson7b3c8c57DecodeTrip2gInternalModel(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *FederationResult) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson7b3c8c57DecodeTrip2gInternalModel2(l, v)
+	easyjson7b3c8c57DecodeTrip2gInternalModel(l, v)
 }
-func easyjson7b3c8c57DecodeTrip2gInternalModel3(in *jlexer.Lexer, out *FederationPeer) {
+func easyjson7b3c8c57DecodeTrip2gInternalModel1(in *jlexer.Lexer, out *FederationPeer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -414,7 +177,7 @@ func easyjson7b3c8c57DecodeTrip2gInternalModel3(in *jlexer.Lexer, out *Federatio
 		in.Consumed()
 	}
 }
-func easyjson7b3c8c57EncodeTrip2gInternalModel3(out *jwriter.Writer, in FederationPeer) {
+func easyjson7b3c8c57EncodeTrip2gInternalModel1(out *jwriter.Writer, in FederationPeer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -454,520 +217,27 @@ func easyjson7b3c8c57EncodeTrip2gInternalModel3(out *jwriter.Writer, in Federati
 // MarshalJSON supports json.Marshaler interface
 func (v FederationPeer) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson7b3c8c57EncodeTrip2gInternalModel3(&w, v)
+	easyjson7b3c8c57EncodeTrip2gInternalModel1(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v FederationPeer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson7b3c8c57EncodeTrip2gInternalModel3(w, v)
+	easyjson7b3c8c57EncodeTrip2gInternalModel1(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *FederationPeer) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson7b3c8c57DecodeTrip2gInternalModel3(&r, v)
+	easyjson7b3c8c57DecodeTrip2gInternalModel1(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *FederationPeer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson7b3c8c57DecodeTrip2gInternalModel3(l, v)
+	easyjson7b3c8c57DecodeTrip2gInternalModel1(l, v)
 }
-func easyjson7b3c8c57DecodeTrip2gInternalModel4(in *jlexer.Lexer, out *FederationNoteHTMLParams) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "kb_id":
-			out.KBID = string(in.String())
-		case "pid":
-			out.PID = int64(in.Int64())
-		case "note_id":
-			out.NoteID = string(in.String())
-		case "path":
-			out.Path = string(in.String())
-		case "href":
-			out.Href = string(in.String())
-		case "match_id":
-			out.MatchID = string(in.String())
-		case "context_words":
-			out.ContextWords = int(in.Int())
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson7b3c8c57EncodeTrip2gInternalModel4(out *jwriter.Writer, in FederationNoteHTMLParams) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	if in.KBID != "" {
-		const prefix string = ",\"kb_id\":"
-		first = false
-		out.RawString(prefix[1:])
-		out.String(string(in.KBID))
-	}
-	if in.PID != 0 {
-		const prefix string = ",\"pid\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Int64(int64(in.PID))
-	}
-	if in.NoteID != "" {
-		const prefix string = ",\"note_id\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.NoteID))
-	}
-	if in.Path != "" {
-		const prefix string = ",\"path\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Path))
-	}
-	if in.Href != "" {
-		const prefix string = ",\"href\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Href))
-	}
-	if in.MatchID != "" {
-		const prefix string = ",\"match_id\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.MatchID))
-	}
-	if in.ContextWords != 0 {
-		const prefix string = ",\"context_words\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Int(int(in.ContextWords))
-	}
-	out.RawByte('}')
-}
-
-// MarshalJSON supports json.Marshaler interface
-func (v FederationNoteHTMLParams) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjson7b3c8c57EncodeTrip2gInternalModel4(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v FederationNoteHTMLParams) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson7b3c8c57EncodeTrip2gInternalModel4(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *FederationNoteHTMLParams) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjson7b3c8c57DecodeTrip2gInternalModel4(&r, v)
-	return r.Error()
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *FederationNoteHTMLParams) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson7b3c8c57DecodeTrip2gInternalModel4(l, v)
-}
-func easyjson7b3c8c57DecodeTrip2gInternalModel5(in *jlexer.Lexer, out *FederationInstructionsParams) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "kb_id":
-			out.KBID = string(in.String())
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson7b3c8c57EncodeTrip2gInternalModel5(out *jwriter.Writer, in FederationInstructionsParams) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	if in.KBID != "" {
-		const prefix string = ",\"kb_id\":"
-		first = false
-		out.RawString(prefix[1:])
-		out.String(string(in.KBID))
-	}
-	out.RawByte('}')
-}
-
-// MarshalJSON supports json.Marshaler interface
-func (v FederationInstructionsParams) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjson7b3c8c57EncodeTrip2gInternalModel5(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v FederationInstructionsParams) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson7b3c8c57EncodeTrip2gInternalModel5(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *FederationInstructionsParams) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjson7b3c8c57DecodeTrip2gInternalModel5(&r, v)
-	return r.Error()
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *FederationInstructionsParams) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson7b3c8c57DecodeTrip2gInternalModel5(l, v)
-}
-func easyjson7b3c8c57DecodeTrip2gInternalModel6(in *jlexer.Lexer, out *FederationGraphQLParams) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "kb_id":
-			out.KBID = string(in.String())
-		case "query":
-			out.Query = string(in.String())
-		case "variables":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				in.Delim('{')
-				if !in.IsDelim('}') {
-					out.Variables = make(map[string]interface{})
-				} else {
-					out.Variables = nil
-				}
-				for !in.IsDelim('}') {
-					key := string(in.String())
-					in.WantColon()
-					var v10 interface{}
-					if m, ok := v10.(easyjson.Unmarshaler); ok {
-						m.UnmarshalEasyJSON(in)
-					} else if m, ok := v10.(json.Unmarshaler); ok {
-						_ = m.UnmarshalJSON(in.Raw())
-					} else {
-						v10 = in.Interface()
-					}
-					(out.Variables)[key] = v10
-					in.WantComma()
-				}
-				in.Delim('}')
-			}
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson7b3c8c57EncodeTrip2gInternalModel6(out *jwriter.Writer, in FederationGraphQLParams) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	if in.KBID != "" {
-		const prefix string = ",\"kb_id\":"
-		first = false
-		out.RawString(prefix[1:])
-		out.String(string(in.KBID))
-	}
-	{
-		const prefix string = ",\"query\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Query))
-	}
-	if len(in.Variables) != 0 {
-		const prefix string = ",\"variables\":"
-		out.RawString(prefix)
-		{
-			out.RawByte('{')
-			v11First := true
-			for v11Name, v11Value := range in.Variables {
-				if v11First {
-					v11First = false
-				} else {
-					out.RawByte(',')
-				}
-				out.String(string(v11Name))
-				out.RawByte(':')
-				if m, ok := v11Value.(easyjson.Marshaler); ok {
-					m.MarshalEasyJSON(out)
-				} else if m, ok := v11Value.(json.Marshaler); ok {
-					out.Raw(m.MarshalJSON())
-				} else {
-					out.Raw(json.Marshal(v11Value))
-				}
-			}
-			out.RawByte('}')
-		}
-	}
-	out.RawByte('}')
-}
-
-// MarshalJSON supports json.Marshaler interface
-func (v FederationGraphQLParams) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjson7b3c8c57EncodeTrip2gInternalModel6(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v FederationGraphQLParams) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson7b3c8c57EncodeTrip2gInternalModel6(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *FederationGraphQLParams) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjson7b3c8c57DecodeTrip2gInternalModel6(&r, v)
-	return r.Error()
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *FederationGraphQLParams) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson7b3c8c57DecodeTrip2gInternalModel6(l, v)
-}
-func easyjson7b3c8c57DecodeTrip2gInternalModel7(in *jlexer.Lexer, out *FederationExpandParams) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "kb_id":
-			out.KBID = string(in.String())
-		case "pid":
-			out.PID = int64(in.Int64())
-		case "note_id":
-			out.NoteID = string(in.String())
-		case "path":
-			out.Path = string(in.String())
-		case "href":
-			out.Href = string(in.String())
-		case "toc_path":
-			if in.IsNull() {
-				in.Skip()
-				out.TocPath = nil
-			} else {
-				in.Delim('[')
-				if out.TocPath == nil {
-					if !in.IsDelim(']') {
-						out.TocPath = make([]string, 0, 4)
-					} else {
-						out.TocPath = []string{}
-					}
-				} else {
-					out.TocPath = (out.TocPath)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v12 string
-					v12 = string(in.String())
-					out.TocPath = append(out.TocPath, v12)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson7b3c8c57EncodeTrip2gInternalModel7(out *jwriter.Writer, in FederationExpandParams) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	if in.KBID != "" {
-		const prefix string = ",\"kb_id\":"
-		first = false
-		out.RawString(prefix[1:])
-		out.String(string(in.KBID))
-	}
-	if in.PID != 0 {
-		const prefix string = ",\"pid\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Int64(int64(in.PID))
-	}
-	if in.NoteID != "" {
-		const prefix string = ",\"note_id\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.NoteID))
-	}
-	if in.Path != "" {
-		const prefix string = ",\"path\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Path))
-	}
-	if in.Href != "" {
-		const prefix string = ",\"href\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Href))
-	}
-	if len(in.TocPath) != 0 {
-		const prefix string = ",\"toc_path\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		{
-			out.RawByte('[')
-			for v13, v14 := range in.TocPath {
-				if v13 > 0 {
-					out.RawByte(',')
-				}
-				out.String(string(v14))
-			}
-			out.RawByte(']')
-		}
-	}
-	out.RawByte('}')
-}
-
-// MarshalJSON supports json.Marshaler interface
-func (v FederationExpandParams) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjson7b3c8c57EncodeTrip2gInternalModel7(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v FederationExpandParams) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson7b3c8c57EncodeTrip2gInternalModel7(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *FederationExpandParams) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjson7b3c8c57DecodeTrip2gInternalModel7(&r, v)
-	return r.Error()
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *FederationExpandParams) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson7b3c8c57DecodeTrip2gInternalModel7(l, v)
-}
-func easyjson7b3c8c57DecodeTrip2gInternalModel8(in *jlexer.Lexer, out *FederationContent) {
+func easyjson7b3c8c57DecodeTrip2gInternalModel2(in *jlexer.Lexer, out *FederationContent) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1000,7 +270,7 @@ func easyjson7b3c8c57DecodeTrip2gInternalModel8(in *jlexer.Lexer, out *Federatio
 		in.Consumed()
 	}
 }
-func easyjson7b3c8c57EncodeTrip2gInternalModel8(out *jwriter.Writer, in FederationContent) {
+func easyjson7b3c8c57EncodeTrip2gInternalModel2(out *jwriter.Writer, in FederationContent) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1020,23 +290,23 @@ func easyjson7b3c8c57EncodeTrip2gInternalModel8(out *jwriter.Writer, in Federati
 // MarshalJSON supports json.Marshaler interface
 func (v FederationContent) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson7b3c8c57EncodeTrip2gInternalModel8(&w, v)
+	easyjson7b3c8c57EncodeTrip2gInternalModel2(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v FederationContent) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson7b3c8c57EncodeTrip2gInternalModel8(w, v)
+	easyjson7b3c8c57EncodeTrip2gInternalModel2(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *FederationContent) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson7b3c8c57DecodeTrip2gInternalModel8(&r, v)
+	easyjson7b3c8c57DecodeTrip2gInternalModel2(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *FederationContent) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson7b3c8c57DecodeTrip2gInternalModel8(l, v)
+	easyjson7b3c8c57DecodeTrip2gInternalModel2(l, v)
 }

--- a/internal/model/mcp_params.go
+++ b/internal/model/mcp_params.go
@@ -1,0 +1,59 @@
+package model
+
+// One params type per MCP tool, shared by all three places a tool call passes
+// through: the local handler decoding a client's arguments, the hub decoding a
+// federated_* call, and the wire format sent to a peer. They used to be three
+// parallel struct families, which silently dropped any field one of them was
+// missing (limit, detail_limit, toc_path) and disagreed on the type of note_id.
+//
+// Deliberately kept out of federation.go: easyjson generates over that file,
+// and its decoder reports "parse error near offset 11" where encoding/json
+// says which field had the wrong type — and these errors are read by models
+// correcting their own tool calls.
+
+type MCPSearchParams struct {
+	Query       string   `json:"query"`
+	KBID        string   `json:"kb_id,omitempty"`
+	KBIDs       []string `json:"kb_ids,omitempty"`
+	Limit       int      `json:"limit,omitempty"`
+	DetailLimit int      `json:"detail_limit,omitempty"`
+}
+
+type MCPSimilarParams struct {
+	KBID   string `json:"kb_id,omitempty"`
+	PID    PID    `json:"pid,omitzero"`
+	NoteID PID    `json:"note_id,omitzero"`
+	Path   string `json:"path,omitempty"`
+	Href   string `json:"href,omitempty"`
+	Limit  int    `json:"limit,omitempty"`
+}
+
+type MCPInstructionsParams struct {
+	KBID string `json:"kb_id,omitempty"`
+}
+
+type MCPGraphQLParams struct {
+	KBID      string         `json:"kb_id,omitempty"`
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables,omitempty"`
+}
+
+type MCPNoteHTMLParams struct {
+	KBID         string   `json:"kb_id,omitempty"`
+	PID          PID      `json:"pid,omitzero"`
+	NoteID       PID      `json:"note_id,omitzero"`
+	Path         string   `json:"path,omitempty"`
+	Href         string   `json:"href,omitempty"`
+	MatchID      string   `json:"match_id,omitempty"`
+	ContextWords int      `json:"context_words,omitempty"`
+	TocPath      []string `json:"toc_path,omitempty"`
+}
+
+type MCPExpandParams struct {
+	KBID    string   `json:"kb_id,omitempty"`
+	PID     PID      `json:"pid,omitzero"`
+	NoteID  PID      `json:"note_id,omitzero"`
+	Path    string   `json:"path,omitempty"`
+	Href    string   `json:"href,omitempty"`
+	TocPath []string `json:"toc_path,omitempty"`
+}

--- a/internal/model/pid.go
+++ b/internal/model/pid.go
@@ -1,0 +1,55 @@
+package model
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
+// PID is a note id that tolerates what models actually send: a JSON number,
+// a numeric string ("70"), or a non-numeric string like a chunk match_id
+// ("p36:c2") or a path. Non-numeric input parses to Value 0 with Raw kept for
+// error messages, so a valid path in the same call can still resolve instead
+// of the whole request failing on unmarshal.
+type PID struct {
+	Value int64
+	Raw   string
+}
+
+func (p *PID) UnmarshalJSON(b []byte) error {
+	s := strings.TrimSpace(string(b))
+	if s == "null" {
+		return nil
+	}
+	if strings.HasPrefix(s, `"`) {
+		var raw string
+		if err := json.Unmarshal(b, &raw); err != nil {
+			return err
+		}
+		p.Raw = raw
+		if v, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64); err == nil {
+			p.Value = v
+		}
+		return nil
+	}
+	return json.Unmarshal(b, &p.Value)
+}
+
+// MarshalJSON emits null for an absent id rather than 0. The generated wire
+// encoder cannot evaluate omitempty on a struct field, so it always writes the
+// key; null is the one form every peer decodes without error, whether it reads
+// note_id as a string, an int64, or a PID.
+func (p PID) MarshalJSON() ([]byte, error) {
+	if p.Value == 0 {
+		// Raw is kept for error messages but is not a usable id, so a
+		// non-numeric pid crosses the wire as absent, not as a bogus 0.
+		return []byte("null"), nil
+	}
+	return json.Marshal(p.Value)
+}
+
+// IsZero reports whether no id was supplied, so encoding/json's omitzero and
+// the handlers agree on what "absent" means.
+func (p PID) IsZero() bool {
+	return p.Value == 0 && p.Raw == ""
+}


### PR DESCRIPTION
Acts on the two field reports from the live MCP testing (18.08). Everything here was reproduced against production or pinned by a test first.

## P0 — chunk overlap cut UTF-8 by byte offset

`mdchunk.Split` prepends the previous block's tail to every chunk after the first, sliced as `last[len(last)-200:]` — 200 **bytes**. Half of all multibyte cases lost their leading rune, which surfaced as `�слепляет` (Cyrillic) and `� τίνων` (Greek). Backing off to the next rune boundary fixes both; the test drives four byte-offsets across two alphabets and fails on the old code.

Grepped every other byte-index slice in `mdchunk`, `sitesearch` and `mcp` — this was the only unsafe one. `SnippetFromChunk` converts to `[]rune` and is what *rendered* the stored bad byte as U+FFFD.

Already-indexed chunks stay broken until re-chunked: the regen cron gates on the whole-note hash, which a chunker change does not move. Per-chunk hashes are already content-sensitive, so a cron pass that enqueues every note version repairs only the affected chunks. Not in this PR.

## P1 — the federated hop dropped arguments it advertised

Three parallel struct families described the same call: the peer's local arguments, the hub's `federated_*` arguments, and the wire params. Nothing linked them, so fields existed in one and not the others:

| tool | lost |
|---|---|
| `search` | `limit`, `detail_limit` — advertised, absent from the wire struct |
| `note_html` | `toc_path` — absent from the federated variant entirely; `context_words` never populated |
| `similar` | `note_id` — `string` on the wire, `int64` at the peer, fails to unmarshal |

Measured on production before the fix:

```
federated note_html, no toc_path : 73617 bytes
federated note_html, w/ toc_path : 73617 bytes   ← identical, dropped
local     note_html, no toc_path : 26829 bytes
local     note_html, w/ toc_path :   374 bytes   ← 72×
```

Section reads were unavailable across federation entirely — every remote read returned the whole note. `federated_search(limit=2)` returned 6.

Now one `model.MCP*Params` per tool, used by all three, with `model.PID` (tolerant of number / numeric string / garbage) for both id fields. The handlers forward the decoded arguments instead of copying field by field, so nothing can be dropped by forgetting one. Kept out of `federation.go` on purpose: easyjson generates over that file and reports `parse error near offset 11` where `encoding/json` names the bad field — and models read those errors to correct their own calls.

`PID` marshals as `null` when absent, which every peer version decodes without error whether it reads `note_id` as a string, an int64, or a `PID`.

## Federated hop had no deadline

Only fan-out went through `callPeer`. `federated_similar`, `federated_note_html` and `federated_expand` had no context deadline at all. The reported 4-minute hang does **not** reproduce — both failing calls now answer in <1s against production, on every route, and the server is stateless with no SSE path that could stall — so this is defensive: an unanswered peer becomes a fast error instead of a tool that never returns. Test asserts the handler gives up on its own deadline.

The single-KB path was also missing `rewriteFederatedResponse`, so its results carried no `kb_id` in the caller's frame despite the tool descriptions promising one.

## Expand was unusable on aphoristic corpora

`federated_expand` on a book returned 39 subsections titled `1`, `2`, … `39` — structurally correct, nothing to choose by. Headings shorter than 15 **runes** (`Книга 10` is 8 runes but 15 bytes) now carry the section's opening words.

The leading H1 is the note's title — the template already renders it in place of its own — so it no longer eats a level of navigation. A second or later H1 is a real section and stays. Levels are deliberately **not** renumbered: that would mean reslicing `note.Headings`, whose backing array is shared by every reader of the note cache.

Shortened `toc_path` values still resolve, because `navigateSectionPath` searches each step's whole subtree; pinned end-to-end in the golden file. Added a golden fixture with a real leading H1 — neither suite had one, so a regression here would have shipped silently.

## Tool notes in search results

`instructions.md` came back as a search hit. `IsSystem()` matches on path only (leading `_`), so a tool note without the underscore convention slipped through. A note carrying `mcp_method` is server infrastructure — an agent gets its body from `initialize` or from calling the tool — and is now skipped. The golden file shows the note surfacing, then filtered.

## Docs

The wiki instruction told agents `note_html(pid=...)` against every tool description's "prefer path", and never mentioned `match_id`. The GET help text read as if `mcp_method: initialize` shadowed the protocol handshake, listed no tools, and left the three auth variants unlabelled.

## Note

`TestSessionKeyStableWithinHourAndAnonymous` (`internal/movebus`) is flaky on `main`, unrelated to this branch: it asserts an 8-byte hex token does not contain `"42"`, which it does by chance in some hours.
