### PR TITLE
memcli: seed OWNER_PERSONAL_TOKEN_VALUE so an instance can host a fleet

### DIFF
--- a/cli/memcli/dist/memcli.js
+++ b/cli/memcli/dist/memcli.js
@@ -30,9 +30,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/version.js
+// ../../../../node_modules/graphql/version.js
 var require_version = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/version.js"(exports) {
+  "../../../../node_modules/graphql/version.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -50,9 +50,9 @@ var require_version = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/devAssert.js
+// ../../../../node_modules/graphql/jsutils/devAssert.js
 var require_devAssert = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/devAssert.js"(exports) {
+  "../../../../node_modules/graphql/jsutils/devAssert.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -68,9 +68,9 @@ var require_devAssert = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/isPromise.js
+// ../../../../node_modules/graphql/jsutils/isPromise.js
 var require_isPromise = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/isPromise.js"(exports) {
+  "../../../../node_modules/graphql/jsutils/isPromise.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -83,9 +83,9 @@ var require_isPromise = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/isObjectLike.js
+// ../../../../node_modules/graphql/jsutils/isObjectLike.js
 var require_isObjectLike = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/isObjectLike.js"(exports) {
+  "../../../../node_modules/graphql/jsutils/isObjectLike.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -98,9 +98,9 @@ var require_isObjectLike = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/invariant.js
+// ../../../../node_modules/graphql/jsutils/invariant.js
 var require_invariant = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/invariant.js"(exports) {
+  "../../../../node_modules/graphql/jsutils/invariant.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -118,9 +118,9 @@ var require_invariant = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/location.js
+// ../../../../node_modules/graphql/language/location.js
 var require_location = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/location.js"(exports) {
+  "../../../../node_modules/graphql/language/location.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -148,9 +148,9 @@ var require_location = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/printLocation.js
+// ../../../../node_modules/graphql/language/printLocation.js
 var require_printLocation = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/printLocation.js"(exports) {
+  "../../../../node_modules/graphql/language/printLocation.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -209,9 +209,9 @@ var require_printLocation = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/error/GraphQLError.js
+// ../../../../node_modules/graphql/error/GraphQLError.js
 var require_GraphQLError = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/error/GraphQLError.js"(exports) {
+  "../../../../node_modules/graphql/error/GraphQLError.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -388,9 +388,9 @@ var require_GraphQLError = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/error/syntaxError.js
+// ../../../../node_modules/graphql/error/syntaxError.js
 var require_syntaxError = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/error/syntaxError.js"(exports) {
+  "../../../../node_modules/graphql/error/syntaxError.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -407,9 +407,9 @@ var require_syntaxError = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/ast.js
+// ../../../../node_modules/graphql/language/ast.js
 var require_ast = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/ast.js"(exports) {
+  "../../../../node_modules/graphql/language/ast.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -598,9 +598,9 @@ var require_ast = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/directiveLocation.js
+// ../../../../node_modules/graphql/language/directiveLocation.js
 var require_directiveLocation = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/directiveLocation.js"(exports) {
+  "../../../../node_modules/graphql/language/directiveLocation.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -632,9 +632,9 @@ var require_directiveLocation = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/kinds.js
+// ../../../../node_modules/graphql/language/kinds.js
 var require_kinds = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/kinds.js"(exports) {
+  "../../../../node_modules/graphql/language/kinds.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -690,9 +690,9 @@ var require_kinds = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/characterClasses.js
+// ../../../../node_modules/graphql/language/characterClasses.js
 var require_characterClasses = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/characterClasses.js"(exports) {
+  "../../../../node_modules/graphql/language/characterClasses.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -726,9 +726,9 @@ var require_characterClasses = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/blockString.js
+// ../../../../node_modules/graphql/language/blockString.js
 var require_blockString = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/blockString.js"(exports) {
+  "../../../../node_modules/graphql/language/blockString.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -852,9 +852,9 @@ var require_blockString = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/tokenKind.js
+// ../../../../node_modules/graphql/language/tokenKind.js
 var require_tokenKind = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/tokenKind.js"(exports) {
+  "../../../../node_modules/graphql/language/tokenKind.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -889,9 +889,9 @@ var require_tokenKind = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/lexer.js
+// ../../../../node_modules/graphql/language/lexer.js
 var require_lexer = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/lexer.js"(exports) {
+  "../../../../node_modules/graphql/language/lexer.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -1549,9 +1549,9 @@ var require_lexer = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/inspect.js
+// ../../../../node_modules/graphql/jsutils/inspect.js
 var require_inspect = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/inspect.js"(exports) {
+  "../../../../node_modules/graphql/jsutils/inspect.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -1648,9 +1648,9 @@ var require_inspect = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/instanceOf.js
+// ../../../../node_modules/graphql/jsutils/instanceOf.js
 var require_instanceOf = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/instanceOf.js"(exports) {
+  "../../../../node_modules/graphql/jsutils/instanceOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -1698,9 +1698,9 @@ spurious results.`);
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/source.js
+// ../../../../node_modules/graphql/language/source.js
 var require_source = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/source.js"(exports) {
+  "../../../../node_modules/graphql/language/source.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -1746,9 +1746,9 @@ var require_source = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/parser.js
+// ../../../../node_modules/graphql/language/parser.js
 var require_parser = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/parser.js"(exports) {
+  "../../../../node_modules/graphql/language/parser.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -3072,9 +3072,9 @@ var require_parser = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/didYouMean.js
+// ../../../../node_modules/graphql/jsutils/didYouMean.js
 var require_didYouMean = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/didYouMean.js"(exports) {
+  "../../../../node_modules/graphql/jsutils/didYouMean.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -3104,9 +3104,9 @@ var require_didYouMean = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/identityFunc.js
+// ../../../../node_modules/graphql/jsutils/identityFunc.js
 var require_identityFunc = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/identityFunc.js"(exports) {
+  "../../../../node_modules/graphql/jsutils/identityFunc.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -3119,9 +3119,9 @@ var require_identityFunc = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/keyMap.js
+// ../../../../node_modules/graphql/jsutils/keyMap.js
 var require_keyMap = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/keyMap.js"(exports) {
+  "../../../../node_modules/graphql/jsutils/keyMap.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -3138,9 +3138,9 @@ var require_keyMap = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/keyValMap.js
+// ../../../../node_modules/graphql/jsutils/keyValMap.js
 var require_keyValMap = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/keyValMap.js"(exports) {
+  "../../../../node_modules/graphql/jsutils/keyValMap.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -3157,9 +3157,9 @@ var require_keyValMap = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/mapValue.js
+// ../../../../node_modules/graphql/jsutils/mapValue.js
 var require_mapValue = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/mapValue.js"(exports) {
+  "../../../../node_modules/graphql/jsutils/mapValue.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -3176,9 +3176,9 @@ var require_mapValue = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/naturalCompare.js
+// ../../../../node_modules/graphql/jsutils/naturalCompare.js
 var require_naturalCompare = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/naturalCompare.js"(exports) {
+  "../../../../node_modules/graphql/jsutils/naturalCompare.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -3232,9 +3232,9 @@ var require_naturalCompare = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/suggestionList.js
+// ../../../../node_modules/graphql/jsutils/suggestionList.js
 var require_suggestionList = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/suggestionList.js"(exports) {
+  "../../../../node_modules/graphql/jsutils/suggestionList.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -3338,9 +3338,9 @@ var require_suggestionList = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/toObjMap.js
+// ../../../../node_modules/graphql/jsutils/toObjMap.js
 var require_toObjMap = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/toObjMap.js"(exports) {
+  "../../../../node_modules/graphql/jsutils/toObjMap.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -3363,9 +3363,9 @@ var require_toObjMap = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/printString.js
+// ../../../../node_modules/graphql/language/printString.js
 var require_printString = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/printString.js"(exports) {
+  "../../../../node_modules/graphql/language/printString.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -3550,9 +3550,9 @@ var require_printString = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/visitor.js
+// ../../../../node_modules/graphql/language/visitor.js
 var require_visitor = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/visitor.js"(exports) {
+  "../../../../node_modules/graphql/language/visitor.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -3765,9 +3765,9 @@ var require_visitor = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/printer.js
+// ../../../../node_modules/graphql/language/printer.js
 var require_printer = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/printer.js"(exports) {
