### PR TITLE
feat(metrics): fleet and codellm expose prometheus on a loopback internal listener

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,7 @@ Read the relevant doc before working in that area. Docs are partially outdated (
 | `config_refactoring.md` | Config refactoring plan |
 | `multidomain.md` | Multi-domain routing |
 | `simplebackup.md` | Simple backup system |
+| `fleet_codellm_metrics.md` | fleet/codellm Prometheus metrics: second listener, metric catalog, what to alert on |
 | `sitemap.md` | Sitemap.xml generation |
 | `rss.md` | RSS feed |
 | `vector_search.md` | Vector search (OpenAI embeddings) |

--- a/cmd/codellm/README.md
+++ b/cmd/codellm/README.md
@@ -266,8 +266,9 @@ curl -s http://127.0.0.1:18087/metrics | grep '^codellm_'
 The block series carry what a stability check needs: outcome and real exit code
 per interpreter (`codellm_blocks_total`, `codellm_block_exit_codes_total`),
 duration and peak RSS, stdout size plus a truncation counter, and
-`codellm_exec_errors_total{kind}` for failures that never reached a child
-(unknown fence, disallowed program, sandbox refused). `codellm_sandbox_fallbacks_total`
-is the one to watch: it means a `besteffort` policy ran code unsandboxed.
+`codellm_exec_errors_total{kind}`, which classifies every failed run — from a
+disallowed program that never reached a child to a timeout or an unparseable
+stdout. `codellm_sandbox_fallbacks_total` is the one to watch: it means a
+`besteffort` policy ran code unsandboxed.
 
 Full catalog, the fleet's side, and what to alert on: `docs/dev/fleet_codellm_metrics.md`.

--- a/cmd/codellm/README.md
+++ b/cmd/codellm/README.md
@@ -252,3 +252,22 @@ are silently weaker while namespaces still apply. Verify the host supports it
 
 Verify a deployment with `scripts/test-codellm-sandbox.sh`, which checks both
 that the toolbox works and that the denials still hold.
+
+## Metrics
+
+A second, loopback-only listener serves Prometheus, pprof and the probes
+(`--metrics-addr` / `CODELLM_METRICS_ADDR`, default `127.0.0.1:18087`; empty
+disables it). Nothing on that port is authenticated — never bind it off-box.
+
+```bash
+curl -s http://127.0.0.1:18087/metrics | grep '^codellm_'
+```
+
+The block series carry what a stability check needs: outcome and real exit code
+per interpreter (`codellm_blocks_total`, `codellm_block_exit_codes_total`),
+duration and peak RSS, stdout size plus a truncation counter, and
+`codellm_exec_errors_total{kind}` for failures that never reached a child
+(unknown fence, disallowed program, sandbox refused). `codellm_sandbox_fallbacks_total`
+is the one to watch: it means a `besteffort` policy ran code unsandboxed.
+
+Full catalog, the fleet's side, and what to alert on: `docs/dev/fleet_codellm_metrics.md`.

--- a/cmd/codellm/appconfig/config.go
+++ b/cmd/codellm/appconfig/config.go
@@ -31,7 +31,7 @@ type Config struct {
 
 	// MetricsAddr is the internal listener: Prometheus /metrics, pprof, and the
 	// liveness/readiness probes. Loopback by default and unauthenticated, exactly
-	// like the monolith's internal listener — never expose it. Empty disables it.
+	// like the monolith's internal listener. Empty disables it.
 	MetricsAddr string
 
 	// AllowedPrograms is the interpreter allowlist (python, bash, node, ...).
@@ -81,9 +81,11 @@ type Config struct {
 // Defaults.
 const (
 	DefaultAddr = "127.0.0.1:8087"
-	// DefaultMetricsAddr follows the deployment convention of a "1"-prefixed
-	// twin of the service port for the internal listener (see infra/site.yml:
-	// 8087 -> 19087), so codellm's 8087 pairs with 18087.
+	// DefaultMetricsAddr puts the internal listener in the 18xxx band. The
+	// monolith's own internal listeners occupy 19xxx (infra/site.yml, one per
+	// site, "MUST be unique per service" — 19087 is already trip2g_landing's),
+	// so the standalone binaries stay clear of it: codellm 8087 -> 18087,
+	// fleet 9090 -> 18090.
 	DefaultMetricsAddr     = "127.0.0.1:18087"
 	DefaultAllowedPrograms = "python,bash,node"
 	DefaultTimeout         = 300 * time.Second
@@ -138,7 +140,9 @@ func (c *Config) applyEnv() {
 	if v := os.Getenv("CODELLM_ADDR"); v != "" {
 		c.Addr = v
 	}
-	if v := os.Getenv("CODELLM_METRICS_ADDR"); v != "" {
+	// LookupEnv, not Getenv: an explicitly empty CODELLM_METRICS_ADDR is how an
+	// operator turns the listener off, and Getenv cannot tell that from unset.
+	if v, ok := os.LookupEnv("CODELLM_METRICS_ADDR"); ok {
 		c.MetricsAddr = v
 	}
 	if v := os.Getenv("CODELLM_ALLOWED_PROGRAMS"); v != "" {

--- a/cmd/codellm/appconfig/config.go
+++ b/cmd/codellm/appconfig/config.go
@@ -29,6 +29,11 @@ type Config struct {
 	// must be an explicit operator opt-in, not the default.
 	Addr string
 
+	// MetricsAddr is the internal listener: Prometheus /metrics, pprof, and the
+	// liveness/readiness probes. Loopback by default and unauthenticated, exactly
+	// like the monolith's internal listener — never expose it. Empty disables it.
+	MetricsAddr string
+
 	// AllowedPrograms is the interpreter allowlist (python, bash, node, ...).
 	// Empty disables code execution (every request then fails 422).
 	AllowedPrograms []string
@@ -75,7 +80,11 @@ type Config struct {
 
 // Defaults.
 const (
-	DefaultAddr            = "127.0.0.1:8087"
+	DefaultAddr = "127.0.0.1:8087"
+	// DefaultMetricsAddr follows the deployment convention of a "1"-prefixed
+	// twin of the service port for the internal listener (see infra/site.yml:
+	// 8087 -> 19087), so codellm's 8087 pairs with 18087.
+	DefaultMetricsAddr     = "127.0.0.1:18087"
 	DefaultAllowedPrograms = "python,bash,node"
 	DefaultTimeout         = 300 * time.Second
 	DefaultTrip2gBaseURL   = "http://127.0.0.1:8081"
@@ -90,6 +99,7 @@ const minAPIKeyLength = 32
 func DefaultConfig() Config {
 	return Config{
 		Addr:            DefaultAddr,
+		MetricsAddr:     DefaultMetricsAddr,
 		AllowedPrograms: splitCSV(DefaultAllowedPrograms),
 		Sandbox:         coderun.SandboxNative,
 		Timeout:         DefaultTimeout,
@@ -127,6 +137,9 @@ func GetArgs(args []string) (*Config, error) {
 func (c *Config) applyEnv() {
 	if v := os.Getenv("CODELLM_ADDR"); v != "" {
 		c.Addr = v
+	}
+	if v := os.Getenv("CODELLM_METRICS_ADDR"); v != "" {
+		c.MetricsAddr = v
 	}
 	if v := os.Getenv("CODELLM_ALLOWED_PROGRAMS"); v != "" {
 		c.AllowedPrograms = splitCSV(v)
@@ -176,6 +189,8 @@ func (c *Config) defineAndParseFlags(args []string) error {
 	exposeEnvPrefix := strings.Join(c.ExposeEnvPrefix, ",")
 
 	fs.StringVar(&c.Addr, "addr", c.Addr, "listen address for the OpenAI-compatible API; defaults to loopback since auth is a no-op seam")
+	fs.StringVar(&c.MetricsAddr, "metrics-addr", c.MetricsAddr,
+		"loopback listen address for /metrics, pprof and the liveness/readiness probes; empty = disabled")
 	fs.StringVar(&allowedPrograms, "allowed-programs", allowedPrograms, "comma-separated interpreter allowlist; empty disables code execution")
 	fs.StringVar(&sandbox, "sandbox", sandbox, "sandbox mode: native | besteffort | off")
 	fs.BoolVar(&sandboxNetwork, "sandbox-network", sandboxNetwork, "allow network access from sandboxed blocks")

--- a/cmd/codellm/appconfig/config_test.go
+++ b/cmd/codellm/appconfig/config_test.go
@@ -95,3 +95,20 @@ func TestGetArgs_MinLengthAPIKeyAccepted(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, string(key), cfg.APIKey)
 }
+
+// TestGetArgs_MetricsAddr covers the internal listener's config lane: a
+// loopback default, env and flag overrides, and empty = disabled.
+func TestGetArgs_MetricsAddr(t *testing.T) {
+	cfg, err := GetArgs(nil)
+	require.NoError(t, err)
+	require.Equal(t, DefaultMetricsAddr, cfg.MetricsAddr, "the internal listener must default to loopback")
+
+	t.Setenv("CODELLM_METRICS_ADDR", "127.0.0.1:19000")
+	cfg, err = GetArgs(nil)
+	require.NoError(t, err)
+	require.Equal(t, "127.0.0.1:19000", cfg.MetricsAddr)
+
+	cfg, err = GetArgs([]string{"--metrics-addr", ""})
+	require.NoError(t, err)
+	require.Empty(t, cfg.MetricsAddr, "an empty address must disable the listener, not fail validation")
+}

--- a/cmd/codellm/internal/codellm/server.go
+++ b/cmd/codellm/internal/codellm/server.go
@@ -128,10 +128,16 @@ func BrowserAuthWithMetrics(
 		gated := admin(next)
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if tokenCheck != nil {
-				if err := tokenCheck(r); err == nil {
+				err := tokenCheck(r)
+				if err == nil {
 					m.RecordAuth(codellmmetrics.LaneAPIKey, codellmmetrics.Allowed)
 					next.ServeHTTP(w, r)
 					return
+				}
+				// A caller that presented a key and got rejected is the probing
+				// signal; a caller with no key at all is just using the cookie lane.
+				if bearerToken(r) != "" {
+					m.RecordAuth(codellmmetrics.LaneAPIKey, codellmmetrics.Denied)
 				}
 			}
 			rec := &authStatusWriter{ResponseWriter: w, status: http.StatusOK}
@@ -156,6 +162,9 @@ func (w *authStatusWriter) WriteHeader(code int) {
 	w.status = code
 	w.ResponseWriter.WriteHeader(code)
 }
+
+// Unwrap keeps http.ResponseController able to reach the real writer.
+func (w *authStatusWriter) Unwrap() http.ResponseWriter { return w.ResponseWriter }
 
 // Server is the codellm HTTP service.
 type Server struct {

--- a/cmd/codellm/internal/codellm/server.go
+++ b/cmd/codellm/internal/codellm/server.go
@@ -28,6 +28,7 @@ import (
 	goopenai "github.com/sashabaranov/go-openai"
 
 	"trip2g/cmd/codellm/internal/codellm/codellmgql"
+	"trip2g/cmd/codellm/internal/codellmmetrics"
 	"trip2g/cmd/codellm/internal/coderun"
 	"trip2g/internal/webhookutil"
 )
@@ -89,6 +90,11 @@ type Config struct {
 	// secure default). Kept distinct from Auth so the transport-lock and the
 	// caller-identity concerns wire independently.
 	TokenCheck func(*http.Request) error
+
+	// Metrics is the Prometheus sink served on the internal listener. nil
+	// disables recording entirely (every call site is nil-safe), which is what
+	// tests and a --metrics-addr="" run get.
+	Metrics *codellmmetrics.Metrics
 }
 
 // BrowserAuth composes codellm's two auth regimes into one middleware for the
@@ -106,18 +112,49 @@ type Config struct {
 // tokenCheck nil → no key auth; every request must pass the browser admin gate
 // (the secure default until an api_key is configured).
 func BrowserAuth(admin func(http.Handler) http.Handler, tokenCheck func(*http.Request) error) func(http.Handler) http.Handler {
+	return BrowserAuthWithMetrics(admin, tokenCheck, nil)
+}
+
+// BrowserAuthWithMetrics is BrowserAuth plus auth accounting: which lane
+// admitted (or rejected) each request. The cookie lane's verdict is only
+// visible from the response status the admin middleware wrote, so it is read
+// back off the wrapped writer. m may be nil.
+func BrowserAuthWithMetrics(
+	admin func(http.Handler) http.Handler,
+	tokenCheck func(*http.Request) error,
+	m *codellmmetrics.Metrics,
+) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		gated := admin(next)
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if tokenCheck != nil {
 				if err := tokenCheck(r); err == nil {
+					m.RecordAuth(codellmmetrics.LaneAPIKey, codellmmetrics.Allowed)
 					next.ServeHTTP(w, r)
 					return
 				}
 			}
-			gated.ServeHTTP(w, r)
+			rec := &authStatusWriter{ResponseWriter: w, status: http.StatusOK}
+			gated.ServeHTTP(rec, r)
+			result := codellmmetrics.Allowed
+			if rec.status == http.StatusUnauthorized {
+				result = codellmmetrics.Denied
+			}
+			m.RecordAuth(codellmmetrics.LaneCookie, result)
 		})
 	}
+}
+
+// authStatusWriter captures the status the admin gate wrote so the cookie
+// lane's allow/deny verdict can be counted.
+type authStatusWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (w *authStatusWriter) WriteHeader(code int) {
+	w.status = code
+	w.ResponseWriter.WriteHeader(code)
 }
 
 // Server is the codellm HTTP service.
@@ -128,14 +165,18 @@ type Server struct {
 type blockRunner struct{ cfg Config }
 
 func (r blockRunner) RunBlocks(ctx context.Context, req codellmgql.BlockRunRequest) (codellmgql.BlockRunResult, error) {
+	observe, blocks := blockObserver(r.cfg.Metrics)
 	out, debug, err := coderun.ExecBlocksDebug(ctx, coderun.CodeInput{
 		Body: req.Body, Input: req.FleetInput,
 		AllowedPrograms: r.cfg.AllowedPrograms,
 		Sandbox:         r.cfg.Sandbox, MaxStdoutBytes: r.cfg.MaxStdoutBytes,
 		Timeout: r.cfg.Timeout, EnvPassthrough: r.cfg.ExposeEnv,
 		EnvPrefix: r.cfg.ExposeEnvPrefix,
+		Observe:   observe,
 	}, req.MaxSteps)
+	r.cfg.Metrics.ObserveRequestBlocks(*blocks)
 	if err != nil {
+		r.cfg.Metrics.RecordExecError(err)
 		return codellmgql.BlockRunResult{}, err
 	}
 	results := make([]codellmgql.BlockResult, 0, len(debug))
@@ -164,13 +205,16 @@ func New(cfg Config) *Server {
 func (s *Server) Handler() http.Handler {
 	const graphqlPrefix = "/_system/codellm/graphql"
 
+	m := s.cfg.Metrics
 	mux := http.NewServeMux()
 	graphqlHandler := codellmgql.NewHTTPHandler(nil, blockRunner{cfg: s.cfg})
 	gqlAuthHandler := s.cfg.Auth(graphqlHandler)
 	// Auth-gated (browser cookie / fleet channel token — see cfg.Auth).
-	mux.Handle("POST /v1/chat/completions", s.cfg.Auth(http.HandlerFunc(s.handleChatCompletions)))
-	mux.Handle("POST "+graphqlPrefix, gqlAuthHandler)
-	mux.Handle("GET "+graphqlPrefix, s.cfg.Auth(playground.Handler("CodeLLM GraphQL Playground", graphqlPrefix)))
+	mux.Handle("POST /v1/chat/completions",
+		m.Instrument("chat_completions", s.cfg.Auth(http.HandlerFunc(s.handleChatCompletions))))
+	mux.Handle("POST "+graphqlPrefix, m.Instrument("graphql", gqlAuthHandler))
+	mux.Handle("GET "+graphqlPrefix,
+		m.Instrument("graphql_playground", s.cfg.Auth(playground.Handler("CodeLLM GraphQL Playground", graphqlPrefix))))
 	// Open: liveness + client compatibility, never gated.
 	mux.HandleFunc("GET /v1/models", s.handleModels)
 	mux.HandleFunc("GET /healthz", s.handleHealthz)
@@ -205,6 +249,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// (ExposeEnv/ExposeEnvPrefix). buildChildEnv sources the VALUES from codellm's
 	// OWN environment for those names; the request carries nothing about env.
 	s.logExposedEnv()
+	observe, blocks := blockObserver(s.cfg.Metrics)
 	in := coderun.CodeInput{
 		Body:            body,
 		AllowedPrograms: s.cfg.AllowedPrograms,
@@ -214,15 +259,21 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		Input:           bag,
 		EnvPassthrough:  s.cfg.ExposeEnv,
 		EnvPrefix:       s.cfg.ExposeEnvPrefix,
+		Observe:         observe,
 	}
 
 	changes, answer, err := coderun.ExecCode(r.Context(), in)
+	s.cfg.Metrics.ObserveRequestBlocks(*blocks)
 	if err != nil {
 		// Apply-error semantics = hard-fail 422 (decision b): a failing block,
 		// timeout, or unparseable stdout is a deterministic failure, not a soft
 		// skip. 422 (not 5xx) so fleet's OpenAILLM does not retry it.
+		s.cfg.Metrics.RecordExecError(err)
 		writeError(w, http.StatusUnprocessableEntity, "code_execution_error", err.Error())
 		return
+	}
+	for _, ch := range changes {
+		s.cfg.Metrics.RecordChange(ch.Kind)
 	}
 
 	resp := buildResponse(req.Model, changes, answer)
@@ -372,4 +423,15 @@ func mustJSON(v any) string {
 		panic(errors.New("codellm: marshal tool arguments: " + err.Error()))
 	}
 	return string(b)
+}
+
+// blockObserver builds the coderun observe hook that feeds the block metrics,
+// plus the per-request block counter it increments. The counter is request-
+// local: coderun calls the observer from the request's own goroutine.
+func blockObserver(m *codellmmetrics.Metrics) (func(coderun.BlockStats), *int) {
+	n := 0
+	return func(st coderun.BlockStats) {
+		n++
+		m.RecordBlock(st)
+	}, &n
 }

--- a/cmd/codellm/internal/codellm/server_metrics_test.go
+++ b/cmd/codellm/internal/codellm/server_metrics_test.go
@@ -1,0 +1,88 @@
+package codellm
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	goopenai "github.com/sashabaranov/go-openai"
+	"github.com/stretchr/testify/require"
+
+	"trip2g/cmd/codellm/internal/codellmmetrics"
+	"trip2g/cmd/codellm/internal/coderun"
+)
+
+// newMeteredTestServer is newTestServer with a live metrics sink attached.
+func newMeteredTestServer() (*Server, *codellmmetrics.Metrics) {
+	m := codellmmetrics.New()
+	return New(Config{
+		AllowedPrograms: []string{"bash"},
+		Sandbox:         coderun.SandboxPolicy{Mode: coderun.SandboxOff},
+		Metrics:         m,
+	}), m
+}
+
+// scrape renders the registry the way Prometheus would read it.
+func scrape(t *testing.T, m *codellmmetrics.Metrics) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	m.Handler(nil).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	return rec.Body.String()
+}
+
+// TestMetrics_SuccessfulCompletion asserts a served completion lands in the
+// request, block and change series.
+func TestMetrics_SuccessfulCompletion(t *testing.T) {
+	srv, m := newMeteredTestServer()
+	rec := doChat(t, srv, []goopenai.ChatCompletionMessage{
+		bashBody(`echo '{"changes":[{"path":"notes/a.md","content":"hi"}],"answer":"done"}'`),
+	})
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	out := scrape(t, m)
+	require.Contains(t, out, `codellm_requests_total{endpoint="chat_completions",status="200"} 1`)
+	require.Contains(t, out, `codellm_blocks_total{outcome="ok",program="bash"} 1`)
+	require.Contains(t, out, `codellm_block_exit_codes_total{exit_code="0",program="bash"} 1`)
+	require.Contains(t, out, `codellm_changes_total{kind="write"} 1`)
+}
+
+// TestMetrics_FailedBlockIsCountedByKind asserts a 422 is attributed to the
+// coderun failure kind AND to the block's real exit code — the two signals the
+// service's stability is read from.
+func TestMetrics_FailedBlockIsCountedByKind(t *testing.T) {
+	srv, m := newMeteredTestServer()
+	rec := doChat(t, srv, []goopenai.ChatCompletionMessage{bashBody(`echo boom >&2; exit 7`)})
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+
+	out := scrape(t, m)
+	require.Contains(t, out, `codellm_requests_total{endpoint="chat_completions",status="422"} 1`)
+	require.Contains(t, out, `codellm_exec_errors_total{kind="nonzero_exit"} 1`)
+	require.Contains(t, out, `codellm_blocks_total{outcome="nonzero_exit",program="bash"} 1`)
+	require.Contains(t, out, `codellm_block_exit_codes_total{exit_code="7",program="bash"} 1`)
+}
+
+// TestMetrics_AuthLanes asserts the api-key lane and a denied cookie request
+// are counted separately: a rising denied rate on an endpoint that executes
+// code is a probing signal.
+func TestMetrics_AuthLanes(t *testing.T) {
+	m := codellmmetrics.New()
+	denyAll := func(http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+		})
+	}
+	key := "codellm-test-key-0123456789abcdefghij"
+	auth := BrowserAuthWithMetrics(denyAll, APIKeyCheck(key), m)
+	served := auth(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }))
+
+	withKey := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	withKey.Header.Set("Authorization", "Bearer "+key)
+	served.ServeHTTP(httptest.NewRecorder(), withKey)
+
+	served.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil))
+
+	out := scrape(t, m)
+	require.Contains(t, out, `codellm_auth_total{lane="apikey",result="allowed"} 1`)
+	require.Contains(t, out, `codellm_auth_total{lane="cookie",result="denied"} 1`)
+}

--- a/cmd/codellm/internal/codellmmetrics/metrics.go
+++ b/cmd/codellm/internal/codellmmetrics/metrics.go
@@ -1,0 +1,283 @@
+// Package codellmmetrics is codellm's Prometheus surface: the collectors plus
+// the internal listener's handler (/metrics, pprof, liveness/readiness).
+//
+// It owns its OWN registry rather than the global default one, so codellm stays
+// independent of the monolith's internal/metrics (which registers globally) and
+// a test can gather a clean snapshot. Every record method is nil-safe, so call
+// sites stay unconditional when metrics are disabled (tests, --metrics-addr="").
+package codellmmetrics
+
+import (
+	"net/http"
+	"net/http/pprof"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"trip2g/cmd/codellm/internal/coderun"
+)
+
+// Auth lanes and results reported by RecordAuth.
+const (
+	LaneAPIKey  = "apikey"
+	LaneCookie  = "cookie"
+	Allowed     = "allowed"
+	Denied      = "denied"
+	statusLabel = "status"
+)
+
+// Metrics holds codellm's collectors and the registry they live in.
+type Metrics struct {
+	reg *prometheus.Registry
+
+	requests  *prometheus.CounterVec
+	duration  *prometheus.HistogramVec
+	inFlight  prometheus.Gauge
+	auth      *prometheus.CounterVec
+	execError *prometheus.CounterVec
+
+	blocks          *prometheus.CounterVec
+	blockExitCodes  *prometheus.CounterVec
+	blockDuration   *prometheus.HistogramVec
+	blockMaxRSS     *prometheus.HistogramVec
+	blockStdout     *prometheus.HistogramVec
+	blockTruncated  *prometheus.CounterVec
+	sandboxFallback *prometheus.CounterVec
+	requestBlocks   prometheus.Histogram
+
+	changes    *prometheus.CounterVec
+	configInfo *prometheus.GaugeVec
+}
+
+// New builds the collectors on a private registry, together with the standard
+// Go runtime and process collectors (goroutines, GC, open fds, RSS) — a service
+// that forks a child per code block lives or dies by those.
+func New() *Metrics {
+	m := &Metrics{
+		reg: prometheus.NewRegistry(),
+		requests: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "codellm_requests_total",
+			Help: "Total HTTP requests served by codellm, by endpoint and status code",
+		}, []string{"endpoint", statusLabel}),
+		duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "codellm_request_duration_seconds",
+			Help:    "codellm HTTP request duration in seconds, by endpoint",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"endpoint"}),
+		inFlight: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "codellm_requests_in_flight",
+			Help: "Requests currently being served; each one may fork an interpreter child",
+		}),
+		auth: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "codellm_auth_total",
+			Help: "Auth decisions on the browser-facing endpoints, by lane (apikey|cookie) and result",
+		}, []string{"lane", "result"}),
+		execError: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "codellm_exec_errors_total",
+			Help: "Code-execution failures by kind (unknown_fence, disallowed_program, sandbox_refused, timeout, parse_error, ...)",
+		}, []string{"kind"}),
+		blocks: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "codellm_blocks_total",
+			Help: "Executed code blocks by interpreter and outcome (ok|nonzero_exit|timeout|start_failed)",
+		}, []string{"program", "outcome"}),
+		blockExitCodes: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "codellm_block_exit_codes_total",
+			Help: "Executed code blocks by interpreter and process exit code (-1 = never produced one)",
+		}, []string{"program", "exit_code"}),
+		blockDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "codellm_block_duration_seconds",
+			Help:    "Wall time of one executed code block in seconds",
+			Buckets: []float64{0.01, 0.05, 0.1, 0.5, 1, 5, 15, 30, 60, 300},
+		}, []string{"program"}),
+		blockMaxRSS: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "codellm_block_max_rss_bytes",
+			Help:    "Peak resident memory of one executed code block in bytes",
+			Buckets: prometheus.ExponentialBuckets(1<<20, 4, 8),
+		}, []string{"program"}),
+		blockStdout: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "codellm_block_stdout_bytes",
+			Help:    "Captured stdout size of one executed code block in bytes",
+			Buckets: prometheus.ExponentialBuckets(256, 4, 8),
+		}, []string{"program"}),
+		blockTruncated: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "codellm_block_stdout_truncated_total",
+			Help: "Code blocks whose stdout hit the cap and was cut (the overflow is dropped, which later reads as a parse error)",
+		}, []string{"program"}),
+		sandboxFallback: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "codellm_sandbox_fallbacks_total",
+			Help: "Blocks a besteffort policy degraded to unsandboxed execution, by reason",
+		}, []string{"reason"}),
+		requestBlocks: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "codellm_request_blocks",
+			Help:    "Number of fenced code blocks executed per request",
+			Buckets: []float64{1, 2, 3, 5, 8, 13, 21},
+		}),
+		changes: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "codellm_changes_total",
+			Help: "Note changes returned as tool_calls, by kind (write|patch)",
+		}, []string{"kind"}),
+		configInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "codellm_config_info",
+			Help: "Always 1; labels carry the execution posture this process runs with",
+		}, []string{"sandbox_mode", "sandbox_network", "allowed_programs"}),
+	}
+
+	m.reg.MustRegister(
+		collectors.NewGoCollector(),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+		m.requests, m.duration, m.inFlight, m.auth, m.execError,
+		m.blocks, m.blockExitCodes, m.blockDuration, m.blockMaxRSS,
+		m.blockStdout, m.blockTruncated, m.sandboxFallback, m.requestBlocks,
+		m.changes, m.configInfo,
+	)
+	return m
+}
+
+// Registry exposes the private registry for tests and for callers that want to
+// register their own collectors alongside codellm's.
+func (m *Metrics) Registry() *prometheus.Registry {
+	if m == nil {
+		return nil
+	}
+	return m.reg
+}
+
+// Handler builds the internal listener's mux: Prometheus scrape, pprof, and
+// the k8s-convention probes. It mirrors the monolith's internal listener
+// (cmd/server: /metrics + /debug/pprof/* + /healthz + /livez + /readyz), which
+// is why the whole port must stay loopback-bound: none of it is authenticated.
+// ready may be nil (always ready).
+func (m *Metrics) Handler(ready func() bool) http.Handler {
+	mux := http.NewServeMux()
+	if m != nil {
+		mux.Handle("GET /metrics", promhttp.HandlerFor(m.reg, promhttp.HandlerOpts{Registry: m.reg}))
+	}
+
+	mux.HandleFunc("GET /debug/pprof/", pprof.Index)
+	mux.HandleFunc("GET /debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("GET /debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("GET /debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("GET /debug/pprof/trace", pprof.Trace)
+
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("GET /livez", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("alive"))
+	})
+	mux.HandleFunc("GET /readyz", func(w http.ResponseWriter, _ *http.Request) {
+		if ready != nil && !ready() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("not ready"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ready"))
+	})
+	return mux
+}
+
+// Instrument wraps next with the request lane: in-flight gauge, duration, and
+// the status-code counter under the given endpoint label.
+func (m *Metrics) Instrument(endpoint string, next http.Handler) http.Handler {
+	if m == nil {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.inFlight.Inc()
+		defer m.inFlight.Dec()
+
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		timer := prometheus.NewTimer(m.duration.WithLabelValues(endpoint))
+		next.ServeHTTP(rec, r)
+		timer.ObserveDuration()
+		m.requests.WithLabelValues(endpoint, strconv.Itoa(rec.status)).Inc()
+	})
+}
+
+// RecordAuth counts one auth decision: lane is LaneAPIKey or LaneCookie,
+// result is Allowed or Denied. A rising denied rate on an endpoint that
+// executes code is a probing signal, not noise.
+func (m *Metrics) RecordAuth(lane, result string) {
+	if m == nil {
+		return
+	}
+	m.auth.WithLabelValues(lane, result).Inc()
+}
+
+// RecordBlock records one executed code block. It is the coderun.CodeInput
+// Observe seam, so it takes what coderun measured verbatim.
+func (m *Metrics) RecordBlock(s coderun.BlockStats) {
+	if m == nil {
+		return
+	}
+	program := s.Program
+	if program == "" {
+		program = "unknown"
+	}
+	m.blocks.WithLabelValues(program, s.Outcome).Inc()
+	m.blockExitCodes.WithLabelValues(program, strconv.Itoa(s.ExitCode)).Inc()
+	m.blockDuration.WithLabelValues(program).Observe(float64(s.DurationMs) / 1000)
+	if s.MaxRSSBytes > 0 {
+		m.blockMaxRSS.WithLabelValues(program).Observe(float64(s.MaxRSSBytes))
+	}
+	if s.StdoutBytes > 0 {
+		m.blockStdout.WithLabelValues(program).Observe(float64(s.StdoutBytes))
+	}
+	if s.StdoutTruncated {
+		m.blockTruncated.WithLabelValues(program).Inc()
+	}
+	if s.SandboxFallback != "" {
+		m.sandboxFallback.WithLabelValues(s.SandboxFallback).Inc()
+	}
+}
+
+// RecordExecError counts one failed run by coderun's failure kind. A no-op for
+// a nil error so the call site stays a single unconditional line.
+func (m *Metrics) RecordExecError(err error) {
+	if m == nil || err == nil {
+		return
+	}
+	m.execError.WithLabelValues(coderun.ErrorKind(err)).Inc()
+}
+
+// ObserveRequestBlocks records how many blocks one request executed.
+func (m *Metrics) ObserveRequestBlocks(n int) {
+	if m == nil {
+		return
+	}
+	m.requestBlocks.Observe(float64(n))
+}
+
+// RecordChange counts one returned note change by kind (write|patch).
+func (m *Metrics) RecordChange(kind string) {
+	if m == nil {
+		return
+	}
+	m.changes.WithLabelValues(kind).Inc()
+}
+
+// SetConfigInfo publishes the execution posture this process runs with, so an
+// operator can see sandbox mode, network access and the interpreter allowlist
+// from a scrape instead of from the box.
+func (m *Metrics) SetConfigInfo(sandboxMode, sandboxNetwork, allowedPrograms string) {
+	if m == nil {
+		return
+	}
+	m.configInfo.WithLabelValues(sandboxMode, sandboxNetwork, allowedPrograms).Set(1)
+}
+
+// statusRecorder captures the response status for the request counter.
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	r.status = code
+	r.ResponseWriter.WriteHeader(code)
+}

