### PR TITLE
fix(fleet): close frontmatter bypasses in the role-authoring guard

### DIFF
--- a/cmd/fleet/internal/agentruntime/roleguard.go
+++ b/cmd/fleet/internal/agentruntime/roleguard.go
@@ -29,6 +29,14 @@ var ErrRoleAuthoringDenied = errors.New("write denied: agents may not author or 
 // the note could not be read. It fails closed, and is kept distinct from
 // ErrRoleAuthoringDenied so an infrastructure failure is never reported as an
 // accusation of role authoring.
+//
+// "Not found" fails closed too, and deliberately: remoteKB reads through the
+// DELIVERY-SCOPED client, so a missing note and a note outside this token's
+// read scope are indistinguishable here. Letting "not found" through would hand
+// a role that can write a path it cannot read exactly the bypass the unscoped
+// verification read exists to prevent. The cost is that patching a genuinely
+// absent note reports this instead of trip2g's own "note not found" — so the
+// underlying error is wrapped in, and this is NOT classified as a denial.
 var ErrRoleGuardUnverifiable = errors.New("write denied: cannot verify the patched note is not a role note")
 
 // declaresRole reports whether content's YAML frontmatter declares a top-level

--- a/cmd/fleet/internal/agentruntime/roleguard.go
+++ b/cmd/fleet/internal/agentruntime/roleguard.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // ErrRoleAuthoringDenied is returned when a write or patch would create a role
@@ -31,32 +31,33 @@ var ErrRoleAuthoringDenied = errors.New("write denied: agents may not author or 
 // accusation of role authoring.
 var ErrRoleGuardUnverifiable = errors.New("write denied: cannot verify the patched note is not a role note")
 
-const frontmatterDelimiter = "---"
-
 // declaresRole reports whether content's YAML frontmatter declares a top-level
 // fleet_id key, with or without a value: an empty fleet_id cannot run, but it
 // is one keystroke from one that can, and nothing legitimate writes it.
 //
-// Only a top-level key counts, matching how fleet reads role config out of
-// trip2g's flat note meta. The parse is deliberately more permissive than
-// trip2g's about what counts as frontmatter (leading blank lines, CRLF,
-// trailing spaces on the delimiters) — erring towards seeing a role that
-// trip2g would not is a false denial, which is loud and recoverable, while the
-// opposite is a silent hole.
+// The frontmatter rules mirror goldmark-meta, which is what actually produces a
+// note's meta in trip2g (internal/mdloader -> NoteView.RawMeta -> the GraphQL
+// meta field fleet's DiscoverRoles reads fleet_id from). Mirroring matters more
+// than elegance here: every input goldmark parses as frontmatter but this
+// function does not is a silent hole in the guard, which is why
+// TestDeclaresRoleMatchesGoldmark diffs the two directly. The YAML library is
+// v2 for the same reason, not by preference: v3 rejects duplicate keys that v2
+// accepts, and a note goldmark parses but this rejects is a bypass, not a
+// stricter check.
+//
+// Erring the other way is fine — a false denial is loud and recoverable — so
+// leading blank lines count here even though goldmark requires the fence on
+// line 0.
 func declaresRole(content string) bool {
 	body := strings.ReplaceAll(content, "\r\n", "\n")
 	body = strings.TrimPrefix(body, "\uFEFF")
 	body = strings.TrimLeft(body, "\n")
 	lines := strings.Split(body, "\n")
-	if strings.TrimRight(lines[0], " \t") != frontmatterDelimiter {
-		return false
-	}
-	front, ok := untilClosingDelimiter(lines[1:])
-	if !ok {
+	if !isFrontmatterFence(lines[0]) {
 		return false
 	}
 	var meta map[string]any
-	if err := yaml.Unmarshal([]byte(front), &meta); err != nil {
+	if err := yaml.Unmarshal([]byte(frontmatterBody(lines[1:])), &meta); err != nil {
 		// Unparseable frontmatter yields no meta in trip2g either, so the note
 		// cannot become a role through it.
 		return false
@@ -65,17 +66,25 @@ func declaresRole(content string) bool {
 	return found
 }
 
-// untilClosingDelimiter returns everything before the closing "---" line and
-// whether one was found. Frontmatter without a terminator is not frontmatter.
-func untilClosingDelimiter(lines []string) (string, bool) {
-	var out []string
-	for _, line := range lines {
-		if strings.TrimRight(line, " \t") == frontmatterDelimiter {
-			return strings.Join(out, "\n"), true
+// isFrontmatterFence mirrors goldmark-meta's isSeparator: ANY run of dashes,
+// surrounded by optional whitespace. Not just "---" — "----" opens frontmatter
+// just as well, and the opening and closing fences need not be the same length.
+func isFrontmatterFence(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return trimmed != "" && strings.Trim(trimmed, "-") == ""
+}
+
+// frontmatterBody returns the lines up to the closing fence — or all of them
+// when there is none. An unterminated block is NOT "not frontmatter": goldmark
+// closes the open block at EOF and parses what it collected, so a note ending
+// mid-frontmatter still carries meta.
+func frontmatterBody(lines []string) string {
+	for i, line := range lines {
+		if isFrontmatterFence(line) {
+			return strings.Join(lines[:i], "\n")
 		}
-		out = append(out, line)
 	}
-	return "", false
+	return strings.Join(lines, "\n")
 }
 
 // applyPatchPreview returns what the note would contain after a find/replace,

--- a/cmd/fleet/internal/agentruntime/roleguard_goldmark_test.go
+++ b/cmd/fleet/internal/agentruntime/roleguard_goldmark_test.go
@@ -1,0 +1,79 @@
+package agentruntime
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark"
+	meta "github.com/yuin/goldmark-meta"
+	"github.com/yuin/goldmark/parser"
+)
+
+// goldmarkDeclaresRole reports what trip2g would actually see: internal/mdloader
+// parses notes with goldmark-meta into NoteView.RawMeta, the GraphQL meta field
+// serves that map, and fleet's DiscoverRoles reads fleet_id out of it.
+func goldmarkDeclaresRole(t *testing.T, src string) bool {
+	t.Helper()
+	md := goldmark.New(goldmark.WithExtensions(meta.Meta))
+	ctx := parser.NewContext()
+	require.NoError(t, md.Convert([]byte(src), &bytes.Buffer{}, parser.WithContext(ctx)))
+	_, found := meta.Get(ctx)["fleet_id"]
+	return found
+}
+
+// TestDeclaresRoleMatchesGoldmark is the guard's real contract: every note
+// trip2g would treat as a role must be seen as one here. A hand-written table
+// cannot establish that — it only encodes what the author already thought of,
+// and the first version of this guard shipped with four bypasses (a "----"
+// fence, mismatched fence lengths, a longer dash run, and an unterminated block
+// that goldmark still closes at EOF) precisely because it was checked against
+// such a table instead of against the parser it has to mirror.
+//
+// The other direction is allowed: seeing a role where goldmark would not is a
+// false denial, which surfaces loudly in the run log.
+func TestDeclaresRoleMatchesGoldmark(t *testing.T) {
+	corpus := map[string]string{
+		"exact fence":              "---\nfleet_id: evil\n---\nbody\n",
+		"four dashes":              "----\nfleet_id: evil\n----\nbody\n",
+		"mismatched fence lengths": "---\nfleet_id: evil\n----------\nbody\n",
+		"long dash run":            "--------\nfleet_id: evil\n--------\nbody\n",
+		"unterminated at eof":      "---\nfleet_id: evil\n",
+		"unterminated no newline":  "---\nfleet_id: evil",
+		"trailing spaces on fence": "--- \nfleet_id: evil\n--- \nbody\n",
+		"trailing tab on fence":    "---\t\nfleet_id: evil\n---\t\nbody\n",
+		"crlf":                     "---\r\nfleet_id: evil\r\n---\r\nbody\r\n",
+		"quoted value":             "---\nfleet_id: \"evil\"\n---\n",
+		"single quoted value":      "---\nfleet_id: 'evil'\n---\n",
+		"empty value":              "---\nfleet_id:\n---\n",
+		"null value":               "---\nfleet_id: ~\n---\n",
+		"numeric value":            "---\nfleet_id: 42\n---\n",
+		"duplicate keys":           "---\nfleet_id: a\nfleet_id: b\n---\n",
+		"anchor and alias":         "---\nbase: &a evil\nfleet_id: *a\n---\n",
+		"merge key":                "---\nbase: &a\n  fleet_id: evil\nmerged:\n  <<: *a\n---\n",
+		"folded value":             "---\nfleet_id: >\n  evil\n---\n",
+		"literal value":            "---\nfleet_id: |\n  evil\n---\n",
+		"key with trailing space":  "---\nfleet_id : evil\n---\n",
+		"document end marker":      "---\nfleet_id: evil\n...\n---\n",
+		"comment before key":       "---\n# c\nfleet_id: evil\n---\n",
+		"other keys around":        "---\ntitle: x\nfleet_id: evil\nmode: cron\n---\n",
+		"body mentions fleet_id":   "---\ntitle: x\n---\n\nfleet_id: evil\n",
+		"fenced block in body":     "---\ntitle: x\n---\n\n```yaml\nfleet_id: evil\n```\n",
+		"nested only":              "---\nmeta:\n  fleet_id: evil\n---\n",
+		"no frontmatter":           "# Title\n\nfleet_id: evil\n",
+		"plain frontmatter":        "---\ntitle: x\n---\nbody\n",
+		"invalid yaml":             "---\nfleet_id: [unclosed\n---\n",
+		"empty":                    "",
+		"list body":                "- item\n- item2\n",
+		"thematic rule body":       "text\n\n---\n\nmore\n",
+	}
+
+	for name, src := range corpus {
+		t.Run(name, func(t *testing.T) {
+			if goldmarkDeclaresRole(t, src) {
+				require.True(t, declaresRole(src),
+					"BYPASS: trip2g would run this as a role, the guard would let an agent write it")
+			}
+		})
+	}
+}

--- a/cmd/fleet/internal/agentruntime/roleguard_test.go
+++ b/cmd/fleet/internal/agentruntime/roleguard_test.go
@@ -23,7 +23,13 @@ func TestDeclaresRole(t *testing.T) {
 		{"frontmatter not at start", "intro\n\n---\nfleet_id: codellm\n---\n", false},
 		{"leading blank lines then frontmatter", "\n\n---\nfleet_id: codellm\n---\n", true},
 		{"crlf line endings", "---\r\nfleet_id: codellm\r\n---\r\nbody\r\n", true},
-		{"unterminated frontmatter", "---\nfleet_id: codellm\n", false},
+		// goldmark closes an open block at EOF and parses what it collected, so
+		// an unterminated frontmatter still makes the note a role.
+		{"unterminated frontmatter", "---\nfleet_id: codellm\n", true},
+		{"four-dash fence", "----\nfleet_id: codellm\n----\n", true},
+		{"mismatched fence lengths", "---\nfleet_id: codellm\n--------\n", true},
+		{"duplicate fleet_id keys", "---\nfleet_id: a\nfleet_id: b\n---\n", true},
+		{"list body is not a fence", "- item\n- other\n", false},
 		{"empty content", "", false},
 		{"nested fleet_id is not a role marker", "---\nmeta:\n  fleet_id: codellm\n---\n", false},
 	}

--- a/cmd/fleet/internal/agentruntime/roleguard_test.go
+++ b/cmd/fleet/internal/agentruntime/roleguard_test.go
@@ -272,3 +272,35 @@ func TestRun_AllowRoleAuthoringOptsOut(t *testing.T) {
 	require.Len(t, res.Changes, 1)
 	require.Empty(t, res.Denials)
 }
+
+// Patching a note that does not exist is an ordinary apply failure, not a
+// denial. It still fails closed — a scoped reader cannot tell "absent" from
+// "outside my read scope" — but it must not be logged as a role-authoring hit,
+// or the denial log fills with false accusations and hides trip2g's own reason.
+func TestScopedKB_PatchMissingNoteIsNotReportedAsDenial(t *testing.T) {
+	kb := newMemKB(nil)
+	scoped := NewScopedKB(kb, nil, []string{"**"})
+
+	err := scoped.Patch(context.Background(), "notes/absent.md", "a", "b")
+
+	require.ErrorIs(t, err, ErrRoleGuardUnverifiable)
+	require.NotErrorIs(t, err, ErrRoleAuthoringDenied)
+
+	_, isDenial := writeDenial(err, "patch", "notes/absent.md")
+	require.False(t, isDenial, "must not be classified as a denial")
+	require.ErrorContains(t, err, "not found", "the underlying cause must reach the operator")
+}
+
+// The two real denials stay denials, with the reason the operator needs.
+func TestWriteDenialClassification(t *testing.T) {
+	scopeMsg, ok := writeDenial(ErrWriteDenied, "write", "a.md")
+	require.True(t, ok)
+	require.Equal(t, "write a.md", scopeMsg)
+
+	roleMsg, ok := writeDenial(ErrRoleAuthoringDenied, "write", "a.md")
+	require.True(t, ok)
+	require.Contains(t, roleMsg, "fleet_id")
+
+	_, ok = writeDenial(errors.New("boom"), "write", "a.md")
+	require.False(t, ok)
+}

--- a/cmd/fleet/internal/agentruntime/runtime.go
+++ b/cmd/fleet/internal/agentruntime/runtime.go
@@ -558,7 +558,11 @@ func execReadNote(ctx context.Context, scoped *ScopedKB, res *Result, call ToolC
 }
 
 // writeDenial classifies a ScopedKB write/patch error as a denial and builds the
-// operator-facing run-log line. A denial is soft: the loop reports it and keeps
+// operator-facing run-log line. ErrRoleGuardUnverifiable is deliberately absent:
+// it is not an authorization decision but a failure to check, most often a patch
+// against a note that does not exist. Reporting it as a denial would fill the
+// denial log with false role-authoring hits and hide trip2g's real reason, so it
+// falls through to the apply-failure path it took before the guard existed. A denial is soft: the loop reports it and keeps
 // going. It is deliberately NOT folded into the generic apply-failure path,
 // because a denial the operator cannot see is the known failure mode here — the
 // model paraphrases the tool error as its own refusal and the real cause never
@@ -569,8 +573,6 @@ func writeDenial(err error, verb, path string) (string, bool) {
 		return verb + " " + path, true
 	case errors.Is(err, ErrRoleAuthoringDenied):
 		return verb + " " + path + ": role note (fleet_id) — agents may not author roles", true
-	case errors.Is(err, ErrRoleGuardUnverifiable):
-		return verb + " " + path + ": could not be verified as a non-role note", true
 	default:
 		return "", false
 	}

--- a/cmd/fleet/internal/agentruntime/scope.go
+++ b/cmd/fleet/internal/agentruntime/scope.go
@@ -3,6 +3,7 @@ package agentruntime
 import (
 	"context"
 	"errors"
+	"fmt"
 	pathpkg "path"
 	"strings"
 
@@ -186,7 +187,7 @@ func (s *ScopedKB) checkPatchNotRoleAuthoring(ctx context.Context, path, find, r
 	}
 	current, err := s.kb.Read(ctx, path)
 	if err != nil {
-		return ErrRoleGuardUnverifiable
+		return fmt.Errorf("%w: %w", ErrRoleGuardUnverifiable, err)
 	}
 	if declaresRole(current) || declaresRole(applyPatchPreview(current, find, replace)) {
 		return ErrRoleAuthoringDenied

--- a/docs/dev/fleet_write_validation.md
+++ b/docs/dev/fleet_write_validation.md
@@ -136,7 +136,21 @@ forms).
   defeated by the role's own `read_patterns`.
 - An unreadable note fails closed, under a distinct error
   (`ErrRoleGuardUnverifiable`), so an infrastructure failure is never reported as
-  an accusation of role authoring.
+  an accusation of role authoring. "Not found" fails closed too: `remoteKB` reads
+  through the delivery-scoped client, so an absent note and one outside this
+  token's read scope look identical, and letting "not found" through would hand a
+  role that can write a path it cannot read the very bypass the unscoped
+  verification read exists to prevent. It is classified as an apply failure
+  rather than a denial, and wraps the underlying cause, so the denial log does not
+  fill with false role-authoring hits.
+- The marker parser mirrors `goldmark-meta`, which is what actually produces a
+  note's meta in trip2g — not a hand-written idea of what frontmatter looks like.
+  The first version did the latter and shipped five bypasses (`----` fences,
+  mismatched fence lengths, longer dash runs, unterminated blocks that goldmark
+  still closes at EOF, and duplicate YAML keys that yaml.v2 accepts and v3
+  rejects). `TestDeclaresRoleMatchesGoldmark` now diffs the two parsers over a
+  corpus and asserts the only property that matters: if trip2g would run it as a
+  role, the guard must see a role.
 - `--allow-role-authoring` (env `TRIP2G_FLEET_ALLOW_ROLE_AUTHORING`) turns it off
   fleet-wide for operators who do want agents managing roles. It logs a WARN at
   startup when off, because a guard silently disabled is worse than none.

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.45.0
 	golang.org/x/text v0.37.0
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	maragu.dev/goqite v0.3.1
 	modernc.org/sqlite v1.53.0
@@ -381,7 +382,6 @@ require (
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gorm.io/driver/bigquery v1.2.0 // indirect
 	gorm.io/gorm v1.25.12 // indirect
 	honnef.co/go/tools v0.6.1 // indirect


### PR DESCRIPTION
Follow-up to #315. The guard shipped with **five bypasses**, each a complete defeat of
its purpose: an agent could write a note that trip2g runs as a role while
`declaresRole` reported it as an ordinary note.

The cause is one mistake, not five: `declaresRole` was written against a hand-made
table of what frontmatter "looks like" instead of against the parser trip2g actually
uses — `goldmark-meta`, via `internal/mdloader` → `NoteView.RawMeta` → the GraphQL
`meta` field that `DiscoverRoles` reads `fleet_id` from.

## The bypasses

| Input | goldmark | old guard |
|---|---|---|
| `----` fence | role | not a role |
| mismatched fence lengths (`---` open, `----------` close) | role | not a role |
| any longer dash run | role | not a role |
| unterminated frontmatter (EOF before the closing fence) | role | not a role |
| duplicate `fleet_id:` keys | role | not a role |

`goldmark-meta`'s `isSeparator` accepts **any** run of dashes with optional surrounding
whitespace, and open/close need not match. Its `Continue` never closes on a blank line,
so an open block runs to EOF and is parsed there — an unterminated block still carries
meta. And it parses with **yaml.v2**, which accepts duplicate keys; the guard used
yaml.v3, which errors on them, and the guard read that error as "not frontmatter".

Exploit for any of them: a role scoped to `transcripts/**`, driven by prompt-injected
note content, writes a note with a `----` fence declaring `fleet_id` and
`write_patterns: ["**"]`. The write passes, the reconciler picks it up on its next
poll, and the successor runs with attacker-chosen scope.

## The fix

`isFrontmatterFence` and `frontmatterBody` mirror `isSeparator`/`Continue`, and the
YAML library is now v2 — matching the parser, not preference. Being *more* permissive
than goldmark stays fine (a leading blank line still counts here); that direction is a
false denial, which surfaces loudly in the run log.

## The test that matters

`TestDeclaresRoleMatchesGoldmark` runs a corpus through the real `goldmark-meta`
pipeline and asserts the implication that actually defines the guard:

> if trip2g would run it as a role, `declaresRole` must say so

The corpus covers fence variants, unterminated blocks, CRLF, quoting, anchors and
aliases, merge keys, duplicate keys, folded and literal scalars, `...` document
markers, comments, nested-only keys, and body text that merely mentions `fleet_id`.

A hand-written table cannot establish this property — it only encodes what the author
thought of, which is exactly how the five bypasses shipped. Three of them were found by
this test within a minute of it existing; the duplicate-key one was found only by it.

The stale table in `roleguard_test.go` is corrected too: it asserted that an
unterminated frontmatter is *not* a role, pinning the bug in place.

## Second commit: an unverifiable patch is not a denial

`patch_note` against a note that does not exist made the guard report
`ErrRoleGuardUnverifiable` **as a denial**, with the message "could not be verified as
a non-role note". Before #315 that same case was an ordinary apply failure carrying
trip2g's own "note not found". So the guard filled the denial log with false
role-authoring hits and hid the real reason — undercutting the goal of #315, which was
to make denials legible.

It still **fails closed**, and that part is deliberate rather than an oversight:
`remoteKB` reads through the **delivery-scoped** client, so "not found" and "outside
this token's read scope" are indistinguishable at that seam. Letting "not found"
through would hand a role that can write a path it cannot read precisely the bypass the
unscoped verification read exists to prevent.

What changed is only the classification and the message: the underlying error is
wrapped in, and `writeDenial` no longer claims it, so it falls back to the
apply-failure path it took before the guard existed.

## Not fixed here

`checkPatchNotRoleAuthoring` verifies through `remoteKB.Read`, which serves from an
overlay seeded at delivery start (`cmd/fleet/internal/fleet/remotekb.go:61`), so the
guard can verify stale content if another writer changes the note mid-delivery. It
cannot conjure a role from nothing and needs a concurrent writer, but "verify what you
are about to mutate" is violated. Both candidate fixes — a live-read path, or threading
`ExpectedHash` so trip2g rejects drift server-side — change the `KB` interface, so they
are left for a separate decision.