+  "../../../../node_modules/graphql/language/printer.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -4025,9 +4025,9 @@ var require_printer = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/valueFromASTUntyped.js
+// ../../../../node_modules/graphql/utilities/valueFromASTUntyped.js
 var require_valueFromASTUntyped = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/valueFromASTUntyped.js"(exports) {
+  "../../../../node_modules/graphql/utilities/valueFromASTUntyped.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -4065,9 +4065,9 @@ var require_valueFromASTUntyped = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/type/assertName.js
+// ../../../../node_modules/graphql/type/assertName.js
 var require_assertName = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/type/assertName.js"(exports) {
+  "../../../../node_modules/graphql/type/assertName.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -4112,9 +4112,9 @@ var require_assertName = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/type/definition.js
+// ../../../../node_modules/graphql/type/definition.js
 var require_definition = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/type/definition.js"(exports) {
+  "../../../../node_modules/graphql/type/definition.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -5014,9 +5014,9 @@ var require_definition = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/typeComparators.js
+// ../../../../node_modules/graphql/utilities/typeComparators.js
 var require_typeComparators = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/typeComparators.js"(exports) {
+  "../../../../node_modules/graphql/utilities/typeComparators.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -5082,9 +5082,9 @@ var require_typeComparators = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/type/scalars.js
+// ../../../../node_modules/graphql/type/scalars.js
 var require_scalars = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/type/scalars.js"(exports) {
+  "../../../../node_modules/graphql/type/scalars.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -5365,9 +5365,9 @@ var require_scalars = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/type/directives.js
+// ../../../../node_modules/graphql/type/directives.js
 var require_directives = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/type/directives.js"(exports) {
+  "../../../../node_modules/graphql/type/directives.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -5530,9 +5530,9 @@ var require_directives = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/isIterableObject.js
+// ../../../../node_modules/graphql/jsutils/isIterableObject.js
 var require_isIterableObject = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/isIterableObject.js"(exports) {
+  "../../../../node_modules/graphql/jsutils/isIterableObject.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -5545,9 +5545,9 @@ var require_isIterableObject = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/astFromValue.js
+// ../../../../node_modules/graphql/utilities/astFromValue.js
 var require_astFromValue = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/astFromValue.js"(exports) {
+  "../../../../node_modules/graphql/utilities/astFromValue.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -5669,9 +5669,9 @@ var require_astFromValue = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/type/introspection.js
+// ../../../../node_modules/graphql/type/introspection.js
 var require_introspection = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/type/introspection.js"(exports) {
+  "../../../../node_modules/graphql/type/introspection.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -6203,9 +6203,9 @@ var require_introspection = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/type/schema.js
+// ../../../../node_modules/graphql/type/schema.js
 var require_schema = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/type/schema.js"(exports) {
+  "../../../../node_modules/graphql/type/schema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -6444,9 +6444,9 @@ var require_schema = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/type/validate.js
+// ../../../../node_modules/graphql/type/validate.js
 var require_validate = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/type/validate.js"(exports) {
+  "../../../../node_modules/graphql/type/validate.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -6939,9 +6939,9 @@ var require_validate = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/typeFromAST.js
+// ../../../../node_modules/graphql/utilities/typeFromAST.js
 var require_typeFromAST = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/typeFromAST.js"(exports) {
+  "../../../../node_modules/graphql/utilities/typeFromAST.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -6967,9 +6967,9 @@ var require_typeFromAST = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/TypeInfo.js
+// ../../../../node_modules/graphql/utilities/TypeInfo.js
 var require_TypeInfo = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/TypeInfo.js"(exports) {
+  "../../../../node_modules/graphql/utilities/TypeInfo.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -7249,9 +7249,9 @@ var require_TypeInfo = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/predicates.js
+// ../../../../node_modules/graphql/language/predicates.js
 var require_predicates = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/predicates.js"(exports) {
+  "../../../../node_modules/graphql/language/predicates.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -7310,9 +7310,9 @@ var require_predicates = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/ExecutableDefinitionsRule.js
+// ../../../../node_modules/graphql/validation/rules/ExecutableDefinitionsRule.js
 var require_ExecutableDefinitionsRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/ExecutableDefinitionsRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/ExecutableDefinitionsRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -7345,9 +7345,9 @@ var require_ExecutableDefinitionsRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/FieldsOnCorrectTypeRule.js
+// ../../../../node_modules/graphql/validation/rules/FieldsOnCorrectTypeRule.js
 var require_FieldsOnCorrectTypeRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/FieldsOnCorrectTypeRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/FieldsOnCorrectTypeRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -7437,9 +7437,9 @@ var require_FieldsOnCorrectTypeRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/FragmentsOnCompositeTypesRule.js
+// ../../../../node_modules/graphql/validation/rules/FragmentsOnCompositeTypesRule.js
 var require_FragmentsOnCompositeTypesRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/FragmentsOnCompositeTypesRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/FragmentsOnCompositeTypesRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -7494,9 +7494,9 @@ var require_FragmentsOnCompositeTypesRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/KnownArgumentNamesRule.js
+// ../../../../node_modules/graphql/validation/rules/KnownArgumentNamesRule.js
 var require_KnownArgumentNamesRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/KnownArgumentNamesRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/KnownArgumentNamesRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -7582,9 +7582,9 @@ var require_KnownArgumentNamesRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/KnownDirectivesRule.js
+// ../../../../node_modules/graphql/validation/rules/KnownDirectivesRule.js
 var require_KnownDirectivesRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/KnownDirectivesRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/KnownDirectivesRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -7707,9 +7707,9 @@ var require_KnownDirectivesRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/KnownFragmentNamesRule.js
+// ../../../../node_modules/graphql/validation/rules/KnownFragmentNamesRule.js
 var require_KnownFragmentNamesRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/KnownFragmentNamesRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/KnownFragmentNamesRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -7738,9 +7738,9 @@ var require_KnownFragmentNamesRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/KnownTypeNamesRule.js
+// ../../../../node_modules/graphql/validation/rules/KnownTypeNamesRule.js
 var require_KnownTypeNamesRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/KnownTypeNamesRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/KnownTypeNamesRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -7803,9 +7803,9 @@ var require_KnownTypeNamesRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/LoneAnonymousOperationRule.js
+// ../../../../node_modules/graphql/validation/rules/LoneAnonymousOperationRule.js
 var require_LoneAnonymousOperationRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/LoneAnonymousOperationRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/LoneAnonymousOperationRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -7839,9 +7839,9 @@ var require_LoneAnonymousOperationRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/LoneSchemaDefinitionRule.js
+// ../../../../node_modules/graphql/validation/rules/LoneSchemaDefinitionRule.js
 var require_LoneSchemaDefinitionRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/LoneSchemaDefinitionRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/LoneSchemaDefinitionRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -7884,9 +7884,9 @@ var require_LoneSchemaDefinitionRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/MaxIntrospectionDepthRule.js
+// ../../../../node_modules/graphql/validation/rules/MaxIntrospectionDepthRule.js
 var require_MaxIntrospectionDepthRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/MaxIntrospectionDepthRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/MaxIntrospectionDepthRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -7952,9 +7952,9 @@ var require_MaxIntrospectionDepthRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/NoFragmentCyclesRule.js
+// ../../../../node_modules/graphql/validation/rules/NoFragmentCyclesRule.js
 var require_NoFragmentCyclesRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/NoFragmentCyclesRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/NoFragmentCyclesRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -8014,9 +8014,9 @@ var require_NoFragmentCyclesRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/NoUndefinedVariablesRule.js
+// ../../../../node_modules/graphql/validation/rules/NoUndefinedVariablesRule.js
 var require_NoUndefinedVariablesRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/NoUndefinedVariablesRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/NoUndefinedVariablesRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -8056,9 +8056,9 @@ var require_NoUndefinedVariablesRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/NoUnusedFragmentsRule.js
+// ../../../../node_modules/graphql/validation/rules/NoUnusedFragmentsRule.js
 var require_NoUnusedFragmentsRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/NoUnusedFragmentsRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/NoUnusedFragmentsRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -8108,9 +8108,9 @@ var require_NoUnusedFragmentsRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/NoUnusedVariablesRule.js