--- a/cmd/codellm/internal/codellmmetrics/metrics.go
+++ b/cmd/codellm/internal/codellmmetrics/metrics.go
@@ -52,8 +52,7 @@ type Metrics struct {
 }
 
 // New builds the collectors on a private registry, together with the standard
-// Go runtime and process collectors (goroutines, GC, open fds, RSS) — a service
-// that forks a child per code block lives or dies by those.
+// Go runtime and process collectors (goroutines, GC, open fds, RSS).
 func New() *Metrics {
 	m := &Metrics{
 		reg: prometheus.NewRegistry(),
@@ -72,7 +71,7 @@ func New() *Metrics {
 		}),
 		auth: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "codellm_auth_total",
-			Help: "Auth decisions on the browser-facing endpoints, by lane (apikey|cookie) and result",
+			Help: "Auth decisions on the browser-facing endpoints, by lane (apikey|cookie) and result; denials on a code-executing endpoint are a probing signal",
 		}, []string{"lane", "result"}),
 		execError: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "codellm_exec_errors_total",
@@ -200,8 +199,7 @@ func (m *Metrics) Instrument(endpoint string, next http.Handler) http.Handler {
 }
 
 // RecordAuth counts one auth decision: lane is LaneAPIKey or LaneCookie,
-// result is Allowed or Denied. A rising denied rate on an endpoint that
-// executes code is a probing signal, not noise.
+// result is Allowed or Denied.
 func (m *Metrics) RecordAuth(lane, result string) {
 	if m == nil {
 		return
@@ -225,9 +223,7 @@ func (m *Metrics) RecordBlock(s coderun.BlockStats) {
 	if s.MaxRSSBytes > 0 {
 		m.blockMaxRSS.WithLabelValues(program).Observe(float64(s.MaxRSSBytes))
 	}
-	if s.StdoutBytes > 0 {
-		m.blockStdout.WithLabelValues(program).Observe(float64(s.StdoutBytes))
-	}
+	m.blockStdout.WithLabelValues(program).Observe(float64(s.StdoutBytes))
 	if s.StdoutTruncated {
 		m.blockTruncated.WithLabelValues(program).Inc()
 	}
@@ -253,7 +249,7 @@ func (m *Metrics) ObserveRequestBlocks(n int) {
 	m.requestBlocks.Observe(float64(n))
 }
 
-// RecordChange counts one returned note change by kind (write|patch).
+// RecordChange counts one returned note change.
 func (m *Metrics) RecordChange(kind string) {
 	if m == nil {
 		return
@@ -281,3 +277,8 @@ func (r *statusRecorder) WriteHeader(code int) {
 	r.status = code
 	r.ResponseWriter.WriteHeader(code)
 }
+
+// Unwrap keeps http.ResponseController able to reach the real writer, so
+// wrapping does not quietly disable flushing or hijacking for a future
+// streaming endpoint.
+func (r *statusRecorder) Unwrap() http.ResponseWriter { return r.ResponseWriter }

--- a/cmd/codellm/internal/codellmmetrics/metrics_test.go
+++ b/cmd/codellm/internal/codellmmetrics/metrics_test.go
@@ -1,0 +1,143 @@
+package codellmmetrics
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"trip2g/cmd/codellm/internal/coderun"
+)
+
+// TestInstrument_CountsStatusAndInFlight asserts the request lane records the
+// real response status and leaves the in-flight gauge back at zero.
+func TestInstrument_CountsStatusAndInFlight(t *testing.T) {
+	m := New()
+	var inFlightDuring float64
+	h := m.Instrument("chat_completions", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		inFlightDuring = testutil.ToFloat64(m.inFlight)
+		w.WriteHeader(http.StatusUnprocessableEntity)
+	}))
+
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil))
+
+	require.InDelta(t, 1.0, inFlightDuring, 0.001)
+	require.InDelta(t, 0.0, testutil.ToFloat64(m.inFlight), 0.001)
+	require.InDelta(t, 1.0, testutil.ToFloat64(m.requests.WithLabelValues("chat_completions", "422")), 0.001)
+	require.Equal(t, 1, testutil.CollectAndCount(m.duration))
+}
+
+// TestRecordBlock_ExitCodeAndTruncation asserts a failed block lands in the
+// outcome, exit-code and truncation series.
+func TestRecordBlock_ExitCodeAndTruncation(t *testing.T) {
+	m := New()
+	m.RecordBlock(coderun.BlockStats{
+		Program:         "python",
+		Outcome:         coderun.BlockNonZeroExit,
+		ExitCode:        3,
+		DurationMs:      120,
+		MaxRSSBytes:     4 << 20,
+		StdoutBytes:     1024,
+		StdoutTruncated: true,
+		SandboxFallback: "unsupported OS",
+	})
+
+	require.InDelta(t, 1.0, testutil.ToFloat64(m.blocks.WithLabelValues("python", coderun.BlockNonZeroExit)), 0.001)
+	require.InDelta(t, 1.0, testutil.ToFloat64(m.blockExitCodes.WithLabelValues("python", "3")), 0.001)
+	require.InDelta(t, 1.0, testutil.ToFloat64(m.blockTruncated.WithLabelValues("python")), 0.001)
+	require.InDelta(t, 1.0, testutil.ToFloat64(m.sandboxFallback.WithLabelValues("unsupported OS")), 0.001)
+}
+
+// TestRecordExecError_UsesCoderunKind asserts failures are counted by coderun's
+// classification rather than by message text.
+func TestRecordExecError_UsesCoderunKind(t *testing.T) {
+	m := New()
+	m.RecordExecError(nil)
+	m.RecordExecError(&coderun.ExecError{Kind: coderun.KindSandboxRefused, Err: errors.New("refused")})
+	m.RecordExecError(errors.New("plain"))
+
+	require.InDelta(t, 1.0, testutil.ToFloat64(m.execError.WithLabelValues(coderun.KindSandboxRefused)), 0.001)
+	require.InDelta(t, 1.0, testutil.ToFloat64(m.execError.WithLabelValues(coderun.KindUnclassified)), 0.001)
+}
+
+// TestHandler_ServesScrapeAndProbes asserts the internal listener exposes the
+// scrape endpoint and the k8s-convention probes, and that readiness can fail.
+func TestHandler_ServesScrapeAndProbes(t *testing.T) {
+	m := New()
+	m.SetConfigInfo("native", "false", "python,bash")
+	m.RecordAuth(LaneCookie, Denied)
+
+	ready := false
+	h := m.Handler(func() bool { return ready })
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "codellm_config_info")
+	require.Contains(t, rec.Body.String(), `codellm_auth_total{lane="cookie",result="denied"} 1`)
+	require.Contains(t, rec.Body.String(), "go_goroutines")
+
+	for _, path := range []string{"/healthz", "/livez"} {
+		rec = httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		require.Equal(t, http.StatusOK, rec.Code, path)
+	}
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+
+	ready = true
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestNilMetrics_IsSafe asserts every call site can stay unconditional when
+// metrics are disabled (--metrics-addr="").
+func TestNilMetrics_IsSafe(t *testing.T) {
+	var m *Metrics
+	require.NotPanics(t, func() {
+		m.RecordAuth(LaneAPIKey, Allowed)
+		m.RecordBlock(coderun.BlockStats{})
+		m.RecordExecError(errors.New("boom"))
+		m.ObserveRequestBlocks(2)
+		m.RecordChange("write")
+		m.SetConfigInfo("native", "false", "python")
+		require.Nil(t, m.Registry())
+
+		next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusTeapot) })
+		rec := httptest.NewRecorder()
+		m.Instrument("chat_completions", next).ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil))
+		require.Equal(t, http.StatusTeapot, rec.Code)
+
+		rec = httptest.NewRecorder()
+		m.Handler(nil).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+		require.Equal(t, http.StatusOK, rec.Code)
+	})
+}
+
+// TestMetricNames_FollowPrometheusConventions guards the naming the scrape
+// contract depends on: counters end in _total, durations are in seconds.
+func TestMetricNames_FollowPrometheusConventions(t *testing.T) {
+	m := New()
+	problems, err := testutil.GatherAndLint(m.reg)
+	require.NoError(t, err)
+	var msgs []string
+	for _, p := range problems {
+		// The Go runtime collector's own names are client_golang's business.
+		if strings.HasPrefix(p.Metric, "go_") || strings.HasPrefix(p.Metric, "process_") {
+			continue
+		}
+		msgs = append(msgs, p.Metric+": "+p.Text)
+	}
+	require.Empty(t, msgs, strings.Join(msgs, "\n"))
+}

--- a/cmd/codellm/internal/coderun/coderun.go
+++ b/cmd/codellm/internal/coderun/coderun.go
@@ -299,6 +299,11 @@ func RunBlock(ctx context.Context, spec CodeSpec) (string, string, bool, error) 
 		if msg == "" {
 			msg = runErr.Error()
 		}
+		// No ProcessState means the child never ran (exec failed): that is a start
+		// failure, not an exit status the code chose.
+		if cmd.ProcessState == nil {
+			return outStr, errStr, false, execErrf(KindStartFailed, "coderun: start failed: %s", msg)
+		}
 		return outStr, errStr, false, execErrf(KindNonZeroExit, "coderun: non-zero exit: %s", msg)
 	}
 	return outStr, errStr, false, nil

--- a/cmd/codellm/internal/coderun/coderun.go
+++ b/cmd/codellm/internal/coderun/coderun.go
@@ -139,9 +139,17 @@ type CodeSpec struct {
 	Stats          *RunBlockStats // optional execution metrics sink
 }
 
+// RunBlockStats is the optional execution-metrics sink for one RunBlock call.
+// Outcome/ExitCode are filled even when RunBlock returns an error, so a caller
+// can count HOW a block failed, not just that it did.
 type RunBlockStats struct {
-	DurationMs  int64
-	MaxRSSBytes int64
+	DurationMs      int64
+	MaxRSSBytes     int64
+	Outcome         string
+	ExitCode        int
+	StdoutBytes     int
+	StdoutTruncated bool
+	SandboxFallback string
 }
 
 // codeOutput is the stdout JSON contract that every code program must emit.
