### PR TITLE
feat(codellm): ship fleetkit so python blocks stop hand-building notes and json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,9 @@ jobs:
   # quietly reporting "green" for tests that never ran. Network is left BLOCKED
   # here on purpose (no network env override): TestSandbox_NetworkBlocked
   # must enforce. python3 is installed explicitly because the golang image is
-  # minimal; bash is already present.
+  # minimal; bash is already present. python3-yaml, node and a global yaml are
+  # what the fleetkit behaviour tests execute: without them those tests would
+  # skip, and MUST_ENFORCE turns that skip into the failure it should be.
   sandbox:
     runs-on: ubuntu-24.04
     steps:
@@ -72,7 +74,10 @@ jobs:
             -e FLEET_SANDBOX_MUST_ENFORCE=1 \
             -e CGO_ENABLED=0 \
             golang:1.26 \
-            sh -c "apt-get update -q && apt-get install -y -q python3 && go test -tags dev -count=1 -timeout 120s ./cmd/codellm/internal/coderun/..."
+            sh -c "apt-get update -q \
+              && apt-get install -y -q python3 python3-yaml nodejs npm \
+              && npm install -g --loglevel=error yaml \
+              && go test -tags dev -count=1 -timeout 180s ./cmd/codellm/internal/coderun/..."
 
   e2e:
     runs-on: ubuntu-latest

--- a/Dockerfile.codellm
+++ b/Dockerfile.codellm
@@ -17,7 +17,7 @@ FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl gnupg \
-    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && install -m 755 -d /etc/apt/keyrings \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
       -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
@@ -39,14 +39,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pip3 install --no-cache-dir --break-system-packages \
       --target=/usr/lib/python3/dist-packages \
       requests httpx beautifulsoup4 lxml python-dateutil \
-      pyjwt cryptography tenacity pydantic pyyaml \
+      pyjwt cryptography tenacity pydantic pyyaml jsonschema \
       tzdata
 
 # npm's global prefix is /usr, so modules land in /usr/lib/node_modules, which
 # NODE_PATH points at for require().
 RUN npm install -g --loglevel=error \
       axios cheerio zod dayjs lodash \
-      jsonwebtoken csv-parse axios-retry pg qs
+      jsonwebtoken csv-parse axios-retry pg qs yaml ajv ajv-formats
 
 # NODE_PATH covers require() but is never consulted for ESM import. Node instead
 # walks up from the script looking for node_modules, and a block runs from a
@@ -63,6 +63,7 @@ RUN install -D /etc/ssl/certs/ca-certificates.crt /usr/lib/ssl-certs/ca-bundle.c
 # above — /usr/lib/python3/dist-packages is on the default sys.path and is the
 # subtree the sandbox grants; /usr/local would be unreachable from a block.
 COPY cmd/codellm/fleetkit/fleetkit.py /usr/lib/python3/dist-packages/fleetkit.py
+COPY cmd/codellm/fleetkit/node /usr/lib/node_modules/fleetkit
 
 COPY --from=builder /codellm /codellm
 ENTRYPOINT ["/codellm"]

--- a/Dockerfile.codellm
+++ b/Dockerfile.codellm
@@ -58,5 +58,11 @@ RUN ln -s /usr/lib/node_modules /tmp/node_modules
 # read this copy instead via SSL_CERT_FILE/CURL_CA_BUNDLE/GIT_SSL_CAINFO.
 RUN install -D /etc/ssl/certs/ca-certificates.crt /usr/lib/ssl-certs/ca-bundle.crt
 
+# fleetkit: the {changes, answer} stdout contract and note rendering, so a role
+# note does not re-derive either. Same destination rule as the pip packages
+# above — /usr/lib/python3/dist-packages is on the default sys.path and is the
+# subtree the sandbox grants; /usr/local would be unreachable from a block.
+COPY cmd/codellm/fleetkit/fleetkit.py /usr/lib/python3/dist-packages/fleetkit.py
+
 COPY --from=builder /codellm /codellm
 ENTRYPOINT ["/codellm"]

--- a/cmd/codellm/README.md
+++ b/cmd/codellm/README.md
@@ -35,6 +35,44 @@ there, since `curl`, `git`, node and python all need them. Change a path here
 and you must change `Dockerfile.codellm` to match, or the guard silently drops
 the variable; `TestInterpretersJSON_ShippedEnv` pins the pair together.
 
+### fleetkit
+
+A block's contract with the fleet is one line of JSON on stdout —
+`{"changes": [...], "answer": "..."}`. `fleetkit` builds it, and the notes that
+go into it, so a role does not re-derive the shape or glue YAML by hand:
+
+```python
+import fleetkit
+
+meetings = ...
+changes = [
+    fleetkit.note('transcripts/%s.md' % m['id'], {'title': m['name']}, m['text'])
+    for m in meetings
+]
+fleetkit.emit(changes, 'ingested %d' % len(changes))
+```
+
+| Function | What it returns |
+|----------|-----------------|
+| `render(meta, body='')` | markdown: YAML frontmatter + body, quoting decided by `yaml.safe_dump` |
+| `note(path, meta, body='')` | a write change carrying a rendered note |
+| `write(path, content)` | a change that replaces the whole note |
+| `patch(path, find, replace)` | a change that swaps the first occurrence of `find` |
+| `emit(changes, answer)` | prints the stdout contract — call once, and last |
+| `bag()` | the delivery bag from `FLEET_INPUT`; `{}` outside a delivery |
+
+The source is `cmd/codellm/fleetkit/fleetkit.py`, installed to
+`/usr/lib/python3/dist-packages/fleetkit.py` by `Dockerfile.codellm` — on the
+default `sys.path` and inside the subtree the sandbox grants.
+
+**This is an API that role notes in user vaults import.** Those notes are not in
+this repo, have no build step and are not rolled back with the image, so a
+rename or a signature change breaks them at runtime with nothing to catch it
+first. `TestFleetkit_SourceExports` pins the exported names for that reason;
+add functions freely, change existing ones only deliberately.
+
+There is no Node equivalent yet — a node block still assembles the JSON itself.
+
 ### Python
 
 Installed into `/usr/lib/python3/dist-packages`.