+// ../../../../node_modules/graphql/validation/rules/NoUnusedVariablesRule.js
 var require_NoUnusedVariablesRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/NoUnusedVariablesRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/NoUnusedVariablesRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -8154,9 +8154,9 @@ var require_NoUnusedVariablesRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/sortValueNode.js
+// ../../../../node_modules/graphql/utilities/sortValueNode.js
 var require_sortValueNode = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/sortValueNode.js"(exports) {
+  "../../../../node_modules/graphql/utilities/sortValueNode.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -8193,9 +8193,9 @@ var require_sortValueNode = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/OverlappingFieldsCanBeMergedRule.js
+// ../../../../node_modules/graphql/validation/rules/OverlappingFieldsCanBeMergedRule.js
 var require_OverlappingFieldsCanBeMergedRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/OverlappingFieldsCanBeMergedRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/OverlappingFieldsCanBeMergedRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -8744,9 +8744,9 @@ var require_OverlappingFieldsCanBeMergedRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/PossibleFragmentSpreadsRule.js
+// ../../../../node_modules/graphql/validation/rules/PossibleFragmentSpreadsRule.js
 var require_PossibleFragmentSpreadsRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/PossibleFragmentSpreadsRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/PossibleFragmentSpreadsRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -8819,9 +8819,9 @@ var require_PossibleFragmentSpreadsRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/PossibleTypeExtensionsRule.js
+// ../../../../node_modules/graphql/validation/rules/PossibleTypeExtensionsRule.js
 var require_PossibleTypeExtensionsRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/PossibleTypeExtensionsRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/PossibleTypeExtensionsRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -8955,9 +8955,9 @@ var require_PossibleTypeExtensionsRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/ProvidedRequiredArgumentsRule.js
+// ../../../../node_modules/graphql/validation/rules/ProvidedRequiredArgumentsRule.js
 var require_ProvidedRequiredArgumentsRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/ProvidedRequiredArgumentsRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/ProvidedRequiredArgumentsRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -9064,9 +9064,9 @@ var require_ProvidedRequiredArgumentsRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/ScalarLeafsRule.js
+// ../../../../node_modules/graphql/validation/rules/ScalarLeafsRule.js
 var require_ScalarLeafsRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/ScalarLeafsRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/ScalarLeafsRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -9125,9 +9125,9 @@ var require_ScalarLeafsRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/printPathArray.js
+// ../../../../node_modules/graphql/jsutils/printPathArray.js
 var require_printPathArray = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/printPathArray.js"(exports) {
+  "../../../../node_modules/graphql/jsutils/printPathArray.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -9142,9 +9142,9 @@ var require_printPathArray = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/Path.js
+// ../../../../node_modules/graphql/jsutils/Path.js
 var require_Path = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/Path.js"(exports) {
+  "../../../../node_modules/graphql/jsutils/Path.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -9172,9 +9172,9 @@ var require_Path = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/coerceInputValue.js
+// ../../../../node_modules/graphql/utilities/coerceInputValue.js
 var require_coerceInputValue = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/coerceInputValue.js"(exports) {
+  "../../../../node_modules/graphql/utilities/coerceInputValue.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -9346,9 +9346,9 @@ var require_coerceInputValue = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/valueFromAST.js
+// ../../../../node_modules/graphql/utilities/valueFromAST.js
 var require_valueFromAST = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/valueFromAST.js"(exports) {
+  "../../../../node_modules/graphql/utilities/valueFromAST.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -9470,9 +9470,9 @@ var require_valueFromAST = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/execution/values.js
+// ../../../../node_modules/graphql/execution/values.js
 var require_values = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/execution/values.js"(exports) {
+  "../../../../node_modules/graphql/execution/values.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -9686,9 +9686,9 @@ var require_values = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/execution/collectFields.js
+// ../../../../node_modules/graphql/execution/collectFields.js
 var require_collectFields = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/execution/collectFields.js"(exports) {
+  "../../../../node_modules/graphql/execution/collectFields.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -9834,9 +9834,9 @@ var require_collectFields = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/SingleFieldSubscriptionsRule.js
+// ../../../../node_modules/graphql/validation/rules/SingleFieldSubscriptionsRule.js
 var require_SingleFieldSubscriptionsRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/SingleFieldSubscriptionsRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/SingleFieldSubscriptionsRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -9904,9 +9904,9 @@ var require_SingleFieldSubscriptionsRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/groupBy.js
+// ../../../../node_modules/graphql/jsutils/groupBy.js
 var require_groupBy = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/groupBy.js"(exports) {
+  "../../../../node_modules/graphql/jsutils/groupBy.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -9929,9 +9929,9 @@ var require_groupBy = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/UniqueArgumentDefinitionNamesRule.js
+// ../../../../node_modules/graphql/validation/rules/UniqueArgumentDefinitionNamesRule.js
 var require_UniqueArgumentDefinitionNamesRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/UniqueArgumentDefinitionNamesRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/UniqueArgumentDefinitionNamesRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -9989,9 +9989,9 @@ var require_UniqueArgumentDefinitionNamesRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/UniqueArgumentNamesRule.js
+// ../../../../node_modules/graphql/validation/rules/UniqueArgumentNamesRule.js
 var require_UniqueArgumentNamesRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/UniqueArgumentNamesRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/UniqueArgumentNamesRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -10030,9 +10030,9 @@ var require_UniqueArgumentNamesRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/UniqueDirectiveNamesRule.js
+// ../../../../node_modules/graphql/validation/rules/UniqueDirectiveNamesRule.js
 var require_UniqueDirectiveNamesRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/UniqueDirectiveNamesRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/UniqueDirectiveNamesRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -10076,9 +10076,9 @@ var require_UniqueDirectiveNamesRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/UniqueDirectivesPerLocationRule.js
+// ../../../../node_modules/graphql/validation/rules/UniqueDirectivesPerLocationRule.js
 var require_UniqueDirectivesPerLocationRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/UniqueDirectivesPerLocationRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/UniqueDirectivesPerLocationRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -10147,9 +10147,9 @@ var require_UniqueDirectivesPerLocationRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/UniqueEnumValueNamesRule.js
+// ../../../../node_modules/graphql/validation/rules/UniqueEnumValueNamesRule.js
 var require_UniqueEnumValueNamesRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/UniqueEnumValueNamesRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/UniqueEnumValueNamesRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -10206,9 +10206,9 @@ var require_UniqueEnumValueNamesRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/UniqueFieldDefinitionNamesRule.js
+// ../../../../node_modules/graphql/validation/rules/UniqueFieldDefinitionNamesRule.js
 var require_UniqueFieldDefinitionNamesRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/UniqueFieldDefinitionNamesRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/UniqueFieldDefinitionNamesRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -10275,9 +10275,9 @@ var require_UniqueFieldDefinitionNamesRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/UniqueFragmentNamesRule.js
+// ../../../../node_modules/graphql/validation/rules/UniqueFragmentNamesRule.js
 var require_UniqueFragmentNamesRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/UniqueFragmentNamesRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/UniqueFragmentNamesRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -10310,9 +10310,9 @@ var require_UniqueFragmentNamesRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/UniqueInputFieldNamesRule.js
+// ../../../../node_modules/graphql/validation/rules/UniqueInputFieldNamesRule.js
 var require_UniqueInputFieldNamesRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/UniqueInputFieldNamesRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/UniqueInputFieldNamesRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -10356,9 +10356,9 @@ var require_UniqueInputFieldNamesRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/UniqueOperationNamesRule.js
+// ../../../../node_modules/graphql/validation/rules/UniqueOperationNamesRule.js
 var require_UniqueOperationNamesRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/UniqueOperationNamesRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/UniqueOperationNamesRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -10396,9 +10396,9 @@ var require_UniqueOperationNamesRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/UniqueOperationTypesRule.js
+// ../../../../node_modules/graphql/validation/rules/UniqueOperationTypesRule.js
 var require_UniqueOperationTypesRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/UniqueOperationTypesRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/UniqueOperationTypesRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -10453,9 +10453,9 @@ var require_UniqueOperationTypesRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/UniqueTypeNamesRule.js
