### PR TITLE
fix(webhooks): trigger note change events for agent response changes

### DIFF
--- a/e2e/webhooks.spec.js
+++ b/e2e/webhooks.spec.js
@@ -367,6 +367,78 @@ test.describe.serial('Webhook E2E Tests', () => {
     expect(noteContent).toContain('Modified by agent');
   });
 
+  test('agent response changes cascade to downstream webhooks', async ({ request }) => {
+    // Two webhooks: the first writes into e2e_wh_cascade/out/ through its
+    // response body, the second watches that folder. Notes applied from a
+    // response body must trigger change webhooks like any other write, so the
+    // second webhook has to receive a delivery for the written note.
+    const agentResponse = JSON.stringify({
+      status: 'ok',
+      changes: [
+        {
+          path: 'e2e_wh_cascade/out/result.md',
+          content: '---\nfree: true\n---\n\n# Result\n\nWritten by the agent response.',
+        },
+      ],
+    });
+
+    const createQuery = `
+      mutation ChangeWebhookCreate($input: ChangeWebhookCreateInput!) {
+        admin {
+          changeWebhookCreate(input: $input) {
+            ... on ChangeWebhookCreatePayload {
+              webhook {
+                id
+              }
+              secret
+            }
+          }
+        }
+      }
+    `;
+
+    const producer = await graphqlAdmin(request, adminCookie, createQuery, {
+      input: {
+        url: `${APP_URL}/debug/test_webhook?body=${encodeURIComponent(agentResponse)}`,
+        includePatterns: ['e2e_wh_cascade/src/**'],
+        passApiKey: true,
+        maxDepth: 3,
+        writePatterns: ['e2e_wh_cascade/out/**'],
+      },
+    });
+    changeWebhookIds.push(producer.admin.changeWebhookCreate.webhook.id);
+
+    const consumer = await graphqlAdmin(request, adminCookie, createQuery, {
+      input: {
+        url: `${APP_URL}/debug/test_webhook`,
+        includePatterns: ['e2e_wh_cascade/out/**'],
+        passApiKey: false,
+        maxDepth: 3,
+      },
+    });
+    changeWebhookIds.push(consumer.admin.changeWebhookCreate.webhook.id);
+
+    await pushAndCommit(request, apiKey, [
+      {
+        path: 'e2e_wh_cascade/src/trigger.md',
+        content: '---\nfree: true\n---\n\n# Trigger\n\nTriggers the producer webhook.',
+      },
+    ]);
+    await waitAllJobs(request);
+
+    // The producer's own delivery carries src/trigger.md; only a downstream
+    // delivery carries the note the agent response wrote. depth must be 1: a
+    // depth-0 delivery for that path would mean it was committed by an ordinary
+    // request (e.g. a leftover note from an earlier run), not caused by this run.
+    const calls = await getWebhookCalls(request);
+    const downstream = calls.filter(
+      (call) =>
+        call.body?.depth === 1 &&
+        (call.body?.changes || []).some((change) => change.path === 'e2e_wh_cascade/out/result.md'),
+    );
+    expect(downstream.length).toBeGreaterThan(0);
+  });
+
   test('cron webhook fires with instruction', async ({ request }) => {
     // 1. Create cron webhook
     const createQuery = `

--- a/internal/appreq/request.go
+++ b/internal/appreq/request.go
@@ -278,6 +278,24 @@ func (c *Request) resolvePersonalToken(plaintext string) (*usertoken.Data, error
 	return c.PersonalTokenResolver.Resolve(c.Req, plaintext)
 }
 
+// NewDeliveryRequest returns a Request for a webhook delivery job that applies
+// an agent's note changes itself (the "changes in the response body" path). The
+// job worker has no fasthttp request, so the appreq is synthesized to carry what
+// the scoped api_token would have carried had the agent written back through the
+// API: the delivery identity (so note versions are attributed to this delivery)
+// and depth (so the change webhooks those writes trigger stay under the depth
+// guard instead of restarting the counter at zero). The token is anonymous and
+// pre-extracted, so nothing reads headers off the absent fasthttp context.
+func NewDeliveryRequest(kind string, deliveryID int64, depth int) *Request {
+	req := &Request{
+		WebhookDepth:        depth,
+		WebhookDeliveryKind: kind,
+		WebhookDeliveryID:   deliveryID,
+	}
+	req.SetUserToken(nil)
+	return req
+}
+
 // NewContext returns a copy of parent with req stored as the appreq value.
 // Use this to pass an appreq through a standard context.Context when the
 // original fasthttp.RequestCtx is no longer available (e.g. SSE streams).

--- a/internal/case/backjob/deliverchangewebhook/mocks_test.go
+++ b/internal/case/backjob/deliverchangewebhook/mocks_test.go
@@ -30,6 +30,9 @@ var _ deliverchangewebhook.Env = &EnvMock{}
 //			GetSecretValuesFunc: func(ctx context.Context, like string) (map[string]string, error) {
 //				panic("mock out the GetSecretValues method")
 //			},
+//			HandleLatestNotesAfterSaveFunc: func(ctx context.Context, pathIDs []int64) error {
+//				panic("mock out the HandleLatestNotesAfterSave method")
+//			},
 //			InsertNoteFunc: func(ctx context.Context, note model.RawNote) (int64, error) {
 //				panic("mock out the InsertNote method")
 //			},
@@ -72,6 +75,9 @@ type EnvMock struct {
 
 	// GetSecretValuesFunc mocks the GetSecretValues method.
 	GetSecretValuesFunc func(ctx context.Context, like string) (map[string]string, error)
+
+	// HandleLatestNotesAfterSaveFunc mocks the HandleLatestNotesAfterSave method.
+	HandleLatestNotesAfterSaveFunc func(ctx context.Context, pathIDs []int64) error
 
 	// InsertNoteFunc mocks the InsertNote method.
 	InsertNoteFunc func(ctx context.Context, note model.RawNote) (int64, error)
@@ -118,6 +124,13 @@ type EnvMock struct {
 			Ctx context.Context
 			// Like is the like argument value.
 			Like string
+		}
+		// HandleLatestNotesAfterSave holds details about calls to the HandleLatestNotesAfterSave method.
+		HandleLatestNotesAfterSave []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// PathIDs is the pathIDs argument value.
+			PathIDs []int64
 		}
 		// InsertNote holds details about calls to the InsertNote method.
 		InsertNote []struct {
@@ -176,6 +189,7 @@ type EnvMock struct {
 	}
 	lockEnqueueDeliverChangeWebhook sync.RWMutex
 	lockGetSecretValues             sync.RWMutex
+	lockHandleLatestNotesAfterSave  sync.RWMutex
 	lockInsertNote                  sync.RWMutex
 	lockInsertWebhookDeliveryLog    sync.RWMutex
 	lockLatestNoteViews             sync.RWMutex
@@ -257,6 +271,42 @@ func (mock *EnvMock) GetSecretValuesCalls() []struct {
 	mock.lockGetSecretValues.RLock()
 	calls = mock.calls.GetSecretValues
 	mock.lockGetSecretValues.RUnlock()
+	return calls
+}
+
+// HandleLatestNotesAfterSave calls HandleLatestNotesAfterSaveFunc.
+func (mock *EnvMock) HandleLatestNotesAfterSave(ctx context.Context, pathIDs []int64) error {
+	if mock.HandleLatestNotesAfterSaveFunc == nil {
+		panic("EnvMock.HandleLatestNotesAfterSaveFunc: method is nil but Env.HandleLatestNotesAfterSave was just called")
+	}
+	callInfo := struct {
+		Ctx     context.Context
+		PathIDs []int64
+	}{
+		Ctx:     ctx,
+		PathIDs: pathIDs,
+	}
+	mock.lockHandleLatestNotesAfterSave.Lock()
+	mock.calls.HandleLatestNotesAfterSave = append(mock.calls.HandleLatestNotesAfterSave, callInfo)
+	mock.lockHandleLatestNotesAfterSave.Unlock()
+	return mock.HandleLatestNotesAfterSaveFunc(ctx, pathIDs)
+}
+
+// HandleLatestNotesAfterSaveCalls gets all the calls that were made to HandleLatestNotesAfterSave.
+// Check the length with:
+//
+//	len(mockedEnv.HandleLatestNotesAfterSaveCalls())
+func (mock *EnvMock) HandleLatestNotesAfterSaveCalls() []struct {
+	Ctx     context.Context
+	PathIDs []int64
+} {
+	var calls []struct {
+		Ctx     context.Context
+		PathIDs []int64
+	}
+	mock.lockHandleLatestNotesAfterSave.RLock()
+	calls = mock.calls.HandleLatestNotesAfterSave
+	mock.lockHandleLatestNotesAfterSave.RUnlock()
 	return calls
 }
 

--- a/internal/case/backjob/deliverchangewebhook/resolve.go
+++ b/internal/case/backjob/deliverchangewebhook/resolve.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"trip2g/internal/appreq"
 	"trip2g/internal/case/handlenotewebhooks"
 	"trip2g/internal/db"
 	"trip2g/internal/jsonneteval"
@@ -27,6 +28,7 @@ type Env interface {
 	InsertWebhookDeliveryLog(ctx context.Context, arg db.InsertWebhookDeliveryLogParams) error
 	InsertNote(ctx context.Context, note model.RawNote) (int64, error)
 	PrepareLatestNotes(ctx context.Context, partial bool) (*model.NoteViews, error)
+	HandleLatestNotesAfterSave(ctx context.Context, pathIDs []int64) error
 	LatestNoteViews() *model.NoteViews
 	EnqueueDeliverChangeWebhook(ctx context.Context, params handlenotewebhooks.DeliverChangeWebhookParams) error
 	ShortAPITokenSecret() string
@@ -101,7 +103,7 @@ func Resolve(ctx context.Context, env Env, params handlenotewebhooks.DeliverChan
 			Depth:         params.Depth + 1,
 			ReadPatterns:  readPatterns,
 			WritePatterns: writePatterns,
-			DeliveryKind:  "change",
+			DeliveryKind:  deliveryKindChange,
 			DeliveryID:    params.DeliveryID,
 		}, env.ShortAPITokenSecret(), ttl)
 		if signErr != nil {
@@ -204,7 +206,11 @@ func Resolve(ctx context.Context, env Env, params handlenotewebhooks.DeliverChan
 	// Parse agent response for changes.
 	var applyErr error
 	if result.StatusCode >= 200 && result.StatusCode < 300 && result.StatusCode != http.StatusAccepted {
-		applyErr = applyAgentChanges(ctx, env, result, writePatterns)
+		// Apply under a synthesized delivery appreq: the notes are attributed to
+		// this delivery and the webhooks they trigger inherit depth+1, exactly as
+		// if the agent had written them back through the scoped api_token.
+		applyCtx := appreq.NewContext(ctx, appreq.NewDeliveryRequest(deliveryKindChange, params.DeliveryID, params.Depth+1))
+		applyErr = applyAgentChanges(applyCtx, env, result, writePatterns)
 	}
 
 	// Handle agent response errors with retry.
@@ -355,6 +361,10 @@ func TransformExtVarsForTest(payloadBytes []byte) map[string]string {
 	return transformExtVars(payloadBytes)
 }
 
+// deliveryKindChange is this lane's delivery kind, carried by the scoped
+// api_token and by the appreq the apply path synthesizes.
+const deliveryKindChange = "change"
+
 // applyAgentChanges parses, validates, and applies agent response changes.
 // The whole batch is validated (write patterns, expected_hash CAS, patch
 // resolution) before any item is written, so an invalid item rejects the
@@ -373,16 +383,27 @@ func applyAgentChanges(ctx context.Context, env Env, result webhookutil.Delivery
 		return resolveErr
 	}
 
+	pathIDs := make([]int64, 0, len(notes))
 	for _, note := range notes {
-		if _, insertErr := env.InsertNote(ctx, note); insertErr != nil {
+		pathID, insertErr := env.InsertNote(ctx, note)
+		if insertErr != nil {
 			return fmt.Errorf("failed to apply change for %s: %w", note.Path, insertErr)
 		}
+		pathIDs = append(pathIDs, pathID)
 	}
 
 	// Refresh LatestNoteViews cache after applying changes.
 	_, prepareErr := env.PrepareLatestNotes(ctx, false)
 	if prepareErr != nil {
 		return fmt.Errorf("failed to refresh note views: %w", prepareErr)
+	}
+
+	// Notes applied here are ordinary note changes: they must materialize their
+	// frontmatter, reach SSE subscribers and trigger change webhooks like any
+	// other write. A failure here does not undo the writes and must not re-run
+	// the agent, so it is logged rather than returned.
+	if handleErr := env.HandleLatestNotesAfterSave(ctx, pathIDs); handleErr != nil {
+		env.Logger().Error("failed to handle notes applied from agent response", "error", handleErr)
 	}
 
 	return nil

--- a/internal/case/backjob/deliverchangewebhook/resolve_test.go
+++ b/internal/case/backjob/deliverchangewebhook/resolve_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"trip2g/internal/appreq"
 	"trip2g/internal/case/backjob/deliverchangewebhook"
 	"trip2g/internal/case/handlenotewebhooks"
 	"trip2g/internal/db"
@@ -52,6 +53,9 @@ func baseEnv(t *testing.T, url string, secretValues map[string]string) *EnvMock 
 		},
 		PrepareLatestNotesFunc: func(_ context.Context, _ bool) (*model.NoteViews, error) {
 			return nil, nil
+		},
+		HandleLatestNotesAfterSaveFunc: func(_ context.Context, _ []int64) error {
+			return nil
 		},
 		EnqueueDeliverChangeWebhookFunc: func(_ context.Context, _ handlenotewebhooks.DeliverChangeWebhookParams) error {
 			return nil
@@ -693,4 +697,50 @@ func TestResolve_AgentChanges_PatchKind_FindMissing_Error(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, insertCalled, "InsertNote must not be called when patch find string is absent")
 	require.Equal(t, "failed", got.Status, "delivery must be marked failed when patch find is missing")
+}
+
+// Notes applied from an agent response are ordinary note changes: they must go
+// through the post-save handler so frontmatter materializes, SSE fires and
+// downstream change webhooks trigger. The synthesized request carries this
+// delivery's identity and depth+1, so the depth guard still applies.
+func TestResolve_AgentChanges_RunPostSaveHandlerWithDeliveryIdentity(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok","changes":[{"path":"notes/todo.md","content":"x"}]}`))
+	}))
+	defer srv.Close()
+
+	env := baseEnv(t, srv.URL, nil)
+	env.WebhookByIDFunc = func(_ context.Context, id int64) (db.ChangeWebhook, error) {
+		return db.ChangeWebhook{
+			ID:             id,
+			Url:            srv.URL,
+			TimeoutSeconds: 10,
+			WritePatterns:  `["notes/**"]`,
+			ReadPatterns:   "[]",
+		}, nil
+	}
+	env.InsertNoteFunc = func(_ context.Context, _ model.RawNote) (int64, error) {
+		return 77, nil
+	}
+	env.PrepareLatestNotesFunc = func(_ context.Context, _ bool) (*model.NoteViews, error) {
+		return model.NewNoteViews(), nil
+	}
+
+	var gotPathIDs []int64
+	var gotReq *appreq.Request
+	env.HandleLatestNotesAfterSaveFunc = func(ctx context.Context, pathIDs []int64) error {
+		gotPathIDs = pathIDs
+		gotReq, _ = appreq.FromCtx(ctx)
+		return nil
+	}
+
+	err := deliverchangewebhook.Resolve(context.Background(), env,
+		handlenotewebhooks.DeliverChangeWebhookParams{WebhookID: 1, DeliveryID: 11, Attempt: 1, Depth: 2})
+	require.NoError(t, err)
+	require.Equal(t, []int64{77}, gotPathIDs)
+	require.NotNil(t, gotReq, "post-save handler must run under a delivery appreq")
+	require.Equal(t, 3, gotReq.WebhookDepth, "writes inherit the delivery depth + 1")
+	require.Equal(t, "change", gotReq.WebhookDeliveryKind)
+	require.EqualValues(t, 11, gotReq.WebhookDeliveryID)
 }

