### PR TITLE
feat(codellm): ship a python/node/cli toolbox in the runtime image

### DIFF
--- a/Dockerfile.codellm
+++ b/Dockerfile.codellm
@@ -43,11 +43,16 @@ RUN pip3 install --no-cache-dir --break-system-packages \
       tzdata
 
 # npm's global prefix is /usr, so modules land in /usr/lib/node_modules, which
-# NODE_PATH points at. CommonJS only — NODE_PATH is not consulted for ESM
-# imports, so ESM-only packages would be unresolvable from a block.
+# NODE_PATH points at for require().
 RUN npm install -g --loglevel=error \
       axios cheerio zod dayjs lodash \
       jsonwebtoken csv-parse axios-retry pg qs
+
+# NODE_PATH covers require() but is never consulted for ESM import. Node instead
+# walks up from the script looking for node_modules, and a block runs from a
+# temp dir under /tmp — so this symlink is what lets `import` resolve the same
+# packages. Landlock allows it: the resolved path is /usr/lib/node_modules.
+RUN ln -s /usr/lib/node_modules /tmp/node_modules
 
 # The system CA store lives in /etc, which the sandbox denies; curl/git/openssl
 # read this copy instead via SSL_CERT_FILE/CURL_CA_BUNDLE/GIT_SSL_CAINFO.

--- a/Dockerfile.codellm
+++ b/Dockerfile.codellm
@@ -9,7 +9,49 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o /codellm ./cmd/codellm
 
-FROM alpine:latest
-RUN apk add --no-cache ca-certificates python3
+# Runtime carries the interpreters and the toolbox that executed blocks draw on.
+# Everything must land under /usr/bin or /usr/lib: the landlock sandbox
+# (internal/coderun/sandbox_linux.go) grants those read-only and denies the rest
+# of the filesystem, so /usr/local and /opt are unreachable from a block.
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl gnupg \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && install -m 755 -d /etc/apt/keyrings \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+      python3 python3-pip \
+      nodejs \
+      bash jq miller sqlite3 openssl ripgrep git gh \
+      unzip xz-utils dnsutils netcat-openbsd yq file gawk wget tzdata \
+    && apt-get purge -y gnupg && apt-get autoremove -y \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# --target is required: Debian's pip ignores --prefix and defaults to
+# /usr/local/lib/python3.11/dist-packages, which the sandbox denies.
+# /usr/lib/python3/dist-packages is on the default sys.path and is allowed.
+RUN pip3 install --no-cache-dir --break-system-packages \
+      --target=/usr/lib/python3/dist-packages \
+      requests httpx beautifulsoup4 lxml python-dateutil \
+      pyjwt cryptography tenacity pydantic pyyaml \
+      tzdata
+
+# npm's global prefix is /usr, so modules land in /usr/lib/node_modules, which
+# NODE_PATH points at. CommonJS only — NODE_PATH is not consulted for ESM
+# imports, so ESM-only packages would be unresolvable from a block.
+RUN npm install -g --loglevel=error \
+      axios cheerio zod dayjs lodash \
+      jsonwebtoken csv-parse axios-retry pg qs
+
+# The system CA store lives in /etc, which the sandbox denies; curl/git/openssl
+# read this copy instead via SSL_CERT_FILE/CURL_CA_BUNDLE/GIT_SSL_CAINFO.
+RUN install -D /etc/ssl/certs/ca-certificates.crt /usr/lib/ssl-certs/ca-bundle.crt
+
 COPY --from=builder /codellm /codellm
 ENTRYPOINT ["/codellm"]