+// ../../../../node_modules/graphql/validation/rules/UniqueTypeNamesRule.js
 var require_UniqueTypeNamesRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/UniqueTypeNamesRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/UniqueTypeNamesRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -10506,9 +10506,9 @@ var require_UniqueTypeNamesRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/UniqueVariableNamesRule.js
+// ../../../../node_modules/graphql/validation/rules/UniqueVariableNamesRule.js
 var require_UniqueVariableNamesRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/UniqueVariableNamesRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/UniqueVariableNamesRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -10544,9 +10544,9 @@ var require_UniqueVariableNamesRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/ValuesOfCorrectTypeRule.js
+// ../../../../node_modules/graphql/validation/rules/ValuesOfCorrectTypeRule.js
 var require_ValuesOfCorrectTypeRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/ValuesOfCorrectTypeRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/ValuesOfCorrectTypeRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -10765,9 +10765,9 @@ var require_ValuesOfCorrectTypeRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/VariablesAreInputTypesRule.js
+// ../../../../node_modules/graphql/validation/rules/VariablesAreInputTypesRule.js
 var require_VariablesAreInputTypesRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/VariablesAreInputTypesRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/VariablesAreInputTypesRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -10803,9 +10803,9 @@ var require_VariablesAreInputTypesRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/VariablesInAllowedPositionRule.js
+// ../../../../node_modules/graphql/validation/rules/VariablesInAllowedPositionRule.js
 var require_VariablesInAllowedPositionRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/VariablesInAllowedPositionRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/VariablesInAllowedPositionRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -10880,9 +10880,9 @@ var require_VariablesInAllowedPositionRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/specifiedRules.js
+// ../../../../node_modules/graphql/validation/specifiedRules.js
 var require_specifiedRules = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/specifiedRules.js"(exports) {
+  "../../../../node_modules/graphql/validation/specifiedRules.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -10978,9 +10978,9 @@ var require_specifiedRules = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/ValidationContext.js
+// ../../../../node_modules/graphql/validation/ValidationContext.js
 var require_ValidationContext = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/ValidationContext.js"(exports) {
+  "../../../../node_modules/graphql/validation/ValidationContext.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -11165,9 +11165,9 @@ var require_ValidationContext = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/validate.js
+// ../../../../node_modules/graphql/validation/validate.js
 var require_validate2 = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/validate.js"(exports) {
+  "../../../../node_modules/graphql/validation/validate.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -11253,9 +11253,9 @@ var require_validate2 = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/memoize3.js
+// ../../../../node_modules/graphql/jsutils/memoize3.js
 var require_memoize3 = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/memoize3.js"(exports) {
+  "../../../../node_modules/graphql/jsutils/memoize3.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -11289,9 +11289,9 @@ var require_memoize3 = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/promiseForObject.js
+// ../../../../node_modules/graphql/jsutils/promiseForObject.js
 var require_promiseForObject = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/promiseForObject.js"(exports) {
+  "../../../../node_modules/graphql/jsutils/promiseForObject.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -11310,9 +11310,9 @@ var require_promiseForObject = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/promiseReduce.js
+// ../../../../node_modules/graphql/jsutils/promiseReduce.js
 var require_promiseReduce = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/promiseReduce.js"(exports) {
+  "../../../../node_modules/graphql/jsutils/promiseReduce.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -11330,9 +11330,9 @@ var require_promiseReduce = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/toError.js
+// ../../../../node_modules/graphql/jsutils/toError.js
 var require_toError = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/toError.js"(exports) {
+  "../../../../node_modules/graphql/jsutils/toError.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -11356,9 +11356,9 @@ var require_toError = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/error/locatedError.js
+// ../../../../node_modules/graphql/error/locatedError.js
 var require_locatedError = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/error/locatedError.js"(exports) {
+  "../../../../node_modules/graphql/error/locatedError.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -11388,9 +11388,9 @@ var require_locatedError = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/execution/execute.js
+// ../../../../node_modules/graphql/execution/execute.js
 var require_execute = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/execution/execute.js"(exports) {
+  "../../../../node_modules/graphql/execution/execute.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -12043,9 +12043,9 @@ var require_execute = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/graphql.js
+// ../../../../node_modules/graphql/graphql.js
 var require_graphql = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/graphql.js"(exports) {
+  "../../../../node_modules/graphql/graphql.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -12120,9 +12120,9 @@ var require_graphql = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/type/index.js
+// ../../../../node_modules/graphql/type/index.js
 var require_type = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/type/index.js"(exports) {
+  "../../../../node_modules/graphql/type/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -12671,9 +12671,9 @@ var require_type = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/index.js
+// ../../../../node_modules/graphql/language/index.js
 var require_language = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/language/index.js"(exports) {
+  "../../../../node_modules/graphql/language/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -12879,9 +12879,9 @@ var require_language = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/isAsyncIterable.js
+// ../../../../node_modules/graphql/jsutils/isAsyncIterable.js
 var require_isAsyncIterable = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/jsutils/isAsyncIterable.js"(exports) {
+  "../../../../node_modules/graphql/jsutils/isAsyncIterable.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -12894,9 +12894,9 @@ var require_isAsyncIterable = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/execution/mapAsyncIterator.js
+// ../../../../node_modules/graphql/execution/mapAsyncIterator.js
 var require_mapAsyncIterator = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/execution/mapAsyncIterator.js"(exports) {
+  "../../../../node_modules/graphql/execution/mapAsyncIterator.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -12949,9 +12949,9 @@ var require_mapAsyncIterator = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/execution/subscribe.js
+// ../../../../node_modules/graphql/execution/subscribe.js
 var require_subscribe = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/execution/subscribe.js"(exports) {
+  "../../../../node_modules/graphql/execution/subscribe.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -13092,9 +13092,9 @@ var require_subscribe = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/execution/index.js
+// ../../../../node_modules/graphql/execution/index.js
 var require_execution = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/execution/index.js"(exports) {
+  "../../../../node_modules/graphql/execution/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -13166,9 +13166,9 @@ var require_execution = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/custom/NoDeprecatedCustomRule.js
+// ../../../../node_modules/graphql/validation/rules/custom/NoDeprecatedCustomRule.js
 var require_NoDeprecatedCustomRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/custom/NoDeprecatedCustomRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/custom/NoDeprecatedCustomRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -13267,9 +13267,9 @@ var require_NoDeprecatedCustomRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/custom/NoSchemaIntrospectionCustomRule.js
+// ../../../../node_modules/graphql/validation/rules/custom/NoSchemaIntrospectionCustomRule.js
 var require_NoSchemaIntrospectionCustomRule = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/rules/custom/NoSchemaIntrospectionCustomRule.js"(exports) {
+  "../../../../node_modules/graphql/validation/rules/custom/NoSchemaIntrospectionCustomRule.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -13299,9 +13299,9 @@ var require_NoSchemaIntrospectionCustomRule = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/index.js
+// ../../../../node_modules/graphql/validation/index.js
 var require_validation = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/validation/index.js"(exports) {
+  "../../../../node_modules/graphql/validation/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -13595,9 +13595,9 @@ var require_validation = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/error/index.js
+// ../../../../node_modules/graphql/error/index.js
 var require_error = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/error/index.js"(exports) {
+  "../../../../node_modules/graphql/error/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -13638,9 +13638,9 @@ var require_error = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/getIntrospectionQuery.js
+// ../../../../node_modules/graphql/utilities/getIntrospectionQuery.js
 var require_getIntrospectionQuery = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/getIntrospectionQuery.js"(exports) {
+  "../../../../node_modules/graphql/utilities/getIntrospectionQuery.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -13777,9 +13777,9 @@ var require_getIntrospectionQuery = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/getOperationAST.js
+// ../../../../node_modules/graphql/utilities/getOperationAST.js
 var require_getOperationAST = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/getOperationAST.js"(exports) {
+  "../../../../node_modules/graphql/utilities/getOperationAST.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -13807,9 +13807,9 @@ var require_getOperationAST = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/getOperationRootType.js
+// ../../../../node_modules/graphql/utilities/getOperationRootType.js
 var require_getOperationRootType = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/getOperationRootType.js"(exports) {