--- a/internal/case/backjob/delivercronwebhook/mocks_test.go
+++ b/internal/case/backjob/delivercronwebhook/mocks_test.go
@@ -32,6 +32,9 @@ var _ delivercronwebhook.Env = &EnvMock{}
 //			GetSecretValuesFunc: func(ctx context.Context, like string) (map[string]string, error) {
 //				panic("mock out the GetSecretValues method")
 //			},
+//			HandleLatestNotesAfterSaveFunc: func(ctx context.Context, pathIDs []int64) error {
+//				panic("mock out the HandleLatestNotesAfterSave method")
+//			},
 //			InsertNoteFunc: func(ctx context.Context, note model.RawNote) (int64, error) {
 //				panic("mock out the InsertNote method")
 //			},
@@ -46,6 +49,9 @@ var _ delivercronwebhook.Env = &EnvMock{}
 //			},
 //			MarkCronWebhookDeliveryRunningFunc: func(ctx context.Context, id int64) error {
 //				panic("mock out the MarkCronWebhookDeliveryRunning method")
+//			},
+//			PrepareLatestNotesFunc: func(ctx context.Context, partial bool) (*model.NoteViews, error) {
+//				panic("mock out the PrepareLatestNotes method")
 //			},
 //			ShortAPITokenSecretFunc: func() string {
 //				panic("mock out the ShortAPITokenSecret method")