--- a/cmd/codellm/README.md
+++ b/cmd/codellm/README.md
@@ -58,11 +58,35 @@ Not installed on purpose: `pandas`/`numpy` (~120 MB for work the `csv` module an
 
 ### Node.js
 
-Installed globally into `/usr/lib/node_modules`, reachable via `NODE_PATH`.
+Installed globally into `/usr/lib/node_modules`. **Both `require` and `import`
+work** — write whichever.
 
-**Write CommonJS (`require`).** `NODE_PATH` is not consulted for ESM `import`, so
-`import` of a global package fails with `ERR_MODULE_NOT_FOUND`. This is also why
-ESM-only packages (`p-retry` >= 5, `got`, `node-fetch` v3) are absent.
+The details behind that, since they are easy to break:
+
+- A block is written to `run.js` in a temp dir and executed as `node run.js`;
+  the fence tag picks the interpreter, the `ext` field names the file. For node
+  the extension is load-bearing, because it selects the module system: `.mjs` is
+  always ESM, `.cjs` always CommonJS, `.js` depends on the nearest
+  `package.json` — and there is none in a temp dir.
+- That would make `.js` CommonJS, except Node 20.19+ **detects ESM syntax** in
+  `.js` and switches by itself. So a block using `import` or top-level `await`
+  runs as ESM with no flag and no separate fence tag. No node flag can do this
+  for a file: `--input-type=module` applies only to `-e` and stdin.
+- Resolution is the part that does not follow automatically. `NODE_PATH`
+  (set for the node interpreter in `interpreters.json`) is consulted **only** by
+  `require`; ESM ignores it entirely and instead walks up from the script
+  looking for `node_modules`. `Dockerfile.codellm` symlinks
+  `/tmp/node_modules` → `/usr/lib/node_modules` so that walk succeeds, since a
+  block always runs from a temp dir under `/tmp`. Landlock permits it because
+  the resolved path is in the read-only allowlist.
+- Consequence when changing any of this: dropping the symlink silently breaks
+  every `import` with `ERR_MODULE_NOT_FOUND` while `require` keeps working, and
+  moving `TMPDIR` off `/tmp` does the same. `scripts/test-codellm-sandbox.sh`
+  covers both syntaxes so the break surfaces.
+
+ESM-only packages are still avoided in the list below — not for resolution
+reasons any more, but because a CommonJS-capable package works under both
+syntaxes and an ESM-only one does not.
 
 | Package | What it is for |
 |---------|----------------|

--- a/cmd/codellm/README.md
+++ b/cmd/codellm/README.md
@@ -18,6 +18,23 @@ writes against what is actually installed instead of guessing.
 Interpreters are `python`, `node` and `bash` (`internal/coderun/interpreters.json`),
 gated at runtime by `CODELLM_ALLOWED_PROGRAMS`.
 
+That file also declares the env each interpreter needs to find its packages, so
+the paths baked into the image live next to the interpreter they belong to
+rather than in Go. An entry is applied only when its `if_exists` path is
+present, which is what keeps a dev run outside the image (`make aircodellm`)
+from being pointed at a bundle that is not there:
+
+```json
+{"name": "node", "cmd": ["node"], "ext": ".js",
+ "env": [{"name": "NODE_PATH", "value": "/usr/lib/node_modules",
+          "if_exists": "/usr/lib/node_modules"}]}
+```
+
+The top-level `env` array applies to every interpreter — the CA variables live
+there, since `curl`, `git`, node and python all need them. Change a path here
+and you must change `Dockerfile.codellm` to match, or the guard silently drops
+the variable; `TestInterpretersJSON_ShippedEnv` pins the pair together.
+
 ### Python
 
 Installed into `/usr/lib/python3/dist-packages`.
@@ -94,17 +111,18 @@ only. Consequences worth knowing when adding tools:
   defaults to `/usr/local/lib/python3.11/dist-packages` and ignores `--prefix`.
 - `/etc` is denied apart from a named handful of files, so the system CA store
   is invisible. The image copies the bundle to `/usr/lib/ssl-certs/ca-bundle.crt`
-  and `coderun` exports `SSL_CERT_FILE`, `CURL_CA_BUNDLE` and `GIT_SSL_CAINFO`
-  when that file exists. Python (certifi) and Node (CAs compiled in) do not
+  and the global `env` in `interpreters.json` exports `SSL_CERT_FILE`,
+  `CURL_CA_BUNDLE` and `GIT_SSL_CAINFO` when that file exists. Python (certifi) and Node (CAs compiled in) do not
   depend on it.
-- `/usr/share/zoneinfo` is denied, so `coderun` sets an empty `PYTHONTZPATH` to
-  send `zoneinfo` to the `tzdata` package instead. Bash `TZ=...` does not work.
+- `/usr/share/zoneinfo` is denied, so the python interpreter declares an empty
+  `PYTHONTZPATH` to send `zoneinfo` to the `tzdata` package instead. Bash
+  `TZ=...` does not work.
 - The network is in a private namespace unless `CODELLM_SANDBOX_NETWORK=true`.
   That flag also adds `/etc/resolv.conf`, `/etc/hosts`, `/etc/nsswitch.conf`,
   `/etc/services` and `/etc/gai.conf` to the allowlist — without them name
   resolution fails and only raw IPs are reachable. `/etc/ssl/openssl.cnf` is
   always granted: node aborts at startup without it, even for an offline block.
-- The child environment is scrubbed to the toolbox vars plus `PATH` and
+- The child environment is scrubbed to the declared env plus `PATH` and
   `FLEET_INPUT`; secrets reach a block only through `CODELLM_EXPOSE_ENV` /
   `CODELLM_EXPOSE_ENV_PREFIX`. Tools that authenticate from the environment need
   their var named there — `gh`, for one, is unauthenticated unless codellm runs

--- a/cmd/codellm/README.md
+++ b/cmd/codellm/README.md
@@ -8,3 +8,98 @@ CODELLM_SANDBOX_NETWORK=true \
 CODELLM_EXPOSE_ENV_PREFIX=KRISP_ \
 make aircodellm
 ```
+
+## Tools
+
+What a block can use inside the runtime image (`Dockerfile.codellm`). The list is
+deliberately short: it is meant to be pasted into the system prompt so the model
+writes against what is actually installed instead of guessing.
+
+Interpreters are `python`, `node` and `bash` (`internal/coderun/interpreters.json`),
+gated at runtime by `CODELLM_ALLOWED_PROGRAMS`.
+
+### Python
+
+Installed into `/usr/lib/python3/dist-packages`.
+
+| Package | What it is for |
+|---------|----------------|
+| `requests` | HTTP client for REST calls: sessions, headers, timeouts, uploads |
+| `httpx` | HTTP client with async and HTTP/2 when `requests` is not enough |
+| `beautifulsoup4` | Forgiving HTML parsing when an API is only a web page |
+| `lxml` | Fast HTML/XML backend for bs4, plus XPath for XML APIs |
+| `python-dateutil` | Parses the arbitrary date formats third-party APIs return |
+| `pyjwt` | Encode, decode and verify JWTs (`import jwt`) |
+| `cryptography` | HMAC/RSA/ECDSA request signing; backs RS256/ES256 JWTs |
+| `tenacity` | Retry with exponential backoff against flaky APIs |
+| `pydantic` | Validate and reshape response JSON into typed models |
+| `pyyaml` | YAML configs, OpenAPI specs |
+| `tzdata` | Timezone database for `zoneinfo` — `/usr/share/zoneinfo` is denied by the sandbox |
+
+Not installed on purpose: `pandas`/`numpy` (~120 MB for work the `csv` module and
+`mlr` already cover), `orjson` (stdlib `json` is enough at this size).
+
+### Node.js
+
+Installed globally into `/usr/lib/node_modules`, reachable via `NODE_PATH`.
+
+**Write CommonJS (`require`).** `NODE_PATH` is not consulted for ESM `import`, so
+`import` of a global package fails with `ERR_MODULE_NOT_FOUND`. This is also why
+ESM-only packages (`p-retry` >= 5, `got`, `node-fetch` v3) are absent.
+
+| Package | What it is for |
+|---------|----------------|
+| `axios` | HTTP client: JSON, headers, timeouts, interceptors |
+| `cheerio` | jQuery-style HTML parsing |
+| `zod` | Validate and reshape response payloads |
+| `dayjs` | Date parsing, formatting and arithmetic |
+| `lodash` | Reshaping data: `groupBy`, `chunk`, `get` |
+| `jsonwebtoken` | Sign and verify JWTs |
+| `csv-parse` | CSV parsing, streaming or synchronous |
+| `axios-retry` | Retry policies layered onto axios |
+| `pg` | PostgreSQL client |
+| `qs` | Nested query-string parsing and serialization |
+
+Node 20 already provides `fetch`, `crypto.randomUUID()` and full ICU, so
+`node-fetch`, `uuid` and `crypto-js` are not installed.
+
+### CLI
+
+On `PATH` in `/usr/bin`, for `bash` blocks and for shelling out.
+
+| Tool | What it is for |
+|------|----------------|
+| `jq` | Query and reshape JSON |
+| `curl`, `wget` | HTTP from a shell block |
+| `mlr` (miller) | Convert and reshape CSV/TSV/JSON — the CLI answer to "no pandas" |
+| `sqlite3` | Scratch database; joins and aggregates over CSV without writing code |
+| `openssl` | HMAC signing, base64, certificate inspection |
+| `rg` (ripgrep) | Search dumps and payloads |
+| `git` | Fetch a repo or config the script needs |
+| `gh` | GitHub API and repos: issues, PRs, releases, `gh api` for raw calls |
+| `unzip`, `xz`, `gzip`, `tar` | Unpack API exports |
+| `dig`, `nc` | Diagnose why an endpoint is unreachable |
+| `yq` | YAML/XML into a jq pipeline |
+| `file`, `gawk`, `sed`, `grep` | Ordinary shell plumbing |
+
+### Sandbox constraints
+
+Under the default `CODELLM_SANDBOX=native`, blocks run under landlock with
+read-only access to `/bin`, `/sbin`, `/usr/bin`, `/usr/sbin` and `/usr/lib*`
+only. Consequences worth knowing when adding tools:
+
+- Anything installed to `/usr/local` or `/opt` is **unreachable**. A downloaded
+  binary has to go to `/usr/bin`; Python packages need
+  `pip --target=/usr/lib/python3/dist-packages`, because Debian's pip otherwise
+  defaults to `/usr/local/lib/python3.11/dist-packages` and ignores `--prefix`.
+- `/etc` is denied apart from `ld.so.cache`, so the system CA store is invisible.
+  The image copies the bundle to `/usr/lib/ssl-certs/ca-bundle.crt` and
+  `coderun` exports `SSL_CERT_FILE`, `CURL_CA_BUNDLE` and `GIT_SSL_CAINFO` when
+  that file exists. Python (certifi) and Node (CAs compiled in) do not depend on
+  it.
+- The network is in a private namespace unless `CODELLM_SANDBOX_NETWORK=true`.
+- The child environment is scrubbed to the toolbox vars plus `PATH` and
+  `FLEET_INPUT`; secrets reach a block only through `CODELLM_EXPOSE_ENV` /
+  `CODELLM_EXPOSE_ENV_PREFIX`. Tools that authenticate from the environment need
+  their var named there — `gh`, for one, is unauthenticated unless codellm runs
+  with `CODELLM_EXPOSE_ENV=GH_TOKEN` and holds the value.

--- a/cmd/codellm/README.md
+++ b/cmd/codellm/README.md
@@ -92,14 +92,55 @@ only. Consequences worth knowing when adding tools:
   binary has to go to `/usr/bin`; Python packages need
   `pip --target=/usr/lib/python3/dist-packages`, because Debian's pip otherwise
   defaults to `/usr/local/lib/python3.11/dist-packages` and ignores `--prefix`.
-- `/etc` is denied apart from `ld.so.cache`, so the system CA store is invisible.
-  The image copies the bundle to `/usr/lib/ssl-certs/ca-bundle.crt` and
-  `coderun` exports `SSL_CERT_FILE`, `CURL_CA_BUNDLE` and `GIT_SSL_CAINFO` when
-  that file exists. Python (certifi) and Node (CAs compiled in) do not depend on
-  it.
+- `/etc` is denied apart from a named handful of files, so the system CA store
+  is invisible. The image copies the bundle to `/usr/lib/ssl-certs/ca-bundle.crt`
+  and `coderun` exports `SSL_CERT_FILE`, `CURL_CA_BUNDLE` and `GIT_SSL_CAINFO`
+  when that file exists. Python (certifi) and Node (CAs compiled in) do not
+  depend on it.
+- `/usr/share/zoneinfo` is denied, so `coderun` sets an empty `PYTHONTZPATH` to
+  send `zoneinfo` to the `tzdata` package instead. Bash `TZ=...` does not work.
 - The network is in a private namespace unless `CODELLM_SANDBOX_NETWORK=true`.
+  That flag also adds `/etc/resolv.conf`, `/etc/hosts`, `/etc/nsswitch.conf`,
+  `/etc/services` and `/etc/gai.conf` to the allowlist — without them name
+  resolution fails and only raw IPs are reachable. `/etc/ssl/openssl.cnf` is
+  always granted: node aborts at startup without it, even for an offline block.
 - The child environment is scrubbed to the toolbox vars plus `PATH` and
   `FLEET_INPUT`; secrets reach a block only through `CODELLM_EXPOSE_ENV` /
   `CODELLM_EXPOSE_ENV_PREFIX`. Tools that authenticate from the environment need
   their var named there — `gh`, for one, is unauthenticated unless codellm runs
   with `CODELLM_EXPOSE_ENV=GH_TOKEN` and holds the value.
+
+### Running the enforcing sandbox under an orchestrator
+
+Docker's defaults do **not** allow `CODELLM_SANDBOX=native` — the run fails
+closed ("refusing to run unsandboxed") rather than degrading silently. The
+minimum grant, established by bisection:
+
+```hcl
+# Nomad job — docker driver
+config {
+  cap_add      = ["sys_admin"]              # PID + mount namespaces
+  security_opt = ["apparmor=unconfined"]    # docker-default denies remounting / private
+}
+```
+
+`privileged = true` also works but grants far more than needed. Docker's default
+seccomp profile needs no change. The Nomad **client** must permit the capability
+as well — `sys_admin` is not in the docker driver's default `allow_caps`:
+
+```hcl
+plugin "docker" {
+  config {
+    allow_caps = ["chown", "dac_override", "fowner", "fsetid", "kill", "mknod",
+                  "net_bind_service", "setfcap", "setgid", "setpcap", "setuid",
+                  "sys_chroot", "audit_write", "sys_admin"]
+  }
+}
+```
+
+Landlock is applied best-effort: on a kernel without it the path restrictions
+are silently weaker while namespaces still apply. Verify the host supports it
+(`grep landlock /sys/kernel/security/lsm`) rather than assuming.
+
+Verify a deployment with `scripts/test-codellm-sandbox.sh`, which checks both
+that the toolbox works and that the denials still hold.

--- a/cmd/codellm/internal/coderun/coderun.go
+++ b/cmd/codellm/internal/coderun/coderun.go
@@ -434,6 +434,7 @@ func buildChildEnv(inputFile string, passthrough, prefix []string) []string {
 const (
 	toolboxNodeModules = "/usr/lib/node_modules"
 	toolboxCABundle    = "/usr/lib/ssl-certs/ca-bundle.crt"
+	toolboxTZData      = "/usr/lib/python3/dist-packages/tzdata"
 )
 
 // toolboxEnv points the interpreters at the packages and CA bundle installed in
@@ -457,6 +458,13 @@ func toolboxEnv() []string {
 			"CURL_CA_BUNDLE="+toolboxCABundle,
 			"GIT_SSL_CAINFO="+toolboxCABundle,
 		)
+	}
+	// An empty TZPATH sends zoneinfo straight to the tzdata package. Without it
+	// zoneinfo tries /usr/share/zoneinfo first, which the sandbox denies, and
+	// the resulting PermissionError is not a miss — so the fallback that would
+	// otherwise reach tzdata never runs.
+	if fi, err := os.Stat(toolboxTZData); err == nil && fi.IsDir() {
+		env = append(env, "PYTHONTZPATH=")
 	}
 	return env
 }

--- a/cmd/codellm/internal/coderun/coderun.go
+++ b/cmd/codellm/internal/coderun/coderun.go
@@ -390,8 +390,8 @@ func extractFirstFencedBlock(body string) (string, string) {
 }
 
 // buildChildEnv constructs the child process environment: a minimal base
-// (PATH + FLEET_INPUT) plus selected parent vars via the explicit-allowlist
-// (passthrough) and prefix-match mechanisms.
+// (PATH + FLEET_INPUT + the static toolbox paths) plus selected parent vars via
+// the explicit-allowlist (passthrough) and prefix-match mechanisms.
 //
 // Secret-scrub guarantee: only vars that are explicitly listed in passthrough
 // OR whose name starts with an entry in prefix are forwarded. No other parent
@@ -401,6 +401,7 @@ func buildChildEnv(inputFile string, passthrough, prefix []string) []string {
 		"PATH=" + os.Getenv("PATH"),
 		"FLEET_INPUT=" + inputFile,
 	}
+	env = append(env, toolboxEnv()...)
 	if len(passthrough) == 0 && len(prefix) == 0 {
 		return env
 	}
@@ -423,6 +424,39 @@ func buildChildEnv(inputFile string, passthrough, prefix []string) []string {
 				break
 			}
 		}
+	}
+	return env
+}
+
+// Toolbox paths baked into the runtime image (Dockerfile.codellm). Both sit
+// under /usr/lib because the sandbox grants that read-only and denies the rest
+// of the filesystem — notably /etc, where the system CA store normally lives.
+const (
+	toolboxNodeModules = "/usr/lib/node_modules"
+	toolboxCABundle    = "/usr/lib/ssl-certs/ca-bundle.crt"
+)
+
+// toolboxEnv points the interpreters at the packages and CA bundle installed in
+// the image: NODE_PATH so require() resolves the global node modules (ESM
+// imports ignore it, hence the CommonJS-only package list), and the SSL vars so
+// curl/git/openssl verify TLS without reading /etc.
+//
+// Each var is set only when its target exists, so a dev run outside the image
+// (make aircodellm) keeps the host defaults instead of being pointed at a
+// missing CA bundle, which would break TLS rather than fix it.
+//
+// These are static paths, not parent env, so the secret-scrub guarantee holds.
+func toolboxEnv() []string {
+	var env []string
+	if fi, err := os.Stat(toolboxNodeModules); err == nil && fi.IsDir() {
+		env = append(env, "NODE_PATH="+toolboxNodeModules)
+	}
+	if fi, err := os.Stat(toolboxCABundle); err == nil && !fi.IsDir() {
+		env = append(env,
+			"SSL_CERT_FILE="+toolboxCABundle,
+			"CURL_CA_BUNDLE="+toolboxCABundle,
+			"GIT_SSL_CAINFO="+toolboxCABundle,
+		)
 	}
 	return env
 }

--- a/cmd/codellm/internal/coderun/coderun.go
+++ b/cmd/codellm/internal/coderun/coderun.go
@@ -20,18 +20,32 @@ import (
 //go:embed interpreters.json
 var defaultInterpretersJSON []byte
 
-// interpreter describes one language runtime: binary argv prefix, fence labels, temp-file extension.
+// interpreter describes one language runtime: binary argv prefix, fence labels,
+// temp-file extension, and the env it needs to find its packages.
 type interpreter struct {
 	Name            string   `json:"name"`
 	Cmd             []string `json:"cmd"`
 	CodeBlockLabels []string `json:"code_block_labels"`
 	Ext             string   `json:"ext"`
+	Env             []envVar `json:"env"`
 }
 
-// interpreterRegistry holds two indices built from the loaded interpreter list.
+// envVar is one declarative child-env entry. IfExists names a path that must be
+// present for the var to be set, so an entry describing a path baked into the
+// runtime image is simply skipped in a dev run outside it — pointing an
+// interpreter at a missing bundle breaks it rather than configures it.
+type envVar struct {
+	Name     string `json:"name"`
+	Value    string `json:"value"`
+	IfExists string `json:"if_exists"`
+}
+
+// interpreterRegistry holds two indices built from the loaded interpreter list,
+// plus the env applied to every interpreter.
 type interpreterRegistry struct {
 	byLabel map[string]*interpreter
 	byName  map[string]*interpreter
+	env     []envVar
 }
 
 // registry is guarded by registryMu: a startup --interpreters override may race
@@ -63,6 +77,7 @@ func mustBuildRegistry(data []byte) *interpreterRegistry {
 // buildRegistry parses an interpreters JSON blob and builds byLabel and byName indices.
 func buildRegistry(data []byte) (*interpreterRegistry, error) {
 	var payload struct {
+		Env          []envVar      `json:"env"`
 		Interpreters []interpreter `json:"interpreters"`
 	}
 	if err := json.Unmarshal(data, &payload); err != nil {
@@ -71,6 +86,7 @@ func buildRegistry(data []byte) (*interpreterRegistry, error) {
 	reg := &interpreterRegistry{
 		byLabel: make(map[string]*interpreter),
 		byName:  make(map[string]*interpreter),
+		env:     payload.Env,
 	}
 	for i := range payload.Interpreters {
 		interp := &payload.Interpreters[i]
@@ -197,7 +213,7 @@ func RunBlock(ctx context.Context, spec CodeSpec) (string, string, bool, error) 
 	// Secret-scrub: build an explicit MINIMAL env. NEVER nil (inherits parent)
 	// or os.Environ() (exposes all secrets). The base is PATH + FLEET_INPUT only.
 	// Selective pass-through adds only explicitly declared vars/prefixes on top.
-	env := buildChildEnv(inputFile, spec.EnvPassthrough, spec.EnvPrefix)
+	env := buildChildEnv(inputFile, interp, spec.EnvPassthrough, spec.EnvPrefix)
 	limit := spec.MaxStdoutBytes
 	if limit == 0 {
 		limit = 1 << 20
@@ -390,18 +406,22 @@ func extractFirstFencedBlock(body string) (string, string) {
 }
 
 // buildChildEnv constructs the child process environment: a minimal base
-// (PATH + FLEET_INPUT + the static toolbox paths) plus selected parent vars via
-// the explicit-allowlist (passthrough) and prefix-match mechanisms.
+// (PATH + FLEET_INPUT + the env declared in interpreters.json, globally and for
+// this interpreter) plus selected parent vars via the explicit-allowlist
+// (passthrough) and prefix-match mechanisms.
 //
 // Secret-scrub guarantee: only vars that are explicitly listed in passthrough
 // OR whose name starts with an entry in prefix are forwarded. No other parent
 // env var is included. An empty passthrough AND empty prefix → base only.
-func buildChildEnv(inputFile string, passthrough, prefix []string) []string {
+func buildChildEnv(inputFile string, interp *interpreter, passthrough, prefix []string) []string {
 	env := []string{
 		"PATH=" + os.Getenv("PATH"),
 		"FLEET_INPUT=" + inputFile,
 	}
-	env = append(env, toolboxEnv()...)
+	env = append(env, resolveEnvVars(currentRegistry().env)...)
+	if interp != nil {
+		env = append(env, resolveEnvVars(interp.Env)...)
+	}
 	if len(passthrough) == 0 && len(prefix) == 0 {
 		return env
 	}
@@ -428,43 +448,21 @@ func buildChildEnv(inputFile string, passthrough, prefix []string) []string {
 	return env
 }
 
-// Toolbox paths baked into the runtime image (Dockerfile.codellm). Both sit
-// under /usr/lib because the sandbox grants that read-only and denies the rest
-// of the filesystem — notably /etc, where the system CA store normally lives.
-const (
-	toolboxNodeModules = "/usr/lib/node_modules"
-	toolboxCABundle    = "/usr/lib/ssl-certs/ca-bundle.crt"
-	toolboxTZData      = "/usr/lib/python3/dist-packages/tzdata"
-)
-
-// toolboxEnv points the interpreters at the packages and CA bundle installed in
-// the image: NODE_PATH so require() resolves the global node modules (ESM
-// imports ignore it, hence the CommonJS-only package list), and the SSL vars so
-// curl/git/openssl verify TLS without reading /etc.
-//
-// Each var is set only when its target exists, so a dev run outside the image
-// (make aircodellm) keeps the host defaults instead of being pointed at a
-// missing CA bundle, which would break TLS rather than fix it.
-//
-// These are static paths, not parent env, so the secret-scrub guarantee holds.
-func toolboxEnv() []string {
+// resolveEnvVars renders declared env entries, skipping any whose IfExists path
+// is absent. The values are static config, not parent env, so the secret-scrub
+// guarantee holds.
+func resolveEnvVars(decls []envVar) []string {
 	var env []string
-	if fi, err := os.Stat(toolboxNodeModules); err == nil && fi.IsDir() {
-		env = append(env, "NODE_PATH="+toolboxNodeModules)
-	}
-	if fi, err := os.Stat(toolboxCABundle); err == nil && !fi.IsDir() {
-		env = append(env,
-			"SSL_CERT_FILE="+toolboxCABundle,
-			"CURL_CA_BUNDLE="+toolboxCABundle,
-			"GIT_SSL_CAINFO="+toolboxCABundle,
-		)
-	}
-	// An empty TZPATH sends zoneinfo straight to the tzdata package. Without it
-	// zoneinfo tries /usr/share/zoneinfo first, which the sandbox denies, and
-	// the resulting PermissionError is not a miss — so the fallback that would
-	// otherwise reach tzdata never runs.
-	if fi, err := os.Stat(toolboxTZData); err == nil && fi.IsDir() {
-		env = append(env, "PYTHONTZPATH=")
+	for _, v := range decls {
+		if v.Name == "" {
+			continue
+		}
+		if v.IfExists != "" {
+			if _, err := os.Stat(v.IfExists); err != nil {
+				continue
+			}
+		}
+		env = append(env, v.Name+"="+v.Value)
 	}
 	return env
 }

--- a/cmd/codellm/internal/coderun/coderun_test.go
+++ b/cmd/codellm/internal/coderun/coderun_test.go
@@ -2,6 +2,8 @@ package coderun
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -402,3 +404,59 @@ fi`
 
 // Tests in this file use t.Setenv which correctly restores values on cleanup.
 // The parent-env isolation under test is enforced by buildChildEnv in coderun.go.
+
+// TestResolveEnvVars_IfExistsGate covers the declarative env in interpreters.json:
+// an entry whose if_exists path is missing must be skipped, so a dev run outside
+// the runtime image is not pointed at a bundle that isn't there.
+func TestResolveEnvVars_IfExistsGate(t *testing.T) {
+	dir := t.TempDir()
+	present := filepath.Join(dir, "present")
+	require.NoError(t, os.WriteFile(present, []byte("x"), 0o600))
+
+	got := resolveEnvVars([]envVar{
+		{Name: "UNGUARDED", Value: "always"},
+		{Name: "GUARDED_OK", Value: "set", IfExists: present},
+		{Name: "GUARDED_MISSING", Value: "skipped", IfExists: filepath.Join(dir, "absent")},
+		{Name: "EMPTY_VALUE", Value: "", IfExists: present},
+		{Name: "", Value: "nameless"},
+	})
+
+	require.Equal(t, []string{"UNGUARDED=always", "GUARDED_OK=set", "EMPTY_VALUE="}, got)
+}
+
+// TestBuildRegistry_Env checks that global and per-interpreter env survive the
+// JSON round-trip, including an interpreter that declares none.
+func TestBuildRegistry_Env(t *testing.T) {
+	reg, err := buildRegistry([]byte(`{"env":[{"name":"GLOBAL","value":"g"}],
+	  "interpreters":[
+	    {"name":"node","cmd":["node"],"code_block_labels":["js"],"ext":".js",
+	     "env":[{"name":"NODE_PATH","value":"/usr/lib/node_modules"}]},
+	    {"name":"bash","cmd":["bash"],"code_block_labels":["sh"],"ext":".sh"}]}`))
+	require.NoError(t, err)
+	require.Equal(t, []envVar{{Name: "GLOBAL", Value: "g"}}, reg.env)
+	require.Equal(t, []envVar{{Name: "NODE_PATH", Value: "/usr/lib/node_modules"}}, reg.byName["node"].Env)
+	require.Empty(t, reg.byName["bash"].Env)
+}
+
+// TestInterpretersJSON_ShippedEnv pins the env the shipped interpreters.json
+// declares — these paths are created by Dockerfile.codellm, so a change to one
+// without the other silently drops packages or TLS trust.
+func TestInterpretersJSON_ShippedEnv(t *testing.T) {
+	reg, err := buildRegistry(defaultInterpretersJSON)
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(reg.env))
+	for _, v := range reg.env {
+		names = append(names, v.Name)
+		require.Equal(t, "/usr/lib/ssl-certs/ca-bundle.crt", v.Value)
+		require.Equal(t, v.Value, v.IfExists, "CA vars must be gated on the bundle itself")
+	}
+	require.Equal(t, []string{"SSL_CERT_FILE", "CURL_CA_BUNDLE", "GIT_SSL_CAINFO"}, names)
+
+	require.Equal(t, []envVar{{
+		Name: "NODE_PATH", Value: "/usr/lib/node_modules", IfExists: "/usr/lib/node_modules",
+	}}, reg.byName["node"].Env)
+	require.Equal(t, []envVar{{
+		Name: "PYTHONTZPATH", Value: "", IfExists: "/usr/lib/python3/dist-packages/tzdata",
+	}}, reg.byName["python"].Env)
+}

