### PR TITLE
Allow private/internal webhook delivery addresses behind a flag

### DIFF
--- a/cmd/server/boot.go
+++ b/cmd/server/boot.go
@@ -156,7 +156,7 @@ func (a *app) constructJobs() {
 	a.GenerateNoteVersionEmbeddingJob = generatenoteversionembedding.New(a)
 	a.DeliverChangeWebhookJob = deliverchangewebhook.New(a)
 	a.DeliverCronWebhookJob = delivercronwebhook.New(a)
-	a.webhookHTTPClient = webhookutil.NewClient(a.config.DevMode)
+	a.webhookHTTPClient = webhookutil.NewClient(a.config.DevMode || a.config.WebhookAllowPrivate)
 	a.fedHTTPClient = webhookutil.NewClient(a.config.DevMode || a.config.MCPFederationAllowPrivate)
 
 	a.initDebugJobs()

--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -81,6 +81,7 @@ type Config struct {
 	LeaderAddr                 string
 	MCPFederationMaxDepth      int
 	MCPFederationAllowPrivate  bool
+	WebhookAllowPrivate        bool
 	MCPFederatedGraphQLEnabled bool
 	FederatedFanoutConcurrency int
 	FederatedFanoutLimit       int
@@ -545,6 +546,12 @@ func (c *Config) defineServerFlags() {
 		"mcp-federation-allow-private",
 		false,
 		"Disable SSRF protection for federation calls (allow private/internal addresses).",
+	)
+	flag.BoolVar(
+		&c.WebhookAllowPrivate,
+		"webhook-allow-private",
+		false,
+		"Disable SSRF protection for webhook deliveries (allow private/internal addresses).",
 	)
 	flag.BoolVar(&c.MCPFederatedGraphQLEnabled, "mcp-federated-graphql", false,
 		"Enable the federated_graphql_request MCP tool (query-only, subgraph-scoped). Off by default.")

--- a/internal/appconfig/config_test.go
+++ b/internal/appconfig/config_test.go
@@ -17,6 +17,16 @@ func TestDefaultInternalListenAddrIsLoopback(t *testing.T) {
 	}
 }
 
+// Webhook deliveries go through the SSRF-safe dialer by default; only an
+// operator setting -webhook-allow-private opts a deployment out of it.
+func TestDefaultConfigWebhookAllowPrivateIsFalse(t *testing.T) {
+	t.Parallel()
+
+	if DefaultConfig().WebhookAllowPrivate {
+		t.Fatal("webhook-allow-private must default to false")
+	}
+}
+
 // applyStorageEnvFallback must accept the canonical S3 secret-key env name
 // (MINIO_SECRET_ACCESS_KEY) when -minio-secret-key was never explicitly set, and
 // must never clobber an explicitly set -minio-secret-key — even one whose value
@@ -47,6 +57,16 @@ func TestApplyStorageEnvFallbackSecretKey(t *testing.T) {
 
 		if c.Storage.SecretKey != DefaultMinIOSecretKey {
 			t.Fatalf("explicitly set flag was clobbered by fallback: got %q", c.Storage.SecretKey)
+		}
+	})
+
+	t.Run("webhook-allow-private flag can be set", func(t *testing.T) {
+		if err := flag.CommandLine.Set("webhook-allow-private", "true"); err != nil {
+			t.Fatalf("failed to set webhook-allow-private flag: %v", err)
+		}
+
+		if !c.WebhookAllowPrivate {
+			t.Fatal("webhook-allow-private flag did not set Config.WebhookAllowPrivate")
 		}
 	})
 }


### PR DESCRIPTION
## Problem

Webhook deliveries (change webhooks and cron webhooks) go through an SSRF-safe HTTP client that refuses to dial private/internal addresses. When a webhook target is a loopback or RFC1918 address, delivery fails at the dialer:

    HTTP request failed: ssrfsafe: address is blocked (private/internal): 127.0.0.1 resolves to 127.0.0.1

There was no way to allow this for a specific, intentional deployment without enabling `--dev`, which does much more than lift the SSRF check: it also relaxes production validation (accepts the default user-token secret and data-encryption key) and exposes debug endpoints. That is too broad a change just to let webhook deliveries reach a private origin.

## Fix

Add `-webhook-allow-private` (env `TRIP2G_WEBHOOK_ALLOW_PRIVATE`), a narrow, off-by-default flag that disables SSRF protection only for webhook deliveries. It mirrors the existing `-mcp-federation-allow-private` flag, which does the same for MCP federation calls.

Default stays `false`: nothing changes unless an operator explicitly opts in.

## Test plan

- [x] `go test -tags dev ./...`
- [x] `make lint`