--- a/cmd/codellm/README.md
+++ b/cmd/codellm/README.md
@@ -60,10 +60,36 @@ fleetkit.emit(changes, 'ingested %d' % len(changes))
 | `patch(path, find, replace)` | a change that swaps the first occurrence of `find` |
 | `emit(changes, answer)` | prints the stdout contract — call once, and last |
 | `bag()` | the delivery bag from `FLEET_INPUT`; `{}` outside a delivery |
+| `note_frontmatter(path)` | the frontmatter of a note in the bag; raises if the bag has no such path |
+| `parse_frontmatter(content)` | the frontmatter block of a markdown string; empty when there is none |
 
-The source is `cmd/codellm/fleetkit/fleetkit.py`, installed to
-`/usr/lib/python3/dist-packages/fleetkit.py` by `Dockerfile.codellm` — on the
-default `sys.path` and inside the subtree the sandbox grants.
+`note_frontmatter(path)` reads a note the delivery bag carries, so a lint role
+is plain code with no schema DSL to learn:
+
+```python
+data = fleetkit.note_frontmatter('calls/a.md')
+if not data.title:
+    issues.append('calls/a.md: no title')
+```
+
+A missing key reads as `None` (python) / `undefined` (node) rather than
+raising, so the `if` says what it looks like. A path the bag does not carry
+raises instead — that is the role's `attach_notes` being too narrow, not a
+finding about the note. Bring `jsonschema` or `zod` if you want a schema; the
+helper deliberately has no opinion.
+
+**Both languages, same names.** The twins are function-for-function identical
+and the node one keeps snake_case for that reason: a role moved between them
+should not have to relearn the API. `node` renders with YAML **version 1.1** to
+match PyYAML — not cosmetic, since under the 1.2 default a timestamp-shaped
+string is emitted bare and reads back as a timestamp, and `yes` reads back as
+`true`. `TestFleetkitRuns_EmitsTheContract` runs both and compares the parsed
+result.
+
+Sources are `cmd/codellm/fleetkit/fleetkit.py` and `cmd/codellm/fleetkit/node/`,
+installed by `Dockerfile.codellm` to `/usr/lib/python3/dist-packages/fleetkit.py`
+and `/usr/lib/node_modules/fleetkit` — on the default `sys.path` and where both
+`require` and `import` resolve, inside the subtree the sandbox grants.
 
 **This is an API that role notes in user vaults import.** Those notes are not in
 this repo, have no build step and are not rolled back with the image, so a
@@ -71,7 +97,6 @@ rename or a signature change breaks them at runtime with nothing to catch it
 first. `TestFleetkit_SourceExports` pins the exported names for that reason;
 add functions freely, change existing ones only deliberately.
 
-There is no Node equivalent yet — a node block still assembles the JSON itself.
 
 ### Python
 
@@ -89,6 +114,7 @@ Installed into `/usr/lib/python3/dist-packages`.
 | `tenacity` | Retry with exponential backoff against flaky APIs |
 | `pydantic` | Validate and reshape response JSON into typed models |
 | `pyyaml` | YAML configs, OpenAPI specs |
+| `jsonschema` | Validate frontmatter or an API response against a JSON Schema |
 | `tzdata` | Timezone database for `zoneinfo` — `/usr/share/zoneinfo` is denied by the sandbox |
 
 Not installed on purpose: `pandas`/`numpy` (~120 MB for work the `csv` module and
@@ -137,6 +163,8 @@ syntaxes and an ESM-only one does not.
 | `csv-parse` | CSV parsing, streaming or synchronous |
 | `axios-retry` | Retry policies layered onto axios |
 | `pg` | PostgreSQL client |
+| `yaml` | YAML parse/stringify; what `fleetkit` renders frontmatter with |
+| `ajv` / `ajv-formats` | JSON Schema validation, the node counterpart to `jsonschema` |
 | `qs` | Nested query-string parsing and serialization |
 
 Node 20 already provides `fetch`, `crypto.randomUUID()` and full ICU, so

--- a/cmd/codellm/fleetkit/fleetkit.py
+++ b/cmd/codellm/fleetkit/fleetkit.py
@@ -1,0 +1,76 @@
+"""fleetkit — helpers for the python blocks codellm executes.
+
+A block's whole contract with the fleet is one line of JSON on stdout:
+``{"changes": [...], "answer": "..."}``. These helpers build that line, and the
+markdown notes that go into it, so a role note does not re-derive either and
+does not glue YAML together by hand.
+
+Dockerfile.codellm installs this module on python's default sys.path
+(/usr/lib/python3/dist-packages), inside the subtree landlock grants read-only,
+so every block can just ``import fleetkit``.
+
+    import fleetkit
+
+    fleetkit.emit(
+        [fleetkit.note('calls/2026-01-15.md', {'title': 'Q1 planning'}, '# Q1\n')],
+        'wrote 1 note',
+    )
+"""
+
+import json
+import os
+
+import yaml
+
+__all__ = ["render", "note", "write", "patch", "emit", "bag"]
+
+
+def render(meta, body=""):
+    """Render a note: YAML frontmatter, then body.
+
+    yaml.safe_dump decides the quoting, so a title carrying a colon, a quote or
+    a leading digit survives instead of producing frontmatter that parses as
+    something else entirely. Key order is kept as given, not sorted.
+    """
+    if not meta:
+        return body
+    front = yaml.safe_dump(meta, sort_keys=False, allow_unicode=True).rstrip()
+    return "---\n" + front + "\n---\n" + body
+
+
+def write(path, content):
+    """A change that replaces the whole note at path."""
+    return {"path": path, "content": content}
+
+
+def note(path, meta, body=""):
+    """A change that writes a rendered note — write(path, render(meta, body))."""
+    return write(path, render(meta, body))
+
+
+def patch(path, find, replace):
+    """A change that swaps the first occurrence of find for replace."""
+    return {"path": path, "find": find, "replace": replace}
+
+
+def emit(changes=(), answer=""):
+    """Print the stdout contract.
+
+    Call once, and last: codellm parses the stdout of the final block, so an
+    earlier print of anything else takes its place and fails the run.
+    """
+    print(json.dumps({"changes": list(changes), "answer": answer}))
+
+
+def bag():
+    """The delivery bag codellm exposes through FLEET_INPUT.
+
+    Carries changed_files, change_file, attached_notes and depth (see
+    internal/fleetinput). Returns {} when the block runs outside a delivery,
+    so `for c in fleetkit.bag().get('changed_files', [])` is safe either way.
+    """
+    path = os.environ.get("FLEET_INPUT")
+    if not path:
+        return {}
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)

