### PR TITLE
feat(webhooks): configurable delivery retention, 90 days by default

### DIFF
--- a/cmd/server/cronjobs.go
+++ b/cmd/server/cronjobs.go
@@ -32,8 +32,8 @@ func getCronJobConfigs(app *app) []cronjobs.Job {
 		refreshtelegramchatusernames.New(app),
 		regeneratenoteembeddings.New(app),
 		executecronwebhooks.New(app, app.config.CronExecuteWebhooksSchedule),
-		cleanupwebhookdeliverylogs.New(app),
-		cleanupwebhookdeliveries.New(app),
+		cleanupwebhookdeliverylogs.New(app, app.config.WebhookDeliveryLogs),
+		cleanupwebhookdeliveries.New(app, app.config.WebhookDeliveries),
 		cleanupapikeylogs.New(app, app.config.APIKeyLogs),
 		expirestalewebhookdeliveries.New(app),
 	}

--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -14,6 +14,8 @@ import (
 	"trip2g/internal/boostyjobs"
 	"trip2g/internal/case/admin/renderpreview"
 	cleanupapikeylogs "trip2g/internal/case/cronjob/cleanupapikeylogs"
+	"trip2g/internal/case/cronjob/cleanupwebhookdeliveries"
+	"trip2g/internal/case/cronjob/cleanupwebhookdeliverylogs"
 	"trip2g/internal/dataencryption"
 	"trip2g/internal/datasize"
 	"trip2g/internal/features"
@@ -147,6 +149,9 @@ type Config struct {
 
 	APIKeyLogs cleanupapikeylogs.Config
 
+	WebhookDeliveries   cleanupwebhookdeliveries.Config
+	WebhookDeliveryLogs cleanupwebhookdeliverylogs.Config
+
 	DataEncryption dataencryption.Config
 
 	SimpleBackup SimpleBackupConfig
@@ -268,6 +273,8 @@ func DefaultConfig() *Config {
 		Metrics:              DefaultMetricsConfig(),
 		RenderPreview:        renderpreview.DefaultConfig(),
 		APIKeyLogs:           cleanupapikeylogs.DefaultConfig(),
+		WebhookDeliveries:    cleanupwebhookdeliveries.DefaultConfig(),
+		WebhookDeliveryLogs:  cleanupwebhookdeliverylogs.DefaultConfig(),
 	}
 }
 
@@ -628,6 +635,18 @@ func (c *Config) defineMinioFlags() {
 		"api-key-logs-retention",
 		c.APIKeyLogs.Retention,
 		"How long to keep API key access logs (default 90d)",
+	)
+	flag.DurationVar(
+		&c.WebhookDeliveries.Retention,
+		"webhook-deliveries-retention",
+		c.WebhookDeliveries.Retention,
+		"How long to keep webhook delivery rows (default 90d)",
+	)
+	flag.DurationVar(
+		&c.WebhookDeliveryLogs.Retention,
+		"webhook-delivery-logs-retention",
+		c.WebhookDeliveryLogs.Retention,
+		"How long to keep webhook delivery request/response bodies (default 90d)",
 	)
 }
 

--- a/internal/case/cronjob/cleanupwebhookdeliveries/config.go
+++ b/internal/case/cronjob/cleanupwebhookdeliveries/config.go
@@ -1,0 +1,15 @@
+package cleanupwebhookdeliveries
+
+import "time"
+
+// Config holds configuration for the webhook deliveries cleanup job.
+type Config struct {
+	Retention time.Duration
+}
+
+// DefaultConfig returns a Config with a 90-day retention period.
+func DefaultConfig() Config {
+	return Config{
+		Retention: 90 * 24 * time.Hour,
+	}
+}