@@ -72,6 +78,9 @@ type EnvMock struct {
 	// GetSecretValuesFunc mocks the GetSecretValues method.
 	GetSecretValuesFunc func(ctx context.Context, like string) (map[string]string, error)
 
+	// HandleLatestNotesAfterSaveFunc mocks the HandleLatestNotesAfterSave method.
+	HandleLatestNotesAfterSaveFunc func(ctx context.Context, pathIDs []int64) error
+
 	// InsertNoteFunc mocks the InsertNote method.
 	InsertNoteFunc func(ctx context.Context, note model.RawNote) (int64, error)
 
@@ -86,6 +95,9 @@ type EnvMock struct {
 
 	// MarkCronWebhookDeliveryRunningFunc mocks the MarkCronWebhookDeliveryRunning method.
 	MarkCronWebhookDeliveryRunningFunc func(ctx context.Context, id int64) error
+
+	// PrepareLatestNotesFunc mocks the PrepareLatestNotes method.
+	PrepareLatestNotesFunc func(ctx context.Context, partial bool) (*model.NoteViews, error)
 
 	// ShortAPITokenSecretFunc mocks the ShortAPITokenSecret method.
 	ShortAPITokenSecretFunc func() string
@@ -119,6 +131,13 @@ type EnvMock struct {
 			// Like is the like argument value.
 			Like string
 		}
+		// HandleLatestNotesAfterSave holds details about calls to the HandleLatestNotesAfterSave method.
+		HandleLatestNotesAfterSave []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// PathIDs is the pathIDs argument value.
+			PathIDs []int64
+		}
 		// InsertNote holds details about calls to the InsertNote method.
 		InsertNote []struct {
 			// Ctx is the ctx argument value.
@@ -146,6 +165,13 @@ type EnvMock struct {
 			// ID is the id argument value.
 			ID int64
 		}
+		// PrepareLatestNotes holds details about calls to the PrepareLatestNotes method.
+		PrepareLatestNotes []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Partial is the partial argument value.
+			Partial bool
+		}
 		// ShortAPITokenSecret holds details about calls to the ShortAPITokenSecret method.
 		ShortAPITokenSecret []struct {
 		}
@@ -163,11 +189,13 @@ type EnvMock struct {
 	lockCronWebhookByID                 sync.RWMutex
 	lockEnqueueDeliverCronWebhook       sync.RWMutex
 	lockGetSecretValues                 sync.RWMutex
+	lockHandleLatestNotesAfterSave      sync.RWMutex
 	lockInsertNote                      sync.RWMutex
 	lockInsertWebhookDeliveryLog        sync.RWMutex
 	lockLatestNoteViews                 sync.RWMutex
 	lockLogger                          sync.RWMutex
 	lockMarkCronWebhookDeliveryRunning  sync.RWMutex
+	lockPrepareLatestNotes              sync.RWMutex
 	lockShortAPITokenSecret             sync.RWMutex
 	lockUpdateCronWebhookDeliveryResult sync.RWMutex
 	lockWebhookHTTPClient               sync.RWMutex
@@ -278,6 +306,42 @@ func (mock *EnvMock) GetSecretValuesCalls() []struct {
 	mock.lockGetSecretValues.RLock()
 	calls = mock.calls.GetSecretValues
 	mock.lockGetSecretValues.RUnlock()
+	return calls
+}
+
+// HandleLatestNotesAfterSave calls HandleLatestNotesAfterSaveFunc.
+func (mock *EnvMock) HandleLatestNotesAfterSave(ctx context.Context, pathIDs []int64) error {
+	if mock.HandleLatestNotesAfterSaveFunc == nil {
+		panic("EnvMock.HandleLatestNotesAfterSaveFunc: method is nil but Env.HandleLatestNotesAfterSave was just called")
+	}
+	callInfo := struct {
+		Ctx     context.Context
+		PathIDs []int64
+	}{
+		Ctx:     ctx,
+		PathIDs: pathIDs,
+	}
+	mock.lockHandleLatestNotesAfterSave.Lock()
+	mock.calls.HandleLatestNotesAfterSave = append(mock.calls.HandleLatestNotesAfterSave, callInfo)
+	mock.lockHandleLatestNotesAfterSave.Unlock()
+	return mock.HandleLatestNotesAfterSaveFunc(ctx, pathIDs)
+}
+
+// HandleLatestNotesAfterSaveCalls gets all the calls that were made to HandleLatestNotesAfterSave.
+// Check the length with:
+//
+//	len(mockedEnv.HandleLatestNotesAfterSaveCalls())
+func (mock *EnvMock) HandleLatestNotesAfterSaveCalls() []struct {
+	Ctx     context.Context
+	PathIDs []int64
+} {
+	var calls []struct {
+		Ctx     context.Context
+		PathIDs []int64
+	}
+	mock.lockHandleLatestNotesAfterSave.RLock()
+	calls = mock.calls.HandleLatestNotesAfterSave
+	mock.lockHandleLatestNotesAfterSave.RUnlock()
 	return calls
 }
 
@@ -440,6 +504,42 @@ func (mock *EnvMock) MarkCronWebhookDeliveryRunningCalls() []struct {
 	mock.lockMarkCronWebhookDeliveryRunning.RLock()
 	calls = mock.calls.MarkCronWebhookDeliveryRunning
 	mock.lockMarkCronWebhookDeliveryRunning.RUnlock()
+	return calls
+}
+
+// PrepareLatestNotes calls PrepareLatestNotesFunc.
+func (mock *EnvMock) PrepareLatestNotes(ctx context.Context, partial bool) (*model.NoteViews, error) {
+	if mock.PrepareLatestNotesFunc == nil {
+		panic("EnvMock.PrepareLatestNotesFunc: method is nil but Env.PrepareLatestNotes was just called")
+	}
+	callInfo := struct {
+		Ctx     context.Context
+		Partial bool
+	}{
+		Ctx:     ctx,
+		Partial: partial,
+	}
+	mock.lockPrepareLatestNotes.Lock()
+	mock.calls.PrepareLatestNotes = append(mock.calls.PrepareLatestNotes, callInfo)
+	mock.lockPrepareLatestNotes.Unlock()
+	return mock.PrepareLatestNotesFunc(ctx, partial)
+}
+
+// PrepareLatestNotesCalls gets all the calls that were made to PrepareLatestNotes.
+// Check the length with:
+//
+//	len(mockedEnv.PrepareLatestNotesCalls())
+func (mock *EnvMock) PrepareLatestNotesCalls() []struct {
+	Ctx     context.Context
+	Partial bool
+} {
+	var calls []struct {
+		Ctx     context.Context
+		Partial bool
+	}
+	mock.lockPrepareLatestNotes.RLock()
+	calls = mock.calls.PrepareLatestNotes
+	mock.lockPrepareLatestNotes.RUnlock()
 	return calls
 }
 

--- a/internal/case/backjob/delivercronwebhook/resolve.go
+++ b/internal/case/backjob/delivercronwebhook/resolve.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"trip2g/internal/appreq"
 	"trip2g/internal/db"
 	"trip2g/internal/jsonneteval"
 	"trip2g/internal/logger"
@@ -45,6 +46,8 @@ type Env interface {
 	UpdateCronWebhookDeliveryResult(ctx context.Context, arg db.UpdateCronWebhookDeliveryResultParams) error
 	InsertWebhookDeliveryLog(ctx context.Context, arg db.InsertWebhookDeliveryLogParams) error
 	InsertNote(ctx context.Context, note model.RawNote) (int64, error)
+	PrepareLatestNotes(ctx context.Context, partial bool) (*model.NoteViews, error)
+	HandleLatestNotesAfterSave(ctx context.Context, pathIDs []int64) error
 	LatestNoteViews() *model.NoteViews
 	EnqueueDeliverCronWebhook(ctx context.Context, params DeliverCronParams) error
 	ShortAPITokenSecret() string
@@ -139,10 +142,10 @@ func Resolve(ctx context.Context, env Env, params DeliverCronParams) error {
 		ttl := time.Duration(wh.TimeoutSeconds)*time.Second + tokenTTLMargin
 
 		token, signErr := shortapitoken.Sign(shortapitoken.Data{
-			Depth:         1, // Cron webhooks always start at depth 1.
+			Depth:         cronStartDepth,
 			ReadPatterns:  readPatterns,
 			WritePatterns: writePatterns,
-			DeliveryKind:  "cron",
+			DeliveryKind:  deliveryKindCron,
 			DeliveryID:    params.DeliveryID,
 		}, env.ShortAPITokenSecret(), ttl)
 		if signErr != nil {
@@ -235,7 +238,11 @@ func Resolve(ctx context.Context, env Env, params DeliverCronParams) error {
 	// Parse agent response for changes.
 	var applyErr error
 	if result.StatusCode >= 200 && result.StatusCode < 300 && result.StatusCode != http.StatusAccepted {
-		applyErr = applyCronAgentChanges(ctx, env, result, writePatterns)
+		// Apply under a synthesized delivery appreq: the notes are attributed to
+		// this delivery and the webhooks they trigger inherit depth+1, exactly as
+		// if the agent had written them back through the scoped api_token.
+		applyCtx := appreq.NewContext(ctx, appreq.NewDeliveryRequest(deliveryKindCron, params.DeliveryID, cronStartDepth))
+		applyErr = applyCronAgentChanges(applyCtx, env, result, writePatterns)
 	}
 
 	// Handle agent response errors with retry.
@@ -369,6 +376,15 @@ func transformExtVars(payloadBytes []byte) map[string]string {
 	return ev
 }
 
+// cronStartDepth is the depth a cron delivery's writes carry: a cron run is
+// itself the root, so what it writes sits one level down. Both the scoped
+// api_token and the apply path's synthesized appreq use it.
+const cronStartDepth = 1
+
+// deliveryKindCron is this lane's delivery kind, carried by the scoped
+// api_token and by the appreq the apply path synthesizes.
+const deliveryKindCron = "cron"
+
 // applyCronAgentChanges parses, validates, and applies agent response changes.
 // The whole batch is validated (write patterns, expected_hash CAS, patch
 // resolution) before any item is written, so an invalid item rejects the
@@ -387,10 +403,28 @@ func applyCronAgentChanges(ctx context.Context, env Env, result webhookutil.Deli
 		return resolveErr
 	}
 
+	pathIDs := make([]int64, 0, len(notes))
 	for _, note := range notes {
-		if _, insertErr := env.InsertNote(ctx, note); insertErr != nil {
+		pathID, insertErr := env.InsertNote(ctx, note)
+		if insertErr != nil {
 			return fmt.Errorf("failed to apply change for %s: %w", note.Path, insertErr)
 		}
+		pathIDs = append(pathIDs, pathID)
+	}
+
+	// Refresh LatestNoteViews so the applied notes are visible to the change
+	// webhooks they trigger (matchChange resolves each path through the view).
+	_, prepareErr := env.PrepareLatestNotes(ctx, false)
+	if prepareErr != nil {
+		return fmt.Errorf("failed to refresh note views: %w", prepareErr)
+	}
+
+	// Notes applied here are ordinary note changes: they must materialize their
+	// frontmatter, reach SSE subscribers and trigger change webhooks like any
+	// other write. A failure here does not undo the writes and must not re-run
+	// the agent, so it is logged rather than returned.
+	if handleErr := env.HandleLatestNotesAfterSave(ctx, pathIDs); handleErr != nil {
+		env.Logger().Error("failed to handle notes applied from agent response", "error", handleErr)
 	}
 
 	return nil

--- a/internal/case/backjob/delivercronwebhook/resolve_test.go
+++ b/internal/case/backjob/delivercronwebhook/resolve_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"trip2g/internal/appreq"
 	"trip2g/internal/case/backjob/delivercronwebhook"
 	"trip2g/internal/db"
 	"trip2g/internal/logger"
@@ -46,6 +47,12 @@ func baseEnv(t *testing.T, url string, secretValues map[string]string) *EnvMock 
 		},
 		InsertNoteFunc: func(_ context.Context, _ model.RawNote) (int64, error) {
 			return 0, nil
+		},
+		PrepareLatestNotesFunc: func(_ context.Context, _ bool) (*model.NoteViews, error) {
+			return nil, nil
+		},
+		HandleLatestNotesAfterSaveFunc: func(_ context.Context, _ []int64) error {
+			return nil
 		},
 		LatestNoteViewsFunc: func() *model.NoteViews { return nil },
 		EnqueueDeliverCronWebhookFunc: func(_ context.Context, _ delivercronwebhook.DeliverCronParams) error {
@@ -583,4 +590,49 @@ func TestResolve_CronAttachNotes_GateSkipWhenNoneMatch(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, called, "HTTP endpoint must not be called when attach_notes gate is not satisfied")
 	require.Equal(t, "success", got.Status, "delivery must be marked success (skipped) when gate not satisfied")
+}
+
+// Same contract as the change lane: notes applied from a cron agent response
+// run through the post-save handler, under this delivery's identity and the
+// cron start depth.
+func TestResolve_CronAgentChanges_RunPostSaveHandlerWithDeliveryIdentity(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok","changes":[{"path":"notes/todo.md","content":"x"}]}`))
+	}))
+	defer srv.Close()
+
+	env := baseEnv(t, srv.URL, nil)
+	env.CronWebhookByIDFunc = func(_ context.Context, id int64) (db.CronWebhook, error) {
+		return db.CronWebhook{
+			ID:             id,
+			Url:            srv.URL,
+			TimeoutSeconds: 10,
+			WritePatterns:  `["notes/**"]`,
+			ReadPatterns:   "[]",
+		}, nil
+	}
+	env.InsertNoteFunc = func(_ context.Context, _ model.RawNote) (int64, error) {
+		return 88, nil
+	}
+	env.PrepareLatestNotesFunc = func(_ context.Context, _ bool) (*model.NoteViews, error) {
+		return model.NewNoteViews(), nil
+	}
+
+	var gotPathIDs []int64
+	var gotReq *appreq.Request
+	env.HandleLatestNotesAfterSaveFunc = func(ctx context.Context, pathIDs []int64) error {
+		gotPathIDs = pathIDs
+		gotReq, _ = appreq.FromCtx(ctx)
+		return nil
+	}
+
+	err := delivercronwebhook.Resolve(context.Background(), env,
+		delivercronwebhook.DeliverCronParams{CronWebhookID: 1, DeliveryID: 12, Attempt: 1})
+	require.NoError(t, err)
+	require.Equal(t, []int64{88}, gotPathIDs)
+	require.NotNil(t, gotReq, "post-save handler must run under a delivery appreq")
+	require.Equal(t, 1, gotReq.WebhookDepth, "cron writes start at depth 1")
+	require.Equal(t, "cron", gotReq.WebhookDeliveryKind)
+	require.EqualValues(t, 12, gotReq.WebhookDeliveryID)
 }


### PR DESCRIPTION
Notes applied from a webhook agent's response body (`applyAgentChanges`, the `pass_api_key=false` path) were written straight through `InsertNote` without ever reaching `HandleLatestNotesAfterSave`. They therefore never materialized their frontmatter, never reached SSE subscribers, were never attributed to the delivery, and — the visible symptom — never triggered downstream change webhooks. A chain of agent roles only cascaded when every hop wrote back through its scoped `api_token`.

The cron lane had the same hole, plus it never refreshed the note snapshot after applying, so its writes were invisible to webhook path matching regardless.

## Fix

Both delivery lanes now apply the agent's changes under a synthesized `appreq` (`appreq.NewDeliveryRequest`) carrying what the scoped `api_token` would have carried: the delivery identity (so note versions are attributed) and the depth (`params.Depth + 1` for change, `cronStartDepth` for cron), so the webhooks these writes trigger stay under the existing depth guard instead of restarting the counter at zero. After the reload, `HandleLatestNotesAfterSave` runs. A failure there is logged, not returned — the writes are already applied and re-running the agent over a bookkeeping error would be wrong.

`cronStartDepth` replaces the hardcoded `Depth: 1` literal so the token and the apply path cannot drift apart.

## Tests

- `e2e/webhooks.spec.js`: new `agent response changes cascade to downstream webhooks` — one webhook writes into a folder a second webhook watches, and the downstream delivery must arrive at `depth === 1` (a depth-0 delivery would mean an ordinary commit, not a cascade). Red before the fix on a clean DB, green after.
- Unit tests in both delivery packages assert the post-save handler runs with the inserted path ids and a context carrying the right depth, delivery kind and delivery id.

The existing `depth protection prevents infinite loop` test kept passing throughout — it was green for the wrong reason, since no cascade existed at any `maxDepth`. It now exercises the real guard.

Full webhook e2e suite: 7 passed. `go test ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)