--- a/cmd/codellm/fleetkit/fleetkit.py
+++ b/cmd/codellm/fleetkit/fleetkit.py
@@ -22,7 +22,7 @@ import os
 
 import yaml
 
-__all__ = ["render", "note", "write", "patch", "emit", "bag"]
+__all__ = ["render", "note", "write", "patch", "emit", "bag", "note_frontmatter"]
 
 
 def render(meta, body=""):
@@ -60,6 +60,46 @@ def emit(changes=(), answer=""):
     earlier print of anything else takes its place and fails the run.
     """
     print(json.dumps({"changes": list(changes), "answer": answer}))
+
+
+class Frontmatter(dict):
+    """A frontmatter mapping whose missing keys read as None.
+
+    So `if not data.title` says what it looks like instead of raising, and
+    matches what the node twin gets from a plain object for free. Still a dict:
+    data["title"], data.get("title") and **data all work.
+    """
+
+    def __getattr__(self, name):
+        return self.get(name)
+
+
+def note_frontmatter(path):
+    """Parse the frontmatter of a note the delivery bag carries.
+
+    A block has no vault filesystem — notes arrive in the bag, so this looks
+    `path` up among attached_notes and changed_files. A path the bag does not
+    carry is a role misconfiguration, not a finding, so it raises rather than
+    reading as a note with no fields.
+    """
+    for key in ("attached_notes", "changed_files"):
+        for entry in bag().get(key) or []:
+            if entry.get("path") == path:
+                return parse_frontmatter(entry.get("content") or "")
+    raise KeyError(
+        "note %r is not in the delivery bag; widen the role's attach_notes to cover it" % path
+    )
+
+
+def parse_frontmatter(content):
+    """The frontmatter block of a markdown string, or empty when there is none."""
+    if not content.startswith("---\n"):
+        return Frontmatter()
+    end = content.find("\n---", 3)
+    if end < 0:
+        return Frontmatter()
+    loaded = yaml.safe_load(content[4:end])
+    return Frontmatter(loaded if isinstance(loaded, dict) else {})
 
 
 def bag():

--- a/cmd/codellm/fleetkit/node/index.js
+++ b/cmd/codellm/fleetkit/node/index.js
@@ -1,0 +1,92 @@
+// fleetkit — helpers for the node blocks codellm executes.
+//
+// The twin of cmd/codellm/fleetkit/fleetkit.py, deliberately function-for-
+// function and name-for-name identical: a role moved between the two languages
+// should not have to relearn the API, so the names stay snake_case here rather
+// than turning camelCase.
+//
+// A block's whole contract with the fleet is one line of JSON on stdout:
+// {"changes": [...], "answer": "..."}. These build it, and the notes that go
+// into it, so a role does not re-derive either.
+//
+//   const fleetkit = require('fleetkit');   // import works too
+//   fleetkit.emit([fleetkit.note('a.md', {title: 'T'}, '# T\n')], 'wrote 1');
+
+const fs = require('fs');
+const YAML = require('yaml');
+
+/**
+ * Render a note: YAML frontmatter, then body. Key order is kept as given.
+ *
+ * version 1.1 matches PyYAML, which the python twin uses, and it is not
+ * cosmetic: under the library's 1.2 default a timestamp-shaped string is
+ * emitted bare and reads back as a timestamp, and 'yes' reads back as true.
+ * The two twins have to write the same note for the same input.
+ */
+function render(meta, body = '') {
+  if (!meta || Object.keys(meta).length === 0) return body;
+  const front = YAML.stringify(meta, { version: '1.1' }).replace(/\n$/, '');
+  return '---\n' + front + '\n---\n' + body;
+}
+
+/** A change that replaces the whole note at path. */
+function write(path, content) {
+  return { path, content };
+}
+
+/** A change that writes a rendered note — write(path, render(meta, body)). */
+function note(path, meta, body = '') {
+  return write(path, render(meta, body));
+}
+
+/** A change that swaps the first occurrence of find for replace. */
+function patch(path, find, replace) {
+  return { path, find, replace };
+}
+
+/**
+ * Print the stdout contract. Call once, and last: codellm parses the stdout of
+ * the final block, so printing anything else after it fails the run.
+ */
+function emit(changes = [], answer = '') {
+  console.log(JSON.stringify({ changes: Array.from(changes), answer }));
+}
+
+/**
+ * The delivery bag codellm exposes through FLEET_INPUT: changed_files,
+ * change_file, attached_notes, depth. Empty object outside a delivery.
+ */
+function bag() {
+  const path = process.env.FLEET_INPUT;
+  if (!path) return {};
+  return JSON.parse(fs.readFileSync(path, 'utf8'));
+}
+
+/** The frontmatter block of a markdown string, or {} when there is none. */
+function parse_frontmatter(content) {
+  if (!content.startsWith('---\n')) return {};
+  const end = content.indexOf('\n---', 3);
+  if (end < 0) return {};
+  const loaded = YAML.parse(content.slice(4, end), { version: '1.1' });
+  return loaded && typeof loaded === 'object' && !Array.isArray(loaded) ? loaded : {};
+}
+
+/**
+ * Parse the frontmatter of a note the delivery bag carries. A block has no
+ * vault filesystem, so this looks path up among attached_notes and
+ * changed_files. A path the bag does not carry is a role misconfiguration, not
+ * a finding, so it throws rather than reading as a note with no fields.
+ */
+function note_frontmatter(path) {
+  const b = bag();
+  for (const key of ['attached_notes', 'changed_files']) {
+    for (const entry of b[key] || []) {
+      if (entry.path === path) return parse_frontmatter(entry.content || '');
+    }
+  }
+  throw new Error(
+    `note '${path}' is not in the delivery bag; widen the role's attach_notes to cover it`,
+  );
+}
+
+module.exports = { render, note, write, patch, emit, bag, note_frontmatter, parse_frontmatter };

--- a/cmd/codellm/fleetkit/node/package.json
+++ b/cmd/codellm/fleetkit/node/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "fleetkit",
+  "version": "1.0.0",
+  "description": "Helpers for the node blocks codellm executes: note rendering and the {changes, answer} stdout contract.",
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/cmd/codellm/internal/coderun/fleetkit_behaviour_test.go
+++ b/cmd/codellm/internal/coderun/fleetkit_behaviour_test.go
@@ -1,0 +1,259 @@
+package coderun
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// The static pins in fleetkit_test.go only read the source. These run it: both
+// twins are executed by their real interpreter, so a helper that parses, quotes
+// or emits wrongly fails here rather than inside a delivery.
+//
+// Under FLEET_SANDBOX_MUST_ENFORCE=1 a missing interpreter or YAML package is a
+// hard failure, matching the sandbox tests — otherwise CI could go green on
+// tests that never ran.
+
+func fleetkitSrc(t *testing.T, rel string) string {
+	t.Helper()
+
+	abs, err := filepath.Abs(filepath.Join("..", "..", "fleetkit", rel))
+	require.NoError(t, err)
+	return abs
+}
+
+// runPython executes src with the python fleetkit on PYTHONPATH.
+func runPython(t *testing.T, src string) string {
+	t.Helper()
+
+	exe, err := exec.LookPath("python3")
+	if err != nil {
+		skipOrFail(t, "python3 not installed: %v", err)
+	}
+	return run(t, exe, t.TempDir(), "probe.py", src,
+		[]string{"PYTHONPATH=" + fleetkitSrc(t, "")})
+}
+
+// runNode executes src against the node fleetkit. Dockerfile.codellm installs
+// the module as .../node_modules/fleetkit, so the test reproduces that name:
+// the source directory is called "node", and resolution keys on the directory
+// name, not on what is inside it. yaml is linked in beside it because the
+// module imports it, exactly as the image's global install provides it.
+func runNode(t *testing.T, src string) string {
+	t.Helper()
+
+	exe, err := exec.LookPath("node")
+	if err != nil {
+		skipOrFail(t, "node not installed: %v", err)
+	}
+
+	dir := t.TempDir()
+	mods := filepath.Join(dir, "node_modules")
+	require.NoError(t, os.MkdirAll(mods, 0o755))
+	require.NoError(t, os.Symlink(fleetkitSrc(t, "node"), filepath.Join(mods, "fleetkit")))
+
+	yamlDir := findNodeYAML(t, exe)
+	require.NoError(t, os.Symlink(yamlDir, filepath.Join(mods, "yaml")))
+
+	return run(t, exe, dir, "probe.js", src, nil)
+}
+
+// findNodeYAML locates the yaml package the node twin imports. The runtime
+// image installs it globally; a checkout may have it under node_modules. Not
+// finding it is a skip locally and a hard failure in the enforcing lane, so CI
+// cannot report green on a twin that never ran.
+func findNodeYAML(t *testing.T, nodeExe string) string {
+	t.Helper()
+
+	candidates := []string{}
+	if repo, err := filepath.Abs(filepath.Join("..", "..", "..", "..", "node_modules", "yaml")); err == nil {
+		candidates = append(candidates, repo)
+	}
+	if out, err := exec.Command(filepath.Join(filepath.Dir(nodeExe), "npm"), "root", "-g").Output(); err == nil {
+		candidates = append(candidates, filepath.Join(strings.TrimSpace(string(out)), "yaml"))
+	}
+	for _, dir := range candidates {
+		if _, err := os.Stat(dir); err == nil {
+			return dir
+		}
+	}
+	skipOrFail(t, "node yaml package not found in %v; npm i -g yaml", candidates)
+	return ""
+}
+
+// run writes src into dir and executes it, returning combined output.
+func run(t *testing.T, exe, dir, name, src string, env []string) string {
+	t.Helper()
+
+	file := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(file, []byte(src), 0o600))
+
+	cmd := exec.Command(exe, file)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), env...)
+	out, err := cmd.CombinedOutput()
+	if err != nil && strings.Contains(string(out), "yaml") {
+		skipOrFail(t, "%s has no yaml package: %s", exe, strings.TrimSpace(string(out)))
+	}
+	require.NoError(t, err, "helper run failed: %s", out)
+	return string(out)
+}
+
+// parseFrontmatterYAML reads the frontmatter block back with the repo's YAML
+// library — the same one that parses a note after it is written.
+func parseFrontmatterYAML(t *testing.T, content string) map[string]any {
+	t.Helper()
+
+	require.True(t, strings.HasPrefix(content, "---\n"), "no frontmatter: %q", content)
+	end := strings.Index(content[3:], "\n---")
+	require.GreaterOrEqual(t, end, 0, "unterminated frontmatter: %q", content)
+
+	var out map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(content[4:end+3]), &out))
+	return out
+}
+
+// emitted is the stdout contract both twins must produce.
+type emitted struct {
+	Changes []map[string]string `json:"changes"`
+	Answer  string              `json:"answer"`
+}
+
+func decodeEmitted(t *testing.T, stdout string) emitted {
+	t.Helper()
+
+	var got emitted
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(stdout)), &got), "stdout: %q", stdout)
+	return got
+}
+
+const pyProbe = `
+import fleetkit
+fleetkit.emit([
+    fleetkit.note("a.md", {"title": "T: q", "created_at": "2026-01-15T10:00:00+00:00",
+                           "truthy": "yes", "padded": "007"}, "# T\n"),
+    fleetkit.patch("b.md", "old", "new"),
+], "done")
+`
+
+const jsProbe = `
+const fleetkit = require('fleetkit');
+fleetkit.emit([
+  fleetkit.note('a.md', {title: 'T: q', created_at: '2026-01-15T10:00:00+00:00',
+                         truthy: 'yes', padded: '007'}, '# T\n'),
+  fleetkit.patch('b.md', 'old', 'new'),
+], 'done');
+`
+
+// TestFleetkitRuns_EmitsTheContract runs both twins and holds them to the same
+// output: the awkward title quoted, the timestamp kept a string, and a patch
+// distinguishable from a write by which keys are present.
+func TestFleetkitRuns_EmitsTheContract(t *testing.T) {
+	cases := []struct {
+		name string
+		run  func(*testing.T, string) string
+		src  string
+	}{
+		{"python", runPython, pyProbe},
+		{"node", runNode, jsProbe},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decodeEmitted(t, tc.run(t, tc.src))
+
+			require.Equal(t, "done", got.Answer)
+			require.Len(t, got.Changes, 2)
+
+			require.Equal(t, "a.md", got.Changes[0]["path"])
+			content := got.Changes[0]["content"]
+			require.True(t, strings.HasPrefix(content, "---\n"), "content: %q", content)
+			require.True(t, strings.HasSuffix(content, "---\n# T\n"), "content: %q", content)
+
+			// Assert the meaning, not the quote character: the twins pick
+			// different quoting and both are valid YAML. What must hold is that
+			// a colon title and a timestamp-shaped value survive as strings —
+			// emitted bare, the latter reads back as a timestamp instead.
+			require.Equal(t,
+				map[string]any{
+					"title": "T: q", "created_at": "2026-01-15T10:00:00+00:00",
+					// 'yes' and '007' are where the twins drifted: emitted bare
+					// they read back as a boolean and an int.
+					"truthy": "yes", "padded": "007",
+				},
+				parseFrontmatterYAML(t, content))
+
+			require.Equal(t, "b.md", got.Changes[1]["path"])
+			require.Equal(t, "old", got.Changes[1]["find"])
+			require.Equal(t, "new", got.Changes[1]["replace"])
+			require.NotContains(t, got.Changes[1], "content", "a patch must not carry content")
+
+			// The emitted JSON is what the real parser consumes, so close the loop.
+			parsed, answer, err := ParseCodeOutput(strings.TrimSpace(tc.run(t, tc.src)))
+			require.NoError(t, err)
+			require.Equal(t, "done", answer)
+			require.Len(t, parsed, 2)
+		})
+	}
+}
+
+const pyFrontmatter = `
+import json, fleetkit
+cases = {
+    "plain":    fleetkit.parse_frontmatter("---\ntitle: T\ntags: [a, b]\n---\n# body\n"),
+    "none":     fleetkit.parse_frontmatter("# just a body\n"),
+    "unclosed": fleetkit.parse_frontmatter("---\ntitle: T\n"),
+    "notadict": fleetkit.parse_frontmatter("---\n- a\n- b\n---\nbody"),
+}
+missing = cases["plain"].nope
+print(json.dumps({"cases": {k: dict(v) for k, v in cases.items()}, "missing": missing}))
+`
+
+const jsFrontmatter = `
+const fleetkit = require('fleetkit');
+const cases = {
+  plain:    fleetkit.parse_frontmatter('---\ntitle: T\ntags: [a, b]\n---\n# body\n'),
+  none:     fleetkit.parse_frontmatter('# just a body\n'),
+  unclosed: fleetkit.parse_frontmatter('---\ntitle: T\n'),
+  notadict: fleetkit.parse_frontmatter('---\n- a\n- b\n---\nbody'),
+};
+console.log(JSON.stringify({cases, missing: cases.plain.nope ?? null}));
+`
+
+// TestFleetkitRuns_ParseFrontmatter pins the parse half, including the shapes
+// that are not a mapping: a lint role iterating a vault meets all of them, and
+// any of them raising would take the whole delivery down.
+func TestFleetkitRuns_ParseFrontmatter(t *testing.T) {
+	cases := []struct {
+		name string
+		run  func(*testing.T, string) string
+		src  string
+	}{
+		{"python", runPython, pyFrontmatter},
+		{"node", runNode, jsFrontmatter},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got struct {
+				Cases   map[string]map[string]any `json:"cases"`
+				Missing any                       `json:"missing"`
+			}
+			out := tc.run(t, tc.src)
+			require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &got), "stdout: %q", out)
+
+			require.Equal(t, "T", got.Cases["plain"]["title"])
+			require.Equal(t, []any{"a", "b"}, got.Cases["plain"]["tags"])
+			require.Empty(t, got.Cases["none"], "a note with no frontmatter yields no fields")
+			require.Empty(t, got.Cases["unclosed"], "an unterminated block yields no fields")
+			require.Empty(t, got.Cases["notadict"], "a non-mapping document yields no fields")
+			require.Nil(t, got.Missing, "a missing key must read as empty, not raise")
+		})
+	}
+}

--- a/cmd/codellm/internal/coderun/fleetkit_test.go
+++ b/cmd/codellm/internal/coderun/fleetkit_test.go
@@ -1,0 +1,81 @@
+package coderun
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trip2g/internal/webhookutil"
+)
+
+// fleetkitDest is where Dockerfile.codellm must install the helper module: on
+// python's default sys.path AND inside the /usr/lib subtree landlock grants.
+const fleetkitDest = "/usr/lib/python3/dist-packages/fleetkit.py"
+
+func repoFile(t *testing.T, rel string) string {
+	t.Helper()
+
+	body, err := os.ReadFile(filepath.Join("..", "..", "..", "..", rel))
+	require.NoError(t, err)
+	return string(body)
+}
+
+// TestFleetkit_ShippedToSandboxPath pins the Dockerfile against the sandbox:
+// the helper is worthless if it lands somewhere a block cannot import, and
+// /usr/local is denied exactly like the pip packages above it.
+func TestFleetkit_ShippedToSandboxPath(t *testing.T) {
+	dockerfile := repoFile(t, "Dockerfile.codellm")
+
+	require.Contains(t, dockerfile, fleetkitDest,
+		"Dockerfile.codellm must install fleetkit on the default sys.path under /usr/lib")
+	require.Contains(t, dockerfile, "cmd/codellm/fleetkit/fleetkit.py",
+		"the module must be COPYed from its source in the repo")
+}
+
+// TestFleetkit_SourceExports pins the helper's surface. Role notes live in user
+// vaults outside this repo, so removing or renaming one of these breaks them at
+// runtime with nothing to catch it first.
+func TestFleetkit_SourceExports(t *testing.T) {
+	src := repoFile(t, "cmd/codellm/fleetkit/fleetkit.py")
+
+	for _, fn := range []string{"render", "note", "write", "patch", "emit", "bag"} {
+		require.Contains(t, src, "def "+fn+"(",
+			"fleetkit must keep exporting %q — vault role notes depend on it", fn)
+	}
+}
+
+// TestFleetkit_EmitParsesAsTheContract feeds what emit() prints back through the
+// real parser. The helper exists to stop roles re-deriving this shape, so the
+// two must be pinned to each other.
+func TestFleetkit_EmitParsesAsTheContract(t *testing.T) {
+	// Verbatim stdout of:
+	//   emit([note("a.md", {"title": "T: q"}, "# T\n"), patch("b.md", "x", "y")], "done")
+	const stdout = `{"changes": [{"path": "a.md", "content": "---\ntitle: 'T: q'\n---\n# T\n"}, ` +
+		`{"path": "b.md", "find": "x", "replace": "y"}], "answer": "done"}`
+
+	changes, answer, err := ParseCodeOutput(stdout)
+	require.NoError(t, err)
+	require.Equal(t, "done", answer)
+	require.Len(t, changes, 2)
+
+	require.Equal(t, webhookutil.AgentChangeKindWrite, changes[0].Kind)
+	require.Equal(t, "a.md", changes[0].Path)
+	require.True(t, strings.HasPrefix(changes[0].Content, "---\ntitle: 'T: q'\n---\n"),
+		"render() must quote a title carrying a colon, got: %q", changes[0].Content)
+
+	require.Equal(t, webhookutil.AgentChangeKindPatch, changes[1].Kind)
+	require.Equal(t, "x", changes[1].Find)
+	require.Equal(t, "y", changes[1].Replace)
+}
+
+// TestFleetkit_EmptyEmitIsValid: a role that decides there is nothing to write
+// must still produce parseable stdout rather than an empty run.
+func TestFleetkit_EmptyEmitIsValid(t *testing.T) {
+	changes, answer, err := ParseCodeOutput(`{"changes": [], "answer": "nothing to do"}`)
+	require.NoError(t, err)
+	require.Empty(t, changes)
+	require.Equal(t, "nothing to do", answer)
+}

--- a/cmd/codellm/internal/coderun/fleetkit_test.go
+++ b/cmd/codellm/internal/coderun/fleetkit_test.go
@@ -13,7 +13,20 @@ import (
 
 // fleetkitDest is where Dockerfile.codellm must install the helper module: on
 // python's default sys.path AND inside the /usr/lib subtree landlock grants.
-const fleetkitDest = "/usr/lib/python3/dist-packages/fleetkit.py"
+const (
+	fleetkitPyDest   = "/usr/lib/python3/dist-packages/fleetkit.py"
+	fleetkitNodeDest = "/usr/lib/node_modules/fleetkit"
+)
+
+// fleetkitAPI is the surface role notes import. Vault notes are outside this
+// repo, have no build step and are not rolled back with the image, so removing
+// or renaming one of these breaks them at runtime with nothing to catch it.
+func fleetkitAPI() []string {
+	return []string{
+		"render", "note", "write", "patch", "emit", "bag",
+		"note_frontmatter", "parse_frontmatter",
+	}
+}
 
 func repoFile(t *testing.T, rel string) string {
 	t.Helper()
@@ -29,10 +42,42 @@ func repoFile(t *testing.T, rel string) string {
 func TestFleetkit_ShippedToSandboxPath(t *testing.T) {
 	dockerfile := repoFile(t, "Dockerfile.codellm")
 
-	require.Contains(t, dockerfile, fleetkitDest,
+	require.Contains(t, dockerfile, fleetkitPyDest,
 		"Dockerfile.codellm must install fleetkit on the default sys.path under /usr/lib")
 	require.Contains(t, dockerfile, "cmd/codellm/fleetkit/fleetkit.py",
 		"the module must be COPYed from its source in the repo")
+
+	// NODE_PATH covers require(); the /tmp/node_modules symlink covers import.
+	// Both resolve through /usr/lib/node_modules, so the twin must land there.
+	require.Contains(t, dockerfile, fleetkitNodeDest,
+		"the node twin must install where NODE_PATH and the ESM symlink both resolve")
+	require.Contains(t, dockerfile, "cmd/codellm/fleetkit/node",
+		"the node twin must be COPYed from its source in the repo")
+}
+
+// TestFleetkit_TwinsAreSymmetric holds the two halves to the same surface. The
+// point of the node twin is that a role moving between languages keeps the same
+// calls, so a function added to one and forgotten in the other is a defect.
+func TestFleetkit_TwinsAreSymmetric(t *testing.T) {
+	py := repoFile(t, "cmd/codellm/fleetkit/fleetkit.py")
+	js := repoFile(t, "cmd/codellm/fleetkit/node/index.js")
+
+	for _, fn := range fleetkitAPI() {
+		require.Contains(t, py, "def "+fn+"(", "python fleetkit must export %q", fn)
+		require.Contains(t, js, "function "+fn+"(", "node fleetkit must export %q", fn)
+		require.Contains(t, js, fn, "node fleetkit must include %q in module.exports", fn)
+	}
+}
+
+// TestFleetkit_ToolboxPinsValidators pins the validator packages against the
+// README that advertises them: a block importing one that was dropped from the
+// image fails at runtime inside a delivery.
+func TestFleetkit_ToolboxPinsValidators(t *testing.T) {
+	dockerfile := repoFile(t, "Dockerfile.codellm")
+
+	require.Contains(t, dockerfile, "jsonschema", "python needs a JSON Schema validator")
+	require.Contains(t, dockerfile, "ajv", "node needs a JSON Schema validator")
+	require.Contains(t, dockerfile, " yaml", "the node twin needs a YAML package")
 }
 
 // TestFleetkit_SourceExports pins the helper's surface. Role notes live in user
@@ -41,7 +86,7 @@ func TestFleetkit_ShippedToSandboxPath(t *testing.T) {
 func TestFleetkit_SourceExports(t *testing.T) {
 	src := repoFile(t, "cmd/codellm/fleetkit/fleetkit.py")
 
-	for _, fn := range []string{"render", "note", "write", "patch", "emit", "bag"} {
+	for _, fn := range fleetkitAPI() {
 		require.Contains(t, src, "def "+fn+"(",
 			"fleetkit must keep exporting %q — vault role notes depend on it", fn)
 	}

--- a/scripts/test-codellm-sandbox.sh
+++ b/scripts/test-codellm-sandbox.sh
@@ -172,6 +172,31 @@ ANSWER = "ok" if ok else "bad=" + repr(lines[:3])
 import fleetkit
 ANSWER = "empty" if fleetkit.bag() == {} else "unexpected"
 ''' + EMIT_PY, lambda a: a == "empty"),
+
+    # The node twin ships in the same image and must resolve the same way the
+    # other global packages do.
+    ("fleetkit node twin renders identically", "node", """
+const fleetkit = require('fleetkit');
+const c = fleetkit.note('a.md', {title: 'T: q', when: '2026-01-15T10:00:00+00:00'}, '# T').content;
+const want = ['---', 'title: "T: q"', 'when: "2026-01-15T10:00:00+00:00"', '---', '# T'].join(String.fromCharCode(10));
+console.log(JSON.stringify({changes: [], answer: c === want ? 'ok' : 'bad=' + JSON.stringify(c)}));
+""", lambda a: a == "ok"),
+
+    ("python jsonschema and node ajv import", "python", '''
+import jsonschema
+jsonschema.validate({"a": 1}, {"type": "object", "required": ["a"]})
+try:
+    jsonschema.validate({}, {"type": "object", "required": ["a"]})
+    ANSWER = "missing-required-not-caught"
+except jsonschema.ValidationError:
+    ANSWER = "ok"
+''' + EMIT_PY, lambda a: a == "ok"),
+
+    ("node ajv validates", "node", """
+const Ajv = require('ajv');
+const ok = new Ajv().compile({type: 'object', required: ['a']})({a: 1});
+console.log(JSON.stringify({changes: [], answer: ok ? 'ok' : 'bad'}));
+""", lambda a: a == "ok"),
 ]
 
 failed = 0

--- a/scripts/test-codellm-sandbox.sh
+++ b/scripts/test-codellm-sandbox.sh
@@ -156,6 +156,22 @@ jq -nc --arg r "$r" '{changes: [], answer: $r}'
 if [ -z "$FLEET_SANDBOX_SENTINEL" ]; then r=absent; else r=LEAKED; fi
 jq -nc --arg r "$r" '{changes: [], answer: $r}'
 ''', lambda a: a == "absent"),
+
+    # fleetkit is shipped by the same Dockerfile and must be importable under the
+    # enforcing sandbox, not just with CODELLM_SANDBOX=off.
+    ("fleetkit imports and renders", "python", """
+import fleetkit
+n = fleetkit.note("a.md", {"title": "T: q"}, "# T")
+lines = n["content"].split(chr(10))
+q = chr(39)
+ok = lines[0] == "---" and lines[1] == "title: " + q + "T: q" + q and lines[2] == "---"
+ANSWER = "ok" if ok else "bad=" + repr(lines[:3])
+""" + EMIT_PY, lambda a: a == "ok"),
+
+    ("fleetkit bag is empty outside a delivery", "python", '''
+import fleetkit
+ANSWER = "empty" if fleetkit.bag() == {} else "unexpected"
+''' + EMIT_PY, lambda a: a == "empty"),
 ]
 
 failed = 0


### PR DESCRIPTION
A code block's whole contract with the fleet is one line of JSON on stdout — `{"changes": [...], "answer": "..."}`. Every role re-derived it by hand, and built its markdown by gluing YAML strings. `fleetkit` does both.

```python
import fleetkit

fleetkit.emit(
    [fleetkit.note('transcripts/%s.md' % mid, {'title': name}, text)],
    'ingested 1',
)
```

| Function | Returns |
|----------|---------|
| `render(meta, body='')` | YAML frontmatter + body, quoting decided by `yaml.safe_dump` |
| `note(path, meta, body='')` | a write change carrying a rendered note |
| `write(path, content)` | a change replacing the whole note |
| `patch(path, find, replace)` | a change swapping the first occurrence of `find` |
| `emit(changes, answer)` | prints the stdout contract |
| `bag()` | the delivery bag from `FLEET_INPUT`; `{}` outside a delivery |

Source is `cmd/codellm/fleetkit/fleetkit.py`, installed to `/usr/lib/python3/dist-packages/fleetkit.py` — the same destination rule as the pip packages, since `/usr/local` is unreachable from a sandboxed block.

## The cost this takes on, stated plainly

This is an API imported by role notes that live **in user vaults, outside this repo**. They have no build step, no CI, and are not rolled back with the image, so a rename or a signature change breaks them at runtime with nothing to catch it first. `TestFleetkit_SourceExports` pins the exported names, and the README says the same: add functions freely, change existing ones deliberately.

## Tests

- `TestFleetkit_ShippedToSandboxPath` pins Dockerfile ↔ sandbox path, in the spirit of `TestInterpretersJSON_ShippedEnv` — a helper installed where landlock denies reads is worthless.
- `TestFleetkit_SourceExports` pins the six exported names.
- `TestFleetkit_EmitParsesAsTheContract` feeds `emit()`'s verbatim stdout through the real `ParseCodeOutput`, asserting write vs patch kinds and that a `T: q` title comes back quoted. The golden string was taken from an actual run, not written by hand.
- Two new checks in `scripts/test-codellm-sandbox.sh`, so the module is exercised under `CODELLM_SANDBOX=native`, not only with the sandbox off.

## Verified

`go test ./...` and `make lint` green. Image built from this branch and exercised twice:

- `CODELLM_SANDBOX=off`: a block importing fleetkit returned `write_note` with `---\ntitle: 'Q1: "planning"'\ncreated_at: '2026-01-15T10:00:00+00:00'\n---\n# Q1\n`, a `patch_note`, and `finish` with `bag={} wrote=2` — both awkward scalars quoted correctly.
- `CODELLM_SANDBOX=native` via `scripts/test-codellm-sandbox.sh`: **all 12 checks passed**, the two fleetkit ones included.

## Not covered

No Node equivalent — a node block still assembles the JSON itself. The README says so rather than leaving it implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update: node twin, note_frontmatter, Node 24, JSON Schema

**The twins are symmetric** — function-for-function and name-for-name, so the node one keeps snake_case: a role moved between languages should not relearn the API. Source in `cmd/codellm/fleetkit/node/`, installed to `/usr/lib/node_modules/fleetkit` where both `require` and `import` resolve.

**Writing the twin immediately produced a real bug, which is the argument for testing it.** Under the `yaml` package's 1.2 default, node emitted `created_at: 2026-01-15T10:00:00+00:00` **bare** — it reads back as a timestamp, not the string PyYAML produces — and `yes` bare, which reads back as boolean `true`. The same role written in the two languages produced semantically different notes. Both `render` and `parse_frontmatter` now pin YAML **1.1**, matching PyYAML.

**`note_frontmatter(path)` / `parse_frontmatter(content)`** — no schema argument. A missing key reads as `None`/`undefined` so `if not data.title` says what it looks like; a path the bag does not carry raises and names `attach_notes`, because that is the role scoped too narrowly rather than a finding about a note. Anyone wanting a schema brings `jsonschema` or `zod`.

**Node 20 → 24 LTS** (Krypton), plus `yaml`, `ajv`, `ajv-formats` on the node side and `jsonschema` on the python side.

### Tests that actually run

The earlier pins only read source. `fleetkit_behaviour_test.go` executes both modules through their real interpreters and compares the **parsed** frontmatter, not the byte form — the twins pick different quote characters and both are valid, so asserting bytes would have been wrong while missing the 1.1/1.2 difference that mattered. `'yes'` and `'007'` are in the fixture precisely because that is where they drifted.

The CI sandbox lane now installs `python3-yaml`, `nodejs`, `npm` and a global `yaml`, so these run there instead of skipping — and `FLEET_SANDBOX_MUST_ENFORCE=1` turns a skip into a hard failure, so a missing package fails the build rather than reporting green.

### Verified

- `go test ./...` and `make lint` green.
- **CI lane reproduced locally**, byte-for-byte the command in `ci.yml`, under `--privileged` with `MUST_ENFORCE=1`: `ok trip2g/cmd/codellm/internal/coderun 39.418s`, nothing skipped.
- Image rebuilt: **Node v24.19.0**, `fleetkit` resolving alongside the other globals, `jsonschema` 4.26.0.
- `scripts/test-codellm-sandbox.sh` under `CODELLM_SANDBOX=native`: **all 15 checks passed** — the ten pre-existing ones on Node 24, which is what has to prove the bump, plus five new ones covering both twins and both validators.