--- a/internal/case/cronjob/cleanupwebhookdeliveries/job.go
+++ b/internal/case/cronjob/cleanupwebhookdeliveries/job.go
@@ -7,11 +7,12 @@ import (
 
 // Job implements the cronjobs.Job interface.
 type job struct {
-	env Env
+	env    Env
+	config Config
 }
 
-func New(env Env) cronjobs.Job {
-	return &job{env: env}
+func New(env Env, config Config) cronjobs.Job {
+	return &job{env: env, config: config}
 }
 
 func (j *job) Name() string {
@@ -28,5 +29,5 @@ func (j *job) ExecuteAfterStart() bool {
 }
 
 func (j *job) Execute(ctx context.Context) (any, error) {
-	return Resolve(ctx, j.env)
+	return Resolve(ctx, j.env, j.config)
 }

--- a/internal/case/cronjob/cleanupwebhookdeliveries/resolve.go
+++ b/internal/case/cronjob/cleanupwebhookdeliveries/resolve.go
@@ -3,12 +3,14 @@ package cleanupwebhookdeliveries
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"trip2g/internal/logger"
 )
 
 type Env interface {
-	CleanupOldChangeWebhookDeliveries(ctx context.Context) error
-	CleanupOldCronWebhookDeliveries(ctx context.Context) error
+	CleanupOldChangeWebhookDeliveries(ctx context.Context, cutoffTime time.Time) error
+	CleanupOldCronWebhookDeliveries(ctx context.Context, cutoffTime time.Time) error
 	Logger() logger.Logger
 }
 
@@ -17,14 +19,16 @@ type Result struct {
 	Cleaned bool
 }
 
-// Resolve deletes webhook deliveries older than 30 days.
-func Resolve(ctx context.Context, env Env) (*Result, error) {
-	err := env.CleanupOldChangeWebhookDeliveries(ctx)
+// Resolve deletes webhook deliveries older than the configured retention period.
+func Resolve(ctx context.Context, env Env, cfg Config) (*Result, error) {
+	cutoff := time.Now().Add(-cfg.Retention)
+
+	err := env.CleanupOldChangeWebhookDeliveries(ctx, cutoff)
 	if err != nil {
 		return nil, fmt.Errorf("failed to cleanup old change webhook deliveries: %w", err)
 	}
 
-	err = env.CleanupOldCronWebhookDeliveries(ctx)
+	err = env.CleanupOldCronWebhookDeliveries(ctx, cutoff)
 	if err != nil {
 		return nil, fmt.Errorf("failed to cleanup old cron webhook deliveries: %w", err)
 	}

--- a/internal/case/cronjob/cleanupwebhookdeliverylogs/config.go
+++ b/internal/case/cronjob/cleanupwebhookdeliverylogs/config.go
@@ -1,0 +1,15 @@
+package cleanupwebhookdeliverylogs
+
+import "time"
+
+// Config holds configuration for the webhook delivery logs cleanup job.
+type Config struct {
+	Retention time.Duration
+}
+
+// DefaultConfig returns a Config with a 90-day retention period.
+func DefaultConfig() Config {
+	return Config{
+		Retention: 90 * 24 * time.Hour,
+	}
+}

--- a/internal/case/cronjob/cleanupwebhookdeliverylogs/job.go
+++ b/internal/case/cronjob/cleanupwebhookdeliverylogs/job.go
@@ -7,11 +7,12 @@ import (
 
 // Job implements the cronjobs.Job interface.
 type job struct {
-	env Env
+	env    Env
+	config Config
 }
 
-func New(env Env) cronjobs.Job {
-	return &job{env: env}
+func New(env Env, config Config) cronjobs.Job {
+	return &job{env: env, config: config}
 }
 
 func (j *job) Name() string {
@@ -19,8 +20,8 @@ func (j *job) Name() string {
 }
 
 // Schedule runs daily at midnight. Cron webhook response bodies store full agent
-// payloads (hundreds of KB each), so logs must be pruned frequently to prevent
-// the database from growing into the hundreds of MB range.
+// payloads (hundreds of KB each), so a long retention window grows the database
+// into the hundreds of MB range.
 func (j *job) Schedule() string {
 	return "0 0 0 * * *"
 }
@@ -30,5 +31,5 @@ func (j *job) ExecuteAfterStart() bool {
 }
 
 func (j *job) Execute(ctx context.Context) (any, error) {
-	return Resolve(ctx, j.env)
+	return Resolve(ctx, j.env, j.config)
 }

--- a/internal/case/cronjob/cleanupwebhookdeliverylogs/resolve.go
+++ b/internal/case/cronjob/cleanupwebhookdeliverylogs/resolve.go
@@ -3,11 +3,13 @@ package cleanupwebhookdeliverylogs
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"trip2g/internal/logger"
 )
 
 type Env interface {
-	CleanupOldDeliveryLogs(ctx context.Context) error
+	CleanupOldDeliveryLogs(ctx context.Context, cutoffTime time.Time) error
 	Logger() logger.Logger
 }
 
@@ -16,9 +18,11 @@ type Result struct {
 	Cleaned bool
 }
 
-// Resolve deletes webhook delivery logs older than 1 day.
-func Resolve(ctx context.Context, env Env) (*Result, error) {
-	err := env.CleanupOldDeliveryLogs(ctx)
+// Resolve deletes webhook delivery logs older than the configured retention period.
+func Resolve(ctx context.Context, env Env, cfg Config) (*Result, error) {
+	cutoff := time.Now().Add(-cfg.Retention)
+
+	err := env.CleanupOldDeliveryLogs(ctx, cutoff)
 	if err != nil {
 		return nil, fmt.Errorf("failed to cleanup old delivery logs: %w", err)
 	}

--- a/internal/db/queries.write.sql.go
+++ b/internal/db/queries.write.sql.go
@@ -109,33 +109,33 @@ func (q *WriteQueries) CleanupOldAPIKeyLogs(ctx context.Context, cutoffTime time
 
 const cleanupOldChangeWebhookDeliveries = `-- name: CleanupOldChangeWebhookDeliveries :exec
 delete from change_webhook_deliveries
-where created_at < datetime('now', '-30 days')
+where created_at < ?1
 `
 
-func (q *WriteQueries) CleanupOldChangeWebhookDeliveries(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, cleanupOldChangeWebhookDeliveries)
+func (q *WriteQueries) CleanupOldChangeWebhookDeliveries(ctx context.Context, cutoffTime time.Time) error {
+	_, err := q.db.ExecContext(ctx, cleanupOldChangeWebhookDeliveries, cutoffTime)
 	return err
 }
 
 const cleanupOldCronWebhookDeliveries = `-- name: CleanupOldCronWebhookDeliveries :exec
 delete from cron_webhook_deliveries
-where created_at < datetime('now', '-30 days')
+where created_at < ?1
 `
 
-func (q *WriteQueries) CleanupOldCronWebhookDeliveries(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, cleanupOldCronWebhookDeliveries)
+func (q *WriteQueries) CleanupOldCronWebhookDeliveries(ctx context.Context, cutoffTime time.Time) error {
+	_, err := q.db.ExecContext(ctx, cleanupOldCronWebhookDeliveries, cutoffTime)
 	return err
 }
 
 const cleanupOldDeliveryLogs = `-- name: CleanupOldDeliveryLogs :exec
 delete from webhook_delivery_logs
-where created_at < datetime('now', '-1 days')
+where created_at < ?1
 `
 
 // Cron webhook response bodies can be hundreds of KB (full note content from agents),
-// so logs accumulate fast. Keep only the last day.
-func (q *WriteQueries) CleanupOldDeliveryLogs(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, cleanupOldDeliveryLogs)
+// so logs accumulate fast. The retention window is configurable.
+func (q *WriteQueries) CleanupOldDeliveryLogs(ctx context.Context, cutoffTime time.Time) error {
+	_, err := q.db.ExecContext(ctx, cleanupOldDeliveryLogs, cutoffTime)
 	return err
 }
 

--- a/queries.write.sql
+++ b/queries.write.sql
@@ -1194,17 +1194,17 @@ values (?, ?, ?, ?, ?);
 
 -- name: CleanupOldDeliveryLogs :exec
 -- Cron webhook response bodies can be hundreds of KB (full note content from agents),
--- so logs accumulate fast. Keep only the last day.
+-- so logs accumulate fast. The retention window is configurable.
 delete from webhook_delivery_logs
-where created_at < datetime('now', '-1 days');
+where created_at < sqlc.arg(cutoff_time);
 
 -- name: CleanupOldChangeWebhookDeliveries :exec
 delete from change_webhook_deliveries
-where created_at < datetime('now', '-30 days');
+where created_at < sqlc.arg(cutoff_time);
 
 -- name: CleanupOldCronWebhookDeliveries :exec
 delete from cron_webhook_deliveries
-where created_at < datetime('now', '-30 days');
+where created_at < sqlc.arg(cutoff_time);
 
 -- ============================================
 -- Frontmatter Patches


### PR DESCRIPTION
`webhook_delivery_logs` held request/response bodies for **1 day**, while the delivery rows themselves lived **30 days**. So a chain stayed visible in the admin for a month with the agent's actual response already gone.

Both are now one configurable window, **90 days by default**, following the existing `cleanupapikeylogs` pattern: `Config{Retention}` + `DefaultConfig()` per job, cutoff computed in Go and passed to the query as `sqlc.arg(cutoff_time)` instead of a `datetime('now', '-N days')` literal.

| Flag | Env | Default |
|---|---|---|
| `-webhook-deliveries-retention` | `TRIP2G_WEBHOOK_DELIVERIES_RETENTION` | `2160h` |
| `-webhook-delivery-logs-retention` | `TRIP2G_WEBHOOK_DELIVERY_LOGS_RETENTION` | `2160h` |

Values are Go durations (`2160h`) — the parser does not understand `90d`. The `TRIP2G_` prefix is optional.

No migration: only the three cleanup queries changed, plus `make sqlc`.

Worth knowing before merge: cron webhook response bodies can be hundreds of KB each (that was the stated reason for the original 1-day window), so 90 days of them is a real growth in DB size. The env var is the knob to turn it back down on a deployment where that matters.

## Verified

- `go build ./...`, `go vet ./...` clean.
- `go test ./internal/appconfig/... ./internal/case/cronjob/...` passes.
- `make sqlc` reproduces the committed generated file with no drift.
- `golangci-lint` on the touched packages: 0 issues.

Not verified: no test covers the cleanup jobs themselves — none of the `cleanup*` cron packages have test files, so the new cutoff arithmetic is only checked by the compiler.