--- a/cmd/codellm/internal/coderun/coderun_test.go
+++ b/cmd/codellm/internal/coderun/coderun_test.go
@@ -193,7 +193,7 @@ func TestFenceLangToProgram(t *testing.T) {
 	require.Equal(t, "node", fenceLangToProgram("node"))
 	require.Equal(t, "node", fenceLangToProgram("js"))
 	require.Equal(t, "node", fenceLangToProgram("javascript"))
-	require.Equal(t, "ruby", fenceLangToProgram("ruby"))
+	require.Empty(t, fenceLangToProgram("ruby"))
 }
 
 func TestProgramBinary(t *testing.T) {
@@ -221,8 +221,8 @@ func TestInterpretersJSON_Load(t *testing.T) {
 	require.Equal(t, "python", prog)
 	prog = fenceLangToProgram("py")
 	require.Equal(t, "python", prog)
-	prog = fenceLangToProgram("ruby")
-	require.Equal(t, "ruby", prog)
+	prog = fenceLangToProgram("sh")
+	require.Equal(t, "bash", prog)
 	prog = fenceLangToProgram("haskell")
 	require.Empty(t, prog)
 }

--- a/cmd/codellm/internal/coderun/interpreters.json
+++ b/cmd/codellm/internal/coderun/interpreters.json
@@ -1,8 +1,5 @@
 {"interpreters": [
-  {"name":"python","cmd":["python3","-S"],"code_block_labels":["py","python","python3"],"ext":".py"},
+  {"name":"python","cmd":["python3"],"code_block_labels":["py","python","python3"],"ext":".py"},
   {"name":"node","cmd":["node"],"code_block_labels":["js","javascript","node"],"ext":".js"},
-  {"name":"bash","cmd":["bash"],"code_block_labels":["sh","bash"],"ext":".sh"},
-  {"name":"ruby","cmd":["ruby"],"code_block_labels":["rb","ruby"],"ext":".rb"},
-  {"name":"php","cmd":["php"],"code_block_labels":["php"],"ext":".php"},
-  {"name":"perl","cmd":["perl"],"code_block_labels":["pl","perl"],"ext":".pl"}
+  {"name":"bash","cmd":["bash"],"code_block_labels":["sh","bash"],"ext":".sh"}
 ]}

--- a/cmd/codellm/internal/coderun/interpreters.json
+++ b/cmd/codellm/internal/coderun/interpreters.json
@@ -1,5 +1,11 @@
-{"interpreters": [
-  {"name":"python","cmd":["python3"],"code_block_labels":["py","python","python3"],"ext":".py"},
-  {"name":"node","cmd":["node"],"code_block_labels":["js","javascript","node"],"ext":".js"},
+{"env": [
+  {"name":"SSL_CERT_FILE","value":"/usr/lib/ssl-certs/ca-bundle.crt","if_exists":"/usr/lib/ssl-certs/ca-bundle.crt"},
+  {"name":"CURL_CA_BUNDLE","value":"/usr/lib/ssl-certs/ca-bundle.crt","if_exists":"/usr/lib/ssl-certs/ca-bundle.crt"},
+  {"name":"GIT_SSL_CAINFO","value":"/usr/lib/ssl-certs/ca-bundle.crt","if_exists":"/usr/lib/ssl-certs/ca-bundle.crt"}
+], "interpreters": [
+  {"name":"python","cmd":["python3"],"code_block_labels":["py","python","python3"],"ext":".py",
+   "env":[{"name":"PYTHONTZPATH","value":"","if_exists":"/usr/lib/python3/dist-packages/tzdata"}]},
+  {"name":"node","cmd":["node"],"code_block_labels":["js","javascript","node"],"ext":".js",
+   "env":[{"name":"NODE_PATH","value":"/usr/lib/node_modules","if_exists":"/usr/lib/node_modules"}]},
   {"name":"bash","cmd":["bash"],"code_block_labels":["sh","bash"],"ext":".sh"}
 ]}

--- a/cmd/codellm/internal/coderun/runcode.go
+++ b/cmd/codellm/internal/coderun/runcode.go
@@ -502,7 +502,7 @@ func buildBlockCmd(ctx context.Context, code, program string, in CodeInput) (bui
 		return builtBlock{}, fmt.Errorf("write input file: %w", wErr)
 	}
 
-	env := buildChildEnv(inputFile, in.EnvPassthrough, in.EnvPrefix)
+	env := buildChildEnv(inputFile, interp, in.EnvPassthrough, in.EnvPrefix)
 	fullArgv := append(append([]string{}, interp.Cmd...), codeFile)
 
 	blockCtx := ctx

--- a/cmd/codellm/internal/coderun/sandbox_linux.go
+++ b/cmd/codellm/internal/coderun/sandbox_linux.go
@@ -199,7 +199,7 @@ func sandboxCommand(ctx context.Context, argv []string, workDir string, p Sandbo
 	if err != nil {
 		return nil, fmt.Errorf("sandbox: resolve self: %w", err)
 	}
-	roDirs, roFiles := sandboxROPaths(argv[0])
+	roDirs, roFiles := sandboxROPaths(argv[0], p.Network)
 	spec := sandboxChildSpec{
 		Argv:          argv,
 		WorkDir:       workDir,
@@ -267,17 +267,36 @@ func sandboxCommand(ctx context.Context, argv []string, workDir string, p Sandbo
 }
 
 // sandboxROPaths returns the read-only paths the interpreter needs: the
-// resolved interpreter directory, the core executable and library dirs, and the
-// dynamic-linker cache. Everything else (notably the blanket /etc, /opt and the
+// resolved interpreter directory, the core executable and library dirs, and a
+// named handful of /etc files. Everything else (the blanket /etc, /opt and the
 // rest of /usr) is denied so a compromised interpreter cannot read host config.
-func sandboxROPaths(program string) ([]string, []string) {
+//
+// The /etc files are individually named rather than granted as a directory:
+// node refuses to start without openssl.cnf even for an offline block, and the
+// resolver config is what makes DNS work — without it a block can only reach
+// raw IPs. The resolver files are added only when the network is actually
+// reachable, so a no-network block still sees nothing of the host's DNS setup.
+// /etc/passwd, /etc/shadow and the rest of /etc stay denied in both cases.
+func sandboxROPaths(program string, network bool) ([]string, []string) {
 	dirs := []string{
 		"/bin", "/sbin",
 		"/usr/bin", "/usr/sbin",
 		"/lib", "/lib32", "/lib64",
 		"/usr/lib", "/usr/lib32", "/usr/lib64",
 	}
-	files := []string{"/etc/ld.so.cache"} // dynamic linker cache only, not all of /etc
+	files := []string{
+		"/etc/ld.so.cache",     // dynamic linker cache
+		"/etc/ssl/openssl.cnf", // node aborts at startup without it
+	}
+	if network {
+		files = append(files,
+			"/etc/resolv.conf",
+			"/etc/hosts",
+			"/etc/nsswitch.conf",
+			"/etc/services",
+			"/etc/gai.conf",
+		)
+	}
 	if bin, err := exec.LookPath(program); err == nil {
 		if resolved, rerr := filepath.EvalSymlinks(bin); rerr == nil {
 			bin = resolved

--- a/scripts/test-codellm-sandbox.sh
+++ b/scripts/test-codellm-sandbox.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# Native-sandbox smoke test for the codellm runtime image (Dockerfile.codellm).
+#
+# The landlock sandbox needs CLONE_NEWPID/CLONE_NEWNS, which Docker's default
+# caps and seccomp profile deny — that is why docker-compose.test.yml runs
+# codellm with CODELLM_SANDBOX=off. This script starts the image with the
+# privileges the enforcing posture actually needs and checks two things:
+#
+#   1. the toolbox is reachable from a block under CODELLM_SANDBOX=native
+#      (python/node/bash packages, CA bundle, NODE_PATH, CLI tools)
+#   2. the sandbox still denies what it is supposed to deny
+#      (/etc, /usr/local, parent env secrets)
+#
+# Usage: ./scripts/test-codellm-sandbox.sh          # builds, then tests
+#        SKIP_BUILD=1 ./scripts/test-codellm-sandbox.sh
+#        CAPS=limited ./scripts/test-codellm-sandbox.sh   # SYS_ADMIN instead of --privileged
+#
+# Run under sudo if your user is not in the docker group.
+# Exits non-zero on the first failed check.
+
+set -e
+
+IMAGE=${IMAGE:-codellm-sandbox-test}
+NAME=${NAME:-codellm-sandbox-test}
+PORT=${PORT:-28099}
+KEY=${KEY:-sandbox-smoke-key-0123456789abcdef}
+SENTINEL_VALUE=PARENT_SECRET_MUST_NOT_LEAK
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+
+if [ "${CAPS:-full}" = "limited" ]; then
+  PRIV=(--cap-add SYS_ADMIN --security-opt seccomp=unconfined --security-opt apparmor=unconfined)
+else
+  PRIV=(--privileged)
+fi
+
+cleanup() { docker rm -f "$NAME" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+if [ -z "$SKIP_BUILD" ]; then
+  echo "==> building $IMAGE"
+  docker build -f "$ROOT/Dockerfile.codellm" -t "$IMAGE" "$ROOT"
+fi
+
+cleanup
+echo "==> starting codellm (CODELLM_SANDBOX=native, ${PRIV[*]})"
+docker run -d --name "$NAME" -p "$PORT:8082" "${PRIV[@]}" \
+  -e CODELLM_ADDR=0.0.0.0:8082 \
+  -e CODELLM_TRIP2G_URL=http://example.invalid \
+  -e CODELLM_API_KEY="$KEY" \
+  -e CODELLM_ALLOWED_PROGRAMS=python,bash,node \
+  -e CODELLM_SANDBOX=native \
+  -e CODELLM_SANDBOX_NETWORK=true \
+  -e FLEET_SANDBOX_SENTINEL="$SENTINEL_VALUE" \
+  "$IMAGE" >/dev/null
+
+for _ in $(seq 1 40); do
+  curl -sf "http://localhost:$PORT/healthz" >/dev/null 2>&1 && break
+  sleep 0.25
+done
+if ! curl -sf "http://localhost:$PORT/healthz" >/dev/null 2>&1; then
+  echo "FAIL: server did not come up"
+  docker logs "$NAME" 2>&1 | tail -30
+  exit 1
+fi
+
+PORT="$PORT" KEY="$KEY" SENTINEL_VALUE="$SENTINEL_VALUE" python3 - <<'PYEOF'
+import json, os, sys, urllib.error, urllib.request
+
+URL = "http://localhost:%s/v1/chat/completions" % os.environ["PORT"]
+HDR = {"Content-Type": "application/json",
+       "Authorization": "Bearer " + os.environ["KEY"]}
+
+def run(lang, code):
+    """Execute one block; return (answer, error) — exactly one is non-empty."""
+    body = json.dumps({"model": "codellm",
+                       "messages": [{"role": "user",
+                                     "content": "```%s\n%s\n```" % (lang, code)}]}).encode()
+    req = urllib.request.Request(URL, data=body, headers=HDR)
+    try:
+        resp = json.load(urllib.request.urlopen(req, timeout=120))
+    except urllib.error.HTTPError as e:
+        return "", e.read().decode("utf-8", "replace")[:300]
+    except Exception as e:
+        return "", str(e)[:300]
+    msg = resp["choices"][0]["message"]
+    for call in msg.get("tool_calls") or []:
+        if call["function"]["name"] == "finish":
+            return json.loads(call["function"]["arguments"]).get("answer", ""), ""
+    return msg.get("content") or "", ""
+
+EMIT_PY = 'import json; print(json.dumps({"changes": [], "answer": ANSWER}))'
+
+# (name, lang, code, predicate over the answer string)
+CHECKS = [
+    ("python packages import", "python", '''
+import requests, httpx, bs4, lxml, dateutil, jwt, cryptography, tenacity, pydantic, yaml
+from zoneinfo import ZoneInfo
+ANSWER = "ok tz=%s pydantic=%s" % (ZoneInfo("Europe/Moscow").key, pydantic.VERSION)
+''' + EMIT_PY, lambda a: a.startswith("ok ")),
+
+    ("python https via certifi", "python", '''
+import requests
+ANSWER = "status=%d" % requests.get("https://api.github.com/zen", timeout=30).status_code
+''' + EMIT_PY, lambda a: a == "status=200"),
+
+    ("node packages require via NODE_PATH", "node", '''
+const names = ["axios","cheerio","zod","dayjs","lodash","jsonwebtoken","csv-parse","axios-retry","pg","qs"];
+const bad = names.filter(n => { try { require(n); return false } catch (e) { return true } });
+console.log(JSON.stringify({changes: [], answer: bad.length ? "missing=" + bad : "ok path=" + process.env.NODE_PATH}));
+''', lambda a: a == "ok path=/usr/lib/node_modules"),
+
+    ("node https", "node", '''
+require("axios").get("https://api.github.com/zen", {timeout: 30000})
+  .then(r => console.log(JSON.stringify({changes: [], answer: "status=" + r.status})))
+  .catch(e => console.log(JSON.stringify({changes: [], answer: "error=" + e.message})));
+''', lambda a: a == "status=200"),
+
+    ("cli tools present", "bash", '''
+missing=""
+for t in jq curl mlr sqlite3 openssl rg git gh unzip xz dig nc yq file gawk wget; do
+  command -v "$t" >/dev/null || missing="$missing $t"
+done
+jq -nc --arg m "$missing" '{changes: [], answer: (if $m == "" then "ok" else "missing:\\($m)" end)}'
+''', lambda a: a == "ok"),
+
+    ("curl https uses the copied CA bundle", "bash", '''
+code=$(curl -s -o /dev/null -w '%{http_code}' https://api.github.com/zen)
+jq -nc --arg c "$code" --arg ca "$SSL_CERT_FILE" '{changes: [], answer: "code=\\($c) ca=\\($ca)"}'
+''', lambda a: a == "code=200 ca=/usr/lib/ssl-certs/ca-bundle.crt"),
+
+    # --- enforcement: these must be DENIED ---
+    ("sandbox denies /etc", "bash", '''
+if cat /etc/passwd >/dev/null 2>&1; then r=readable; else r=denied; fi
+jq -nc --arg r "$r" '{changes: [], answer: $r}'
+''', lambda a: a == "denied"),
+
+    ("sandbox denies /usr/local", "bash", '''
+if ls /usr/local >/dev/null 2>&1; then r=readable; else r=denied; fi
+jq -nc --arg r "$r" '{changes: [], answer: $r}'
+''', lambda a: a == "denied"),
+
+    ("parent env secret is scrubbed", "bash", '''
+if [ -z "$FLEET_SANDBOX_SENTINEL" ]; then r=absent; else r=LEAKED; fi
+jq -nc --arg r "$r" '{changes: [], answer: $r}'
+''', lambda a: a == "absent"),
+]
+
+failed = 0
+for name, lang, code, ok in CHECKS:
+    answer, err = run(lang, code.strip())
+    if err:
+        print("FAIL  %-38s error: %s" % (name, err.replace("\n", " ")))
+        failed += 1
+    elif ok(answer):
+        print("ok    %-38s %s" % (name, answer))
+    else:
+        print("FAIL  %-38s got: %s" % (name, answer))
+        failed += 1
+
+print()
+if failed:
+    print("%d/%d checks FAILED" % (failed, len(CHECKS)))
+    sys.exit(1)
+print("all %d checks passed" % len(CHECKS))
+PYEOF
+
+status=$?
+if [ $status -ne 0 ]; then
+  echo "==> server logs"
+  docker logs "$NAME" 2>&1 | tail -30
+fi
+exit $status

--- a/scripts/test-codellm-sandbox.sh
+++ b/scripts/test-codellm-sandbox.sh
@@ -13,10 +13,16 @@
 #
 # Usage: ./scripts/test-codellm-sandbox.sh          # builds, then tests
 #        SKIP_BUILD=1 ./scripts/test-codellm-sandbox.sh
-#        CAPS=limited ./scripts/test-codellm-sandbox.sh   # SYS_ADMIN instead of --privileged
+#        CAPS=limited ./scripts/test-codellm-sandbox.sh   # minimal grant, not --privileged
 #
 # Run under sudo if your user is not in the docker group.
 # Exits non-zero on the first failed check.
+#
+# CAPS=limited is the minimum an orchestrator has to grant, established by
+# bisection: CAP_SYS_ADMIN for the PID/mount namespaces, and an unconfined
+# AppArmor profile because the stock docker-default profile denies the private
+# remount of /. Docker's default seccomp profile needs no change. With neither
+# granted the run fails closed — coderun refuses to execute unsandboxed.
 
 set -e
 
@@ -28,7 +34,7 @@ SENTINEL_VALUE=PARENT_SECRET_MUST_NOT_LEAK
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 
 if [ "${CAPS:-full}" = "limited" ]; then
-  PRIV=(--cap-add SYS_ADMIN --security-opt seccomp=unconfined --security-opt apparmor=unconfined)
+  PRIV=(--cap-add SYS_ADMIN --security-opt apparmor=unconfined)
 else
   PRIV=(--privileged)
 fi

--- a/scripts/test-codellm-sandbox.sh
+++ b/scripts/test-codellm-sandbox.sh
@@ -121,6 +121,13 @@ require("axios").get("https://api.github.com/zen", {timeout: 30000})
   .catch(e => console.log(JSON.stringify({changes: [], answer: "error=" + e.message})));
 ''', lambda a: a == "status=200"),
 
+    # ESM ignores NODE_PATH; this resolves only via the /tmp/node_modules symlink.
+    ("node esm import resolves", "node", '''
+import _ from "lodash";
+import { z } from "zod";
+console.log(JSON.stringify({changes: [], answer: "esm lodash=" + _.VERSION + " zod=" + (typeof z.string === "function")}));
+''', lambda a: a.startswith("esm lodash=") and a.endswith("zod=true")),
+
     ("cli tools present", "bash", '''
 missing=""
 for t in jq curl mlr sqlite3 openssl rg git gh unzip xz dig nc yq file gawk wget; do


### PR DESCRIPTION
The codellm runtime was `alpine` + bare `python3`, so a block could only use the
stdlib. This equips it for the actual workload — calling third-party APIs and
quick throwaway scripting — with a curated toolbox, and fixes the sandbox gaps
that a privileged test run exposed.

## What changed

- **`Dockerfile.codellm`**: runtime stage `alpine` → `debian:bookworm-slim` with
  python3 + Node 20, 11 pip packages, 10 npm packages and the CLI tools
  (`jq`, `mlr`, `sqlite3`, `gh`, `rg`, `yq`, …).
- **`interpreters.json`**: trimmed to `python`, `node`, `bash`; ruby/php/perl
  dropped. `python3 -S` → `python3`, since `-S` keeps `site-packages` off
  `sys.path` and would make every installed package unimportable.
- **`coderun.go`**: `toolboxEnv()` adds `NODE_PATH`, the SSL vars and an empty
  `PYTHONTZPATH`, each guarded by an `os.Stat` so a dev run outside the image
  keeps host defaults instead of being pointed at paths that only exist in the
  container.
- **`sandbox_linux.go`**: name six `/etc` files in the landlock allowlist.
  `openssl.cnf` always (node aborts at startup without it, even offline); the
  five resolver files only when `CODELLM_SANDBOX_NETWORK=true`, so a no-network
  block still sees nothing of the host's DNS setup. `/etc/passwd`, `/etc/shadow`
  and the rest of `/etc` stay denied.
- **`scripts/test-codellm-sandbox.sh`**: smoke test that runs the image with the
  privileges the enforcing sandbox needs and checks both that the toolbox works
  and that the denials still hold.
- **`cmd/codellm/README.md`**: Tools section documenting every package and tool,
  written to be pasted into the system prompt, plus the orchestrator setup.

## Sandbox constraints that shaped the choices

The landlock policy grants read-only `/bin`, `/sbin`, `/usr/bin`, `/usr/sbin`
and `/usr/lib*`. The image was built to fit that rather than to relax it:

- Debian's pip ignores `--prefix` and defaults to `/usr/local/...`, which the
  sandbox denies — hence `--target=/usr/lib/python3/dist-packages`, verified to
  be on the default `sys.path`.
- `/etc` is denied, so the system CA store is invisible. The bundle is copied to
  `/usr/lib/ssl-certs/ca-bundle.crt` and exported via `SSL_CERT_FILE` /
  `CURL_CA_BUNDLE` / `GIT_SSL_CAINFO`.
- `/usr/share/zoneinfo` is denied. The `tzdata` package alone does not fix this:
  `zoneinfo` hits a `PermissionError` on the system dir, which is not a miss, so
  the fallback never runs. An empty `PYTHONTZPATH` sends it straight to `tzdata`.
- **`NODE_PATH` is not consulted for ESM `import`** (verified: global ESM
  packages fail with `ERR_MODULE_NOT_FOUND`). The npm list is CommonJS-only,
  which is why `p-retry`/`got`/`node-fetch` v3 are absent.

`pandas`/`numpy` were deliberately excluded (~120MB for work `csv` and `mlr`
already cover). Image grows ~90MB → 655MB.

## Verification

`scripts/test-codellm-sandbox.sh` passes 9/9 under `CODELLM_SANDBOX=native`,
on both `--privileged` and the minimal grant:

```
ok  python packages import      ok tz=Europe/Moscow pydantic=2.13.4
ok  python https via certifi    status=200
ok  node packages require       ok path=/usr/lib/node_modules
ok  node https                  status=200
ok  cli tools present           ok
ok  curl https uses CA bundle   code=200 ca=/usr/lib/ssl-certs/ca-bundle.crt
ok  sandbox denies /etc         denied
ok  sandbox denies /usr/local   denied
ok  parent env secret scrubbed  absent
```

The first run of that script failed 5/9 — DNS was dead, node would not start at
all, and `zoneinfo` was broken. Those failures are what the `sandbox_linux.go`
and `PYTHONTZPATH` changes fix; they are invisible under `CODELLM_SANDBOX=off`,
which is what `docker-compose.test.yml` runs.

Minimum privileges to run the enforcing sandbox, established by bisecting five
combinations: `CAP_SYS_ADMIN` + an unconfined AppArmor profile. Docker's default
seccomp profile needs no change, and with nothing granted the run fails closed
rather than degrading silently. The Nomad client also has to allow the
capability — `sys_admin` is not in the docker driver's default `allow_caps`.
Documented in the README.

`go test ./...` and golangci-lint pass.

Note: the two `ruby` assertions in `coderun_test.go` were retargeted, since ruby
is no longer a configured interpreter. The secret-scrub tests assert a sentinel
is *absent* rather than an exact env, so the added vars do not weaken them.

## Not verified here

Only exercised on this Ubuntu host (AppArmor, kernel 6.8). Landlock is applied
best-effort, so on a host without it the path denials silently weaken while
namespaces still apply — run the script on a Nomad client before trusting
`native` there. The `apparmor=unconfined` finding is also AppArmor-specific and
may differ on an SELinux host.