@@ -175,19 +183,19 @@ type rawCodeChange struct {
 func RunBlock(ctx context.Context, spec CodeSpec) (string, string, bool, error) {
 	interp, ok := currentRegistry().byName[spec.Program]
 	if !ok {
-		return "", "", false, fmt.Errorf("coderun: unknown program %q", spec.Program)
+		return "", "", false, execErrf(KindUnknownProgram, "coderun: unknown program %q", spec.Program)
 	}
 
 	// Per-run throwaway workdir: prevents cross-run contamination.
 	workDir, mkErr := os.MkdirTemp("", "fleet-coderun-*")
 	if mkErr != nil {
-		return "", "", false, fmt.Errorf("coderun: create workdir: %w", mkErr)
+		return "", "", false, execErrf(KindSetupFailed, "coderun: create workdir: %w", mkErr)
 	}
 	defer os.RemoveAll(workDir)
 
 	codeFile := filepath.Join(workDir, "run"+interp.Ext)
 	if wErr := os.WriteFile(codeFile, []byte(spec.Code), 0o600); wErr != nil {
-		return "", "", false, fmt.Errorf("coderun: write code file: %w", wErr)
+		return "", "", false, execErrf(KindSetupFailed, "coderun: write code file: %w", wErr)
 	}
 
 	inputData := spec.Input
@@ -196,7 +204,7 @@ func RunBlock(ctx context.Context, spec CodeSpec) (string, string, bool, error) 
 	}
 	inputFile := filepath.Join(workDir, "input.json")
 	if wErr := os.WriteFile(inputFile, inputData, 0o600); wErr != nil {
-		return "", "", false, fmt.Errorf("coderun: write input file: %w", wErr)
+		return "", "", false, execErrf(KindSetupFailed, "coderun: write input file: %w", wErr)
 	}
 
 	runCtx := ctx
@@ -224,11 +232,14 @@ func RunBlock(ctx context.Context, spec CodeSpec) (string, string, bool, error) 
 
 	// Fail-closed: when the enforcing mode is requested but the OS cannot
 	// sandbox at all, REFUSE the run — never run untrusted code unconfined.
+	var fallback string
 	if sandboxed && !sandboxSupportedOS {
 		if policy.Mode.enforcing() {
-			return "", "", false, fmt.Errorf("coderun: sandbox mode %q requires Linux; refusing to run unsandboxed", policy.Mode)
+			return "", "", false, execErrf(KindSandboxRefused,
+				"coderun: sandbox mode %q requires Linux; refusing to run unsandboxed", policy.Mode)
 		}
-		warnSandboxFallback("unsupported OS", nil)
+		fallback = "unsupported OS"
+		warnSandboxFallback(fallback, nil)
 		sandboxed = false
 	}
 
@@ -238,9 +249,10 @@ func RunBlock(ctx context.Context, spec CodeSpec) (string, string, bool, error) 
 		if sbErr != nil {
 			// Enforcing mode: a sandbox that cannot be built refuses the run.
 			if policy.Mode.enforcing() {
-				return "", "", false, fmt.Errorf("coderun: sandbox setup failed: %w", sbErr)
+				return "", "", false, execErrf(KindSandboxRefused, "coderun: sandbox setup failed: %w", sbErr)
 			}
-			warnSandboxFallback("sandbox setup failed", sbErr)
+			fallback = "sandbox setup failed"
+			warnSandboxFallback(fallback, sbErr)
 			sandboxed = false
 		} else {
 			cmd = sbCmd
@@ -254,10 +266,7 @@ func RunBlock(ctx context.Context, spec CodeSpec) (string, string, bool, error) 
 
 	startedAt := time.Now()
 	runErr := cmd.Run()
-	if spec.Stats != nil {
-		spec.Stats.DurationMs = time.Since(startedAt).Milliseconds()
-		spec.Stats.MaxRSSBytes = maxRSSBytes(cmd.ProcessState)
-	}
+	elapsed := time.Since(startedAt)
 	// A sandboxed command that failed to START never ran the child: namespace
 	// creation was denied (e.g. unprivileged userns disabled) or a confinement
 	// step failed. Enforcing mode REFUSES the run (the code never ran, so this
@@ -265,27 +274,73 @@ func RunBlock(ctx context.Context, spec CodeSpec) (string, string, bool, error) 
 	// execution with a per-run warning.
 	if runErr != nil && sandboxed && cmd.ProcessState == nil && runCtx.Err() == nil {
 		if policy.Mode.enforcing() {
-			return "", "", false, fmt.Errorf("coderun: sandboxed child failed to start; refusing to run unsandboxed: %w", runErr)
+			return "", "", false, execErrf(KindSandboxRefused,
+				"coderun: sandboxed child failed to start; refusing to run unsandboxed: %w", runErr)
 		}
-		warnSandboxFallback("sandboxed child failed to start", runErr)
+		fallback = "sandboxed child failed to start"
+		warnSandboxFallback(fallback, runErr)
 		cmd = exec.CommandContext(runCtx, fullArgv[0], fullArgv[1:]...)
 		prepareCmd(cmd, workDir, env, spec.Stdin, &outBuf, &errBuf, limit)
+		startedAt = time.Now()
 		runErr = cmd.Run()
+		elapsed = time.Since(startedAt)
 	}
 	outStr := outBuf.String()
 	errStr := errBuf.String()
 
-	if runCtx.Err() != nil {
-		return outStr, errStr, true, errors.New("coderun: timed out")
+	timedOut := runCtx.Err() != nil
+	recordRunBlockStats(spec.Stats, runBlockOutcome(cmd, runErr, timedOut), cmd, elapsed, &outBuf, fallback)
+
+	if timedOut {
+		return outStr, errStr, true, &ExecError{Kind: KindTimeout, Err: errors.New("coderun: timed out")}
 	}
 	if runErr != nil {
 		msg := errStr
 		if msg == "" {
 			msg = runErr.Error()
 		}
-		return outStr, errStr, false, fmt.Errorf("coderun: non-zero exit: %s", msg)
+		return outStr, errStr, false, execErrf(KindNonZeroExit, "coderun: non-zero exit: %s", msg)
 	}
 	return outStr, errStr, false, nil
+}
+
+// runBlockOutcome classifies one finished child: a timeout, a child that never
+// started (no ProcessState), a non-zero exit, or a clean run.
+func runBlockOutcome(cmd *exec.Cmd, runErr error, timedOut bool) string {
+	switch {
+	case timedOut:
+		return BlockTimeout
+	case cmd.ProcessState == nil:
+		return BlockStartFailed
+	case runErr != nil:
+		return BlockNonZeroExit
+	default:
+		return BlockOK
+	}
+}
+
+// recordRunBlockStats fills the caller's optional stats sink. No-op when the
+// caller passed none (the zero-overhead production path before metrics wiring).
+func recordRunBlockStats(stats *RunBlockStats, outcome string, cmd *exec.Cmd, elapsed time.Duration, out *limitedBuffer, fallback string) {
+	if stats == nil {
+		return
+	}
+	stats.DurationMs = elapsed.Milliseconds()
+	stats.MaxRSSBytes = maxRSSBytes(cmd.ProcessState)
+	stats.Outcome = outcome
+	stats.ExitCode = exitCode(cmd.ProcessState)
+	stats.StdoutBytes = len(out.String())
+	stats.StdoutTruncated = out.Truncated()
+	stats.SandboxFallback = fallback
+}
+
+// exitCode reports the child's exit status, or -1 when it never produced one
+// (never started, or killed before reaping).
+func exitCode(state *os.ProcessState) int {
+	if state == nil {
+		return -1
+	}
+	return state.ExitCode()
 }
 
 // prepareCmd applies the run wiring shared by the sandboxed and plain paths:
@@ -312,12 +367,12 @@ func ParseCodeOutput(stdout string) ([]webhookutil.AgentChange, string, error) {
 		if len(preview) > 200 {
 			preview = preview[:200] + "..."
 		}
-		return nil, "", fmt.Errorf("coderun: parse stdout: %w (got: %q)", err, preview)
+		return nil, "", execErrf(KindParseError, "coderun: parse stdout: %w (got: %q)", err, preview)
 	}
 	changes := make([]webhookutil.AgentChange, 0, len(out.Changes))
 	for i, c := range out.Changes {
 		if c.Path == "" {
-			return nil, "", fmt.Errorf("coderun: change[%d]: missing path", i)
+			return nil, "", execErrf(KindParseError, "coderun: change[%d]: missing path", i)
 		}
 		if c.Find != "" || c.Replace != "" {
 			changes = append(changes, webhookutil.AgentChange{
@@ -470,8 +525,9 @@ func resolveEnvVars(decls []envVar) []string {
 // limitedBuffer is an io.Writer that accumulates up to limit bytes and silently
 // discards the rest. Used to bound stdout/stderr capture.
 type limitedBuffer struct {
-	limit int
-	data  []byte
+	limit     int
+	data      []byte
+	truncated bool
 }
 
 func (b *limitedBuffer) Write(p []byte) (int, error) {
@@ -481,9 +537,17 @@ func (b *limitedBuffer) Write(p []byte) (int, error) {
 			b.data = append(b.data, p...)
 		} else {
 			b.data = append(b.data, p[:rem]...)
+			b.truncated = true
 		}
+	} else if len(p) > 0 {
+		b.truncated = true
 	}
 	return len(p), nil
 }
 
 func (b *limitedBuffer) String() string { return string(b.data) }
+
+// Truncated reports whether the writer dropped bytes past its limit. Silent
+// truncation shows up downstream as an unparseable stdout, so it is worth
+// surfacing on its own.
+func (b *limitedBuffer) Truncated() bool { return b.truncated }

--- a/cmd/codellm/internal/coderun/runcode.go
+++ b/cmd/codellm/internal/coderun/runcode.go
@@ -292,6 +292,10 @@ type builtBlock struct {
 	fallback   string // besteffort degradation reason; empty when sandboxed as asked
 	startedAt  time.Time
 	finishedAt time.Time
+	// outcome is classified inside waitOne, while blockCtx.Err() still
+	// distinguishes a real deadline from the teardown cancel that cleanupPipeline
+	// issues on the way out. Empty means the block was never waited on.
+	outcome string
 }
 
 // elapsed is the block's wall time: from Start to the Wait that reaped it, or
@@ -312,9 +316,14 @@ func observePipeline(observe func(BlockStats), built []builtBlock, programs []st
 	}
 	for i := range built {
 		bb := &built[i]
+		// A block that was never waited on never ran to an outcome (the run was
+		// abandoned mid-start); the failure is reported as an exec error instead.
+		if bb.outcome == "" {
+			continue
+		}
 		st := BlockStats{
 			Index:           i,
-			Outcome:         pipelineOutcome(bb),
+			Outcome:         bb.outcome,
 			ExitCode:        exitCode(bb.cmd.ProcessState),
 			DurationMs:      bb.elapsed().Milliseconds(),
 			MaxRSSBytes:     maxRSSBytes(bb.cmd.ProcessState),
@@ -331,9 +340,9 @@ func observePipeline(observe func(BlockStats), built []builtBlock, programs []st
 	}
 }
 
-// pipelineOutcome classifies one finished pipeline block from its process
-// state and its own (timeout-bearing) context.
-func pipelineOutcome(bb *builtBlock) string {
+// classifyPipelineBlock names how one block ended. It must run before
+// cleanupPipeline cancels blockCtx, or every block looks timed out.
+func classifyPipelineBlock(bb *builtBlock) string {
 	switch {
 	case bb.blockCtx.Err() != nil:
 		return BlockTimeout
@@ -500,6 +509,7 @@ func waitPipeline(built []builtBlock, pipes []*io.PipeWriter, sandbox SandboxPol
 func waitOne(idx int, built []builtBlock, pipes []*io.PipeWriter, n int, sandbox SandboxPolicy, ch chan<- pipeWaitResult) {
 	werr := built[idx].cmd.Wait()
 	built[idx].finishedAt = time.Now()
+	built[idx].outcome = classifyPipelineBlock(&built[idx])
 	if idx < n-1 {
 		if werr != nil {
 			_ = pipes[idx].CloseWithError(werr)

--- a/cmd/codellm/internal/coderun/runcode.go
+++ b/cmd/codellm/internal/coderun/runcode.go
@@ -2,7 +2,6 @@ package coderun
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -30,6 +29,11 @@ type CodeInput struct {
 	EnvPrefix       []string      // parent env var name prefixes forwarded to child
 	MaxStdoutBytes  int           // stdout cap per code child; 0 → 1 MiB default
 	Sandbox         SandboxPolicy // OS-level isolation; zero value = safe default (native)
+
+	// Observe, when non-nil, receives one BlockStats per executed block (exit
+	// code, duration, RSS, stdout size). It is the metrics seam: coderun measures
+	// and reports, the caller counts, so this package needs no metrics import.
+	Observe func(BlockStats)
 }
 
 // ExecCode extracts and runs the fenced blocks in in.Body and returns the parsed
@@ -75,7 +79,7 @@ func ExecCodeDebug(ctx context.Context, in CodeInput) ([]webhookutil.AgentChange
 func ExecBlocksDebug(ctx context.Context, in CodeInput, steps int) (string, []BlockDebug, error) {
 	blocks := ExtractFencedBlocks(in.Body)
 	if len(blocks) == 0 {
-		return "", nil, errors.New("coderun: no fenced code block found in rendered body")
+		return "", nil, &ExecError{Kind: KindNoBlocks, Err: errNoFencedBlock}
 	}
 	if steps > 0 && steps < len(blocks) {
 		blocks = blocks[:steps]
@@ -118,7 +122,7 @@ type ExecResult struct {
 func Exec(ctx context.Context, in CodeInput, capture bool) (ExecResult, error) {
 	blocks := ExtractFencedBlocks(in.Body)
 	if len(blocks) == 0 {
-		return ExecResult{}, errors.New("coderun: no fenced code block found in rendered body")
+		return ExecResult{}, &ExecError{Kind: KindNoBlocks, Err: errNoFencedBlock}
 	}
 
 	programs, err := resolvePrograms(blocks, in)
@@ -166,12 +170,16 @@ func runSingleBlock(
 		Sandbox:        in.Sandbox,
 		Stats:          &stats,
 	})
+	observeSingleBlock(in.Observe, program, stats)
 	if runErr != nil {
 		return "", nil, fmt.Errorf("coderun: %w", runErr)
 	}
 	var debug []BlockDebug
 	if capture {
-		debug = []BlockDebug{{Index: 0, ExitCode: 0, DurationMs: stats.DurationMs, MaxRSSBytes: stats.MaxRSSBytes, Stdout: out, Stderr: stderr}}
+		debug = []BlockDebug{{
+			Index: 0, ExitCode: stats.ExitCode, DurationMs: stats.DurationMs,
+			MaxRSSBytes: stats.MaxRSSBytes, Stdout: out, Stderr: stderr,
+		}}
 	}
 	return out, debug, nil
 }
@@ -190,6 +198,7 @@ func runMultiBlock(
 		}
 	}
 	out, stderrs, built, pipeErr := runPipeline(ctx, blocks, programs, in, limit, taps)
+	observePipeline(in.Observe, built, programs)
 	if pipeErr != nil {
 		return "", nil, pipeErr
 	}
@@ -208,8 +217,8 @@ func runMultiBlock(
 func buildBlockDebug(built []builtBlock, taps pipelineDebugTaps, finalStdout string, stderrs []string, n int) []BlockDebug {
 	debug := make([]BlockDebug, n)
 	for i := range n {
-		d := BlockDebug{Index: i, ExitCode: 0}
-		d.DurationMs = time.Since(built[i].startedAt).Milliseconds()
+		d := BlockDebug{Index: i, ExitCode: exitCode(built[i].cmd.ProcessState)}
+		d.DurationMs = built[i].elapsed().Milliseconds()
 		d.MaxRSSBytes = maxRSSBytes(built[i].cmd.ProcessState)
 		if i < len(stderrs) {
 			d.Stderr = stderrs[i]
@@ -251,13 +260,15 @@ func resolvePrograms(blocks []FencedBlock, in CodeInput) ([]string, error) {
 			program = fenceLangToProgram(b.Lang)
 		}
 		if program == "" {
-			return nil, fmt.Errorf("coderun: %sfence language %q not supported (use python, bash, or node)", blockPrefix(i, len(blocks)), b.Lang)
+			return nil, execErrf(KindUnknownFence,
+				"coderun: %sfence language %q not supported (use python, bash, or node)", blockPrefix(i, len(blocks)), b.Lang)
 		}
 		if !IsAllowed(program, in.AllowedPrograms) {
 			if len(in.AllowedPrograms) == 0 {
-				return nil, errors.New("coderun: code execution disabled (set --allowed-programs)")
+				return nil, &ExecError{Kind: KindDisallowedProgram, Err: errExecutionDisabled}
 			}
-			return nil, fmt.Errorf("coderun: %sprogram %q not in --allowed-programs %v", blockPrefix(i, len(blocks)), program, in.AllowedPrograms)
+			return nil, execErrf(KindDisallowedProgram,
+				"coderun: %sprogram %q not in --allowed-programs %v", blockPrefix(i, len(blocks)), program, in.AllowedPrograms)
 		}
 		programs[i] = program
 	}
@@ -272,13 +283,67 @@ type pipelineDebugTaps []*limitedBuffer
 
 // builtBlock is a fully prepared (not yet started) pipeline stage.
 type builtBlock struct {
-	cmd       *exec.Cmd
-	workDir   string
-	blockCtx  context.Context
-	cancel    context.CancelFunc
-	errBuf    limitedBuffer
-	sandboxed bool
-	startedAt time.Time
+	cmd        *exec.Cmd
+	workDir    string
+	blockCtx   context.Context
+	cancel     context.CancelFunc
+	errBuf     limitedBuffer
+	sandboxed  bool
+	fallback   string // besteffort degradation reason; empty when sandboxed as asked
+	startedAt  time.Time
+	finishedAt time.Time
+}
+
+// elapsed is the block's wall time: from Start to the Wait that reaped it, or
+// to now for a block that never finished.
+func (b *builtBlock) elapsed() time.Duration {
+	if b.finishedAt.IsZero() {
+		return time.Since(b.startedAt)
+	}
+	return b.finishedAt.Sub(b.startedAt)
+}
+
+// observePipeline reports one BlockStats per pipeline block. Only the last
+// block's stdout is buffered (the others stream into the next block's stdin),
+// so stdout size and truncation are reported for it alone.
+func observePipeline(observe func(BlockStats), built []builtBlock, programs []string) {
+	if observe == nil {
+		return
+	}
+	for i := range built {
+		bb := &built[i]
+		st := BlockStats{
+			Index:           i,
+			Outcome:         pipelineOutcome(bb),
+			ExitCode:        exitCode(bb.cmd.ProcessState),
+			DurationMs:      bb.elapsed().Milliseconds(),
+			MaxRSSBytes:     maxRSSBytes(bb.cmd.ProcessState),
+			SandboxFallback: bb.fallback,
+		}
+		if i < len(programs) {
+			st.Program = programs[i]
+		}
+		if last, ok := bb.cmd.Stdout.(*limitedBuffer); ok && last != nil {
+			st.StdoutBytes = len(last.String())
+			st.StdoutTruncated = last.Truncated()
+		}
+		observe(st)
+	}
+}
+
+// pipelineOutcome classifies one finished pipeline block from its process
+// state and its own (timeout-bearing) context.
+func pipelineOutcome(bb *builtBlock) string {
+	switch {
+	case bb.blockCtx.Err() != nil:
+		return BlockTimeout
+	case bb.cmd.ProcessState == nil:
+		return BlockStartFailed
+	case bb.cmd.ProcessState.ExitCode() != 0:
+		return BlockNonZeroExit
+	default:
+		return BlockOK
+	}
 }
 
 // runPipeline runs len(blocks) > 1 as a true streaming pipeline: block i's
@@ -373,7 +438,7 @@ func startAll(built []builtBlock, pipes []*io.PipeWriter, n int) error {
 			for j := range i {
 				_ = pipes[j].CloseWithError(sErr)
 			}
-			return fmt.Errorf("coderun: %sstart failed: %w", blockPrefix(i, n), sErr)
+			return execErrf(KindStartFailed, "coderun: %sstart failed: %w", blockPrefix(i, n), sErr)
 		}
 	}
 	return nil
@@ -412,20 +477,20 @@ func waitPipeline(built []builtBlock, pipes []*io.PipeWriter, sandbox SandboxPol
 	for i, e := range errs {
 		if e != nil {
 			if built[i].blockCtx.Err() != nil {
-				return "", stderrs, fmt.Errorf("coderun: %stimed out", blockPrefix(i, n))
+				return "", stderrs, execErrf(KindTimeout, "coderun: %stimed out", blockPrefix(i, n))
 			}
 			msg := stderrs[i]
 			if msg == "" {
 				msg = e.Error()
 			}
-			return "", stderrs, fmt.Errorf("coderun: %snon-zero exit: %s", blockPrefix(i, n), msg)
+			return "", stderrs, execErrf(KindNonZeroExit, "coderun: %snon-zero exit: %s", blockPrefix(i, n), msg)
 		}
 	}
 
 	// All blocks succeeded; extract the last block's stdout via the Stdout pointer.
 	lastBuf, ok := built[n-1].cmd.Stdout.(*limitedBuffer)
 	if !ok || lastBuf == nil {
-		return "", stderrs, errors.New("coderun: internal error: last block stdout not captured")
+		return "", stderrs, &ExecError{Kind: KindInternal, Err: errLastStdoutMissing}
 	}
 	return lastBuf.String(), stderrs, nil
 }
@@ -434,6 +499,7 @@ func waitPipeline(built []builtBlock, pipes []*io.PipeWriter, sandbox SandboxPol
 // downstream pipe writer (if any) so the next block sees EOF.
 func waitOne(idx int, built []builtBlock, pipes []*io.PipeWriter, n int, sandbox SandboxPolicy, ch chan<- pipeWaitResult) {
 	werr := built[idx].cmd.Wait()
+	built[idx].finishedAt = time.Now()
 	if idx < n-1 {
 		if werr != nil {
 			_ = pipes[idx].CloseWithError(werr)
@@ -477,19 +543,19 @@ func closeAllPipes(pipes []*io.PipeWriter) {
 func buildBlockCmd(ctx context.Context, code, program string, in CodeInput) (builtBlock, error) {
 	interp, ok := currentRegistry().byName[program]
 	if !ok {
-		return builtBlock{}, fmt.Errorf("unknown program %q", program)
+		return builtBlock{}, execErrf(KindUnknownProgram, "unknown program %q", program)
 	}
 
 	workDir, mkErr := os.MkdirTemp("", "fleet-coderun-*")
 	if mkErr != nil {
-		return builtBlock{}, fmt.Errorf("create workdir: %w", mkErr)
+		return builtBlock{}, execErrf(KindSetupFailed, "create workdir: %w", mkErr)
 	}
 	tear := func() { _ = os.RemoveAll(workDir) }
 
 	codeFile := filepath.Join(workDir, "run"+interp.Ext)
 	if wErr := os.WriteFile(codeFile, []byte(code), 0o600); wErr != nil {
 		tear()
-		return builtBlock{}, fmt.Errorf("write code file: %w", wErr)
+		return builtBlock{}, execErrf(KindSetupFailed, "write code file: %w", wErr)
 	}
 
 	inputData := in.Input
@@ -499,7 +565,7 @@ func buildBlockCmd(ctx context.Context, code, program string, in CodeInput) (bui
 	inputFile := filepath.Join(workDir, "input.json")
 	if wErr := os.WriteFile(inputFile, inputData, 0o600); wErr != nil {
 		tear()
-		return builtBlock{}, fmt.Errorf("write input file: %w", wErr)
+		return builtBlock{}, execErrf(KindSetupFailed, "write input file: %w", wErr)
 	}
 
 	env := buildChildEnv(inputFile, interp, in.EnvPassthrough, in.EnvPrefix)
@@ -514,13 +580,15 @@ func buildBlockCmd(ctx context.Context, code, program string, in CodeInput) (bui
 	policy := in.Sandbox.withDefaults(in.Timeout)
 	sandboxed := policy.Mode != SandboxOff
 
+	var fallback string
 	if sandboxed && !sandboxSupportedOS {
 		if policy.Mode.enforcing() {
 			cancel()
 			tear()
-			return builtBlock{}, fmt.Errorf("sandbox mode %q requires Linux; refusing to run unsandboxed", policy.Mode)
+			return builtBlock{}, execErrf(KindSandboxRefused, "sandbox mode %q requires Linux; refusing to run unsandboxed", policy.Mode)
 		}
-		warnSandboxFallback("unsupported OS", nil)
+		fallback = "unsupported OS"
+		warnSandboxFallback(fallback, nil)
 		sandboxed = false
 	}
 
@@ -531,9 +599,10 @@ func buildBlockCmd(ctx context.Context, code, program string, in CodeInput) (bui
 			if policy.Mode.enforcing() {
 				cancel()
 				tear()
-				return builtBlock{}, fmt.Errorf("sandbox setup failed: %w", sbErr)
+				return builtBlock{}, execErrf(KindSandboxRefused, "sandbox setup failed: %w", sbErr)
 			}
-			warnSandboxFallback("sandbox setup failed", sbErr)
+			fallback = "sandbox setup failed"
+			warnSandboxFallback(fallback, sbErr)
 			sandboxed = false
 		} else {
 			cmd = sbCmd
@@ -554,6 +623,7 @@ func buildBlockCmd(ctx context.Context, code, program string, in CodeInput) (bui
 		blockCtx:  blockCtx,
 		cancel:    cancel,
 		sandboxed: sandboxed,
+		fallback:  fallback,
 	}, nil
 }
 

--- a/cmd/codellm/internal/coderun/stats.go
+++ b/cmd/codellm/internal/coderun/stats.go
@@ -94,9 +94,11 @@ func execErrf(kind, format string, a ...any) error {
 	return &ExecError{Kind: kind, Err: fmt.Errorf(format, a...)}
 }
 
-// observeSingleBlock reports the single-block path's measured stats.
+// observeSingleBlock reports the single-block path's measured stats. An empty
+// Outcome means RunBlock failed before the child ran (sandbox refused, workdir
+// or file setup) — there is no block to report, only an exec error.
 func observeSingleBlock(observe func(BlockStats), program string, stats RunBlockStats) {
-	if observe == nil {
+	if observe == nil || stats.Outcome == "" {
 		return
 	}
 	observe(BlockStats{

--- a/cmd/codellm/internal/coderun/stats.go
+++ b/cmd/codellm/internal/coderun/stats.go
@@ -1,0 +1,113 @@
+package coderun
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Block outcomes reported through CodeInput.Observe.
+const (
+	BlockOK          = "ok"
+	BlockNonZeroExit = "nonzero_exit"
+	BlockTimeout     = "timeout"
+	BlockStartFailed = "start_failed"
+)
+
+// Failure kinds carried by ExecError. They classify WHY a run failed without
+// the caller matching on message text.
+const (
+	KindNoBlocks          = "no_blocks"
+	KindUnknownFence      = "unknown_fence"
+	KindUnknownProgram    = "unknown_program"
+	KindDisallowedProgram = "disallowed_program"
+	KindSandboxRefused    = "sandbox_refused"
+	KindSetupFailed       = "setup_failed"
+	KindStartFailed       = "start_failed"
+	KindTimeout           = "timeout"
+	KindNonZeroExit       = "nonzero_exit"
+	KindParseError        = "parse_error"
+	KindInternal          = "internal"
+	// KindUnclassified is what ErrorKind reports for an error that carries no
+	// kind of its own — never returned by coderun itself.
+	KindUnclassified = "unclassified"
+)
+
+// BlockStats is one executed block's measured outcome. coderun records no
+// metrics itself: it reports what it measured and the caller (codellm) decides
+// what to count, which keeps this package free of a metrics dependency.
+type BlockStats struct {
+	Index    int
+	Program  string
+	Outcome  string // BlockOK | BlockNonZeroExit | BlockTimeout | BlockStartFailed
+	ExitCode int    // -1 when the child never produced an exit status
+
+	DurationMs  int64
+	MaxRSSBytes int64
+
+	// StdoutBytes / StdoutTruncated describe the stdout this block's caller
+	// captured. Only the block whose stdout is buffered reports them: in a
+	// pipeline the intermediate blocks stream straight into the next block's
+	// stdin, so their sizes are unknown (0/false) unless debug capture is on.
+	StdoutBytes     int
+	StdoutTruncated bool
+
+	// SandboxFallback is non-empty when a besteffort policy degraded this block
+	// to unsandboxed execution, carrying the reason. Enforcing mode refuses the
+	// run instead and never reaches a BlockStats.
+	SandboxFallback string
+}
+
+// Sentinel errors for the two failures that carry no per-run detail.
+var (
+	errNoFencedBlock     = errors.New("coderun: no fenced code block found in rendered body")
+	errExecutionDisabled = errors.New("coderun: code execution disabled (set --allowed-programs)")
+	errLastStdoutMissing = errors.New("coderun: internal error: last block stdout not captured")
+)
+
+// ExecError classifies an execution failure. The message is unchanged from the
+// wrapped error, so callers that match on text keep working; Kind is the stable
+// label to count on.
+type ExecError struct {
+	Kind string
+	Err  error
+}
+
+func (e *ExecError) Error() string { return e.Err.Error() }
+
+func (e *ExecError) Unwrap() error { return e.Err }
+
+// ErrorKind returns the classification of err: "" for nil, the ExecError kind
+// when one is present, KindUnclassified otherwise.
+func ErrorKind(err error) string {
+	if err == nil {
+		return ""
+	}
+	var ee *ExecError
+	if errors.As(err, &ee) {
+		return ee.Kind
+	}
+	return KindUnclassified
+}
+
+// execErrf builds a classified error with a formatted message.
+func execErrf(kind, format string, a ...any) error {
+	return &ExecError{Kind: kind, Err: fmt.Errorf(format, a...)}
+}
+
+// observeSingleBlock reports the single-block path's measured stats.
+func observeSingleBlock(observe func(BlockStats), program string, stats RunBlockStats) {
+	if observe == nil {
+		return
+	}
+	observe(BlockStats{
+		Index:           0,
+		Program:         program,
+		Outcome:         stats.Outcome,
+		ExitCode:        stats.ExitCode,
+		DurationMs:      stats.DurationMs,
+		MaxRSSBytes:     stats.MaxRSSBytes,
+		StdoutBytes:     stats.StdoutBytes,
+		StdoutTruncated: stats.StdoutTruncated,
+		SandboxFallback: stats.SandboxFallback,
+	})
+}

--- a/cmd/codellm/internal/coderun/stats_test.go
+++ b/cmd/codellm/internal/coderun/stats_test.go
@@ -24,6 +24,7 @@ func TestExec_ObserverReportsExitCode(t *testing.T) {
 		Body:            "```bash\necho boom >&2; exit 3\n```",
 		AllowedPrograms: []string{"bash"},
 		Sandbox:         sandboxOff(),
+		Timeout:         300 * time.Second,
 		Observe:         func(s BlockStats) { seen = append(seen, s) },
 	}, false)
 
@@ -43,6 +44,7 @@ func TestExec_ObserverReportsSuccess(t *testing.T) {
 		Body:            "```bash\necho '{\"changes\":[],\"answer\":\"ok\"}'\n```",
 		AllowedPrograms: []string{"bash"},
 		Sandbox:         sandboxOff(),
+		Timeout:         300 * time.Second,
 		Observe:         func(s BlockStats) { seen = append(seen, s) },
 	})
 
@@ -55,7 +57,7 @@ func TestExec_ObserverReportsSuccess(t *testing.T) {
 }
 
 // TestExec_ObserverReportsTruncation asserts stdout hitting MaxStdoutBytes is
-// reported as truncated — today the overflow is dropped silently and only
+// reported as truncated: the overflow is dropped, and without this flag it only
 // surfaces later as a confusing parse error.
 func TestExec_ObserverReportsTruncation(t *testing.T) {
 	var seen []BlockStats
@@ -75,7 +77,11 @@ func TestExec_ObserverReportsTruncation(t *testing.T) {
 }
 
 // TestExec_ObserverReportsEveryPipelineBlock asserts the multi-block path
-// observes each block, not just the last one.
+// observes each block, not just the last one, and that a clean block is
+// reported as such. The Timeout is what production always sets and is load
+// bearing here: it gives each block its own cancellable context, and the
+// pipeline teardown cancels those on the way out — classifying after teardown
+// would report every successful block as a timeout.
 func TestExec_ObserverReportsEveryPipelineBlock(t *testing.T) {
 	var seen []BlockStats
 	body := "```bash\necho hi\n```\n```bash\ncat >/dev/null; echo '{\"changes\":[],\"answer\":\"ok\"}'\n```"
@@ -83,6 +89,7 @@ func TestExec_ObserverReportsEveryPipelineBlock(t *testing.T) {
 		Body:            body,
 		AllowedPrograms: []string{"bash"},
 		Sandbox:         sandboxOff(),
+		Timeout:         300 * time.Second,
 		Observe:         func(s BlockStats) { seen = append(seen, s) },
 	})
 
@@ -161,4 +168,57 @@ func TestErrorKind_ClassifiesSetupFailures(t *testing.T) {
 func TestErrorKind_Fallbacks(t *testing.T) {
 	require.Empty(t, ErrorKind(nil))
 	require.Equal(t, KindUnclassified, ErrorKind(errors.New("boom")))
+}
+
+// TestExec_ObserverReportsPipelineFailure asserts a failing block in a pipeline
+// is reported with its own exit code, not folded into the run-level error.
+func TestExec_ObserverReportsPipelineFailure(t *testing.T) {
+	var seen []BlockStats
+	body := "```bash\necho hi\n```\n```bash\ncat >/dev/null; exit 5\n```"
+	_, _, err := ExecCode(context.Background(), CodeInput{
+		Body:            body,
+		AllowedPrograms: []string{"bash"},
+		Sandbox:         sandboxOff(),
+		Timeout:         300 * time.Second,
+		Observe:         func(s BlockStats) { seen = append(seen, s) },
+	})
+
+	require.Error(t, err)
+	require.Equal(t, KindNonZeroExit, ErrorKind(err))
+	require.Len(t, seen, 2)
+	require.Equal(t, BlockOK, seen[0].Outcome)
+	require.Equal(t, BlockNonZeroExit, seen[1].Outcome)
+	require.Equal(t, 5, seen[1].ExitCode)
+}
+
+// TestExec_ResolveFailureReportsNoBlock asserts a run rejected before any child
+// starts emits an exec error and no block stats — a phantom block with a zero
+// exit code would read as a clean run that never happened.
+func TestExec_ResolveFailureReportsNoBlock(t *testing.T) {
+	var seen []BlockStats
+	_, _, err := ExecCode(context.Background(), CodeInput{
+		Body:            "```bash\necho hi\n```",
+		AllowedPrograms: []string{"python"}, // bash is not allowed: refused up front
+		Sandbox:         sandboxOff(),
+		Observe:         func(s BlockStats) { seen = append(seen, s) },
+	})
+
+	require.Error(t, err)
+	require.Equal(t, KindDisallowedProgram, ErrorKind(err))
+	require.Empty(t, seen)
+}
+
+// TestObserveSingleBlock_SkipsUnrunBlock covers the same guard on the path that
+// cannot be forced from the outside: RunBlock failing during setup (sandbox
+// refused, workdir creation) leaves the stats sink untouched, and an unset
+// Outcome must not be reported as a block.
+func TestObserveSingleBlock_SkipsUnrunBlock(t *testing.T) {
+	var seen []BlockStats
+	observe := func(s BlockStats) { seen = append(seen, s) }
+
+	observeSingleBlock(observe, "bash", RunBlockStats{})
+	require.Empty(t, seen)
+
+	observeSingleBlock(observe, "bash", RunBlockStats{Outcome: BlockOK})
+	require.Len(t, seen, 1)
 }

--- a/cmd/codellm/internal/coderun/stats_test.go
+++ b/cmd/codellm/internal/coderun/stats_test.go
@@ -1,0 +1,164 @@
+package coderun
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// sandboxOff runs the stats tests unsandboxed: what they assert (exit codes,
+// truncation, per-block observation) is sandbox-independent, and an off policy
+// keeps them running on kernels where the native sandbox is unavailable.
+func sandboxOff() SandboxPolicy {
+	return SandboxPolicy{Mode: SandboxOff}
+}
+
+// TestExec_ObserverReportsExitCode is the exit-code plumbing proof: a failing
+// block must report its real exit status, not a collapsed zero.
+func TestExec_ObserverReportsExitCode(t *testing.T) {
+	var seen []BlockStats
+	_, err := Exec(context.Background(), CodeInput{
+		Body:            "```bash\necho boom >&2; exit 3\n```",
+		AllowedPrograms: []string{"bash"},
+		Sandbox:         sandboxOff(),
+		Observe:         func(s BlockStats) { seen = append(seen, s) },
+	}, false)
+
+	require.Error(t, err)
+	require.Equal(t, KindNonZeroExit, ErrorKind(err))
+	require.Len(t, seen, 1)
+	require.Equal(t, 3, seen[0].ExitCode)
+	require.Equal(t, BlockNonZeroExit, seen[0].Outcome)
+	require.Equal(t, "bash", seen[0].Program)
+}
+
+// TestExec_ObserverReportsSuccess asserts a clean block reports exit 0, the ok
+// outcome, and its captured stdout size.
+func TestExec_ObserverReportsSuccess(t *testing.T) {
+	var seen []BlockStats
+	_, _, err := ExecCode(context.Background(), CodeInput{
+		Body:            "```bash\necho '{\"changes\":[],\"answer\":\"ok\"}'\n```",
+		AllowedPrograms: []string{"bash"},
+		Sandbox:         sandboxOff(),
+		Observe:         func(s BlockStats) { seen = append(seen, s) },
+	})
+
+	require.NoError(t, err)
+	require.Len(t, seen, 1)
+	require.Equal(t, BlockOK, seen[0].Outcome)
+	require.Equal(t, 0, seen[0].ExitCode)
+	require.Positive(t, seen[0].StdoutBytes)
+	require.False(t, seen[0].StdoutTruncated)
+}
+
+// TestExec_ObserverReportsTruncation asserts stdout hitting MaxStdoutBytes is
+// reported as truncated — today the overflow is dropped silently and only
+// surfaces later as a confusing parse error.
+func TestExec_ObserverReportsTruncation(t *testing.T) {
+	var seen []BlockStats
+	_, _, err := ExecCode(context.Background(), CodeInput{
+		Body:            "```bash\nhead -c 4096 /dev/zero | tr '\\0' 'x'\n```",
+		AllowedPrograms: []string{"bash"},
+		Sandbox:         sandboxOff(),
+		MaxStdoutBytes:  64,
+		Observe:         func(s BlockStats) { seen = append(seen, s) },
+	})
+
+	require.Error(t, err) // truncated stdout is no longer valid JSON
+	require.Equal(t, KindParseError, ErrorKind(err))
+	require.Len(t, seen, 1)
+	require.True(t, seen[0].StdoutTruncated)
+	require.Equal(t, 64, seen[0].StdoutBytes)
+}
+
+// TestExec_ObserverReportsEveryPipelineBlock asserts the multi-block path
+// observes each block, not just the last one.
+func TestExec_ObserverReportsEveryPipelineBlock(t *testing.T) {
+	var seen []BlockStats
+	body := "```bash\necho hi\n```\n```bash\ncat >/dev/null; echo '{\"changes\":[],\"answer\":\"ok\"}'\n```"
+	_, _, err := ExecCode(context.Background(), CodeInput{
+		Body:            body,
+		AllowedPrograms: []string{"bash"},
+		Sandbox:         sandboxOff(),
+		Observe:         func(s BlockStats) { seen = append(seen, s) },
+	})
+
+	require.NoError(t, err)
+	require.Len(t, seen, 2)
+	require.Equal(t, 0, seen[0].Index)
+	require.Equal(t, 1, seen[1].Index)
+	for _, s := range seen {
+		require.Equal(t, BlockOK, s.Outcome)
+		require.Equal(t, 0, s.ExitCode)
+	}
+}
+
+// TestExec_ObserverReportsTimeout asserts a killed block is reported as a
+// timeout rather than a plain non-zero exit. It runs sandboxed on purpose: only
+// the sandbox's pid namespace reaps the interpreter's own children, so an
+// unsandboxed sleep would hold the captured stdout pipe open past the deadline.
+func TestExec_ObserverReportsTimeout(t *testing.T) {
+	skipIfSandboxUnsupported(t)
+	var seen []BlockStats
+	_, _, err := ExecCode(context.Background(), CodeInput{
+		Body:            "```bash\nsleep 60\n```",
+		AllowedPrograms: []string{"bash"},
+		Timeout:         150 * time.Millisecond,
+		Observe:         func(s BlockStats) { seen = append(seen, s) },
+	})
+
+	require.Error(t, err)
+	require.Equal(t, KindTimeout, ErrorKind(err))
+	require.Len(t, seen, 1)
+	require.Equal(t, BlockTimeout, seen[0].Outcome)
+}
+
+// TestErrorKind_ClassifiesSetupFailures asserts the failure kinds a caller
+// counts on are distinguishable without matching message text.
+func TestErrorKind_ClassifiesSetupFailures(t *testing.T) {
+	tests := []struct {
+		name string
+		in   CodeInput
+		want string
+	}{
+		{
+			name: "no fenced block",
+			in:   CodeInput{Body: "plain prose", AllowedPrograms: []string{"bash"}},
+			want: KindNoBlocks,
+		},
+		{
+			name: "unknown fence language",
+			in:   CodeInput{Body: "```brainfuck\n+++\n```", AllowedPrograms: []string{"bash"}},
+			want: KindUnknownFence,
+		},
+		{
+			name: "program not allowed",
+			in:   CodeInput{Body: "```bash\necho hi\n```", AllowedPrograms: []string{"python"}},
+			want: KindDisallowedProgram,
+		},
+		{
+			name: "execution disabled",
+			in:   CodeInput{Body: "```bash\necho hi\n```"},
+			want: KindDisallowedProgram,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := tt.in
+			in.Sandbox = sandboxOff()
+			_, _, err := ExecCode(context.Background(), in)
+			require.Error(t, err)
+			require.Equal(t, tt.want, ErrorKind(err))
+		})
+	}
+}
+
+// TestErrorKind_Fallbacks asserts the helper is nil-safe and does not invent a
+// kind for errors that carry none.
+func TestErrorKind_Fallbacks(t *testing.T) {
+	require.Empty(t, ErrorKind(nil))
+	require.Equal(t, KindUnclassified, ErrorKind(errors.New("boom")))
+}

--- a/cmd/codellm/main.go
+++ b/cmd/codellm/main.go
@@ -11,6 +11,7 @@ package main
 
 import (
 	"log"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -109,6 +110,7 @@ func startMetricsServer(cfg *appconfig.Config) *codellmmetrics.Metrics {
 	if cfg.MetricsAddr == "" {
 		return nil
 	}
+	warnIfMetricsAddrNonLoopback(cfg.MetricsAddr)
 	m := codellmmetrics.New()
 	m.SetConfigInfo(string(cfg.Sandbox), strconv.FormatBool(cfg.SandboxNetwork), strings.Join(cfg.AllowedPrograms, ","))
 
@@ -125,4 +127,22 @@ func startMetricsServer(cfg *appconfig.Config) *codellmmetrics.Metrics {
 		}
 	}()
 	return m
+}
+
+// warnIfMetricsAddrNonLoopback logs a loud warning when the internal listener
+// is bound off loopback. It is not blocked — scraping a containerized codellm
+// requires binding the container's interface — but /metrics and pprof are
+// unauthenticated, so the exposure must be visible in the log.
+func warnIfMetricsAddrNonLoopback(addr string) {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return
+	}
+	if host == "localhost" {
+		return
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+		return
+	}
+	log.Printf("WARNING: codellm metrics bound non-loopback (%s): /metrics and pprof are unauthenticated", addr)
 }

--- a/cmd/codellm/main.go
+++ b/cmd/codellm/main.go
@@ -12,9 +12,12 @@ package main
 import (
 	"log"
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 
 	"trip2g/cmd/codellm/internal/codellm"
+	"trip2g/cmd/codellm/internal/codellmmetrics"
 	"trip2g/cmd/codellm/internal/coderun"
 	"trip2g/internal/delegatedadmin"
 
@@ -62,8 +65,14 @@ func main() {
 	// 	}
 	// }
 
+	// Metrics live on their own loopback listener (mirrors the monolith's
+	// internal listener): /metrics, pprof and the probes are unauthenticated, so
+	// the port must never leave the box.
+	metrics := startMetricsServer(cfg)
+
 	srvCfg := codellm.Config{
 		AllowedPrograms: cfg.AllowedPrograms,
+		Metrics:         metrics,
 		Sandbox: coderun.SandboxPolicy{
 			Mode:    cfg.Sandbox,
 			Network: cfg.SandboxNetwork,
@@ -79,7 +88,7 @@ func main() {
 		// (fail-safe), leaving the browser delegated-admin gate as the only way in.
 		TokenCheck: codellm.APIKeyCheck(cfg.APIKey),
 	}
-	srvCfg.Auth = codellm.BrowserAuth(admin.Wrap, srvCfg.TokenCheck)
+	srvCfg.Auth = codellm.BrowserAuthWithMetrics(admin.Wrap, srvCfg.TokenCheck, metrics)
 
 	srv := &http.Server{
 		Addr:              cfg.Addr,
@@ -90,4 +99,30 @@ func main() {
 	if err = srv.ListenAndServe(); err != nil {
 		log.Fatalf("server error: %v", err)
 	}
+}
+
+// startMetricsServer brings up the internal listener when --metrics-addr is
+// set and returns the sink the service records into (nil when disabled, which
+// every record call site tolerates). A failure to bind it is logged, not fatal:
+// losing observability must not take the service down.
+func startMetricsServer(cfg *appconfig.Config) *codellmmetrics.Metrics {
+	if cfg.MetricsAddr == "" {
+		return nil
+	}
+	m := codellmmetrics.New()
+	m.SetConfigInfo(string(cfg.Sandbox), strconv.FormatBool(cfg.SandboxNetwork), strings.Join(cfg.AllowedPrograms, ","))
+
+	srv := &http.Server{
+		Addr: cfg.MetricsAddr,
+		// codellm is ready as soon as it listens: it holds no warm-up state.
+		Handler:           m.Handler(nil),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	go func() {
+		log.Printf("codellm metrics listening on %s", cfg.MetricsAddr)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Printf("codellm metrics server error: %v", err)
+		}
+	}()
+	return m
 }

--- a/cmd/codellm/main_metrics_test.go
+++ b/cmd/codellm/main_metrics_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trip2g/cmd/codellm/appconfig"
+	"trip2g/cmd/codellm/internal/coderun"
+)
+
+// TestStartMetricsServer_DisabledByEmptyAddr asserts an empty --metrics-addr
+// starts nothing and yields the nil sink every call site tolerates.
+func TestStartMetricsServer_DisabledByEmptyAddr(t *testing.T) {
+	cfg := appconfig.DefaultConfig()
+	cfg.MetricsAddr = ""
+
+	require.Nil(t, startMetricsServer(&cfg))
+}
+
+// TestStartMetricsServer_PublishesExecutionPosture asserts an enabled listener
+// comes up with the sandbox posture already published, so an operator can read
+// it from a scrape instead of from the box.
+func TestStartMetricsServer_PublishesExecutionPosture(t *testing.T) {
+	cfg := appconfig.DefaultConfig()
+	cfg.MetricsAddr = freeAddr(t)
+	cfg.Sandbox = coderun.SandboxNative
+	cfg.SandboxNetwork = true
+	cfg.AllowedPrograms = []string{"python", "bash"}
+
+	m := startMetricsServer(&cfg)
+	require.NotNil(t, m)
+
+	rec := httptest.NewRecorder()
+	m.Handler(nil).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(),
+		`codellm_config_info{allowed_programs="python,bash",sandbox_mode="native",sandbox_network="true"} 1`)
+}
+
+// freeAddr returns a loopback address that was free a moment ago. The listener
+// under test binds it itself, so it is released first.
+func freeAddr(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.NotFoundHandler())
+	addr := srv.Listener.Addr().String()
+	srv.Close()
+	return addr
+}

--- a/cmd/fleet/appconfig/config.go
+++ b/cmd/fleet/appconfig/config.go
@@ -32,6 +32,13 @@ const (
 	// ingress (mirrors codellm's loopback default). The API is gated by the
 	// delegated-admin middleware regardless of bind.
 	DefaultGraphQLAddr = "127.0.0.1:9093"
+
+	// DefaultMetricsAddr binds the internal listener (Prometheus /metrics, pprof,
+	// liveness/readiness) to loopback: none of it is authenticated, exactly like
+	// the monolith's internal listener. The port follows the deployment
+	// convention of a "1"-prefixed twin of the service port (infra/site.yml:
+	// 8087 -> 19087), so the fleet's 9090 pairs with 19090.
+	DefaultMetricsAddr = "127.0.0.1:19090"
 )
 
 // Config holds the subset of fleet's machine-level settings layered via
@@ -44,6 +51,7 @@ type Config struct {
 	CallbackURL   string   // trip2g-reachable base URL of this fleet (reconcile: webhook target)
 	Trip2gBaseURL string   // trip2g base URL fleet talks to (reconcile: discovery/registration)
 	GraphQLAddr   string   // fleet's own GraphQL read API (roles + roleGraph); empty = disabled
+	MetricsAddr   string   // internal listener: /metrics, pprof, probes; loopback-only, empty = disabled
 	DefaultModel  string   // fallback model when a role omits model
 	OfferedTools  []string // allowed tools a role may declare
 
@@ -58,6 +66,7 @@ func DefaultConfig() *Config {
 		ListenAddr:      DefaultListenAddr,
 		Trip2gBaseURL:   DefaultTrip2gBaseURL,
 		GraphQLAddr:     DefaultGraphQLAddr,
+		MetricsAddr:     DefaultMetricsAddr,
 		DefaultModel:    DefaultModel,
 		offeredToolsCSV: DefaultOfferedTools,
 	}
@@ -82,6 +91,9 @@ func (c *Config) DefineFlags(fs *flag.FlagSet) {
 			"the delegated-admin middleware (forwards the caller's cookie to the monolith's "+
 			"viewer{role}; admin -> serve, else 401, monolith-unreachable -> fail-closed). Front it "+
 			"with Caddy /_fleet/* as the sole ingress; expose a non-loopback bind only behind that proxy")
+	fs.StringVar(&c.MetricsAddr, "metrics-addr", c.MetricsAddr,
+		"loopback listen address serving Prometheus /metrics, pprof and the liveness/readiness probes; "+
+			"unauthenticated by design, so never bind it off-box. Empty = disabled")
 	fs.StringVar(&c.DefaultModel, "default-model", c.DefaultModel,
 		"default model when a role omits model")
 	fs.StringVar(&c.offeredToolsCSV, "offered-tools", c.offeredToolsCSV,

--- a/cmd/fleet/appconfig/config.go
+++ b/cmd/fleet/appconfig/config.go
@@ -35,10 +35,11 @@ const (
 
 	// DefaultMetricsAddr binds the internal listener (Prometheus /metrics, pprof,
 	// liveness/readiness) to loopback: none of it is authenticated, exactly like
-	// the monolith's internal listener. The port follows the deployment
-	// convention of a "1"-prefixed twin of the service port (infra/site.yml:
-	// 8087 -> 19087), so the fleet's 9090 pairs with 19090.
-	DefaultMetricsAddr = "127.0.0.1:19090"
+	// the monolith's internal listener. The 18xxx band keeps the standalone
+	// binaries clear of the 19xxx internal ports infra/site.yml assigns one per
+	// site ("MUST be unique per service"; 19090 is already reserved there):
+	// codellm 8087 -> 18087, fleet 9090 -> 18090.
+	DefaultMetricsAddr = "127.0.0.1:18090"
 )
 
 // Config holds the subset of fleet's machine-level settings layered via

--- a/cmd/fleet/appconfig/config_test.go
+++ b/cmd/fleet/appconfig/config_test.go
@@ -103,3 +103,20 @@ func TestSplitCSV(t *testing.T) {
 		})
 	}
 }
+
+// TestMetricsAddr covers the internal listener's config lane: a loopback
+// default, the TRIP2G_FLEET_ env fallback, and empty = disabled.
+func TestMetricsAddr(t *testing.T) {
+	cfg, err := Get(context.Background(), nil)
+	require.NoError(t, err)
+	require.Equal(t, DefaultMetricsAddr, cfg.MetricsAddr, "the internal listener must default to loopback")
+
+	t.Setenv("TRIP2G_FLEET_METRICS_ADDR", "127.0.0.1:19500")
+	cfg, err = Get(context.Background(), nil)
+	require.NoError(t, err)
+	require.Equal(t, "127.0.0.1:19500", cfg.MetricsAddr)
+
+	cfg, err = Get(context.Background(), []string{"--metrics-addr", ""})
+	require.NoError(t, err)
+	require.Empty(t, cfg.MetricsAddr, "an empty address must disable the listener, not fail validation")
+}

--- a/cmd/fleet/internal/agentruntime/metrics_test.go
+++ b/cmd/fleet/internal/agentruntime/metrics_test.go
@@ -182,8 +182,54 @@ func TestRun_RecordsNotPermittedTool(t *testing.T) {
 		KB:           kb,
 	})
 	require.NoError(t, err)
-	require.Equal(t, outcomeNotPermitted, m.tools[toolWriteNote])
+	// The rejected name is model-supplied, so it is bucketed: a hallucinated or
+	// injected tool name must never mint a metric series of its own.
+	require.Equal(t, outcomeNotPermitted, m.tools[unknownTool])
+	require.NotContains(t, m.tools, toolWriteNote)
 	require.Equal(t, []string{denialNotPermitted}, m.denials)
+}
+
+// TestRun_RecordsFinish asserts the ordinary successful termination is counted:
+// finish is the tool call most runs end on.
+func TestRun_RecordsFinish(t *testing.T) {
+	llm := &stubLLM{fallback: ChatResult{
+		ToolCalls:    []ToolCall{toolCall("1", toolFinish, map[string]any{"answer": "done"})},
+		PromptTokens: 5, CompletionTokens: 5,
+	}}
+	m := newFakeMetrics()
+
+	_, err := Run(context.Background(), Input{
+		Instruction: "Finish.", Model: "test-model", Role: "roles/f.md", Metrics: m,
+		MaxTokens: 1000, MaxSteps: 3, LLM: llm, KB: newMemKB(nil),
+	})
+	require.NoError(t, err)
+	require.Equal(t, outcomeOK, m.tools[toolFinish])
+}
+
+// TestRun_FailedRunKeepsItsSteps asserts a run that dies mid-loop still reports
+// the steps and spend it already burned — otherwise a failing role looks free.
+func TestRun_FailedRunKeepsItsSteps(t *testing.T) {
+	kb := newMemKB(map[string]string{"boards/a.md": "todo todo"})
+	llm := &stubLLM{fallback: ChatResult{
+		ToolCalls: []ToolCall{toolCall("1", toolPatchNote, map[string]any{
+			"path": "boards/a.md", "find": "todo", "replace": "doing",
+		})},
+		PromptTokens: 10, CompletionTokens: 5,
+	}}
+	m := newFakeMetrics()
+
+	res, err := Run(context.Background(), Input{
+		Instruction: "Patch it.", ReadPatterns: []string{"boards/**"}, WritePatterns: []string{"boards/**"},
+		Model: "test-model", Role: "roles/patch.md", Metrics: m, HardFailApply: true,
+		MaxTokens: 10000, MaxSteps: 5, LLM: llm, KB: kb,
+	})
+	require.Error(t, err)
+	require.Nil(t, res, "the caller contract is nil result on error")
+
+	require.Len(t, m.runs, 1)
+	require.Equal(t, statusErrorForRun, m.runs[0].status)
+	require.Equal(t, 1, m.runs[0].steps, "the step it burned before failing must still be reported")
+	require.Equal(t, 15, m.totalTokens())
 }
 
 // llmMetricsRecorder captures the provider-call lane.
@@ -238,4 +284,36 @@ func TestOpenAILLM_RecordsTerminalFailureReason(t *testing.T) {
 
 	require.Empty(t, rec.retries)
 	require.Equal(t, []string{"exec|codellm|4xx"}, rec.requests)
+}
+
+// TestOpenAILLM_ExhaustedRetriesRecordOnce asserts the final failure is the
+// request's outcome and not also counted as a retry — otherwise the retry rate
+// overstates by one per failed call.
+func TestOpenAILLM_ExhaustedRetriesRecordOnce(t *testing.T) {
+	llm, calls := llmStubServer(t, func(int, map[string]any) (int, string) {
+		return http.StatusInternalServerError, `{"error":{"message":"boom","type":"server_error"}}`
+	})
+	rec := &llmMetricsRecorder{}
+	llm.SetMetrics(rec, "llm")
+
+	_, err := llm.Chat(context.Background(), "test-model", []Message{{Role: RoleUser, Content: "x"}}, nil)
+	require.Error(t, err)
+
+	require.Equal(t, int32(llmMaxAttempts), calls.Load())
+	require.Len(t, rec.retries, llmMaxAttempts-1, "the last attempt is the outcome, not a retry")
+	require.Equal(t, []string{"llm|test-model|5xx"}, rec.requests)
+}
+
+// TestOpenAILLM_EmptyCompletionIsNotSuccess asserts a 200 carrying no choices
+// is recorded as the provider-side failure it is.
+func TestOpenAILLM_EmptyCompletionIsNotSuccess(t *testing.T) {
+	llm, _ := llmStubServer(t, func(int, map[string]any) (int, string) {
+		return http.StatusOK, `{"id":"1","object":"chat.completion","choices":[],"usage":{"prompt_tokens":7,"completion_tokens":0}}`
+	})
+	rec := &llmMetricsRecorder{}
+	llm.SetMetrics(rec, "llm")
+
+	_, err := llm.Chat(context.Background(), "test-model", []Message{{Role: RoleUser, Content: "x"}}, nil)
+	require.ErrorIs(t, err, ErrEmptyCompletion)
+	require.Equal(t, []string{"llm|test-model|empty_completion"}, rec.requests)
 }

--- a/cmd/fleet/internal/agentruntime/metrics_test.go
+++ b/cmd/fleet/internal/agentruntime/metrics_test.go
@@ -1,0 +1,241 @@
+package agentruntime
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// recordedRun is one RecordRun call.
+type recordedRun struct {
+	role, status string
+	steps        int
+}
+
+// recordedTokens is one RecordTokens call.
+type recordedTokens struct {
+	model, role, kind string
+	n                 int
+}
+
+// fakeMetrics captures what the loop reports, so a test asserts on the
+// recorded facts rather than on a Prometheus registry.
+type fakeMetrics struct {
+	runs    []recordedRun
+	tokens  []recordedTokens
+	tools   map[string]string // tool -> last outcome
+	denials []string
+	applies []string
+}
+
+func newFakeMetrics() *fakeMetrics {
+	return &fakeMetrics{tools: map[string]string{}}
+}
+
+func (f *fakeMetrics) RecordRun(role, status string, steps int, _ float64) {
+	f.runs = append(f.runs, recordedRun{role: role, status: status, steps: steps})
+}
+
+func (f *fakeMetrics) RecordTokens(model, role, kind string, n int) {
+	f.tokens = append(f.tokens, recordedTokens{model: model, role: role, kind: kind, n: n})
+}
+
+func (f *fakeMetrics) RecordToolCall(tool, outcome string) { f.tools[tool] = outcome }
+
+func (f *fakeMetrics) RecordDenial(kind string) { f.denials = append(f.denials, kind) }
+
+func (f *fakeMetrics) RecordApplyFailure(_, tool string) { f.applies = append(f.applies, tool) }
+
+// totalTokens sums the recorded spend, mirroring what Result.TokensUsed counts.
+func (f *fakeMetrics) totalTokens() int {
+	sum := 0
+	for _, t := range f.tokens {
+		sum += t.n
+	}
+	return sum
+}
+
+// TestRun_RecordsSpendStatusAndDenials drives one run through a denied write,
+// a successful write and finish, then asserts every lane was reported: the
+// terminal status, the token spend split by kind, the tool outcomes and the
+// scope denial.
+func TestRun_RecordsSpendStatusAndDenials(t *testing.T) {
+	kb := newMemKB(map[string]string{"boards/a.md": "todo"})
+	llm := &stubLLM{script: []ChatResult{
+		{ToolCalls: []ToolCall{toolCall("1", toolWriteNote, map[string]any{"path": "secrets/x.md", "content": "nope"})}, PromptTokens: 10, CompletionTokens: 5},
+		{ToolCalls: []ToolCall{toolCall("2", toolWriteNote, map[string]any{"path": "boards/a.md", "content": "doing"})}, PromptTokens: 10, CompletionTokens: 5},
+		{ToolCalls: []ToolCall{toolCall("3", toolFinish, map[string]any{"answer": "ok"})}, PromptTokens: 10, CompletionTokens: 5},
+	}}
+	m := newFakeMetrics()
+
+	res, err := Run(context.Background(), Input{
+		Instruction:   "Move the card.",
+		ReadPatterns:  []string{"boards/**"},
+		WritePatterns: []string{"boards/**"},
+		Model:         "test-model",
+		Role:          "roles/triage.md",
+		Metrics:       m,
+		MaxTokens:     10000,
+		MaxSteps:      10,
+		LLM:           llm,
+		KB:            kb,
+	})
+	require.NoError(t, err)
+	require.Equal(t, StatusCompleted, res.Status)
+
+	require.Len(t, m.runs, 1)
+	require.Equal(t, recordedRun{role: "roles/triage.md", status: StatusCompleted, steps: res.Steps}, m.runs[0])
+
+	// Token spend is reported per model+role and must match the run's own tally.
+	require.Equal(t, res.TokensUsed, m.totalTokens())
+	require.Equal(t, "test-model", m.tokens[0].model)
+	require.Equal(t, "roles/triage.md", m.tokens[0].role)
+
+	// The denied write is the last write_note outcome before the allowed one, so
+	// assert the denial lane explicitly rather than the overwritten tool entry.
+	require.Equal(t, []string{denialWrite}, m.denials)
+	require.Equal(t, outcomeOK, m.tools[toolWriteNote])
+}
+
+// TestRun_RecordsCappedStatus asserts a run stopped by the token hard-cap is
+// reported as capped — the runaway-spend signal.
+func TestRun_RecordsCappedStatus(t *testing.T) {
+	kb := newMemKB(nil)
+	llm := &stubLLM{fallback: ChatResult{
+		ToolCalls:    []ToolCall{toolCall("1", toolSearch, map[string]any{"query": "x"})},
+		PromptTokens: 60, CompletionTokens: 60,
+	}}
+	m := newFakeMetrics()
+
+	res, err := Run(context.Background(), Input{
+		Instruction:  "Search forever.",
+		ReadPatterns: []string{"**"},
+		Model:        "test-model",
+		Role:         "roles/loop.md",
+		Metrics:      m,
+		MaxTokens:    100,
+		MaxSteps:     10,
+		LLM:          llm,
+		KB:           kb,
+	})
+	require.NoError(t, err)
+	require.Equal(t, StatusCapped, res.Status)
+	require.Len(t, m.runs, 1)
+	require.Equal(t, StatusCapped, m.runs[0].status)
+}
+
+// TestRun_RecordsApplyFailure asserts a genuine apply failure is counted (and,
+// under HardFailApply, reported as an errored run rather than a completed one).
+func TestRun_RecordsApplyFailure(t *testing.T) {
+	kb := newMemKB(map[string]string{"boards/a.md": "todo todo"})
+	llm := &stubLLM{fallback: ChatResult{
+		ToolCalls: []ToolCall{toolCall("1", toolPatchNote, map[string]any{
+			"path": "boards/a.md", "find": "todo", "replace": "doing",
+		})},
+		PromptTokens: 10, CompletionTokens: 5,
+	}}
+	m := newFakeMetrics()
+
+	_, err := Run(context.Background(), Input{
+		Instruction:   "Patch it.",
+		ReadPatterns:  []string{"boards/**"},
+		WritePatterns: []string{"boards/**"},
+		Model:         "test-model",
+		Role:          "roles/patch.md",
+		Metrics:       m,
+		HardFailApply: true,
+		MaxTokens:     10000,
+		MaxSteps:      5,
+		LLM:           llm,
+		KB:            kb,
+	})
+	require.Error(t, err) // ambiguous find: the patch cannot be applied
+
+	require.Equal(t, []string{toolPatchNote}, m.applies)
+	require.Equal(t, outcomeApplyFailed, m.tools[toolPatchNote])
+	require.Len(t, m.runs, 1)
+	require.Equal(t, statusErrorForRun, m.runs[0].status)
+}
+
+// TestRun_RecordsNotPermittedTool asserts a tool outside the role's allowlist
+// is counted as such — the hallucination/injection signal.
+func TestRun_RecordsNotPermittedTool(t *testing.T) {
+	kb := newMemKB(nil)
+	llm := &stubLLM{script: []ChatResult{
+		{ToolCalls: []ToolCall{toolCall("1", toolWriteNote, map[string]any{"path": "boards/a.md", "content": "x"})}, PromptTokens: 5, CompletionTokens: 5},
+		{ToolCalls: []ToolCall{toolCall("2", toolFinish, map[string]any{"answer": "done"})}, PromptTokens: 5, CompletionTokens: 5},
+	}}
+	m := newFakeMetrics()
+
+	_, err := Run(context.Background(), Input{
+		Instruction:  "Read only.",
+		ReadPatterns: []string{"boards/**"},
+		Tools:        []string{toolReadNote},
+		Model:        "test-model",
+		Role:         "roles/ro.md",
+		Metrics:      m,
+		MaxTokens:    10000,
+		MaxSteps:     5,
+		LLM:          llm,
+		KB:           kb,
+	})
+	require.NoError(t, err)
+	require.Equal(t, outcomeNotPermitted, m.tools[toolWriteNote])
+	require.Equal(t, []string{denialNotPermitted}, m.denials)
+}
+
+// llmMetricsRecorder captures the provider-call lane.
+type llmMetricsRecorder struct {
+	requests []string // "lane|model|status"
+	retries  []string // "lane|reason"
+}
+
+func (r *llmMetricsRecorder) RecordLLMRequest(lane, model, status string, _ float64) {
+	r.requests = append(r.requests, lane+"|"+model+"|"+status)
+}
+
+func (r *llmMetricsRecorder) RecordLLMRetry(lane, reason string) {
+	r.retries = append(r.retries, lane+"|"+reason)
+}
+
+// TestOpenAILLM_RecordsRetriesByReason asserts each retried attempt is
+// attributed to what caused it — the earliest upstream-instability signal —
+// and that the surrounding call is recorded once, as a success.
+func TestOpenAILLM_RecordsRetriesByReason(t *testing.T) {
+	llm, _ := llmStubServer(t, func(attempt int, _ map[string]any) (int, string) {
+		switch attempt {
+		case 1:
+			return http.StatusTooManyRequests, `{"error":{"message":"rate limited","type":"rate_limit_exceeded"}}`
+		case 2:
+			return http.StatusInternalServerError, `{"error":{"message":"boom","type":"server_error"}}`
+		default:
+			return http.StatusOK, okCompletion
+		}
+	})
+	rec := &llmMetricsRecorder{}
+	llm.SetMetrics(rec, "llm")
+
+	_, err := llm.Chat(context.Background(), "test-model", []Message{{Role: RoleUser, Content: "x"}}, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"llm|429", "llm|5xx"}, rec.retries)
+	require.Equal(t, []string{"llm|test-model|ok"}, rec.requests)
+}
+
+// TestOpenAILLM_RecordsTerminalFailureReason asserts a non-retryable failure is
+// recorded with its HTTP class rather than as a generic error.
+func TestOpenAILLM_RecordsTerminalFailureReason(t *testing.T) {
+	llm, _ := llmStubServer(t, func(int, map[string]any) (int, string) {
+		return http.StatusUnprocessableEntity, `{"error":{"message":"bad code","type":"code_execution_error"}}`
+	})
+	rec := &llmMetricsRecorder{}
+	llm.SetMetrics(rec, "exec")
+
+	_, err := llm.Chat(context.Background(), "codellm", []Message{{Role: RoleUser, Content: "x"}}, nil)
+	require.Error(t, err)
+
+	require.Empty(t, rec.retries)
+	require.Equal(t, []string{"exec|codellm|4xx"}, rec.requests)
+}

--- a/cmd/fleet/internal/agentruntime/openai_llm.go
+++ b/cmd/fleet/internal/agentruntime/openai_llm.go
@@ -34,7 +34,9 @@ const (
 	reasonServer      = "5xx"
 	reasonClient      = "4xx"
 	reasonCanceled    = "canceled"
+	reasonTimeout     = "timeout"
 	reasonNetwork     = "network"
+	reasonEmpty       = "empty_completion"
 	statusOK          = "ok"
 )
 
@@ -93,8 +95,8 @@ func (l *OpenAILLM) chat(ctx context.Context, model string, messages []Message, 
 
 	started := time.Now()
 	resp, err := l.createWithRetry(ctx, req)
-	l.recordRequest(model, err, time.Since(started))
 	if err != nil {
+		l.recordRequest(model, err, time.Since(started))
 		return ChatResult{}, err
 	}
 
@@ -103,8 +105,12 @@ func (l *OpenAILLM) chat(ctx context.Context, model string, messages []Message, 
 		CompletionTokens: resp.Usage.CompletionTokens,
 	}
 	if len(resp.Choices) == 0 {
+		// A 200 with no choices is a provider-side failure, not a success: record
+		// it as one before handing ErrEmptyCompletion back.
+		l.recordRequest(model, ErrEmptyCompletion, time.Since(started))
 		return out, ErrEmptyCompletion
 	}
+	l.recordRequest(model, nil, time.Since(started))
 	msg := resp.Choices[0].Message
 	out.Content = msg.Content
 	for _, tc := range msg.ToolCalls {
@@ -138,7 +144,9 @@ func (l *OpenAILLM) createWithRetry(ctx context.Context, req goopenai.ChatComple
 		if !isRetryableLLMError(ctx, err) {
 			return goopenai.ChatCompletionResponse{}, err
 		}
-		if l.metrics != nil {
+		// Only count it as a retry when another attempt actually follows; the
+		// last failure is the request's outcome, not a retry.
+		if l.metrics != nil && attempt < llmMaxAttempts-1 {
 			l.metrics.RecordLLMRetry(l.lane, llmErrorReason(err))
 		}
 		lastErr = err
@@ -161,7 +169,13 @@ func (l *OpenAILLM) recordRequest(model string, err error, elapsed time.Duration
 // llmErrorReason maps a provider error onto a bounded label: the HTTP class it
 // came back as, a cancellation, or a transport failure.
 func llmErrorReason(err error) string {
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+	if errors.Is(err, ErrEmptyCompletion) {
+		return reasonEmpty
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return reasonTimeout
+	}
+	if errors.Is(err, context.Canceled) {
 		return reasonCanceled
 	}
 	var apiErr *goopenai.APIError

--- a/cmd/fleet/internal/agentruntime/openai_llm.go
+++ b/cmd/fleet/internal/agentruntime/openai_llm.go
@@ -20,6 +20,24 @@ const (
 	llmRetryBaseGap = 500 * time.Millisecond
 )
 
+// LLMMetrics is the optional provider-call sink. Declared here, minimally, so
+// agentruntime never imports the fleet's metrics package. Implementations must
+// be nil-safe.
+type LLMMetrics interface {
+	RecordLLMRequest(lane, model, status string, seconds float64)
+	RecordLLMRetry(lane, reason string)
+}
+
+// Retry/failure reasons reported to LLMMetrics.
+const (
+	reasonRateLimited = "429"
+	reasonServer      = "5xx"
+	reasonClient      = "4xx"
+	reasonCanceled    = "canceled"
+	reasonNetwork     = "network"
+	statusOK          = "ok"
+)
+
 // OpenAILLM is the production LLM backed by any OpenAI-compatible chat
 // completions endpoint. BaseURL is the configurable knob: leave empty for the
 // default OpenAI endpoint, or point it at a local/vendor model
@@ -28,7 +46,18 @@ const (
 // Transient failures (HTTP 429/5xx, network errors) are retried with
 // exponential backoff, bounded by llmMaxAttempts and the caller's context.
 type OpenAILLM struct {
-	client *goopenai.Client
+	client  *goopenai.Client
+	metrics LLMMetrics
+	lane    string
+}
+
+// SetMetrics attaches the metrics sink and names the lane this client serves
+// (fleetmetrics.LaneLLM for the role's model, LaneExec for codellm). Kept a
+// setter so the constructor signature — and every existing call site — stays
+// as it was.
+func (l *OpenAILLM) SetMetrics(m LLMMetrics, lane string) {
+	l.metrics = m
+	l.lane = lane
 }
 
 // NewOpenAILLM builds an OpenAILLM. apiKey is the bearer credential; baseURL,
@@ -62,7 +91,9 @@ func (l *OpenAILLM) chat(ctx context.Context, model string, messages []Message, 
 		req.MaxCompletionTokens = maxCompletionTokens
 	}
 
+	started := time.Now()
 	resp, err := l.createWithRetry(ctx, req)
+	l.recordRequest(model, err, time.Since(started))
 	if err != nil {
 		return ChatResult{}, err
 	}
@@ -107,9 +138,55 @@ func (l *OpenAILLM) createWithRetry(ctx context.Context, req goopenai.ChatComple
 		if !isRetryableLLMError(ctx, err) {
 			return goopenai.ChatCompletionResponse{}, err
 		}
+		if l.metrics != nil {
+			l.metrics.RecordLLMRetry(l.lane, llmErrorReason(err))
+		}
 		lastErr = err
 	}
 	return goopenai.ChatCompletionResponse{}, fmt.Errorf("llm: giving up after %d attempts: %w", llmMaxAttempts, lastErr)
+}
+
+// recordRequest reports one completed chat call (all its attempts included).
+func (l *OpenAILLM) recordRequest(model string, err error, elapsed time.Duration) {
+	if l.metrics == nil {
+		return
+	}
+	status := statusOK
+	if err != nil {
+		status = llmErrorReason(err)
+	}
+	l.metrics.RecordLLMRequest(l.lane, model, status, elapsed.Seconds())
+}
+
+// llmErrorReason maps a provider error onto a bounded label: the HTTP class it
+// came back as, a cancellation, or a transport failure.
+func llmErrorReason(err error) string {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return reasonCanceled
+	}
+	var apiErr *goopenai.APIError
+	if errors.As(err, &apiErr) {
+		return httpStatusReason(apiErr.HTTPStatusCode)
+	}
+	var reqErr *goopenai.RequestError
+	if errors.As(err, &reqErr) {
+		return httpStatusReason(reqErr.HTTPStatusCode)
+	}
+	return reasonNetwork
+}
+
+// httpStatusReason buckets an HTTP status into the reason labels.
+func httpStatusReason(code int) string {
+	switch {
+	case code == http.StatusTooManyRequests:
+		return reasonRateLimited
+	case code >= http.StatusInternalServerError:
+		return reasonServer
+	case code >= http.StatusBadRequest:
+		return reasonClient
+	default:
+		return reasonNetwork
+	}
 }
 
 // isRetryableLLMError reports whether err is worth another attempt: rate

--- a/cmd/fleet/internal/agentruntime/runtime.go
+++ b/cmd/fleet/internal/agentruntime/runtime.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"trip2g/internal/webhookutil"
 )
@@ -38,6 +39,38 @@ const fleetInputMessageName = "fleet_input"
 // register an invoker here via buildInvokers so the loop never needs a new
 // switch case. future: populate from MCP server descriptors, config, etc.
 type toolInvoker func(ctx context.Context, scoped *ScopedKB, res *Result, call ToolCall) string
+
+// Tool-call outcomes reported to Metrics. Only outcomeApplyFailed is a genuine
+// write failure; the rest stay soft and self-correctable.
+const (
+	outcomeOK           = "ok"
+	outcomeDenied       = "denied"
+	outcomeInvalidArgs  = "invalid_args"
+	outcomeError        = "error"
+	outcomeApplyFailed  = "apply_failed"
+	outcomeNotPermitted = "not_permitted"
+)
+
+// Denial kinds reported to Metrics.RecordDenial.
+const (
+	denialRead          = "read"
+	denialWrite         = "write"
+	denialNotPermitted  = "not_permitted"
+	statusErrorForRun   = "error"
+	tokenKindPrompt     = "prompt"
+	tokenKindCompletion = "completion"
+)
+
+// Metrics is the optional run-metrics sink. It is declared here, minimally, so
+// agentruntime never imports the fleet's metrics package: the fleet passes its
+// own implementation, and --once passes none. Implementations must be nil-safe.
+type Metrics interface {
+	RecordRun(role, status string, steps int, seconds float64)
+	RecordTokens(model, role, kind string, n int)
+	RecordToolCall(tool, outcome string)
+	RecordDenial(kind string)
+	RecordApplyFailure(role, tool string)
+}
 
 // Input is one executor run, derived from a webhook delivery
 // (instruction + read_patterns + write_patterns + model) plus the safety
@@ -81,6 +114,14 @@ type Input struct {
 	// so they keep their self-correction loop.
 	HardFailApply bool
 
+	// Role labels this run's metrics (the role note path). Empty for --once and
+	// tests, which report under the empty label.
+	Role string
+
+	// Metrics receives this run's outcome, spend and tool activity. nil records
+	// nothing; the call sites stay unconditional either way.
+	Metrics Metrics
+
 	LLM LLM
 	KB  KB
 }
@@ -117,8 +158,34 @@ Rules:
 - When done, call finish with a concise answer. Do not invent paths you have not seen.`
 
 // Run executes the instruction through the LLM tool-call loop, enforcing scope
-// and the token hard-cap, and returns the answer plus any in-scope changes.
+// and the token hard-cap, and returns the answer plus any in-scope changes. It
+// wraps run so every exit path — including the error ones — is measured once.
 func Run(ctx context.Context, in Input) (*Result, error) {
+	started := time.Now()
+	res, err := run(ctx, in)
+	recordRun(in, res, err, time.Since(started))
+	return res, err
+}
+
+// recordRun reports the run's terminal status, steps and token spend. A run
+// that failed outright has no Result, so it is counted with zero steps under
+// the error status.
+func recordRun(in Input, res *Result, err error, elapsed time.Duration) {
+	if in.Metrics == nil {
+		return
+	}
+	if res == nil {
+		in.Metrics.RecordRun(in.Role, statusErrorForRun, 0, elapsed.Seconds())
+		return
+	}
+	status := res.Status
+	if err != nil {
+		status = statusErrorForRun
+	}
+	in.Metrics.RecordRun(in.Role, status, res.Steps, elapsed.Seconds())
+}
+
+func run(ctx context.Context, in Input) (*Result, error) {
 	if in.LLM == nil {
 		return nil, errors.New("agentruntime: LLM is required")
 	}
@@ -182,6 +249,10 @@ func Run(ctx context.Context, in Input) (*Result, error) {
 		}
 		res.Steps++
 		res.TokensUsed += chat.PromptTokens + chat.CompletionTokens
+		if in.Metrics != nil {
+			in.Metrics.RecordTokens(in.Model, in.Role, tokenKindPrompt, chat.PromptTokens)
+			in.Metrics.RecordTokens(in.Model, in.Role, tokenKindCompletion, chat.CompletionTokens)
+		}
 
 		// No tool calls means the model returned a final answer.
 		if len(chat.ToolCalls) == 0 {
@@ -196,44 +267,89 @@ func Run(ctx context.Context, in Input) (*Result, error) {
 			ToolCalls: chat.ToolCalls,
 		})
 
-		for _, call := range chat.ToolCalls {
-			if call.Name == toolFinish {
-				res.Answer = finishAnswer(call.Arguments)
-				res.Status = StatusCompleted
-				return res, nil
-			}
-			// Execution-time allowlist enforcement: reject any tool not in the
-			// permitted set, even if the model hallucinated or was injected.
-			if !permitted[call.Name] {
-				denial := "tool not permitted: " + call.Name
-				res.Denials = append(res.Denials, denial)
-				messages = append(messages, Message{
-					Role:       RoleTool,
-					ToolCallID: call.ID,
-					Name:       call.Name,
-					Content:    "error: " + denial,
-				})
-				continue
-			}
-			output, applyFailed := execTool(ctx, scoped, res, call, invokers)
-			// Apply-error hard-fail (executor:code/codellm path): a genuine write/
-			// patch apply failure (bad/non-unique find, KB write error) fails the
-			// whole run, preserving the code path's all-or-nothing semantics.
-			// Real-LLM roles (HardFailApply=false) keep the soft, self-correctable
-			// tool result.
-			if applyFailed && in.HardFailApply {
-				return nil, fmt.Errorf("agentruntime: apply %s: %s", call.Name, output)
-			}
-			messages = append(messages, Message{
-				Role:       RoleTool,
-				ToolCallID: call.ID,
-				Name:       call.Name,
-				Content:    output,
-			})
+		done, err := runToolCalls(ctx, in, toolLoop{
+			scoped:    scoped,
+			res:       res,
+			permitted: permitted,
+			invokers:  invokers,
+			messages:  &messages,
+		}, chat.ToolCalls)
+		if err != nil {
+			return nil, err
+		}
+		if done {
+			return res, nil
 		}
 	}
 
 	return res, nil
+}
+
+// toolLoop bundles the per-run state one assistant turn's tool calls act on.
+type toolLoop struct {
+	scoped    *ScopedKB
+	res       *Result
+	permitted map[string]bool
+	invokers  map[string]toolInvoker
+	messages  *[]Message
+}
+
+// runToolCalls executes one assistant turn's tool calls in order, appending
+// each result as a tool message. It returns done=true when the model called
+// finish (the run's terminal state is already set on res), and an error only
+// for a HardFailApply apply failure.
+func runToolCalls(ctx context.Context, in Input, tl toolLoop, calls []ToolCall) (bool, error) {
+	for _, call := range calls {
+		if call.Name == toolFinish {
+			tl.res.Answer = finishAnswer(call.Arguments)
+			tl.res.Status = StatusCompleted
+			return true, nil
+		}
+		// Execution-time allowlist enforcement: reject any tool not in the
+		// permitted set, even if the model hallucinated or was injected.
+		if !tl.permitted[call.Name] {
+			denial := "tool not permitted: " + call.Name
+			tl.res.Denials = append(tl.res.Denials, denial)
+			if in.Metrics != nil {
+				in.Metrics.RecordToolCall(call.Name, outcomeNotPermitted)
+				in.Metrics.RecordDenial(denialNotPermitted)
+			}
+			*tl.messages = append(*tl.messages, Message{
+				Role:       RoleTool,
+				ToolCallID: call.ID,
+				Name:       call.Name,
+				Content:    "error: " + denial,
+			})
+			continue
+		}
+		output, outcome := execTool(ctx, tl.scoped, tl.res, call, tl.invokers)
+		if in.Metrics != nil {
+			in.Metrics.RecordToolCall(call.Name, outcome)
+			if outcome == outcomeDenied {
+				in.Metrics.RecordDenial(denialForTool(call.Name))
+			}
+		}
+		// Apply-error hard-fail (executor:code/codellm path): a genuine write/
+		// patch apply failure (bad/non-unique find, KB write error) fails the
+		// whole run, preserving the code path's all-or-nothing semantics.
+		// Real-LLM roles (HardFailApply=false) keep the soft, self-correctable
+		// tool result.
+		if outcome == outcomeApplyFailed {
+			if in.Metrics != nil {
+				in.Metrics.RecordApplyFailure(in.Role, call.Name)
+			}
+			if in.HardFailApply {
+				return false, fmt.Errorf("agentruntime: apply %s: %s", call.Name, output)
+			}
+		}
+		*tl.messages = append(*tl.messages, Message{
+			Role:       RoleTool,
+			ToolCallID: call.ID,
+			Name:       call.Name,
+			Content:    output,
+		})
+	}
+	return false, nil
 }
 
 // chatWithBudget passes the run's remaining token budget to LLMs that support
@@ -246,107 +362,138 @@ func chatWithBudget(ctx context.Context, llm LLM, model string, messages []Messa
 }
 
 // execTool runs one tool call against the scoped KB and returns the textual
-// result to feed back to the model, plus applyFailed=true ONLY when a write/patch
-// could not be APPLIED (bad/non-unique find, KB write error). That flag is what
-// the HardFailApply path (executor:code/codellm) fails on; scope denials, invalid
-// arguments, and read/search errors keep applyFailed=false so they stay soft/
-// self-correctable in every path. Scope denials are recorded and surfaced to the
-// model (so it learns), never silently swallowed.
+// result to feed back to the model, plus the outcome for metrics. Only
+// outcomeApplyFailed marks a write/patch that could not be APPLIED (bad or
+// non-unique find, KB write error) — that is what the HardFailApply path
+// (executor:code/codellm) fails on. Scope denials, invalid arguments and
+// read/search errors get their own outcomes and stay soft, so they remain
+// self-correctable in every path. Scope denials are recorded and surfaced to
+// the model (so it learns), never silently swallowed.
 // Extension tools registered in invokers are dispatched before the built-in
 // switch, forming the tool registry seam for exec and future MCP plug-ins.
-func execTool(ctx context.Context, scoped *ScopedKB, res *Result, call ToolCall, invokers map[string]toolInvoker) (string, bool) {
+func execTool(ctx context.Context, scoped *ScopedKB, res *Result, call ToolCall, invokers map[string]toolInvoker) (string, string) {
 	if fn, ok := invokers[call.Name]; ok {
-		return fn(ctx, scoped, res, call), false
+		out := fn(ctx, scoped, res, call)
+		return out, outcomeFor(out)
 	}
 	switch call.Name {
 	case toolSearch:
-		var args struct {
-			Query string `json:"query"`
-		}
-		if err := json.Unmarshal([]byte(call.Arguments), &args); err != nil {
-			return "error: invalid arguments: " + err.Error(), false
-		}
-		docs, err := scoped.Search(ctx, args.Query)
-		if err != nil {
-			return "error: " + err.Error(), false
-		}
-		if len(docs) == 0 {
-			return "no in-scope documents matched.", false
-		}
-		var b strings.Builder
-		for _, d := range docs {
-			fmt.Fprintf(&b, "- %s\n", d.Path)
-		}
-		return b.String(), false
-
+		return execSearch(ctx, scoped, call)
 	case toolReadNote:
-		var args struct {
-			Path string `json:"path"`
-		}
-		if err := json.Unmarshal([]byte(call.Arguments), &args); err != nil {
-			return "error: invalid arguments: " + err.Error(), false
-		}
-		content, err := scoped.Read(ctx, args.Path)
-		if errors.Is(err, ErrReadDenied) {
-			res.Denials = append(res.Denials, "read "+args.Path)
-			return "error: " + ErrReadDenied.Error(), false
-		}
-		if err != nil {
-			return "error: " + err.Error(), false
-		}
-		return content, false
-
+		return execReadNote(ctx, scoped, res, call)
 	case toolWriteNote:
-		var args struct {
-			Path    string `json:"path"`
-			Content string `json:"content"`
-		}
-		if err := json.Unmarshal([]byte(call.Arguments), &args); err != nil {
-			return "error: invalid arguments: " + err.Error(), false
-		}
-		err := scoped.Write(ctx, args.Path, args.Content)
-		if errors.Is(err, ErrWriteDenied) {
-			res.Denials = append(res.Denials, "write "+args.Path)
-			return "error: " + ErrWriteDenied.Error(), false
-		}
-		if err != nil {
-			return "error: " + err.Error(), true
-		}
-		res.Changes = append(res.Changes, webhookutil.AgentChange{
-			Path:    args.Path,
-			Content: args.Content,
-			Kind:    webhookutil.AgentChangeKindWrite,
-		})
-		return "ok: wrote " + args.Path, false
-
+		return execWriteNote(ctx, scoped, res, call)
 	case toolPatchNote:
-		var args struct {
-			Path    string `json:"path"`
-			Find    string `json:"find"`
-			Replace string `json:"replace"`
-		}
-		if err := json.Unmarshal([]byte(call.Arguments), &args); err != nil {
-			return "error: invalid arguments: " + err.Error(), false
-		}
-		err := scoped.Patch(ctx, args.Path, args.Find, args.Replace)
-		if errors.Is(err, ErrWriteDenied) {
-			res.Denials = append(res.Denials, "patch "+args.Path)
-			return "error: " + ErrWriteDenied.Error(), false
-		}
-		if err != nil {
-			return "error: " + err.Error(), true
-		}
-		res.Changes = append(res.Changes, webhookutil.AgentChange{
-			Path:    args.Path,
-			Find:    args.Find,
-			Replace: args.Replace,
-			Kind:    webhookutil.AgentChangeKindPatch,
-		})
-		return "ok: patched " + args.Path, false
-
+		return execPatchNote(ctx, scoped, res, call)
 	default:
-		return "error: unknown tool " + call.Name, false
+		return "error: unknown tool " + call.Name, outcomeError
 	}
+}
+
+// outcomeFor classifies an extension tool's textual result: the registry seam
+// returns a string, and "error: ..." is its failure convention.
+func outcomeFor(output string) string {
+	if strings.HasPrefix(output, "error:") {
+		return outcomeError
+	}
+	return outcomeOK
+}
+
+// denialForTool maps a denied tool call to the denial kind it represents.
+func denialForTool(tool string) string {
+	if tool == toolReadNote {
+		return denialRead
+	}
+	return denialWrite
+}
+
+func execSearch(ctx context.Context, scoped *ScopedKB, call ToolCall) (string, string) {
+	var args struct {
+		Query string `json:"query"`
+	}
+	if err := json.Unmarshal([]byte(call.Arguments), &args); err != nil {
+		return "error: invalid arguments: " + err.Error(), outcomeInvalidArgs
+	}
+	docs, err := scoped.Search(ctx, args.Query)
+	if err != nil {
+		return "error: " + err.Error(), outcomeError
+	}
+	if len(docs) == 0 {
+		return "no in-scope documents matched.", outcomeOK
+	}
+	var b strings.Builder
+	for _, d := range docs {
+		fmt.Fprintf(&b, "- %s\n", d.Path)
+	}
+	return b.String(), outcomeOK
+}
+
+func execReadNote(ctx context.Context, scoped *ScopedKB, res *Result, call ToolCall) (string, string) {
+	var args struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal([]byte(call.Arguments), &args); err != nil {
+		return "error: invalid arguments: " + err.Error(), outcomeInvalidArgs
+	}
+	content, err := scoped.Read(ctx, args.Path)
+	if errors.Is(err, ErrReadDenied) {
+		res.Denials = append(res.Denials, "read "+args.Path)
+		return "error: " + ErrReadDenied.Error(), outcomeDenied
+	}
+	if err != nil {
+		return "error: " + err.Error(), outcomeError
+	}
+	return content, outcomeOK
+}
+
+func execWriteNote(ctx context.Context, scoped *ScopedKB, res *Result, call ToolCall) (string, string) {
+	var args struct {
+		Path    string `json:"path"`
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal([]byte(call.Arguments), &args); err != nil {
+		return "error: invalid arguments: " + err.Error(), outcomeInvalidArgs
+	}
+	err := scoped.Write(ctx, args.Path, args.Content)
+	if errors.Is(err, ErrWriteDenied) {
+		res.Denials = append(res.Denials, "write "+args.Path)
+		return "error: " + ErrWriteDenied.Error(), outcomeDenied
+	}
+	if err != nil {
+		return "error: " + err.Error(), outcomeApplyFailed
+	}
+	res.Changes = append(res.Changes, webhookutil.AgentChange{
+		Path:    args.Path,
+		Content: args.Content,
+		Kind:    webhookutil.AgentChangeKindWrite,
+	})
+	return "ok: wrote " + args.Path, outcomeOK
+}
+
+func execPatchNote(ctx context.Context, scoped *ScopedKB, res *Result, call ToolCall) (string, string) {
+	var args struct {
+		Path    string `json:"path"`
+		Find    string `json:"find"`
+		Replace string `json:"replace"`
+	}
+	if err := json.Unmarshal([]byte(call.Arguments), &args); err != nil {
+		return "error: invalid arguments: " + err.Error(), outcomeInvalidArgs
+	}
+	err := scoped.Patch(ctx, args.Path, args.Find, args.Replace)
+	if errors.Is(err, ErrWriteDenied) {
+		res.Denials = append(res.Denials, "patch "+args.Path)
+		return "error: " + ErrWriteDenied.Error(), outcomeDenied
+	}
+	if err != nil {
+		return "error: " + err.Error(), outcomeApplyFailed
+	}
+	res.Changes = append(res.Changes, webhookutil.AgentChange{
+		Path:    args.Path,
+		Find:    args.Find,
+		Replace: args.Replace,
+		Kind:    webhookutil.AgentChangeKindPatch,
+	})
+	return "ok: patched " + args.Path, outcomeOK
 }
 
 func finishAnswer(arguments string) string {

--- a/cmd/fleet/internal/agentruntime/runtime.go
+++ b/cmd/fleet/internal/agentruntime/runtime.go
@@ -53,12 +53,19 @@ const (
 
 // Denial kinds reported to Metrics.RecordDenial.
 const (
-	denialRead          = "read"
-	denialWrite         = "write"
-	denialNotPermitted  = "not_permitted"
+	denialRead         = "read"
+	denialWrite        = "write"
+	denialNotPermitted = "not_permitted"
+)
+
+// Run status and token-kind label values reported to Metrics.
+const (
 	statusErrorForRun   = "error"
 	tokenKindPrompt     = "prompt"
 	tokenKindCompletion = "completion"
+	// unknownTool is the label stand-in for a tool name the model invented. The
+	// name is attacker-controllable, so it must never reach a metric label.
+	unknownTool = "unknown"
 )
 
 // Metrics is the optional run-metrics sink. It is declared here, minimally, so
@@ -162,20 +169,21 @@ Rules:
 // wraps run so every exit path — including the error ones — is measured once.
 func Run(ctx context.Context, in Input) (*Result, error) {
 	started := time.Now()
-	res, err := run(ctx, in)
+	// res is allocated here, not in run, so a run that fails mid-loop still
+	// reports the steps and spend it already consumed. The caller still gets the
+	// nil-result-on-error contract.
+	res := &Result{Status: StatusMaxSteps}
+	err := run(ctx, in, res)
 	recordRun(in, res, err, time.Since(started))
-	return res, err
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
-// recordRun reports the run's terminal status, steps and token spend. A run
-// that failed outright has no Result, so it is counted with zero steps under
-// the error status.
+// recordRun reports the run's terminal status, steps and duration.
 func recordRun(in Input, res *Result, err error, elapsed time.Duration) {
 	if in.Metrics == nil {
-		return
-	}
-	if res == nil {
-		in.Metrics.RecordRun(in.Role, statusErrorForRun, 0, elapsed.Seconds())
 		return
 	}
 	status := res.Status
@@ -185,18 +193,18 @@ func recordRun(in Input, res *Result, err error, elapsed time.Duration) {
 	in.Metrics.RecordRun(in.Role, status, res.Steps, elapsed.Seconds())
 }
 
-func run(ctx context.Context, in Input) (*Result, error) {
+func run(ctx context.Context, in Input, res *Result) error {
 	if in.LLM == nil {
-		return nil, errors.New("agentruntime: LLM is required")
+		return errors.New("agentruntime: LLM is required")
 	}
 	if in.KB == nil {
-		return nil, errors.New("agentruntime: KB is required")
+		return errors.New("agentruntime: KB is required")
 	}
 	if in.MaxTokens <= 0 {
-		return nil, errors.New("agentruntime: MaxTokens must be > 0")
+		return errors.New("agentruntime: MaxTokens must be > 0")
 	}
 	if in.MaxSteps <= 0 {
-		return nil, errors.New("agentruntime: MaxSteps must be > 0")
+		return errors.New("agentruntime: MaxSteps must be > 0")
 	}
 
 	scoped := NewScopedKB(in.KB, in.ReadPatterns, in.WritePatterns)
@@ -234,18 +242,16 @@ func run(ctx context.Context, in Input) (*Result, error) {
 	}
 	messages = append(messages, Message{Role: RoleUser, Content: "Begin."})
 
-	res := &Result{Status: StatusMaxSteps}
-
 	for step := range in.MaxSteps {
 		// Hard-cap check happens BEFORE each model call: once spent, stop.
 		if res.TokensUsed >= in.MaxTokens {
 			res.Status = StatusCapped
-			return res, nil
+			return nil
 		}
 
 		chat, err := chatWithBudget(ctx, in.LLM, in.Model, messages, tools, in.MaxTokens-res.TokensUsed)
 		if err != nil {
-			return nil, fmt.Errorf("agentruntime: chat step %d: %w", step, err)
+			return fmt.Errorf("agentruntime: chat step %d: %w", step, err)
 		}
 		res.Steps++
 		res.TokensUsed += chat.PromptTokens + chat.CompletionTokens
@@ -258,7 +264,7 @@ func run(ctx context.Context, in Input) (*Result, error) {
 		if len(chat.ToolCalls) == 0 {
 			res.Answer = chat.Content
 			res.Status = StatusCompleted
-			return res, nil
+			return nil
 		}
 
 		messages = append(messages, Message{
@@ -275,14 +281,14 @@ func run(ctx context.Context, in Input) (*Result, error) {
 			messages:  &messages,
 		}, chat.ToolCalls)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if done {
-			return res, nil
+			return nil
 		}
 	}
 
-	return res, nil
+	return nil
 }
 
 // toolLoop bundles the per-run state one assistant turn's tool calls act on.
@@ -303,6 +309,9 @@ func runToolCalls(ctx context.Context, in Input, tl toolLoop, calls []ToolCall) 
 		if call.Name == toolFinish {
 			tl.res.Answer = finishAnswer(call.Arguments)
 			tl.res.Status = StatusCompleted
+			if in.Metrics != nil {
+				in.Metrics.RecordToolCall(toolFinish, outcomeOK)
+			}
 			return true, nil
 		}
 		// Execution-time allowlist enforcement: reject any tool not in the
@@ -311,7 +320,9 @@ func runToolCalls(ctx context.Context, in Input, tl toolLoop, calls []ToolCall) 
 			denial := "tool not permitted: " + call.Name
 			tl.res.Denials = append(tl.res.Denials, denial)
 			if in.Metrics != nil {
-				in.Metrics.RecordToolCall(call.Name, outcomeNotPermitted)
+				// The rejected name is model-supplied: bucket it instead of
+				// minting a metric series per hallucination.
+				in.Metrics.RecordToolCall(unknownTool, outcomeNotPermitted)
 				in.Metrics.RecordDenial(denialNotPermitted)
 			}
 			*tl.messages = append(*tl.messages, Message{

--- a/cmd/fleet/internal/fleet/fleet.go
+++ b/cmd/fleet/internal/fleet/fleet.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"trip2g/cmd/fleet/internal/agentruntime"
+	"trip2g/cmd/fleet/internal/fleetmetrics"
 )
 
 // Fleet ties config, the trip2g HTTP client, the LLM, and the live role
@@ -15,6 +16,7 @@ type Fleet struct {
 	hc      *http.Client
 	llm     agentruntime.LLM
 	execLLM agentruntime.LLM // exec-tool endpoint (codellm); nil = exec disabled
+	metrics *fleetmetrics.Metrics
 
 	mu       sync.RWMutex
 	registry map[string]Role // urlKey(notePath) -> Role
@@ -37,6 +39,12 @@ func NewFleet(cfg Config, hc *http.Client, llm, execLLM agentruntime.LLM) *Fleet
 	}
 }
 
+// SetMetrics attaches the metrics sink. Kept a setter so NewFleet's signature —
+// and every existing call site — stays as it was; nil records nothing.
+func (f *Fleet) SetMetrics(m *fleetmetrics.Metrics) {
+	f.metrics = m
+}
+
 // SetRoles atomically swaps the live role registry (called after each poll).
 func (f *Fleet) SetRoles(roles []Role) {
 	reg := make(map[string]Role, len(roles))
@@ -46,6 +54,14 @@ func (f *Fleet) SetRoles(roles []Role) {
 	f.mu.Lock()
 	f.registry = reg
 	f.mu.Unlock()
+
+	misconfigured := 0
+	for _, r := range roles {
+		if r.DeclaresWriteToolsButNoWritePatterns() {
+			misconfigured++
+		}
+	}
+	f.metrics.SetRoles(len(reg), misconfigured)
 }
 
 // WebhookPath is this fleet's delivery path prefix ("/_fleet/<h>/webhook/"),

--- a/cmd/fleet/internal/fleet/fleet.go
+++ b/cmd/fleet/internal/fleet/fleet.go
@@ -55,8 +55,10 @@ func (f *Fleet) SetRoles(roles []Role) {
 	f.registry = reg
 	f.mu.Unlock()
 
+	// Counted over reg, not roles: both gauges must describe the same set, and
+	// reg is deduplicated by urlKey.
 	misconfigured := 0
-	for _, r := range roles {
+	for _, r := range reg {
 		if r.DeclaresWriteToolsButNoWritePatterns() {
 			misconfigured++
 		}

--- a/cmd/fleet/internal/fleet/handler.go
+++ b/cmd/fleet/internal/fleet/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Khan/genqlient/graphql"
 
 	"trip2g/cmd/fleet/internal/agentruntime"
+	"trip2g/cmd/fleet/internal/fleetmetrics"
 	"trip2g/internal/fleetinput"
 	"trip2g/internal/webhookutil"
 )
@@ -57,6 +58,7 @@ const statusError = "error"
 // <h> is this fleet's identity hash. Authenticated by the per-role HMAC secret,
 // NOT the delegated-admin cookie (that gates the separate GraphQL server).
 func (f *Fleet) ServeDelivery(w http.ResponseWriter, r *http.Request) {
+	started := time.Now()
 	rawPath := strings.TrimPrefix(r.URL.Path, f.WebhookPath())
 	isCron := strings.HasPrefix(rawPath, "cron/")
 	key := rawPath
@@ -66,12 +68,14 @@ func (f *Fleet) ServeDelivery(w http.ResponseWriter, r *http.Request) {
 
 	role, ok := f.roleByKey(key)
 	if !ok {
+		f.metrics.RecordDeliveryAuthFailure("unknown_key")
 		http.Error(w, "unknown delivery key", http.StatusNotFound)
 		return
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
+		f.metrics.RecordDeliveryAuthFailure("read_body")
 		http.Error(w, "read body", http.StatusBadRequest)
 		return
 	}
@@ -82,17 +86,26 @@ func (f *Fleet) ServeDelivery(w http.ResponseWriter, r *http.Request) {
 		secret = f.cronSecretFor(role)
 	}
 	if !webhookutil.VerifyHMAC(body, secret, r.Header.Get("X-Webhook-Signature")) {
+		f.metrics.RecordDeliveryAuthFailure("bad_signature")
 		http.Error(w, "bad signature", http.StatusUnauthorized)
 		return
 	}
 
 	if isCron {
-		f.serveCronDelivery(w, r, role, body)
+		f.serveCronDelivery(w, r, role, body, started)
 		return
 	}
+	f.serveChangeDelivery(w, r, role, body, started)
+}
 
+// serveChangeDelivery handles a change-triggered delivery: it fans the payload
+// out into per-item render contexts, runs one agent per item (continue on
+// error), and reports the aggregate spend. started is the delivery's arrival
+// time, carried in so the recorded duration covers the auth work too.
+func (f *Fleet) serveChangeDelivery(w http.ResponseWriter, r *http.Request, role Role, body []byte, started time.Time) {
 	var payload deliveryPayload
 	if uerr := json.Unmarshal(body, &payload); uerr != nil {
+		f.metrics.RecordDeliveryAuthFailure("bad_payload")
 		http.Error(w, "bad payload", http.StatusBadRequest)
 		return
 	}
@@ -114,6 +127,8 @@ func (f *Fleet) ServeDelivery(w http.ResponseWriter, r *http.Request) {
 	// marking the delivery failed.
 	items := fanOut(role.ForEach, base)
 	if len(items) == 0 {
+		f.metrics.ObserveFanout(role.NotePath, 0, 0)
+		f.metrics.RecordDelivery(role.NotePath, fleetmetrics.KindChange, agentruntime.StatusCompleted, time.Since(started).Seconds())
 		writeJSON(w, http.StatusOK, webhookutil.AgentResponse{
 			Status:     agentruntime.StatusCompleted,
 			Message:    "no " + role.ForEach + " items to process",
@@ -171,8 +186,11 @@ func (f *Fleet) ServeDelivery(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	f.metrics.ObserveFanout(role.NotePath, len(items), len(errMsgs))
+
 	// Whole batch failed: surface a non-2xx so trip2g's retry/backoff engages.
 	if successCount == 0 {
+		f.metrics.RecordDelivery(role.NotePath, fleetmetrics.KindChange, statusError, time.Since(started).Seconds())
 		writeJSON(w, http.StatusBadGateway, webhookutil.AgentResponse{
 			Status:  statusError,
 			Message: strings.Join(errMsgs, "; "),
@@ -197,6 +215,7 @@ func (f *Fleet) ServeDelivery(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Changes already applied in-loop via the scoped token; report spend only.
+	f.metrics.RecordDelivery(role.NotePath, fleetmetrics.KindChange, status, time.Since(started).Seconds())
 	writeJSON(w, http.StatusOK, webhookutil.AgentResponse{
 		Status:     status,
 		Message:    message,
@@ -269,9 +288,10 @@ func statusSeverity(status string) int {
 // serveCronDelivery handles a cron-triggered POST /_fleet/<h>/webhook/cron/<key>.
 // Unlike change delivery, there are no changed_files; the role body is rendered
 // once with an empty change context and the wall-clock `now` variable.
-func (f *Fleet) serveCronDelivery(w http.ResponseWriter, r *http.Request, role Role, body []byte) {
+func (f *Fleet) serveCronDelivery(w http.ResponseWriter, r *http.Request, role Role, body []byte, started time.Time) {
 	var payload cronDeliveryPayload
 	if uerr := json.Unmarshal(body, &payload); uerr != nil {
+		f.metrics.RecordDeliveryAuthFailure("bad_payload")
 		http.Error(w, "bad payload", http.StatusBadRequest)
 		return
 	}
@@ -289,6 +309,7 @@ func (f *Fleet) serveCronDelivery(w http.ResponseWriter, r *http.Request, role R
 
 	instruction, rerr := renderInstruction(role.Body, rc)
 	if rerr != nil {
+		f.metrics.RecordDelivery(role.NotePath, fleetmetrics.KindCron, statusError, time.Since(started).Seconds())
 		writeJSON(w, http.StatusBadRequest, webhookutil.AgentResponse{
 			Status:  statusError,
 			Message: fmt.Sprintf("render: %v", rerr),
@@ -312,6 +333,7 @@ func (f *Fleet) serveCronDelivery(w http.ResponseWriter, r *http.Request, role R
 	if runErr != nil {
 		//nolint:sloglint // Fleet has no logger instance; global slog is intentional here
 		slog.WarnContext(r.Context(), "fleet: cron run error", "role", role.NotePath, "error", runErr)
+		f.metrics.RecordDelivery(role.NotePath, fleetmetrics.KindCron, statusError, time.Since(started).Seconds())
 		writeJSON(w, http.StatusBadGateway, webhookutil.AgentResponse{
 			Status:  statusError,
 			Message: runErr.Error(),
@@ -319,6 +341,7 @@ func (f *Fleet) serveCronDelivery(w http.ResponseWriter, r *http.Request, role R
 		return
 	}
 
+	f.metrics.RecordDelivery(role.NotePath, fleetmetrics.KindCron, res.Status, time.Since(started).Seconds())
 	writeJSON(w, http.StatusOK, webhookutil.AgentResponse{
 		Status:     res.Status,
 		Message:    res.Answer,
@@ -363,8 +386,12 @@ type execRoleInput struct {
 // way — fleet runs no code in-process there either.
 func (f *Fleet) execRole(p execRoleInput) (*agentruntime.Result, error) {
 	kb := newRemoteKB(p.GQL, p.Overlay)
+	done := f.metrics.RunStarted()
+	defer done()
 	return agentruntime.Run(p.Ctx, agentruntime.Input{
 		Instruction:   p.Instr,
+		Role:          p.Role.NotePath,
+		Metrics:       f.runMetrics(),
 		ReadPatterns:  p.Role.ReadPatterns,
 		WritePatterns: p.Role.WritePatterns,
 		Tools:         p.Role.Tools,
@@ -383,4 +410,14 @@ func writeJSON(w http.ResponseWriter, code int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	_ = json.NewEncoder(w).Encode(v)
+}
+
+// runMetrics adapts the fleet's metrics sink to agentruntime's interface. A nil
+// sink is passed through as a nil interface so the runtime records nothing at
+// all rather than calling into a typed nil.
+func (f *Fleet) runMetrics() agentruntime.Metrics {
+	if f.metrics == nil {
+		return nil
+	}
+	return f.metrics
 }

--- a/cmd/fleet/internal/fleet/handler_metrics_test.go
+++ b/cmd/fleet/internal/fleet/handler_metrics_test.go
@@ -1,0 +1,88 @@
+package fleet
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trip2g/cmd/fleet/internal/fleetmetrics"
+)
+
+// scrapeFleet renders the fleet's registry the way Prometheus would read it.
+func scrapeFleet(t *testing.T, m *fleetmetrics.Metrics) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	m.Handler(nil).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	return rec.Body.String()
+}
+
+// newMeteredFleet builds the same one-role fleet the handler tests use, with a
+// live metrics sink and a scoped-KB server behind it.
+func newMeteredFleet(t *testing.T) (*Fleet, *fleetmetrics.Metrics) {
+	t.Helper()
+	srv, hc := newScopedKBServer(t, nil)
+	cfg := Config{
+		FleetID: "f1", FleetSecret: "seed", DefaultModel: "gpt-4o-mini",
+		Trip2gBaseURL: srv.URL, TokenCeiling: 100000, StepCeiling: 25,
+	}
+	role := Role{
+		NotePath: "roles/triage.md", Body: "Triage.", Mode: "change",
+		ReadPatterns: []string{"boards/**"}, WritePatterns: []string{"boards/**"},
+		MaxTokens: 4000, MaxSteps: 6, Concurrency: "skip", MaxDepth: 1,
+	}
+	m := fleetmetrics.New()
+	f := NewFleet(cfg, hc, &stubLLM{}, nil)
+	f.SetMetrics(m)
+	f.SetRoles([]Role{role})
+	return f, m
+}
+
+// TestMetrics_DeliveryIsRecorded asserts a served delivery lands in the
+// delivery, fan-out, run and token series — the per-role spend view.
+func TestMetrics_DeliveryIsRecorded(t *testing.T) {
+	f, m := newMeteredFleet(t)
+
+	rec := post(t, f, urlKey("roles/triage.md"), deliveryBody(t), true)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	out := scrapeFleet(t, m)
+	require.Contains(t, out, `fleet_deliveries_total{kind="change",role="roles/triage.md",status="completed"} 1`)
+	require.Contains(t, out, `fleet_runs_total{role="roles/triage.md",status="completed"} 1`)
+	require.Contains(t, out, `fleet_tool_calls_total{outcome="ok",tool="patch_note"} 1`)
+	require.Contains(t, out, `fleet_llm_tokens_total{kind="prompt",model="gpt-4o-mini",role="roles/triage.md"} 20`)
+	require.Contains(t, out, `fleet_llm_tokens_total{kind="completion",model="gpt-4o-mini",role="roles/triage.md"} 10`)
+	require.Contains(t, out, `fleet_runs_in_flight 0`)
+}
+
+// TestMetrics_RejectedDeliveriesAreCounted asserts requests turned away before
+// a run — a wrong HMAC, an unknown key — are visible. Today they are silent.
+func TestMetrics_RejectedDeliveriesAreCounted(t *testing.T) {
+	f, m := newMeteredFleet(t)
+
+	require.Equal(t, http.StatusUnauthorized, post(t, f, urlKey("roles/triage.md"), deliveryBody(t), false).Code)
+	require.Equal(t, http.StatusNotFound, post(t, f, "nope", deliveryBody(t), false).Code)
+
+	out := scrapeFleet(t, m)
+	require.Contains(t, out, `fleet_delivery_auth_failures_total{reason="bad_signature"} 1`)
+	require.Contains(t, out, `fleet_delivery_auth_failures_total{reason="unknown_key"} 1`)
+}
+
+// TestMetrics_RolesGaugeFlagsTheDenyAllTrap asserts a role declaring write
+// tools with no write_patterns is published as misconfigured, not just logged
+// once at startup.
+func TestMetrics_RolesGaugeFlagsTheDenyAllTrap(t *testing.T) {
+	m := fleetmetrics.New()
+	f := NewFleet(Config{FleetID: "f1", FleetSecret: "seed"}, nil, &stubLLM{}, nil)
+	f.SetMetrics(m)
+	f.SetRoles([]Role{
+		{NotePath: "roles/ok.md", Tools: []string{"write_note"}, WritePatterns: []string{"boards/**"}},
+		{NotePath: "roles/trap.md", Tools: []string{"write_note"}},
+	})
+
+	out := scrapeFleet(t, m)
+	require.Contains(t, out, "fleet_roles_registered 2")
+	require.Contains(t, out, "fleet_roles_write_scope_misconfigured 1")
+}

--- a/cmd/fleet/internal/fleet/handler_metrics_test.go
+++ b/cmd/fleet/internal/fleet/handler_metrics_test.go
@@ -1,6 +1,10 @@
 package fleet
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -58,7 +62,7 @@ func TestMetrics_DeliveryIsRecorded(t *testing.T) {
 }
 
 // TestMetrics_RejectedDeliveriesAreCounted asserts requests turned away before
-// a run — a wrong HMAC, an unknown key — are visible. Today they are silent.
+// a run — a wrong HMAC, an unknown key — are visible rather than silent.
 func TestMetrics_RejectedDeliveriesAreCounted(t *testing.T) {
 	f, m := newMeteredFleet(t)
 
@@ -71,8 +75,8 @@ func TestMetrics_RejectedDeliveriesAreCounted(t *testing.T) {
 }
 
 // TestMetrics_RolesGaugeFlagsTheDenyAllTrap asserts a role declaring write
-// tools with no write_patterns is published as misconfigured, not just logged
-// once at startup.
+// tools with no write_patterns is published as misconfigured, rather than only
+// logged once at startup.
 func TestMetrics_RolesGaugeFlagsTheDenyAllTrap(t *testing.T) {
 	m := fleetmetrics.New()
 	f := NewFleet(Config{FleetID: "f1", FleetSecret: "seed"}, nil, &stubLLM{}, nil)
@@ -85,4 +89,61 @@ func TestMetrics_RolesGaugeFlagsTheDenyAllTrap(t *testing.T) {
 	out := scrapeFleet(t, m)
 	require.Contains(t, out, "fleet_roles_registered 2")
 	require.Contains(t, out, "fleet_roles_write_scope_misconfigured 1")
+}
+
+// TestMetrics_ReconcileActionsAreCounted asserts each webhook mutation lands
+// under its own action label and that the owned gauge reports the post-reconcile
+// state: repeated creates or updates in a steady state are how two fleets
+// sharing a fleet_id announce themselves.
+func TestMetrics_ReconcileActionsAreCounted(t *testing.T) {
+	role := Role{NotePath: "roles/triage.md", Mode: "change", MaxDepth: 1, Concurrency: "skip"}
+	staleURL := "https://old-host.example/_fleet/" + fleetHash("f1") + "/webhook/" + urlKey(role.NotePath)
+	foreign := "fleet:f1:roles/gone.md:v0"
+
+	gql := fakeAdminGQL(func(op string, _ json.RawMessage) (string, error) {
+		switch op {
+		case "ListChangeWebhooks":
+			return nodesDataURL(
+				[3]string{"7", markerFor("f1", role), staleURL},
+				[3]string{"8", foreign, ""},
+			), nil
+		case "UpdateChangeWebhook":
+			return updateOKData, nil
+		case "DeleteChangeWebhook":
+			return deleteOKData, nil
+		}
+		return "", fmt.Errorf("unexpected op %q", op)
+	})
+
+	m := fleetmetrics.New()
+	r := newReconciler(gql)
+	r.SetMetrics(m)
+	require.NoError(t, r.Reconcile(context.Background(), []Role{role}))
+
+	out := scrapeFleet(t, m)
+	require.Contains(t, out, `fleet_webhook_actions_total{action="update",status="ok"} 1`)
+	require.Contains(t, out, `fleet_webhook_actions_total{action="delete",status="ok"} 1`)
+	require.Contains(t, out, `fleet_webhooks_owned{kind="change"} 1`)
+}
+
+// TestMetrics_FailedReconcileActionIsCounted asserts a mutation that errors is
+// attributed to the action that failed, not swallowed with the returned error.
+func TestMetrics_FailedReconcileActionIsCounted(t *testing.T) {
+	role := Role{NotePath: "roles/triage.md", Mode: "change", MaxDepth: 1, Concurrency: "skip"}
+	gql := fakeAdminGQL(func(op string, _ json.RawMessage) (string, error) {
+		switch op {
+		case "ListChangeWebhooks":
+			return nodesData(), nil
+		case "CreateChangeWebhook":
+			return "", errors.New("trip2g is down")
+		}
+		return "", fmt.Errorf("unexpected op %q", op)
+	})
+
+	m := fleetmetrics.New()
+	r := newReconciler(gql)
+	r.SetMetrics(m)
+	require.Error(t, r.Reconcile(context.Background(), []Role{role}))
+
+	require.Contains(t, scrapeFleet(t, m), `fleet_webhook_actions_total{action="create",status="error"} 1`)
 }

--- a/cmd/fleet/internal/fleet/reconcile.go
+++ b/cmd/fleet/internal/fleet/reconcile.go
@@ -74,7 +74,6 @@ func (r *Reconciler) reconcileChange(ctx context.Context, roles []Role) error {
 	// extras from a superseded spec version: they share this fleet's
 	// "fleet:<FleetID>:" description-marker prefix — listOwned already filtered
 	// to it — but their old marker/spec-hash suffix no longer matches desired).
-	r.metrics.SetWebhooksOwned(fleetmetrics.KindChange, len(existing))
 	for marker, have := range existing {
 		if _, keep := desired[marker]; !keep {
 			if derr := r.recorded("delete", r.delete(ctx, have.id)); derr != nil {
@@ -104,6 +103,9 @@ func (r *Reconciler) reconcileChange(ctx context.Context, roles []Role) error {
 			}
 		}
 	}
+	// Published after the diff is applied, so the gauge is what this fleet owns
+	// now rather than what it found at the start of the cycle.
+	r.metrics.SetWebhooksOwned(fleetmetrics.KindChange, len(desired))
 	return nil
 }
 
@@ -122,7 +124,6 @@ func (r *Reconciler) reconcileCron(ctx context.Context, roles []Role) error {
 	}
 
 	// Delete owned cron-webhooks whose marker is no longer desired.
-	r.metrics.SetWebhooksOwned(fleetmetrics.KindCron, len(existing))
 	for marker, id := range existing {
 		if _, keep := desired[marker]; !keep {
 			if derr := r.recorded("delete", r.deleteCron(ctx, id)); derr != nil {
@@ -139,6 +140,7 @@ func (r *Reconciler) reconcileCron(ctx context.Context, roles []Role) error {
 			return cerr
 		}
 	}
+	r.metrics.SetWebhooksOwned(fleetmetrics.KindCron, len(desired))
 	return nil
 }
 

--- a/cmd/fleet/internal/fleet/reconcile.go
+++ b/cmd/fleet/internal/fleet/reconcile.go
@@ -13,13 +13,32 @@ import (
 	"github.com/Khan/genqlient/graphql"
 
 	"trip2g/cmd/fleet/internal/fleet/trip2ggql"
+	"trip2g/cmd/fleet/internal/fleetmetrics"
 )
 
 // Reconciler drives the desired-vs-actual webhook diff over the genqlient admin
 // lane.
 type Reconciler struct {
-	gql graphql.Client
-	cfg Config
+	gql     graphql.Client
+	cfg     Config
+	metrics *fleetmetrics.Metrics
+}
+
+// SetMetrics attaches the metrics sink; nil records nothing.
+func (r *Reconciler) SetMetrics(m *fleetmetrics.Metrics) {
+	r.metrics = m
+}
+
+// recorded counts one reconcile action and passes its error through, so a call
+// site stays a single line. Webhook churn (repeated creates/updates in a steady
+// state) is how two fleets sharing a fleet_id announce themselves.
+func (r *Reconciler) recorded(action string, err error) error {
+	status := fleetmetrics.StatusOK
+	if err != nil {
+		status = fleetmetrics.StatusError
+	}
+	r.metrics.RecordWebhookAction(action, status)
+	return err
 }
 
 // NewReconciler builds a Reconciler over the genqlient admin lane.
@@ -55,9 +74,10 @@ func (r *Reconciler) reconcileChange(ctx context.Context, roles []Role) error {
 	// extras from a superseded spec version: they share this fleet's
 	// "fleet:<FleetID>:" description-marker prefix — listOwned already filtered
 	// to it — but their old marker/spec-hash suffix no longer matches desired).
+	r.metrics.SetWebhooksOwned(fleetmetrics.KindChange, len(existing))
 	for marker, have := range existing {
 		if _, keep := desired[marker]; !keep {
-			if derr := r.delete(ctx, have.id); derr != nil {
+			if derr := r.recorded("delete", r.delete(ctx, have.id)); derr != nil {
 				return derr
 			}
 		}
@@ -66,7 +86,7 @@ func (r *Reconciler) reconcileChange(ctx context.Context, roles []Role) error {
 	for marker, role := range desired {
 		have, present := existing[marker]
 		if !present {
-			if cerr := r.create(ctx, role); cerr != nil {
+			if cerr := r.recorded("create", r.create(ctx, role)); cerr != nil {
 				return cerr
 			}
 			continue
@@ -79,7 +99,7 @@ func (r *Reconciler) reconcileChange(ctx context.Context, roles []Role) error {
 		// carries no url to compare (test fakes), so leave it alone.
 		want := changeDeliveryURL(r.cfg.CallbackURL, r.cfg.FleetID, role.NotePath)
 		if have.url != "" && have.url != want {
-			if uerr := r.update(ctx, have.id, want); uerr != nil {
+			if uerr := r.recorded("update", r.update(ctx, have.id, want)); uerr != nil {
 				return uerr
 			}
 		}
@@ -102,9 +122,10 @@ func (r *Reconciler) reconcileCron(ctx context.Context, roles []Role) error {
 	}
 
 	// Delete owned cron-webhooks whose marker is no longer desired.
+	r.metrics.SetWebhooksOwned(fleetmetrics.KindCron, len(existing))
 	for marker, id := range existing {
 		if _, keep := desired[marker]; !keep {
-			if derr := r.deleteCron(ctx, id); derr != nil {
+			if derr := r.recorded("delete", r.deleteCron(ctx, id)); derr != nil {
 				return derr
 			}
 		}
@@ -114,7 +135,7 @@ func (r *Reconciler) reconcileCron(ctx context.Context, roles []Role) error {
 		if _, present := existing[marker]; present {
 			continue // marker already matches => spec unchanged
 		}
-		if cerr := r.createCron(ctx, role); cerr != nil {
+		if cerr := r.recorded("create", r.createCron(ctx, role)); cerr != nil {
 			return cerr
 		}
 	}
@@ -128,7 +149,7 @@ func (r *Reconciler) Deregister(ctx context.Context) error {
 		return err
 	}
 	for _, have := range existing {
-		if derr := r.delete(ctx, have.id); derr != nil {
+		if derr := r.recorded("delete", r.delete(ctx, have.id)); derr != nil {
 			return derr
 		}
 	}
@@ -137,7 +158,7 @@ func (r *Reconciler) Deregister(ctx context.Context) error {
 		return err
 	}
 	for _, id := range existingCron {
-		if derr := r.deleteCron(ctx, id); derr != nil {
+		if derr := r.recorded("delete", r.deleteCron(ctx, id)); derr != nil {
 			return derr
 		}
 	}

--- a/cmd/fleet/internal/fleetmetrics/metrics.go
+++ b/cmd/fleet/internal/fleetmetrics/metrics.go
@@ -1,5 +1,6 @@
 // Package fleetmetrics is the fleet's Prometheus surface: the collectors plus
 // the internal listener's handler (/metrics, pprof, liveness/readiness).
+// Catalog and alerting recipes live in docs/dev/fleet_codellm_metrics.md.
 //
 // It owns its OWN registry rather than the global default one, so the fleet
 // stays independent of the monolith's internal/metrics (which registers
@@ -30,8 +31,11 @@ const (
 	LaneExec = "exec"
 
 	// StatusOK / StatusError are the coarse outcomes shared by several lanes.
-	StatusOK    = "ok"
-	StatusError = "error"
+	// StatusPartial is a sync that refreshed the registry but could not use every
+	// role note it found.
+	StatusOK      = "ok"
+	StatusError   = "error"
+	StatusPartial = "partial"
 
 	roleLabel   = "role"
 	statusLabel = "status"
@@ -62,14 +66,14 @@ type Metrics struct {
 	llmDuration *prometheus.HistogramVec
 	llmRetries  *prometheus.CounterVec
 
-	syncs             *prometheus.CounterVec
-	syncDuration      prometheus.Histogram
-	lastSync          prometheus.Gauge
-	rolesRegistered   prometheus.Gauge
-	rolesSkipped      prometheus.Counter
-	rolesMisconfigred prometheus.Gauge
-	webhookActions    *prometheus.CounterVec
-	webhooksOwned     *prometheus.GaugeVec
+	syncs              *prometheus.CounterVec
+	syncDuration       prometheus.Histogram
+	lastSync           prometheus.Gauge
+	rolesRegistered    prometheus.Gauge
+	rolesSkipped       prometheus.Counter
+	rolesMisconfigured prometheus.Gauge
+	webhookActions     *prometheus.CounterVec
+	webhooksOwned      *prometheus.GaugeVec
 
 	configInfo *prometheus.GaugeVec
 }
@@ -90,7 +94,7 @@ func New() *Metrics {
 		m.runs, m.runSteps, m.runDuration, m.tokens, m.toolCalls, m.denials, m.applyFailures,
 		m.llmRequests, m.llmDuration, m.llmRetries,
 		m.syncs, m.syncDuration, m.lastSync, m.rolesRegistered, m.rolesSkipped,
-		m.rolesMisconfigred, m.webhookActions, m.webhooksOwned, m.configInfo,
+		m.rolesMisconfigured, m.webhookActions, m.webhooksOwned, m.configInfo,
 	)
 	return m
 }
@@ -174,7 +178,7 @@ func (m *Metrics) initRun() {
 func (m *Metrics) initControlPlane() {
 	m.syncs = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "fleet_syncs_total",
-		Help: "Discovery/reconcile poll cycles by outcome",
+		Help: "Discovery/reconcile poll cycles by outcome (ok|partial|error)",
 	}, []string{statusLabel})
 	m.syncDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name:    "fleet_sync_duration_seconds",
@@ -183,7 +187,7 @@ func (m *Metrics) initControlPlane() {
 	})
 	m.lastSync = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "fleet_last_successful_sync_timestamp_seconds",
-		Help: "Unix time of the last fully successful poll cycle; staleness here means the fleet is serving stale roles",
+		Help: "Unix time of the last poll cycle that refreshed the registry (ok or partial); 0 until the first one. Staleness here means the fleet is serving stale roles",
 	})
 	m.rolesRegistered = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "fleet_roles_registered",
@@ -193,7 +197,7 @@ func (m *Metrics) initControlPlane() {
 		Name: "fleet_roles_skipped_total",
 		Help: "Role notes skipped during discovery (parse or validation failure)",
 	})
-	m.rolesMisconfigred = prometheus.NewGauge(prometheus.GaugeOpts{
+	m.rolesMisconfigured = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "fleet_roles_write_scope_misconfigured",
 		Help: "Roles declaring write tools with no write_patterns — every write they attempt is denied",
 	})
@@ -315,7 +319,7 @@ func (m *Metrics) RecordTokens(model, role, kind string, n int) {
 	m.tokens.WithLabelValues(model, role, kind).Add(float64(n))
 }
 
-// RecordToolCall counts one tool invocation and its outcome.
+// RecordToolCall counts one tool invocation.
 func (m *Metrics) RecordToolCall(tool, outcome string) {
 	if m == nil {
 		return
@@ -323,7 +327,7 @@ func (m *Metrics) RecordToolCall(tool, outcome string) {
 	m.toolCalls.WithLabelValues(tool, outcome).Inc()
 }
 
-// RecordDenial counts one scope denial by kind (read|write|not_permitted).
+// RecordDenial counts one scope denial.
 func (m *Metrics) RecordDenial(kind string) {
 	if m == nil {
 		return
@@ -357,16 +361,17 @@ func (m *Metrics) RecordLLMRetry(lane, reason string) {
 	m.llmRetries.WithLabelValues(lane, reason).Inc()
 }
 
-// RecordSync records one poll cycle. A fully successful cycle also stamps the
-// freshness gauge — the single metric worth alerting on, since a fleet serving
-// stale roles otherwise looks perfectly healthy.
+// RecordSync records one poll cycle. Any cycle that refreshed the registry
+// stamps the freshness gauge, StatusPartial included: a single unparseable role
+// note must not freeze it forever. Roles that could not be used are counted
+// separately by AddRolesSkipped.
 func (m *Metrics) RecordSync(status string, seconds float64) {
 	if m == nil {
 		return
 	}
 	m.syncs.WithLabelValues(status).Inc()
 	m.syncDuration.Observe(seconds)
-	if status == StatusOK {
+	if status != StatusError {
 		m.lastSync.Set(float64(time.Now().Unix()))
 	}
 }
@@ -378,7 +383,7 @@ func (m *Metrics) SetRoles(registered, misconfigured int) {
 		return
 	}
 	m.rolesRegistered.Set(float64(registered))
-	m.rolesMisconfigred.Set(float64(misconfigured))
+	m.rolesMisconfigured.Set(float64(misconfigured))
 }
 
 // AddRolesSkipped counts role notes discovery could not use.
@@ -397,7 +402,8 @@ func (m *Metrics) RecordWebhookAction(action, status string) {
 	m.webhookActions.WithLabelValues(action, status).Inc()
 }
 
-// SetWebhooksOwned publishes how many webhooks of a kind this fleet owns.
+// SetWebhooksOwned publishes how many webhooks of a kind this fleet owns after
+// the current reconcile.
 func (m *Metrics) SetWebhooksOwned(kind string, n int) {
 	if m == nil {
 		return

--- a/cmd/fleet/internal/fleetmetrics/metrics.go
+++ b/cmd/fleet/internal/fleetmetrics/metrics.go
@@ -1,0 +1,415 @@
+// Package fleetmetrics is the fleet's Prometheus surface: the collectors plus
+// the internal listener's handler (/metrics, pprof, liveness/readiness).
+//
+// It owns its OWN registry rather than the global default one, so the fleet
+// stays independent of the monolith's internal/metrics (which registers
+// globally) and a test can gather a clean snapshot. Every record method is
+// nil-safe, so call sites stay unconditional when metrics are disabled (tests,
+// --once, --metrics-addr="").
+package fleetmetrics
+
+import (
+	"net/http"
+	"net/http/pprof"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// Delivery kinds and the LLM lanes, used as label values.
+const (
+	KindChange = "change"
+	KindCron   = "cron"
+
+	// LaneLLM is the role's own model endpoint; LaneExec is the exec tool's
+	// endpoint (codellm). Splitting them keeps a degrading code executor
+	// distinguishable from a degrading language model.
+	LaneLLM  = "llm"
+	LaneExec = "exec"
+
+	// StatusOK / StatusError are the coarse outcomes shared by several lanes.
+	StatusOK    = "ok"
+	StatusError = "error"
+
+	roleLabel   = "role"
+	statusLabel = "status"
+	modelLabel  = "model"
+	laneLabel   = "lane"
+)
+
+// Metrics holds the fleet's collectors and the registry they live in.
+type Metrics struct {
+	reg *prometheus.Registry
+
+	deliveries       *prometheus.CounterVec
+	deliveryDuration *prometheus.HistogramVec
+	deliveryAuthFail *prometheus.CounterVec
+	runsInFlight     prometheus.Gauge
+	fanoutItems      *prometheus.HistogramVec
+	fanoutItemErrors *prometheus.CounterVec
+
+	runs          *prometheus.CounterVec
+	runSteps      *prometheus.HistogramVec
+	runDuration   *prometheus.HistogramVec
+	tokens        *prometheus.CounterVec
+	toolCalls     *prometheus.CounterVec
+	denials       *prometheus.CounterVec
+	applyFailures *prometheus.CounterVec
+
+	llmRequests *prometheus.CounterVec
+	llmDuration *prometheus.HistogramVec
+	llmRetries  *prometheus.CounterVec
+
+	syncs             *prometheus.CounterVec
+	syncDuration      prometheus.Histogram
+	lastSync          prometheus.Gauge
+	rolesRegistered   prometheus.Gauge
+	rolesSkipped      prometheus.Counter
+	rolesMisconfigred prometheus.Gauge
+	webhookActions    *prometheus.CounterVec
+	webhooksOwned     *prometheus.GaugeVec
+
+	configInfo *prometheus.GaugeVec
+}
+
+// New builds the collectors on a private registry, together with the standard
+// Go runtime and process collectors.
+func New() *Metrics {
+	m := &Metrics{reg: prometheus.NewRegistry()}
+	m.initDelivery()
+	m.initRun()
+	m.initControlPlane()
+
+	m.reg.MustRegister(
+		collectors.NewGoCollector(),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+		m.deliveries, m.deliveryDuration, m.deliveryAuthFail, m.runsInFlight,
+		m.fanoutItems, m.fanoutItemErrors,
+		m.runs, m.runSteps, m.runDuration, m.tokens, m.toolCalls, m.denials, m.applyFailures,
+		m.llmRequests, m.llmDuration, m.llmRetries,
+		m.syncs, m.syncDuration, m.lastSync, m.rolesRegistered, m.rolesSkipped,
+		m.rolesMisconfigred, m.webhookActions, m.webhooksOwned, m.configInfo,
+	)
+	return m
+}
+
+func (m *Metrics) initDelivery() {
+	m.deliveries = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "fleet_deliveries_total",
+		Help: "Webhook deliveries received, by role, kind (change|cron) and outcome",
+	}, []string{roleLabel, "kind", statusLabel})
+	m.deliveryDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "fleet_delivery_duration_seconds",
+		Help:    "End-to-end delivery handling time in seconds, including the agent run",
+		Buckets: []float64{0.1, 0.5, 1, 5, 15, 30, 60, 120, 300, 600},
+	}, []string{roleLabel, "kind"})
+	m.deliveryAuthFail = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "fleet_delivery_auth_failures_total",
+		Help: "Rejected deliveries by reason (unknown_key|bad_signature|bad_payload|read_body)",
+	}, []string{"reason"})
+	m.runsInFlight = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "fleet_runs_in_flight",
+		Help: "Agent runs currently executing; deliveries are handled synchronously, so this is also the drain backlog",
+	})
+	m.fanoutItems = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "fleet_fanout_items",
+		Help:    "Items one delivery fanned out into (for_each)",
+		Buckets: []float64{0, 1, 2, 5, 10, 25, 50, 100},
+	}, []string{roleLabel})
+	m.fanoutItemErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "fleet_fanout_item_errors_total",
+		Help: "Fan-out items that failed; trip2g records a partial batch as success, so this is the only signal",
+	}, []string{roleLabel})
+}
+
+func (m *Metrics) initRun() {
+	m.runs = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "fleet_runs_total",
+		Help: "Agent runs by role and terminal status (completed|capped|max_steps|error)",
+	}, []string{roleLabel, statusLabel})
+	m.runSteps = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "fleet_run_steps",
+		Help:    "Tool-loop iterations one run consumed; drift toward the step ceiling precedes hitting it",
+		Buckets: []float64{1, 2, 3, 5, 8, 13, 21, 34},
+	}, []string{roleLabel})
+	m.runDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "fleet_run_duration_seconds",
+		Help:    "Agent run duration in seconds",
+		Buckets: []float64{0.5, 1, 5, 15, 30, 60, 120, 300, 600},
+	}, []string{roleLabel})
+	m.tokens = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "fleet_llm_tokens_total",
+		Help: "LLM tokens spent, by model, role and kind (prompt|completion). A codellm-backed fleet reports zero: it executes code, it does not infer",
+	}, []string{modelLabel, roleLabel, "kind"})
+	m.toolCalls = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "fleet_tool_calls_total",
+		Help: "Tool calls by tool and outcome (ok|denied|invalid_args|error|apply_failed|not_permitted)",
+	}, []string{"tool", "outcome"})
+	m.denials = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "fleet_denials_total",
+		Help: "Scope denials by kind (read|write|not_permitted); a steady rate usually means misconfigured read/write_patterns",
+	}, []string{"kind"})
+	m.applyFailures = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "fleet_apply_failures_total",
+		Help: "Write/patch applies that failed, by role and tool. Under HardFailApply each one kills its run",
+	}, []string{roleLabel, "tool"})
+
+	m.llmRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "fleet_llm_requests_total",
+		Help: "Chat-completion requests by lane (llm|exec), model and outcome",
+	}, []string{laneLabel, modelLabel, statusLabel})
+	m.llmDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "fleet_llm_request_duration_seconds",
+		Help:    "Chat-completion request duration in seconds, retries included",
+		Buckets: []float64{0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120},
+	}, []string{laneLabel, modelLabel})
+	m.llmRetries = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "fleet_llm_retries_total",
+		Help: "Retried chat-completion attempts by lane and reason (429|5xx|network); the earliest upstream-instability signal",
+	}, []string{laneLabel, "reason"})
+}
+
+func (m *Metrics) initControlPlane() {
+	m.syncs = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "fleet_syncs_total",
+		Help: "Discovery/reconcile poll cycles by outcome",
+	}, []string{statusLabel})
+	m.syncDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "fleet_sync_duration_seconds",
+		Help:    "Duration of one discovery+reconcile cycle in seconds",
+		Buckets: prometheus.DefBuckets,
+	})
+	m.lastSync = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "fleet_last_successful_sync_timestamp_seconds",
+		Help: "Unix time of the last fully successful poll cycle; staleness here means the fleet is serving stale roles",
+	})
+	m.rolesRegistered = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "fleet_roles_registered",
+		Help: "Roles currently in the live registry",
+	})
+	m.rolesSkipped = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "fleet_roles_skipped_total",
+		Help: "Role notes skipped during discovery (parse or validation failure)",
+	})
+	m.rolesMisconfigred = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "fleet_roles_write_scope_misconfigured",
+		Help: "Roles declaring write tools with no write_patterns — every write they attempt is denied",
+	})
+	m.webhookActions = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "fleet_webhook_actions_total",
+		Help: "Webhook reconcile actions by action (create|update|delete) and outcome; a nonzero steady rate means two fleets are fighting over the same id",
+	}, []string{"action", statusLabel})
+	m.webhooksOwned = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "fleet_webhooks_owned",
+		Help: "Webhooks this fleet owns in trip2g, by kind",
+	}, []string{"kind"})
+	m.configInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "fleet_config_info",
+		Help: "Always 1; labels carry the identity and routing this process runs with",
+	}, []string{"fleet_id", "default_model", "exec_enabled"})
+}
+
+// Registry exposes the private registry for tests and for callers that want to
+// register their own collectors alongside the fleet's.
+func (m *Metrics) Registry() *prometheus.Registry {
+	if m == nil {
+		return nil
+	}
+	return m.reg
+}
+
+// Handler builds the internal listener's mux: Prometheus scrape, pprof, and the
+// k8s-convention probes, mirroring the monolith's internal listener. Nothing
+// here is authenticated, which is why the port stays loopback-bound. ready may
+// be nil (always ready).
+func (m *Metrics) Handler(ready func() bool) http.Handler {
+	mux := http.NewServeMux()
+	if m != nil {
+		mux.Handle("GET /metrics", promhttp.HandlerFor(m.reg, promhttp.HandlerOpts{Registry: m.reg}))
+	}
+
+	mux.HandleFunc("GET /debug/pprof/", pprof.Index)
+	mux.HandleFunc("GET /debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("GET /debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("GET /debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("GET /debug/pprof/trace", pprof.Trace)
+
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("GET /livez", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("alive"))
+	})
+	mux.HandleFunc("GET /readyz", func(w http.ResponseWriter, _ *http.Request) {
+		if ready != nil && !ready() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("not ready"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ready"))
+	})
+	return mux
+}
+
+// RecordDelivery counts one handled delivery and its wall time.
+func (m *Metrics) RecordDelivery(role, kind, status string, seconds float64) {
+	if m == nil {
+		return
+	}
+	m.deliveries.WithLabelValues(role, kind, status).Inc()
+	m.deliveryDuration.WithLabelValues(role, kind).Observe(seconds)
+}
+
+// RecordDeliveryAuthFailure counts a delivery rejected before it ever reached a
+// run: unknown key, bad HMAC, unreadable body.
+func (m *Metrics) RecordDeliveryAuthFailure(reason string) {
+	if m == nil {
+		return
+	}
+	m.deliveryAuthFail.WithLabelValues(reason).Inc()
+}
+
+// RunStarted marks a run as in flight and returns the function that clears it.
+func (m *Metrics) RunStarted() func() {
+	if m == nil {
+		return func() {}
+	}
+	m.runsInFlight.Inc()
+	return m.runsInFlight.Dec
+}
+
+// ObserveFanout records how many items a delivery expanded into and how many
+// of them failed.
+func (m *Metrics) ObserveFanout(role string, items, failed int) {
+	if m == nil {
+		return
+	}
+	m.fanoutItems.WithLabelValues(role).Observe(float64(items))
+	if failed > 0 {
+		m.fanoutItemErrors.WithLabelValues(role).Add(float64(failed))
+	}
+}
+
+// RecordRun records one finished agent run.
+func (m *Metrics) RecordRun(role, status string, steps int, seconds float64) {
+	if m == nil {
+		return
+	}
+	m.runs.WithLabelValues(role, status).Inc()
+	m.runSteps.WithLabelValues(role).Observe(float64(steps))
+	m.runDuration.WithLabelValues(role).Observe(seconds)
+}
+
+// RecordTokens attributes token spend to both the model that burned it and the
+// role that asked for it, so cost-per-model and cost-per-role are two views of
+// one series instead of two counters that can drift apart.
+func (m *Metrics) RecordTokens(model, role, kind string, n int) {
+	if m == nil || n <= 0 {
+		return
+	}
+	m.tokens.WithLabelValues(model, role, kind).Add(float64(n))
+}
+
+// RecordToolCall counts one tool invocation and its outcome.
+func (m *Metrics) RecordToolCall(tool, outcome string) {
+	if m == nil {
+		return
+	}
+	m.toolCalls.WithLabelValues(tool, outcome).Inc()
+}
+
+// RecordDenial counts one scope denial by kind (read|write|not_permitted).
+func (m *Metrics) RecordDenial(kind string) {
+	if m == nil {
+		return
+	}
+	m.denials.WithLabelValues(kind).Inc()
+}
+
+// RecordApplyFailure counts a write/patch that could not be applied.
+func (m *Metrics) RecordApplyFailure(role, tool string) {
+	if m == nil {
+		return
+	}
+	m.applyFailures.WithLabelValues(role, tool).Inc()
+}
+
+// RecordLLMRequest counts one chat-completion call (all retries included) and
+// its duration.
+func (m *Metrics) RecordLLMRequest(lane, model, status string, seconds float64) {
+	if m == nil {
+		return
+	}
+	m.llmRequests.WithLabelValues(lane, model, status).Inc()
+	m.llmDuration.WithLabelValues(lane, model).Observe(seconds)
+}
+
+// RecordLLMRetry counts one retried attempt by reason.
+func (m *Metrics) RecordLLMRetry(lane, reason string) {
+	if m == nil {
+		return
+	}
+	m.llmRetries.WithLabelValues(lane, reason).Inc()
+}
+
+// RecordSync records one poll cycle. A fully successful cycle also stamps the
+// freshness gauge — the single metric worth alerting on, since a fleet serving
+// stale roles otherwise looks perfectly healthy.
+func (m *Metrics) RecordSync(status string, seconds float64) {
+	if m == nil {
+		return
+	}
+	m.syncs.WithLabelValues(status).Inc()
+	m.syncDuration.Observe(seconds)
+	if status == StatusOK {
+		m.lastSync.Set(float64(time.Now().Unix()))
+	}
+}
+
+// SetRoles publishes the live registry size and how many of those roles declare
+// write tools they can never use.
+func (m *Metrics) SetRoles(registered, misconfigured int) {
+	if m == nil {
+		return
+	}
+	m.rolesRegistered.Set(float64(registered))
+	m.rolesMisconfigred.Set(float64(misconfigured))
+}
+
+// AddRolesSkipped counts role notes discovery could not use.
+func (m *Metrics) AddRolesSkipped(n int) {
+	if m == nil || n <= 0 {
+		return
+	}
+	m.rolesSkipped.Add(float64(n))
+}
+
+// RecordWebhookAction counts one reconcile action against trip2g.
+func (m *Metrics) RecordWebhookAction(action, status string) {
+	if m == nil {
+		return
+	}
+	m.webhookActions.WithLabelValues(action, status).Inc()
+}
+
+// SetWebhooksOwned publishes how many webhooks of a kind this fleet owns.
+func (m *Metrics) SetWebhooksOwned(kind string, n int) {
+	if m == nil {
+		return
+	}
+	m.webhooksOwned.WithLabelValues(kind).Set(float64(n))
+}
+
+// SetConfigInfo publishes this process's identity and routing, so an operator
+// can tell two fleets apart from a scrape alone.
+func (m *Metrics) SetConfigInfo(fleetID, defaultModel, execEnabled string) {
+	if m == nil {
+		return
+	}
+	m.configInfo.WithLabelValues(fleetID, defaultModel, execEnabled).Set(1)
+}

--- a/cmd/fleet/internal/fleetmetrics/metrics_test.go
+++ b/cmd/fleet/internal/fleetmetrics/metrics_test.go
@@ -1,0 +1,150 @@
+package fleetmetrics
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// scrape renders the registry the way Prometheus would read it.
+func scrape(t *testing.T, m *Metrics) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	m.Handler(nil).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	return rec.Body.String()
+}
+
+// TestRecordSync_StampsFreshnessOnlyOnSuccess is the alerting contract: the
+// freshness gauge must not advance on a failed cycle, or a fleet serving stale
+// roles looks healthy forever.
+func TestRecordSync_StampsFreshnessOnlyOnSuccess(t *testing.T) {
+	m := New()
+	m.RecordSync(StatusError, 0.2)
+	require.InDelta(t, 0.0, testutil.ToFloat64(m.lastSync), 0.001)
+
+	m.RecordSync(StatusOK, 0.3)
+	require.Positive(t, testutil.ToFloat64(m.lastSync))
+	require.InDelta(t, 1.0, testutil.ToFloat64(m.syncs.WithLabelValues(StatusOK)), 0.001)
+	require.InDelta(t, 1.0, testutil.ToFloat64(m.syncs.WithLabelValues(StatusError)), 0.001)
+}
+
+// TestRecordTokens_AttributesModelAndRole asserts one series answers both
+// "what does this model cost" and "what does this role cost".
+func TestRecordTokens_AttributesModelAndRole(t *testing.T) {
+	m := New()
+	m.RecordTokens("gpt-4o-mini", "roles/triage.md", "prompt", 120)
+	m.RecordTokens("gpt-4o-mini", "roles/triage.md", "completion", 40)
+	m.RecordTokens("gpt-4o-mini", "roles/triage.md", "completion", 0) // ignored
+
+	out := scrape(t, m)
+	require.Contains(t, out, `fleet_llm_tokens_total{kind="prompt",model="gpt-4o-mini",role="roles/triage.md"} 120`)
+	require.Contains(t, out, `fleet_llm_tokens_total{kind="completion",model="gpt-4o-mini",role="roles/triage.md"} 40`)
+}
+
+// TestRunStarted_BalancesInFlight asserts the returned release function clears
+// the gauge, so a leaked run shows up rather than being hidden.
+func TestRunStarted_BalancesInFlight(t *testing.T) {
+	m := New()
+	done := m.RunStarted()
+	require.InDelta(t, 1.0, testutil.ToFloat64(m.runsInFlight), 0.001)
+	done()
+	require.InDelta(t, 0.0, testutil.ToFloat64(m.runsInFlight), 0.001)
+}
+
+// TestObserveFanout_CountsFailuresOnly asserts a clean batch adds nothing to
+// the error counter while a partial one does.
+func TestObserveFanout_CountsFailuresOnly(t *testing.T) {
+	m := New()
+	m.ObserveFanout("roles/a.md", 5, 0)
+	require.Equal(t, 0, testutil.CollectAndCount(m.fanoutItemErrors))
+
+	m.ObserveFanout("roles/a.md", 5, 2)
+	require.InDelta(t, 2.0, testutil.ToFloat64(m.fanoutItemErrors.WithLabelValues("roles/a.md")), 0.001)
+}
+
+// TestHandler_ServesScrapeAndProbes asserts the internal listener exposes the
+// scrape endpoint, pprof and the k8s-convention probes, readiness included.
+func TestHandler_ServesScrapeAndProbes(t *testing.T) {
+	m := New()
+	m.SetConfigInfo("f1", "gpt-4o-mini", "true")
+
+	ready := false
+	h := m.Handler(func() bool { return ready })
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `fleet_config_info{default_model="gpt-4o-mini",exec_enabled="true",fleet_id="f1"} 1`)
+	require.Contains(t, rec.Body.String(), "go_goroutines")
+
+	for _, path := range []string{"/healthz", "/livez"} {
+		rec = httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		require.Equal(t, http.StatusOK, rec.Code, path)
+	}
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+
+	ready = true
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestNilMetrics_IsSafe asserts every call site can stay unconditional when
+// metrics are disabled (--once, --metrics-addr="").
+func TestNilMetrics_IsSafe(t *testing.T) {
+	var m *Metrics
+	require.NotPanics(t, func() {
+		m.RecordDelivery("r", KindChange, StatusOK, 1)
+		m.RecordDeliveryAuthFailure("bad_signature")
+		m.RunStarted()()
+		m.ObserveFanout("r", 1, 1)
+		m.RecordRun("r", StatusOK, 2, 1)
+		m.RecordTokens("m", "r", "prompt", 5)
+		m.RecordToolCall("write_note", "ok")
+		m.RecordDenial("write")
+		m.RecordApplyFailure("r", "patch_note")
+		m.RecordLLMRequest(LaneLLM, "m", StatusOK, 1)
+		m.RecordLLMRetry(LaneExec, "429")
+		m.RecordSync(StatusOK, 1)
+		m.SetRoles(3, 1)
+		m.AddRolesSkipped(2)
+		m.RecordWebhookAction("create", StatusOK)
+		m.SetWebhooksOwned(KindCron, 2)
+		m.SetConfigInfo("f1", "m", "false")
+		require.Nil(t, m.Registry())
+
+		rec := httptest.NewRecorder()
+		m.Handler(nil).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+		require.Equal(t, http.StatusOK, rec.Code)
+	})
+}
+
+// TestMetricNames_FollowPrometheusConventions guards the naming the scrape
+// contract depends on: counters end in _total, durations are in seconds.
+func TestMetricNames_FollowPrometheusConventions(t *testing.T) {
+	m := New()
+	problems, err := testutil.GatherAndLint(m.reg)
+	require.NoError(t, err)
+	var msgs []string
+	for _, p := range problems {
+		// The Go runtime collector's own names are client_golang's business.
+		if strings.HasPrefix(p.Metric, "go_") || strings.HasPrefix(p.Metric, "process_") {
+			continue
+		}
+		msgs = append(msgs, p.Metric+": "+p.Text)
+	}
+	require.Empty(t, msgs, strings.Join(msgs, "\n"))
+}

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -19,7 +19,9 @@ import (
 	"os"
 	"os/signal"
 	"slices"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -28,6 +30,7 @@ import (
 	"trip2g/cmd/fleet/internal/fleet"
 	"trip2g/cmd/fleet/internal/fleet/fleetgql"
 	"trip2g/cmd/fleet/internal/fleet/graph"
+	"trip2g/cmd/fleet/internal/fleetmetrics"
 	"trip2g/internal/appconfig"
 	"trip2g/internal/delegatedadmin"
 	"trip2g/internal/logger"
@@ -82,11 +85,24 @@ func run() error {
 
 	lg := zerologger.New(cli.cfg.LogLevel, false)
 
+	// Metrics live on their own loopback listener (mirrors the monolith's
+	// internal listener). It starts before the first sync so a scrape can see the
+	// fleet warming up.
+	var firstSyncDone atomic.Bool
+	metrics := startMetricsServer(lg, cli, firstSyncDone.Load)
+
 	httpClient := &http.Client{Timeout: 30 * time.Second}
 	adminGQL := fleet.NewAdminGraphQLClient(cli.cfg.Trip2gBaseURL, cli.cfg.Trip2gAdminPersonalToken, httpClient)
 	llm := agentruntime.NewOpenAILLM(cli.cfg.LLMAPIKey, cli.cfg.LLMBaseURL)
+	llm.SetMetrics(metrics, fleetmetrics.LaneLLM)
 
-	f := fleet.NewFleet(cli.cfg, httpClient, llm, execLLM(cli.cfg))
+	exec := execLLM(cli.cfg)
+	if exec != nil {
+		exec.SetMetrics(metrics, fleetmetrics.LaneExec)
+	}
+
+	f := fleet.NewFleet(cli.cfg, httpClient, llm, execAsLLM(exec))
+	f.SetMetrics(metrics)
 	discovery := fleet.NewDiscovery(adminGQL, cli.cfg.FleetID, cli.cfg.AgentsFolder, cli.cfg.OfferedTools)
 
 	// --dry-run: connect, print + flag each role's resolved config, then exit
@@ -97,6 +113,7 @@ func run() error {
 	}
 
 	reconciler := fleet.NewReconciler(adminGQL, cli.cfg)
+	reconciler.SetMetrics(metrics)
 
 	// --graph-addr: localhost-only debug surface serving the dependency graph.
 	graphSrv, err := startGraphDebugServer(lg, discovery, adminGQL, cli)
@@ -123,7 +140,8 @@ func run() error {
 	}
 
 	// First sync before serving so the registry is populated.
-	syncOnce(ctx, lg, f, discovery, reconciler)
+	syncOnce(ctx, lg, f, discovery, reconciler, metrics)
+	firstSyncDone.Store(true)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc(f.WebhookPath(), f.ServeDelivery)
@@ -161,7 +179,7 @@ func run() error {
 				return nil
 			}
 		case <-ticker.C:
-			syncOnce(ctx, lg, f, discovery, reconciler)
+			syncOnce(ctx, lg, f, discovery, reconciler, metrics)
 		}
 	}
 }
@@ -222,11 +240,21 @@ func startFleetGraphQLServer(
 // execLLM builds the exec-tool client (codellm) when --exec-base-url is set.
 // nil disables the exec tool; program allowlisting and sandboxing are the
 // codellm operator's concern — fleet executes no code in-process.
-func execLLM(cfg fleet.Config) agentruntime.LLM {
+func execLLM(cfg fleet.Config) *agentruntime.OpenAILLM {
 	if cfg.ExecBaseURL == "" {
 		return nil
 	}
 	return agentruntime.NewOpenAILLM(cfg.ExecAPIKey, cfg.ExecBaseURL)
+}
+
+// execAsLLM converts the (possibly nil) exec client to the LLM interface. A
+// typed nil in an interface is NOT nil, and the exec tool is enabled by a
+// non-nil LLM, so the conversion has to be explicit.
+func execAsLLM(exec *agentruntime.OpenAILLM) agentruntime.LLM {
+	if exec == nil {
+		return nil
+	}
+	return exec
 }
 
 // newFleetGraphQLHandler builds the fleet GraphQL server's HTTP handler: a mux
@@ -453,18 +481,29 @@ func validateConfig(cfg fleet.Config) error {
 	return nil
 }
 
-func syncOnce(ctx context.Context, lg logger.Logger, f *fleet.Fleet, d *fleet.Discovery, r *fleet.Reconciler) {
+func syncOnce(ctx context.Context, lg logger.Logger, f *fleet.Fleet, d *fleet.Discovery, r *fleet.Reconciler, m *fleetmetrics.Metrics) {
+	started := time.Now()
 	roles, errs := d.DiscoverRoles(ctx)
 	for _, e := range errs {
 		lg.Warn("discover: skipped role", "err", e)
 	}
+	m.AddRolesSkipped(len(errs))
 	for _, role := range roles {
 		role.WarnIfWriteScopeMisconfigured(lg)
 	}
 	f.SetRoles(roles)
+
+	status := fleetmetrics.StatusOK
 	if err := r.Reconcile(ctx, roles); err != nil {
 		lg.Error("reconcile failed", "err", err)
+		status = fleetmetrics.StatusError
 	}
+	if len(errs) > 0 && status == fleetmetrics.StatusOK {
+		// Discovery dropped role notes: the registry is live but incomplete, so
+		// the freshness gauge must not advance as if everything synced.
+		status = "partial"
+	}
+	m.RecordSync(status, time.Since(started).Seconds())
 }
 
 // gracefulShutdown drains in-flight deliveries (srv.Shutdown waits for active
@@ -656,4 +695,28 @@ func reportRoles(roles []fleet.Role, offered []string, defaultModel string) stri
 		b.WriteByte('\n')
 	}
 	return b.String()
+}
+
+// startMetricsServer brings up the internal listener when --metrics-addr is set
+// and returns the sink every component records into (nil when disabled, which
+// all the call sites tolerate). A bind failure is logged, not fatal: losing
+// observability must not take the fleet down. ready reports whether the first
+// discovery sync has been ATTEMPTED, not whether it succeeded: gating readiness
+// on success would cascade a trip2g outage into restart loops here. Staleness
+// is reported by fleet_last_successful_sync_timestamp_seconds instead.
+func startMetricsServer(lg logger.Logger, cli cliFlags, ready func() bool) *fleetmetrics.Metrics {
+	if cli.appCfg.MetricsAddr == "" {
+		return nil
+	}
+	m := fleetmetrics.New()
+	m.SetConfigInfo(cli.cfg.FleetID, cli.cfg.DefaultModel, strconv.FormatBool(cli.cfg.ExecBaseURL != ""))
+
+	srv := &http.Server{Addr: cli.appCfg.MetricsAddr, Handler: m.Handler(ready), ReadHeaderTimeout: 10 * time.Second}
+	go func() {
+		lg.Info("fleet metrics listening", "addr", cli.appCfg.MetricsAddr)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			lg.Error("metrics server failed", "err", err)
+		}
+	}()
+	return m
 }

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -430,14 +430,7 @@ func validateLoopbackAddr(addr string) error {
 // is a legitimate topology, and the delegated-admin gate still authenticates
 // every request — but the operator should see the exposure explicitly.
 func warnIfGraphQLAddrNonLoopback(lg logger.Logger, addr string) {
-	host, _, err := net.SplitHostPort(addr)
-	if err != nil {
-		return
-	}
-	if host == "localhost" {
-		return
-	}
-	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+	if isLoopbackAddr(addr) {
 		return
 	}
 	lg.Warn("fleet GraphQL bound non-loopback; ensure Caddy is the sole ingress + delegated-admin gate", "addr", addr)
@@ -493,17 +486,26 @@ func syncOnce(ctx context.Context, lg logger.Logger, f *fleet.Fleet, d *fleet.Di
 	}
 	f.SetRoles(roles)
 
-	status := fleetmetrics.StatusOK
-	if err := r.Reconcile(ctx, roles); err != nil {
-		lg.Error("reconcile failed", "err", err)
-		status = fleetmetrics.StatusError
+	reconcileErr := r.Reconcile(ctx, roles)
+	if reconcileErr != nil {
+		lg.Error("reconcile failed", "err", reconcileErr)
 	}
-	if len(errs) > 0 && status == fleetmetrics.StatusOK {
-		// Discovery dropped role notes: the registry is live but incomplete, so
-		// the freshness gauge must not advance as if everything synced.
-		status = "partial"
+	m.RecordSync(syncStatus(reconcileErr, len(errs)), time.Since(started).Seconds())
+}
+
+// syncStatus grades one poll cycle. A reconcile failure outranks everything: the
+// cycle did not land. Otherwise dropped role notes make it partial — the
+// registry WAS refreshed, so freshness still advances, and the dropped notes are
+// counted separately by fleet_roles_skipped_total.
+func syncStatus(reconcileErr error, skipped int) string {
+	switch {
+	case reconcileErr != nil:
+		return fleetmetrics.StatusError
+	case skipped > 0:
+		return fleetmetrics.StatusPartial
+	default:
+		return fleetmetrics.StatusOK
 	}
-	m.RecordSync(status, time.Since(started).Seconds())
 }
 
 // gracefulShutdown drains in-flight deliveries (srv.Shutdown waits for active
@@ -701,13 +703,15 @@ func reportRoles(roles []fleet.Role, offered []string, defaultModel string) stri
 // and returns the sink every component records into (nil when disabled, which
 // all the call sites tolerate). A bind failure is logged, not fatal: losing
 // observability must not take the fleet down. ready reports whether the first
-// discovery sync has been ATTEMPTED, not whether it succeeded: gating readiness
-// on success would cascade a trip2g outage into restart loops here. Staleness
-// is reported by fleet_last_successful_sync_timestamp_seconds instead.
+// discovery sync has been ATTEMPTED, not whether it succeeded, so a fleet whose
+// first poll found trip2g down still answers deliveries for whatever it knows
+// rather than parking itself. Staleness is reported by
+// fleet_last_successful_sync_timestamp_seconds instead.
 func startMetricsServer(lg logger.Logger, cli cliFlags, ready func() bool) *fleetmetrics.Metrics {
 	if cli.appCfg.MetricsAddr == "" {
 		return nil
 	}
+	warnIfMetricsAddrNonLoopback(lg, cli.appCfg.MetricsAddr)
 	m := fleetmetrics.New()
 	m.SetConfigInfo(cli.cfg.FleetID, cli.cfg.DefaultModel, strconv.FormatBool(cli.cfg.ExecBaseURL != ""))
 
@@ -719,4 +723,28 @@ func startMetricsServer(lg logger.Logger, cli cliFlags, ready func() bool) *flee
 		}
 	}()
 	return m
+}
+
+// warnIfMetricsAddrNonLoopback logs a loud warning when the internal listener
+// is bound off loopback. It is not blocked — scraping a containerized fleet
+// requires binding the container's interface — but /metrics and pprof are
+// unauthenticated, so the exposure must be visible in the log.
+func warnIfMetricsAddrNonLoopback(lg logger.Logger, addr string) {
+	if isLoopbackAddr(addr) {
+		return
+	}
+	lg.Warn("fleet metrics bound non-loopback: /metrics and pprof are unauthenticated", "addr", addr)
+}
+
+// isLoopbackAddr reports whether a host:port binds only the loopback interface.
+func isLoopbackAddr(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }

--- a/cmd/fleet/main_metrics_test.go
+++ b/cmd/fleet/main_metrics_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	fleetappconfig "trip2g/cmd/fleet/appconfig"
+	"trip2g/cmd/fleet/internal/fleet"
+	"trip2g/cmd/fleet/internal/fleetmetrics"
+	"trip2g/internal/zerologger"
+)
+
+// TestSyncStatus_Precedence pins how a poll cycle is graded: a reconcile
+// failure means the cycle did not land at all, while dropped role notes leave
+// the registry refreshed but incomplete.
+func TestSyncStatus_Precedence(t *testing.T) {
+	tests := []struct {
+		name         string
+		reconcileErr error
+		skipped      int
+		want         string
+	}{
+		{name: "clean cycle", want: fleetmetrics.StatusOK},
+		{name: "dropped role notes", skipped: 2, want: fleetmetrics.StatusPartial},
+		{name: "reconcile failed", reconcileErr: errors.New("trip2g down"), want: fleetmetrics.StatusError},
+		{
+			name:         "reconcile failure outranks dropped notes",
+			reconcileErr: errors.New("trip2g down"),
+			skipped:      2,
+			want:         fleetmetrics.StatusError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, syncStatus(tt.reconcileErr, tt.skipped))
+		})
+	}
+}
+
+// TestSyncStatus_PartialStillRefreshesFreshness is the alerting contract: one
+// permanently unparseable role note must not freeze the staleness gauge and
+// turn the fleet's top alert into a standing complaint about a typo.
+func TestSyncStatus_PartialStillRefreshesFreshness(t *testing.T) {
+	m := fleetmetrics.New()
+	m.RecordSync(syncStatus(nil, 1), 0.1)
+
+	out := scrapeMetrics(t, m)
+	require.Contains(t, out, `fleet_syncs_total{status="partial"} 1`)
+	require.NotContains(t, out, "fleet_last_successful_sync_timestamp_seconds 0\n")
+}
+
+// TestSyncStatus_ErrorLeavesFreshnessUnset asserts a cycle that never reached
+// trip2g does not advance the staleness gauge.
+func TestSyncStatus_ErrorLeavesFreshnessUnset(t *testing.T) {
+	m := fleetmetrics.New()
+	m.RecordSync(syncStatus(errors.New("down"), 0), 0.1)
+
+	out := scrapeMetrics(t, m)
+	require.Contains(t, out, `fleet_syncs_total{status="error"} 1`)
+	require.Contains(t, out, "fleet_last_successful_sync_timestamp_seconds 0\n")
+}
+
+// TestStartMetricsServer_DisabledByEmptyAddr asserts an empty --metrics-addr
+// starts nothing and yields the nil sink every call site tolerates.
+func TestStartMetricsServer_DisabledByEmptyAddr(t *testing.T) {
+	cli := cliFlags{appCfg: fleetappconfig.DefaultConfig()}
+	cli.appCfg.MetricsAddr = ""
+
+	require.Nil(t, startMetricsServer(zerologger.New("error", false), cli, nil))
+}
+
+// TestStartMetricsServer_PublishesIdentity asserts an enabled listener comes up
+// with this process's identity already published, so two fleets are
+// distinguishable from a scrape alone.
+func TestStartMetricsServer_PublishesIdentity(t *testing.T) {
+	cli := cliFlags{appCfg: fleetappconfig.DefaultConfig()}
+	cli.appCfg.MetricsAddr = freeAddr(t)
+	cli.cfg = fleet.Config{FleetID: "f-test", DefaultModel: "gpt-4o-mini", ExecBaseURL: "http://codellm"}
+
+	m := startMetricsServer(zerologger.New("error", false), cli, nil)
+	require.NotNil(t, m)
+	require.Contains(t, scrapeMetrics(t, m),
+		`fleet_config_info{default_model="gpt-4o-mini",exec_enabled="true",fleet_id="f-test"} 1`)
+}
+
+// TestIsLoopbackAddr covers the check behind the non-loopback warning: the
+// internal listener serves unauthenticated pprof, so an off-box bind must be
+// recognised rather than assumed away.
+func TestIsLoopbackAddr(t *testing.T) {
+	tests := []struct {
+		addr string
+		want bool
+	}{
+		{addr: "127.0.0.1:18090", want: true},
+		{addr: "localhost:18090", want: true},
+		{addr: "[::1]:18090", want: true},
+		{addr: "0.0.0.0:18090", want: false},
+		{addr: ":18090", want: false},
+		{addr: "10.0.0.5:18090", want: false},
+		{addr: "garbage", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.addr, func(t *testing.T) {
+			require.Equal(t, tt.want, isLoopbackAddr(tt.addr))
+		})
+	}
+}
+
+// scrapeMetrics renders a registry the way Prometheus would read it.
+func scrapeMetrics(t *testing.T, m *fleetmetrics.Metrics) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	m.Handler(nil).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	return rec.Body.String()
+}
+
+// freeAddr returns a loopback address that was free a moment ago. The listener
+// under test binds it itself, so it is released first.
+func freeAddr(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.NotFoundHandler())
+	addr := srv.Listener.Addr().String()
+	srv.Close()
+	return addr
+}

--- a/docs/dev/fleet_codellm_metrics.md
+++ b/docs/dev/fleet_codellm_metrics.md
@@ -1,0 +1,128 @@
+# fleet & codellm metrics
+
+Both binaries serve Prometheus on a second, loopback-only listener, mirroring
+the monolith's internal listener (`cmd/server`, `127.0.0.1:8082`): `/metrics`,
+`/debug/pprof/*`, `/healthz`, `/livez`, `/readyz`. Nothing on that port is
+authenticated — never bind it off-box.
+
+| Binary | Flag | Env | Default |
+|--------|------|-----|---------|
+| codellm | `--metrics-addr` | `CODELLM_METRICS_ADDR` | `127.0.0.1:18087` |
+| fleet | `--metrics-addr` | `TRIP2G_FLEET_METRICS_ADDR` | `127.0.0.1:19090` |
+
+Empty disables the listener; every record call site is nil-safe, so a disabled
+listener costs nothing. The ports follow the deployment convention of a
+`1`-prefixed twin of the service port (`infra/site.yml`: `8087` → `19087`).
+
+Collectors live in `cmd/codellm/internal/codellmmetrics` and
+`cmd/fleet/internal/fleetmetrics`. Each owns a **private registry** rather than
+the global default, so neither binary depends on the monolith's
+`internal/metrics` (which registers globally) and tests can gather a clean
+snapshot.
+
+## Who spends tokens
+
+codellm spends none. It is a fake LLM: it executes fenced code and always
+answers with `usage: {}`. Token spend is fleet's, recorded in
+`agentruntime` from the provider's usage — which is why `fleet_llm_tokens_total`
+is a fleet metric and a codellm-backed fleet reports zero on it.
+
+## codellm
+
+**Requests**
+
+| Metric | Notes |
+|---|---|
+| `codellm_requests_total{endpoint,status}` | endpoint = `chat_completions` \| `graphql` \| `graphql_playground` |
+| `codellm_request_duration_seconds{endpoint}` | |
+| `codellm_requests_in_flight` | each in-flight request may fork an interpreter child |
+| `codellm_auth_total{lane,result}` | lane = `apikey` \| `cookie`. Denials on an endpoint that executes code are a probing signal |
+
+**Execution**
+
+| Metric | Notes |
+|---|---|
+| `codellm_blocks_total{program,outcome}` | outcome = `ok` \| `nonzero_exit` \| `timeout` \| `start_failed` |
+| `codellm_block_exit_codes_total{program,exit_code}` | `-1` = the child never produced an exit status |
+| `codellm_block_duration_seconds{program}` | |
+| `codellm_block_max_rss_bytes{program}` | from the child's rusage |
+| `codellm_block_stdout_bytes{program}` | only the block whose stdout is buffered reports a size — in a pipeline the intermediate blocks stream into the next block's stdin |
+| `codellm_block_stdout_truncated_total{program}` | stdout hit the cap and the overflow was dropped; downstream this reads as a parse error |
+| `codellm_sandbox_fallbacks_total{reason}` | a `besteffort` policy degraded to unsandboxed execution. Enforcing mode refuses instead, and shows up as `codellm_exec_errors_total{kind="sandbox_refused"}` |
+| `codellm_exec_errors_total{kind}` | `no_blocks`, `unknown_fence`, `disallowed_program`, `sandbox_refused`, `setup_failed`, `start_failed`, `timeout`, `nonzero_exit`, `parse_error` |
+| `codellm_request_blocks` | blocks executed per request |
+| `codellm_changes_total{kind}` | `write` \| `patch` |
+| `codellm_config_info{sandbox_mode,sandbox_network,allowed_programs}` | always 1; the posture this process runs with |
+
+`coderun` records nothing itself. It measures and reports through
+`CodeInput.Observe` (`coderun.BlockStats`) and classifies failures with
+`coderun.ExecError` / `coderun.ErrorKind`; the codellm layer decides what to
+count. That keeps the execution core free of a metrics dependency.
+
+## fleet
+
+**Deliveries**
+
+| Metric | Notes |
+|---|---|
+| `fleet_deliveries_total{role,kind,status}` | kind = `change` \| `cron` |
+| `fleet_delivery_duration_seconds{role,kind}` | includes the agent run |
+| `fleet_delivery_auth_failures_total{reason}` | `unknown_key` \| `bad_signature` \| `bad_payload` \| `read_body` — a rotated secret or a stale reconcile shows up here |
+| `fleet_runs_in_flight` | deliveries are handled synchronously, so this is also the drain backlog |
+| `fleet_fanout_items{role}` / `fleet_fanout_item_errors_total{role}` | trip2g records a partial batch as success, so the error counter is the only signal a `for_each` item failed |
+
+**Runs**
+
+| Metric | Notes |
+|---|---|
+| `fleet_runs_total{role,status}` | `completed` \| `capped` \| `max_steps` \| `error` |
+| `fleet_run_steps{role}` / `fleet_run_duration_seconds{role}` | drift toward the step ceiling precedes hitting it |
+| `fleet_llm_tokens_total{model,role,kind}` | one series answers both cost-per-model and cost-per-role |
+| `fleet_tool_calls_total{tool,outcome}` | `ok` \| `denied` \| `invalid_args` \| `error` \| `apply_failed` \| `not_permitted` |
+| `fleet_denials_total{kind}` | `read` \| `write` \| `not_permitted`; a steady rate usually means misconfigured patterns |
+| `fleet_apply_failures_total{role,tool}` | under `HardFailApply` each one kills its run |
+
+**Upstream LLM**
+
+| Metric | Notes |
+|---|---|
+| `fleet_llm_requests_total{lane,model,status}` | lane = `llm` (role's model) \| `exec` (codellm), so a degrading code executor stays distinguishable |
+| `fleet_llm_request_duration_seconds{lane,model}` | retries included |
+| `fleet_llm_retries_total{lane,reason}` | `429` \| `5xx` \| `network` |
+
+**Control plane**
+
+| Metric | Notes |
+|---|---|
+| `fleet_syncs_total{status}` + `fleet_sync_duration_seconds` | one discovery+reconcile cycle |
+| `fleet_last_successful_sync_timestamp_seconds` | only a fully clean cycle advances it |
+| `fleet_roles_registered` / `fleet_roles_skipped_total` | |
+| `fleet_roles_write_scope_misconfigured` | roles declaring write tools with no `write_patterns` — the deny-all trap, as a gauge instead of one warning at startup |
+| `fleet_webhook_actions_total{action,status}` / `fleet_webhooks_owned{kind}` | a nonzero steady-state create/update rate means two fleets share a `fleet_id` and are re-pointing each other's webhooks |
+| `fleet_config_info{fleet_id,default_model,exec_enabled}` | always 1 |
+
+`/readyz` reports ready once the **first sync attempt completes**, not once it
+succeeds. Gating on success would make the fleet's readiness cascade from a
+trip2g outage and invite restart loops; staleness is what
+`fleet_last_successful_sync_timestamp_seconds` is for.
+
+## What to alert on
+
+1. `fleet_last_successful_sync_timestamp_seconds` older than ~3× the poll
+   interval — the failure mode that hides all the others: the fleet keeps
+   serving a stale registry and otherwise looks healthy.
+2. `rate(fleet_runs_total{status="capped"})` — money burning.
+3. `rate(fleet_llm_retries_total)` — upstream degrading, on either lane.
+4. `codellm_requests_total{status="422"}` as a share of all requests — the exec
+   path is broken; split by `codellm_exec_errors_total{kind}` to see how.
+5. `increase(codellm_sandbox_fallbacks_total)` > 0 — the security posture
+   silently degraded to unsandboxed execution.
+6. `fleet_runs_in_flight` / `codellm_requests_in_flight` growing without
+   draining — a stuck run or a fork pile-up.
+
+## Cardinality
+
+`role` is the role note path, bounded by the number of role notes in the agents
+folder. If that ever grows large, drop `role` from the histograms
+(`fleet_run_steps`, `fleet_run_duration_seconds`, `fleet_delivery_duration_seconds`)
+and keep it on the counters.

--- a/docs/dev/fleet_codellm_metrics.md
+++ b/docs/dev/fleet_codellm_metrics.md
@@ -8,11 +8,18 @@ authenticated — never bind it off-box.
 | Binary | Flag | Env | Default |
 |--------|------|-----|---------|
 | codellm | `--metrics-addr` | `CODELLM_METRICS_ADDR` | `127.0.0.1:18087` |
-| fleet | `--metrics-addr` | `TRIP2G_FLEET_METRICS_ADDR` | `127.0.0.1:19090` |
+| fleet | `--metrics-addr` | `TRIP2G_FLEET_METRICS_ADDR` | `127.0.0.1:18090` |
 
-Empty disables the listener; every record call site is nil-safe, so a disabled
-listener costs nothing. The ports follow the deployment convention of a
-`1`-prefixed twin of the service port (`infra/site.yml`: `8087` → `19087`).
+Empty disables the listener (an explicitly empty env var works too); every
+record call site is nil-safe, so a disabled listener costs nothing. The ports
+sit in the 18xxx band: `infra/site.yml` hands out 19xxx one per site for the
+monolith's own internal listeners and requires them unique, so the standalone
+binaries stay clear of that range — codellm `8087` → `18087`, fleet `9090` →
+`18090`.
+
+A non-loopback bind is warned about, not blocked: scraping a containerized
+instance requires binding the container's interface. Whoever does that owns
+keeping the port private — it serves pprof with no authentication.
 
 Collectors live in `cmd/codellm/internal/codellmmetrics` and
 `cmd/fleet/internal/fleetmetrics`. Each owns a **private registry** rather than
@@ -49,7 +56,7 @@ is a fleet metric and a codellm-backed fleet reports zero on it.
 | `codellm_block_stdout_bytes{program}` | only the block whose stdout is buffered reports a size — in a pipeline the intermediate blocks stream into the next block's stdin |
 | `codellm_block_stdout_truncated_total{program}` | stdout hit the cap and the overflow was dropped; downstream this reads as a parse error |
 | `codellm_sandbox_fallbacks_total{reason}` | a `besteffort` policy degraded to unsandboxed execution. Enforcing mode refuses instead, and shows up as `codellm_exec_errors_total{kind="sandbox_refused"}` |
-| `codellm_exec_errors_total{kind}` | `no_blocks`, `unknown_fence`, `disallowed_program`, `sandbox_refused`, `setup_failed`, `start_failed`, `timeout`, `nonzero_exit`, `parse_error` |
+| `codellm_exec_errors_total{kind}` | every failed run, whether or not a child ran: `no_blocks`, `unknown_fence`, `disallowed_program`, `unknown_program`, `sandbox_refused`, `setup_failed`, `start_failed`, `timeout`, `nonzero_exit`, `parse_error`, `internal`, `unclassified` |
 | `codellm_request_blocks` | blocks executed per request |
 | `codellm_changes_total{kind}` | `write` \| `patch` |
 | `codellm_config_info{sandbox_mode,sandbox_network,allowed_programs}` | always 1; the posture this process runs with |
@@ -94,23 +101,31 @@ count. That keeps the execution core free of a metrics dependency.
 
 | Metric | Notes |
 |---|---|
-| `fleet_syncs_total{status}` + `fleet_sync_duration_seconds` | one discovery+reconcile cycle |
-| `fleet_last_successful_sync_timestamp_seconds` | only a fully clean cycle advances it |
+| `fleet_syncs_total{status}` + `fleet_sync_duration_seconds` | one discovery+reconcile cycle; status = `ok` \| `partial` (registry refreshed, some role notes dropped) \| `error` (reconcile failed — the cycle did not land) |
+| `fleet_last_successful_sync_timestamp_seconds` | advanced by `ok` and `partial`, never by `error`; **0 until the first one**. Partial counts on purpose: one permanently unparseable role note must not freeze the gauge and turn the staleness alert into a standing complaint about a typo — `fleet_roles_skipped_total` is the signal for that |
 | `fleet_roles_registered` / `fleet_roles_skipped_total` | |
 | `fleet_roles_write_scope_misconfigured` | roles declaring write tools with no `write_patterns` — the deny-all trap, as a gauge instead of one warning at startup |
 | `fleet_webhook_actions_total{action,status}` / `fleet_webhooks_owned{kind}` | a nonzero steady-state create/update rate means two fleets share a `fleet_id` and are re-pointing each other's webhooks |
 | `fleet_config_info{fleet_id,default_model,exec_enabled}` | always 1 |
 
 `/readyz` reports ready once the **first sync attempt completes**, not once it
-succeeds. Gating on success would make the fleet's readiness cascade from a
-trip2g outage and invite restart loops; staleness is what
+succeeds: a fleet whose first poll found trip2g down still answers deliveries
+for whatever it knows rather than parking itself. The cost is that a fleet
+which has never synced reports ready with an empty registry, and every delivery
+it receives 404s as `unknown_key`. Staleness is what
 `fleet_last_successful_sync_timestamp_seconds` is for.
 
 ## What to alert on
 
 1. `fleet_last_successful_sync_timestamp_seconds` older than ~3× the poll
    interval — the failure mode that hides all the others: the fleet keeps
-   serving a stale registry and otherwise looks healthy.
+   serving a stale registry and otherwise looks healthy. The gauge is 0 before
+   the first successful cycle, so guard the expression against a fresh process:
+
+   ```promql
+   time() - fleet_last_successful_sync_timestamp_seconds > 90
+     and time() - process_start_time_seconds > 90
+   ```
 2. `rate(fleet_runs_total{status="capped"})` — money burning.
 3. `rate(fleet_llm_retries_total)` — upstream degrading, on either lane.
 4. `codellm_requests_total{status="422"}` as a share of all requests — the exec
@@ -125,4 +140,10 @@ trip2g outage and invite restart loops; staleness is what
 `role` is the role note path, bounded by the number of role notes in the agents
 folder. If that ever grows large, drop `role` from the histograms
 (`fleet_run_steps`, `fleet_run_duration_seconds`, `fleet_delivery_duration_seconds`)
-and keep it on the counters.
+and keep it on the counters. Renamed or deleted roles leave their series behind
+until the process restarts.
+
+`exit_code` is bounded by the exit statuses actually seen (at most ~257 per
+program). The `tool` label is bounded to the offered tool set: a tool name the
+model invented is recorded as `tool="unknown"`, since that name is
+attacker-controllable and must never mint a series.


### PR DESCRIPTION
Both binaries now serve Prometheus on a second, loopback-only listener — `/metrics` + pprof + `/healthz` + `/livez` + `/readyz` — mirroring the monolith's internal listener in `cmd/server`.

| Binary | Flag | Env | Default |
|--------|------|-----|---------|
| codellm | `--metrics-addr` | `CODELLM_METRICS_ADDR` | `127.0.0.1:18087` |
| fleet | `--metrics-addr` | `TRIP2G_FLEET_METRICS_ADDR` | `127.0.0.1:18090` |

Empty disables it. Ports sit in 18xxx because `infra/site.yml` hands out 19xxx one per site and requires them unique. A non-loopback bind is warned about, not blocked (a container has to bind its own interface), since the port serves unauthenticated pprof.

Collectors live in `cmd/fleet/internal/fleetmetrics` and `cmd/codellm/internal/codellmmetrics`, each owning a **private registry** — neither binary depends on the monolith's `internal/metrics`, which registers globally. Every record method is nil-safe, so `--once`, tests and a disabled listener cost nothing.

## Note on tokens

codellm spends none — it is a fake LLM and always answers `usage: {}`. Token spend is fleet's, so `fleet_llm_tokens_total{model,role,kind}` is a fleet metric; one series answers both cost-per-model and cost-per-role.

## What's measured

**codellm** — requests/status/duration/in-flight, auth by lane (apikey vs cookie, allowed vs denied), and the execution lane: per-block outcome and **real exit code**, duration, peak RSS, stdout size + truncation counter, sandbox fallbacks, `codellm_exec_errors_total{kind}`, blocks-per-request, changes by kind, and a config-info gauge carrying the sandbox posture.

**fleet** — deliveries by role/kind/status, HMAC + unknown-key rejections, fan-out items and item errors, runs by terminal status, steps, duration, token spend, tool-call outcomes, scope denials, apply failures; the upstream LLM lane split `llm` vs `exec` (retries by reason); and the control plane: sync status, sync freshness, roles registered/skipped/misconfigured, webhook reconcile actions and owned counts.

Getting exit codes out meant plumbing per-block stats out of `coderun` through a new `CodeInput.Observe` hook plus `coderun.ExecError`/`ErrorKind` classification. `coderun` records no metrics itself: it measures and reports, the codellm layer counts. This also fixed `BlockDebug.ExitCode`, which was hardcoded to 0.

## Alerting

`docs/dev/fleet_codellm_metrics.md` carries the full catalog plus the six signals worth alerting on. The first one — `fleet_last_successful_sync_timestamp_seconds` going stale — is the failure mode that hides all the others: a fleet serving a stale registry otherwise looks perfectly healthy.

## Review

Reviewed by Codex and a second Claude pass before this PR. They found one real bug in the first commit: `pipelineOutcome` classified blocks *after* `cleanupPipeline` had cancelled their contexts, so with any `Timeout` set — i.e. always in production — every successful multi-block run was recorded as `outcome="timeout"`. Fixed by classifying inside `waitOne`, with the pipeline tests now running the production shape (a Timeout set), which is exactly what let it through.

The second commit also: bounds the `tool` label (a hallucinated tool name was going straight into a metric label), stops emitting phantom blocks for runs that never reached a child, distinguishes `start_failed` from `nonzero_exit`, counts the `finish` tool call, keeps the consumed steps on a failed run, stops counting the last LLM attempt as a retry, records an empty completion as the failure it is, adds the apikey-denied lane, lets `partial` syncs advance the freshness gauge (one bad role note must not freeze it), and corrects several doc claims.

## Two open questions for you

1. **`/readyz` semantics** — it reports ready once the first sync *attempt* completes, not once it succeeds. A fleet that has never synced therefore reports ready with an empty registry and 404s every delivery. Gating on first success would shed traffic correctly but couples fleet readiness to trip2g availability. Left as-is; say the word if you want it flipped.
2. **Setter vs constructor injection** — `Fleet`, `Reconciler` and `OpenAILLM` all got a `SetMetrics` setter to leave their constructors alone; codellm passes it through `Config` instead. Threading a parameter would be more consistent with the repo but touches more call sites.

## Verification

Full suite green; `golangci-lint` 0 issues; `-race` clean including the pipeline observer at `-count=20`. Live smoke-tested both binaries: a two-block pipeline now reports `outcome="ok"` (was `timeout`), a failing block reports `exit_code="9"`, a wrong api key lands in `apikey,denied`, and fleet with trip2g down reports `syncs_total{status="error"}` with freshness correctly left at 0.

One flake worth knowing about, unrelated to this diff: `TestSandbox_RlimitsApplied` failed once with `cannot allocate memory` under heavy parallel load, and did not reproduce in four later runs (isolated, stressed, and full-suite on both `main` and this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