+  "../../../../node_modules/graphql/utilities/getOperationRootType.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -13864,9 +13864,9 @@ var require_getOperationRootType = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/introspectionFromSchema.js
+// ../../../../node_modules/graphql/utilities/introspectionFromSchema.js
 var require_introspectionFromSchema = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/introspectionFromSchema.js"(exports) {
+  "../../../../node_modules/graphql/utilities/introspectionFromSchema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -13899,9 +13899,9 @@ var require_introspectionFromSchema = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/buildClientSchema.js
+// ../../../../node_modules/graphql/utilities/buildClientSchema.js
 var require_buildClientSchema = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/buildClientSchema.js"(exports) {
+  "../../../../node_modules/graphql/utilities/buildClientSchema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -14207,9 +14207,9 @@ var require_buildClientSchema = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/extendSchema.js
+// ../../../../node_modules/graphql/utilities/extendSchema.js
 var require_extendSchema = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/extendSchema.js"(exports) {
+  "../../../../node_modules/graphql/utilities/extendSchema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -14726,9 +14726,9 @@ var require_extendSchema = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/buildASTSchema.js
+// ../../../../node_modules/graphql/utilities/buildASTSchema.js
 var require_buildASTSchema = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/buildASTSchema.js"(exports) {
+  "../../../../node_modules/graphql/utilities/buildASTSchema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -14804,9 +14804,9 @@ var require_buildASTSchema = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/lexicographicSortSchema.js
+// ../../../../node_modules/graphql/utilities/lexicographicSortSchema.js
 var require_lexicographicSortSchema = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/lexicographicSortSchema.js"(exports) {
+  "../../../../node_modules/graphql/utilities/lexicographicSortSchema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -14956,9 +14956,9 @@ var require_lexicographicSortSchema = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/printSchema.js
+// ../../../../node_modules/graphql/utilities/printSchema.js
 var require_printSchema = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/printSchema.js"(exports) {
+  "../../../../node_modules/graphql/utilities/printSchema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -15187,9 +15187,9 @@ ${operationTypes.join("\n")}
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/concatAST.js
+// ../../../../node_modules/graphql/utilities/concatAST.js
 var require_concatAST = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/concatAST.js"(exports) {
+  "../../../../node_modules/graphql/utilities/concatAST.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -15210,9 +15210,9 @@ var require_concatAST = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/separateOperations.js
+// ../../../../node_modules/graphql/utilities/separateOperations.js
 var require_separateOperations = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/separateOperations.js"(exports) {
+  "../../../../node_modules/graphql/utilities/separateOperations.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -15278,9 +15278,9 @@ var require_separateOperations = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/stripIgnoredCharacters.js
+// ../../../../node_modules/graphql/utilities/stripIgnoredCharacters.js
 var require_stripIgnoredCharacters = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/stripIgnoredCharacters.js"(exports) {
+  "../../../../node_modules/graphql/utilities/stripIgnoredCharacters.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -15323,9 +15323,9 @@ var require_stripIgnoredCharacters = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/assertValidName.js
+// ../../../../node_modules/graphql/utilities/assertValidName.js
 var require_assertValidName = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/assertValidName.js"(exports) {
+  "../../../../node_modules/graphql/utilities/assertValidName.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -15360,9 +15360,9 @@ var require_assertValidName = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/findBreakingChanges.js
+// ../../../../node_modules/graphql/utilities/findBreakingChanges.js
 var require_findBreakingChanges = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/findBreakingChanges.js"(exports) {
+  "../../../../node_modules/graphql/utilities/findBreakingChanges.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -15790,9 +15790,9 @@ var require_findBreakingChanges = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/index.js
+// ../../../../node_modules/graphql/utilities/index.js
 var require_utilities = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/utilities/index.js"(exports) {
+  "../../../../node_modules/graphql/utilities/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -16007,9 +16007,9 @@ var require_utilities = __commonJS({
   }
 });
 
-// ../../../../home/alexes/projects2/trip2g/node_modules/graphql/index.js
+// ../../../../node_modules/graphql/index.js
 var require_graphql2 = __commonJS({
-  "../../../../home/alexes/projects2/trip2g/node_modules/graphql/index.js"(exports) {
+  "../../../../node_modules/graphql/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -17800,7 +17800,7 @@ function buildToolList() {
 }
 __name(buildToolList, "buildToolList");
 function buildServerEnv(opts) {
-  const { port, iport, email, secret, encryptionKey } = opts;
+  const { port, iport, email, secret, encryptionKey, ownerPersonalToken } = opts;
   const env = {
     LISTEN_ADDR: `0.0.0.0:${port}`,
     INTERNAL_LISTEN_ADDR: `:${iport}`,
@@ -17809,6 +17809,7 @@ function buildServerEnv(opts) {
     PUBLIC_URL: `http://localhost:${port}`,
     JWT_SECRET: secret,
     DATA_ENCRYPTION_KEY: encryptionKey,
+    OWNER_PERSONAL_TOKEN_VALUE: ownerPersonalToken,
     STORAGE_BACKEND: "local",
     STORAGE_LOCAL_DIR: "/data/storage"
   };
@@ -17920,6 +17921,10 @@ async function gqlRequest(endpoint, bearerToken, document, variables) {
   return body.data;
 }
 __name(gqlRequest, "gqlRequest");
+function generateOwnerPersonalToken() {
+  return "t2g_" + crypto.randomBytes(32).toString("hex");
+}
+__name(generateOwnerPersonalToken, "generateOwnerPersonalToken");
 function readEnvFile(envFile) {
   if (!fs.existsSync(envFile)) return {};
   const lines = fs.readFileSync(envFile, "utf8").split("\n");
@@ -18768,8 +18773,9 @@ async function cmdUp(flags, dryRun) {
   }
   let secret;
   let encryptionKey;
+  let ownerPersonalToken;
   const existingEnv = dryRun ? {} : readEnvFile(envFile);
-  const needsWrite = !existingEnv.JWT_SECRET || !existingEnv.DATA_ENCRYPTION_KEY;
+  const needsWrite = !existingEnv.JWT_SECRET || !existingEnv.DATA_ENCRYPTION_KEY || !existingEnv.OWNER_PERSONAL_TOKEN_VALUE;
   if (existingEnv.JWT_SECRET) {
     secret = existingEnv.JWT_SECRET;
     console.log("Reusing existing JWT_SECRET from state dir.");
@@ -18782,11 +18788,24 @@ async function cmdUp(flags, dryRun) {
   } else {
     encryptionKey = crypto.randomBytes(16).toString("hex");
   }
+  if (existingEnv.OWNER_PERSONAL_TOKEN_VALUE) {
+    ownerPersonalToken = existingEnv.OWNER_PERSONAL_TOKEN_VALUE;
+    console.log("Reusing existing OWNER_PERSONAL_TOKEN_VALUE from state dir.");
+  } else {
+    ownerPersonalToken = generateOwnerPersonalToken();
+  }
   if (!dryRun && needsWrite) {
-    writeEnvFile(envFile, { JWT_SECRET: secret, DATA_ENCRYPTION_KEY: encryptionKey });
+    writeEnvFile(envFile, {
+      JWT_SECRET: secret,
+      DATA_ENCRYPTION_KEY: encryptionKey,
+      OWNER_PERSONAL_TOKEN_VALUE: ownerPersonalToken
+    });
     console.log("Generated secrets and wrote to state dir.");
   } else if (dryRun && needsWrite) {
-    console.log("[dry-run] Would generate JWT_SECRET and DATA_ENCRYPTION_KEY and write to", envFile);
+    console.log(
+      "[dry-run] Would generate JWT_SECRET, DATA_ENCRYPTION_KEY and OWNER_PERSONAL_TOKEN_VALUE and write to",
+      envFile
+    );
   }
   if (!dryRun && !containerRunning && await isPortBusy(port, flags.host)) {
     console.error(`Error: port ${port} is busy \u2014 pass --port for this instance (or stop what holds it).`);
@@ -18817,6 +18836,7 @@ async function cmdUp(flags, dryRun) {
     email,
     secret,
     encryptionKey,
+    ownerPersonalToken,
     stateDir,
     image,
     containerName: name,
@@ -19345,6 +19365,7 @@ export {
   extractWikilinks,
   findBrokenLinks,
   formatLintReport,
+  generateOwnerPersonalToken,
   hubSlug,
   installKanban,
   isPortBusy,

--- a/cli/memcli/src/cli.test.ts
+++ b/cli/memcli/src/cli.test.ts
@@ -16,6 +16,7 @@ import {
   buildServerEnv,
   buildDataJson,
   buildDockerRunArgs,
+  generateOwnerPersonalToken,
   buildFeaturesJson,
   buildEmbedServerRunArgs,
   buildHubNote,
@@ -217,54 +218,55 @@ test('parseArgs: --host rejects non-loopback address', () => {
 const FORBIDDEN_KEYS = ['DEV', 'RESEND_API_KEY', 'SMTP_PASSWORD', 'GIT_API_REPO_PATH'];
 
 const TEST_ENC_KEY = crypto.randomBytes(16).toString('hex'); // 32 ASCII chars = 32 bytes
+const TEST_OWNER_TOKEN = 't2g_' + crypto.randomBytes(32).toString('hex');
 
 test('buildServerEnv: STORAGE_BACKEND is "local"', () => {
-  const env = buildServerEnv({ port: 24081, iport: 24082, email: 'a@b.com', secret: 'x', encryptionKey: TEST_ENC_KEY });
+  const env = buildServerEnv({ port: 24081, iport: 24082, email: 'a@b.com', secret: 'x', encryptionKey: TEST_ENC_KEY, ownerPersonalToken: TEST_OWNER_TOKEN });
   assert.equal(env.STORAGE_BACKEND, 'local');
 });
 
 test('buildServerEnv: STORAGE_LOCAL_DIR is set', () => {
-  const env = buildServerEnv({ port: 24081, iport: 24082, email: 'a@b.com', secret: 'x', encryptionKey: TEST_ENC_KEY });
+  const env = buildServerEnv({ port: 24081, iport: 24082, email: 'a@b.com', secret: 'x', encryptionKey: TEST_ENC_KEY, ownerPersonalToken: TEST_OWNER_TOKEN });
   assert.ok(env.STORAGE_LOCAL_DIR, 'STORAGE_LOCAL_DIR must be non-empty');
 });
 
 test('buildServerEnv: contains LISTEN_ADDR with correct port', () => {
-  const env = buildServerEnv({ port: 24081, iport: 24082, email: 'a@b.com', secret: 'x', encryptionKey: TEST_ENC_KEY });
+  const env = buildServerEnv({ port: 24081, iport: 24082, email: 'a@b.com', secret: 'x', encryptionKey: TEST_ENC_KEY, ownerPersonalToken: TEST_OWNER_TOKEN });
   assert.ok(env.LISTEN_ADDR.includes('24081'), `LISTEN_ADDR should include port 24081, got: ${env.LISTEN_ADDR}`);
 });
 
 test('buildServerEnv: contains INTERNAL_LISTEN_ADDR with iport', () => {
-  const env = buildServerEnv({ port: 24081, iport: 24082, email: 'a@b.com', secret: 'x', encryptionKey: TEST_ENC_KEY });
+  const env = buildServerEnv({ port: 24081, iport: 24082, email: 'a@b.com', secret: 'x', encryptionKey: TEST_ENC_KEY, ownerPersonalToken: TEST_OWNER_TOKEN });
   assert.ok(env.INTERNAL_LISTEN_ADDR.includes('24082'), `INTERNAL_LISTEN_ADDR should include 24082, got: ${env.INTERNAL_LISTEN_ADDR}`);
 });
 
 test('buildServerEnv: contains JWT_SECRET', () => {
-  const env = buildServerEnv({ port: 24081, iport: 24082, email: 'a@b.com', secret: 'hunter2', encryptionKey: TEST_ENC_KEY });
+  const env = buildServerEnv({ port: 24081, iport: 24082, email: 'a@b.com', secret: 'hunter2', encryptionKey: TEST_ENC_KEY, ownerPersonalToken: TEST_OWNER_TOKEN });
   assert.equal(env.JWT_SECRET, 'hunter2');
 });
 
 test('buildServerEnv: contains OWNER_EMAIL', () => {
-  const env = buildServerEnv({ port: 24081, iport: 24082, email: 'owner@test.com', secret: 'x', encryptionKey: TEST_ENC_KEY });
+  const env = buildServerEnv({ port: 24081, iport: 24082, email: 'owner@test.com', secret: 'x', encryptionKey: TEST_ENC_KEY, ownerPersonalToken: TEST_OWNER_TOKEN });
   assert.equal(env.OWNER_EMAIL, 'owner@test.com');
 });
 
 test('buildServerEnv: contains DB_FILE', () => {
-  const env = buildServerEnv({ port: 24081, iport: 24082, email: 'a@b.com', secret: 'x', encryptionKey: TEST_ENC_KEY });
+  const env = buildServerEnv({ port: 24081, iport: 24082, email: 'a@b.com', secret: 'x', encryptionKey: TEST_ENC_KEY, ownerPersonalToken: TEST_OWNER_TOKEN });
   assert.ok(env.DB_FILE, 'DB_FILE must be non-empty');
 });
 
 test('buildServerEnv: contains PUBLIC_URL with correct port', () => {
-  const env = buildServerEnv({ port: 24081, iport: 24082, email: 'a@b.com', secret: 'x', encryptionKey: TEST_ENC_KEY });
+  const env = buildServerEnv({ port: 24081, iport: 24082, email: 'a@b.com', secret: 'x', encryptionKey: TEST_ENC_KEY, ownerPersonalToken: TEST_OWNER_TOKEN });
   assert.ok(env.PUBLIC_URL.includes('24081'), `PUBLIC_URL should include port 24081, got: ${env.PUBLIC_URL}`);
 });
 
 test('buildServerEnv: contains DATA_ENCRYPTION_KEY matching the provided value', () => {
-  const env = buildServerEnv({ port: 24081, iport: 24082, email: 'a@b.com', secret: 'x', encryptionKey: TEST_ENC_KEY });
+  const env = buildServerEnv({ port: 24081, iport: 24082, email: 'a@b.com', secret: 'x', encryptionKey: TEST_ENC_KEY, ownerPersonalToken: TEST_OWNER_TOKEN });
   assert.equal(env.DATA_ENCRYPTION_KEY, TEST_ENC_KEY, 'DATA_ENCRYPTION_KEY must match provided value');
 });
 
 test('buildServerEnv: DATA_ENCRYPTION_KEY is exactly 32 bytes (chars)', () => {
-  const env = buildServerEnv({ port: 24081, iport: 24082, email: 'a@b.com', secret: 'x', encryptionKey: TEST_ENC_KEY });
+  const env = buildServerEnv({ port: 24081, iport: 24082, email: 'a@b.com', secret: 'x', encryptionKey: TEST_ENC_KEY, ownerPersonalToken: TEST_OWNER_TOKEN });
   assert.equal(
     Buffer.byteLength(env.DATA_ENCRYPTION_KEY, 'utf8'),
     32,
@@ -273,16 +275,34 @@ test('buildServerEnv: DATA_ENCRYPTION_KEY is exactly 32 bytes (chars)', () => {
 });
 
 test('buildServerEnv: DATA_ENCRYPTION_KEY is not the default placeholder', () => {
-  const env = buildServerEnv({ port: 24081, iport: 24082, email: 'a@b.com', secret: 'x', encryptionKey: TEST_ENC_KEY });
+  const env = buildServerEnv({ port: 24081, iport: 24082, email: 'a@b.com', secret: 'x', encryptionKey: TEST_ENC_KEY, ownerPersonalToken: TEST_OWNER_TOKEN });
   assert.notEqual(env.DATA_ENCRYPTION_KEY, 'please-change-me-to-32-byte-key!', 'DATA_ENCRYPTION_KEY must not be the default value');
 });
 
 for (const key of FORBIDDEN_KEYS) {
   test(`buildServerEnv: does NOT contain ${key}`, () => {
-    const env = buildServerEnv({ port: 24081, iport: 24082, email: 'a@b.com', secret: 'x', encryptionKey: TEST_ENC_KEY }) as unknown as Record<string, unknown>;
+    const env = buildServerEnv({ port: 24081, iport: 24082, email: 'a@b.com', secret: 'x', encryptionKey: TEST_ENC_KEY, ownerPersonalToken: TEST_OWNER_TOKEN }) as unknown as Record<string, unknown>;
     assert.equal(env[key], undefined, `${key} must not be present in server env`);
   });
 }
+
+test('buildServerEnv: contains OWNER_PERSONAL_TOKEN_VALUE matching the provided value', () => {
+  const env = buildServerEnv({ port: 24081, iport: 24082, email: 'a@b.com', secret: 'x', encryptionKey: TEST_ENC_KEY, ownerPersonalToken: TEST_OWNER_TOKEN });
+  assert.equal(env.OWNER_PERSONAL_TOKEN_VALUE, TEST_OWNER_TOKEN);
+});
+
+// The server refuses to boot on a value without the t2g_ prefix, and
+// DisplayPrefix reads its first 8 characters.
+test('generateOwnerPersonalToken: t2g_ prefix and personal-token length', () => {
+  const token = generateOwnerPersonalToken();
+  assert.ok(token.startsWith('t2g_'), `must carry the t2g_ prefix, got: ${token.slice(0, 8)}`);
+  assert.equal(token.length, 68, 't2g_ plus 64 characters, matching personaltoken.Generate()');
+  assert.match(token.slice(4), /^[a-zA-Z0-9]+$/, 'the body must be alphanumeric');
+});
+
+test('generateOwnerPersonalToken: a fresh value every call', () => {
+  assert.notEqual(generateOwnerPersonalToken(), generateOwnerPersonalToken());
+});
 
 // ---------------------------------------------------------------------------
 // buildDockerRunArgs
@@ -295,6 +315,7 @@ test('buildDockerRunArgs: binds to 127.0.0.1 (loopback only)', () => {
     email: 'a@b.com',
     secret: 'x',
     encryptionKey: TEST_ENC_KEY,
+    ownerPersonalToken: TEST_OWNER_TOKEN,
     stateDir: '/tmp/state',
     image: 'ghcr.io/trip2g/trip2g:latest',
   });
@@ -309,6 +330,7 @@ test('buildDockerRunArgs: includes -d flag', () => {
     email: 'a@b.com',
     secret: 'x',
     encryptionKey: TEST_ENC_KEY,
+    ownerPersonalToken: TEST_OWNER_TOKEN,
     stateDir: '/tmp/state',
     image: 'ghcr.io/trip2g/trip2g:latest',
   });
@@ -322,6 +344,7 @@ test('buildDockerRunArgs: includes --name trip2g-memory', () => {
     email: 'a@b.com',
     secret: 'x',
     encryptionKey: TEST_ENC_KEY,
+    ownerPersonalToken: TEST_OWNER_TOKEN,
     stateDir: '/tmp/state',
     image: 'ghcr.io/trip2g/trip2g:latest',
   });
@@ -338,6 +361,7 @@ test('buildDockerRunArgs: image is last argument', () => {
     email: 'a@b.com',
     secret: 'x',
     encryptionKey: TEST_ENC_KEY,
+    ownerPersonalToken: TEST_OWNER_TOKEN,
     stateDir: '/tmp/state',
     image,
   });
@@ -352,6 +376,7 @@ test('buildDockerRunArgs: volume mounts stateDir/data to /data', () => {
     email: 'a@b.com',
     secret: 'x',
     encryptionKey: TEST_ENC_KEY,
+    ownerPersonalToken: TEST_OWNER_TOKEN,
     stateDir,
     image: 'trip2g:local',
   });
@@ -368,6 +393,7 @@ test('buildDockerRunArgs: does not include DEV=true in env args', () => {
     email: 'a@b.com',
     secret: 'x',
     encryptionKey: TEST_ENC_KEY,
+    ownerPersonalToken: TEST_OWNER_TOKEN,
     stateDir: '/tmp/state',
     image: 'trip2g:local',
   });
@@ -384,6 +410,7 @@ test('buildDockerRunArgs: uses custom host for main port binding', () => {
     email: 'a@b.com',
     secret: 'x',
     encryptionKey: TEST_ENC_KEY,
+    ownerPersonalToken: TEST_OWNER_TOKEN,
     stateDir: '/tmp/state',
     image: 'trip2g:local',
     host: '127.0.0.77',
@@ -401,6 +428,7 @@ test('buildDockerRunArgs: keeps 127.0.0.1 for internal port even with custom hos
     email: 'a@b.com',
     secret: 'x',
     encryptionKey: TEST_ENC_KEY,
+    ownerPersonalToken: TEST_OWNER_TOKEN,
     stateDir: '/tmp/state',
     image: 'trip2g:local',
     host: '127.0.0.77',
@@ -422,6 +450,7 @@ test('buildDockerRunArgs: default host is 127.0.0.1 when omitted', () => {
     email: 'a@b.com',
     secret: 'x',
     encryptionKey: TEST_ENC_KEY,
+    ownerPersonalToken: TEST_OWNER_TOKEN,
     stateDir: '/tmp/state',
     image: 'trip2g:local',
   });

--- a/cli/memcli/src/cli.ts
+++ b/cli/memcli/src/cli.ts
@@ -94,6 +94,7 @@ export interface ServerEnv {
   PUBLIC_URL: string;
   JWT_SECRET: string;
   DATA_ENCRYPTION_KEY: string;
+  OWNER_PERSONAL_TOKEN_VALUE: string;
   STORAGE_BACKEND: string;
   STORAGE_LOCAL_DIR: string;
   FEATURES?: string;
@@ -774,9 +775,10 @@ export function buildServerEnv(opts: {
   email: string;
   secret: string;
   encryptionKey: string;
+  ownerPersonalToken: string;
   features?: string;
 }): ServerEnv {
-  const { port, iport, email, secret, encryptionKey } = opts;
+  const { port, iport, email, secret, encryptionKey, ownerPersonalToken } = opts;
   const env: ServerEnv = {
     LISTEN_ADDR: `0.0.0.0:${port}`,
     INTERNAL_LISTEN_ADDR: `:${iport}`,
@@ -785,6 +787,7 @@ export function buildServerEnv(opts: {
     PUBLIC_URL: `http://localhost:${port}`,
     JWT_SECRET: secret,
     DATA_ENCRYPTION_KEY: encryptionKey,
+    OWNER_PERSONAL_TOKEN_VALUE: ownerPersonalToken,
     STORAGE_BACKEND: 'local',
     STORAGE_LOCAL_DIR: '/data/storage',
   };
@@ -811,6 +814,7 @@ export function buildDockerRunArgs(opts: {
   email: string;
   secret: string;
   encryptionKey: string;
+  ownerPersonalToken: string;
   stateDir: string;
   image: string;
   containerName?: string;
@@ -948,6 +952,16 @@ async function gqlRequest<TData, TVariables>(
 // ---------------------------------------------------------------------------
 // Side-effectful helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Mint the value trip2g seeds as the owner's personal token: the credential a
+ * fleet host authenticates with (`--trip2g-admin-personal-token`). Shape
+ * matches personaltoken.Generate() — the `t2g_` prefix the resolver routes on,
+ * then 64 alphanumerics.
+ */
+export function generateOwnerPersonalToken(): string {
+  return 't2g_' + crypto.randomBytes(32).toString('hex');
+}
 
 function readEnvFile(envFile: string): Record<string, string> {
   if (!fs.existsSync(envFile)) return {};
@@ -2016,8 +2030,10 @@ async function cmdUp(flags: Flags, dryRun: boolean): Promise<void> {
 
   let secret: string;
   let encryptionKey: string;
+  let ownerPersonalToken: string;
   const existingEnv = dryRun ? {} : readEnvFile(envFile);
-  const needsWrite = !existingEnv.JWT_SECRET || !existingEnv.DATA_ENCRYPTION_KEY;
+  const needsWrite =
+    !existingEnv.JWT_SECRET || !existingEnv.DATA_ENCRYPTION_KEY || !existingEnv.OWNER_PERSONAL_TOKEN_VALUE;
   if (existingEnv.JWT_SECRET) {
     secret = existingEnv.JWT_SECRET;
     console.log('Reusing existing JWT_SECRET from state dir.');
@@ -2031,11 +2047,26 @@ async function cmdUp(flags: Flags, dryRun: boolean): Promise<void> {
     // AES-256 requires a 32-byte key; hex-encoding 16 random bytes yields 32 ASCII chars
     encryptionKey = crypto.randomBytes(16).toString('hex');
   }
+  if (existingEnv.OWNER_PERSONAL_TOKEN_VALUE) {
+    ownerPersonalToken = existingEnv.OWNER_PERSONAL_TOKEN_VALUE;
+    console.log('Reusing existing OWNER_PERSONAL_TOKEN_VALUE from state dir.');
+  } else {
+    ownerPersonalToken = generateOwnerPersonalToken();
+  }
   if (!dryRun && needsWrite) {
-    writeEnvFile(envFile, { JWT_SECRET: secret, DATA_ENCRYPTION_KEY: encryptionKey });
+    // The whole file is rewritten, so every value goes in — the two reused
+    // above included, or `up` would drop them.
+    writeEnvFile(envFile, {
+      JWT_SECRET: secret,
+      DATA_ENCRYPTION_KEY: encryptionKey,
+      OWNER_PERSONAL_TOKEN_VALUE: ownerPersonalToken,
+    });
     console.log('Generated secrets and wrote to state dir.');
   } else if (dryRun && needsWrite) {
-    console.log('[dry-run] Would generate JWT_SECRET and DATA_ENCRYPTION_KEY and write to', envFile);
+    console.log(
+      '[dry-run] Would generate JWT_SECRET, DATA_ENCRYPTION_KEY and OWNER_PERSONAL_TOKEN_VALUE and write to',
+      envFile,
+    );
   }
 
   if (!dryRun && !containerRunning && (await isPortBusy(port, flags.host))) {
@@ -2065,7 +2096,7 @@ async function cmdUp(flags: Flags, dryRun: boolean): Promise<void> {
   }
 
   const dockerArgs = buildDockerRunArgs({
-    port, iport, host: flags.host, email, secret, encryptionKey, stateDir, image, containerName: name,
+    port, iport, host: flags.host, email, secret, encryptionKey, ownerPersonalToken, stateDir, image, containerName: name,
     ...(embedded ? {
       network: netName,
       features: buildFeaturesJson(embName, flags.reranker),

--- a/docs/en/user/memcli.md
+++ b/docs/en/user/memcli.md
@@ -17,7 +17,7 @@ node cli/memcli/dist/memcli.js up --folder ./memory-vault
 
 **What `up` does:**
 
-1. Creates `./memory-vault/.trip2g-memory/` (mode 700, state dir) and generates a random `JWT_SECRET` there — reused on subsequent runs, so `up` is idempotent.
+1. Creates `./memory-vault/.trip2g-memory/` (mode 700, state dir) and generates a random `JWT_SECRET` and `OWNER_PERSONAL_TOKEN_VALUE` there — reused on subsequent runs, so `up` is idempotent.
 2. Starts a Docker container named `trip2g-memory` with `STORAGE_BACKEND=local` — assets on disk, no S3 or MinIO.
 3. Mints an admin API key via HAT (Hot Auth Token) — no email address, no `DEV=true` flag needed.
 4. Writes the key to `.obsidian/plugins/trip2g/data.json` inside the vault.
@@ -25,6 +25,8 @@ node cli/memcli/dist/memcli.js up --folder ./memory-vault
 6. Prints: `memory live — web: http://localhost:24081  read/write .md in ./memory-vault`
 
 Once up, your agent uses its normal Write/Read/Grep tools on the vault folder. No special memory API needed.
+
+`OWNER_PERSONAL_TOKEN_VALUE` is the owner's personal token: the server seeds it as a `user_tokens` row on boot, and it is the credential a [[en/user/fleet|fleet]] host authenticates with (`--trip2g-admin-personal-token`). You need it only if you run agents; revoke the row in the admin UI to cut a fleet off without stopping the instance.
 
 **Preview without side effects:**
 

--- a/docs/ru/user/memcli.md
+++ b/docs/ru/user/memcli.md
@@ -17,7 +17,7 @@ node cli/memcli/dist/memcli.js up --folder ./memory-vault
 
 **Что делает `up`:**
 
-1. Создаёт `./memory-vault/.trip2g-memory/` (режим 700, директория состояния) и генерирует случайный `JWT_SECRET` — при повторном запуске значение переиспользуется, поэтому `up` идемпотентен.
+1. Создаёт `./memory-vault/.trip2g-memory/` (режим 700, директория состояния) и генерирует случайные `JWT_SECRET` и `OWNER_PERSONAL_TOKEN_VALUE` — при повторном запуске значения переиспользуются, поэтому `up` идемпотентен.
 2. Запускает Docker-контейнер `trip2g-memory` с `STORAGE_BACKEND=local` — ассеты хранятся на диске, S3 и MinIO не нужны.
 3. Выпускает административный API-ключ через HAT (Hot Auth Token) — без адреса электронной почты и без флага `DEV=true`.
 4. Записывает ключ в `.obsidian/plugins/trip2g/data.json` внутри хранилища.
@@ -25,6 +25,8 @@ node cli/memcli/dist/memcli.js up --folder ./memory-vault
 6. Печатает: `memory live — web: http://localhost:24081  read/write .md in ./memory-vault`
 
 После запуска агент работает с папкой хранилища через обычные инструменты Write/Read/Grep. Специальный API памяти не нужен.
+
+`OWNER_PERSONAL_TOKEN_VALUE` — персональный токен владельца: сервер заводит по нему строку в `user_tokens` при старте, и именно с ним авторизуется хост [[ru/user/fleet|флита]] (`--trip2g-admin-personal-token`). Он нужен только если вы запускаете агентов; чтобы отрезать флит, не останавливая инстанс, отзовите строку в админке.
 
 **Предварительный просмотр без побочных эффектов:**
 


### PR DESCRIPTION
Follow-up to #301. After that change a fleet host authenticates with `--trip2g-admin-personal-token`, and the value is supposed to come from `OWNER_PERSONAL_TOKEN_VALUE` on the instance. memcli could not supply it: `buildServerEnv` emits a closed set of env vars with no pass-through, so a memcli-run instance had no way to seed the token, and `memcli key` mints an API key (`createApiKey`), which is the wrong credential.

`up` now generates `OWNER_PERSONAL_TOKEN_VALUE` alongside `JWT_SECRET` and `DATA_ENCRYPTION_KEY`, persists it in `<vault>/.trip2g-memory/env`, and passes it to the container. Same idempotence as the other two: an existing value is reused, and an existing vault gains the token on its next `up` without losing the secrets already in the file (the file is rewritten whole, so all three keys go in).

The generated value is `t2g_` + 64 hex, matching `personaltoken.Generate()` — the server refuses to boot without the prefix, and `DisplayPrefix` reads the first 8 characters.

## Verified

`npm test` in `cli/memcli` (178 pass, 4 new), `go test ./...` and `go build ./...` green. The full chain was exercised against a real container built from current main:

- `up --dry-run` → `[dry-run] Would generate JWT_SECRET, DATA_ENCRYPTION_KEY and OWNER_PERSONAL_TOKEN_VALUE` and the docker argv carries `-e OWNER_PERSONAL_TOKEN_VALUE=t2g_…`
- vault with only the two old secrets → `up` keeps both verbatim and appends the token
- second `up` → `Reusing existing OWNER_PERSONAL_TOKEN_VALUE from state dir`, value unchanged
- container boots → `owner personal token outcome=seeded revokedSuperseded=0`
- the exact query fleet's admin lane runs answers on that token: `{admin{allChangeWebhooks{nodes{id}}}}` → `{"data":{"admin":{"allChangeWebhooks":{"nodes":[]}}}}`; a wrong token → `invalid or expired personal token`

## Notes

- Worth knowing: `ghcr.io/trip2g/trip2g:latest` predates #301 (image built 2026-07-10), so until a new image ships, memcli sets the env var and the server ignores it — no row is seeded and the value silently does nothing. Verification above used a locally built image.
- Every memcli vault now holds a standing admin credential in `.trip2g-memory/env` even for users who never run a fleet. That file already holds `JWT_SECRET`, which is strictly more powerful, so this widens no boundary — but it is a new live `user_tokens` row on every instance. Generating it only on request (`up --fleet-token`) is the alternative if you would rather not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
