### PR TITLE
feat(fleet): make a guarded patch conditional on the verified content

### DIFF
--- a/cmd/fleet/internal/agentruntime/scope.go
+++ b/cmd/fleet/internal/agentruntime/scope.go
@@ -2,6 +2,8 @@ package agentruntime
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	pathpkg "path"
@@ -163,10 +165,33 @@ func (s *ScopedKB) Patch(ctx context.Context, path, find, replace string) error 
 	if norm == "" || !webhookutil.MatchesAny(norm, s.writePatterns) {
 		return ErrWriteDenied
 	}
-	if err := s.checkPatchNotRoleAuthoring(ctx, norm, find, replace); err != nil {
+	verifiedHash, err := s.checkPatchNotRoleAuthoring(ctx, norm, find, replace)
+	if err != nil {
 		return err
 	}
+	if cp, ok := s.kb.(conditionalPatcher); ok && verifiedHash != nil {
+		return cp.PatchIfUnchanged(ctx, norm, find, replace, *verifiedHash)
+	}
 	return s.kb.Patch(ctx, norm, find, replace)
+}
+
+// conditionalPatcher is the optional half of KB: a backend that can apply a
+// patch only if the note still hashes to what the caller verified. remoteKB
+// implements it by passing expectedHash to trip2g, which compares against the
+// live content inside the same atomic mutation. A KB without it (FileKB, test
+// doubles) is patched unconditionally, as before.
+type conditionalPatcher interface {
+	PatchIfUnchanged(ctx context.Context, path, find, replace, expectedHash string) error
+}
+
+// contentHash mirrors trip2g's hashContent (internal/case/updatenotes) byte for
+// byte — base64 URL encoding of the SHA-256 of the raw content. The two are
+// pinned to the same golden value from both sides; see TestContentHashGolden
+// here and its twin in the updatenotes tests. A silent drift between them would
+// turn every conditional patch into a hash mismatch.
+func contentHash(content string) string {
+	sum := sha256.Sum256([]byte(content))
+	return base64.URLEncoding.EncodeToString(sum[:])
 }
 
 // checkPatchNotRoleAuthoring denies a patch that would leave a role note behind,
@@ -181,16 +206,21 @@ func (s *ScopedKB) Patch(ctx context.Context, path, find, replace string) error 
 // The read goes through the underlying KB, not this ScopedKB, on purpose: a
 // role may hold write scope over a path without read scope, and the guard must
 // not be defeated by the role's own read_patterns.
-func (s *ScopedKB) checkPatchNotRoleAuthoring(ctx context.Context, path, find, replace string) error {
+// It returns the hash of the exact bytes it verified, so the caller can make the
+// mutation conditional on them and close the window between checking and
+// patching. A nil hash means nothing was verified (the guard is off), not that
+// the content hashed to the empty string.
+func (s *ScopedKB) checkPatchNotRoleAuthoring(ctx context.Context, path, find, replace string) (*string, error) {
 	if s.allowRoleAuthoring {
-		return nil
+		return nil, nil
 	}
 	current, err := s.kb.Read(ctx, path)
 	if err != nil {
-		return fmt.Errorf("%w: %w", ErrRoleGuardUnverifiable, err)
+		return nil, fmt.Errorf("%w: %w", ErrRoleGuardUnverifiable, err)
 	}
 	if declaresRole(current) || declaresRole(applyPatchPreview(current, find, replace)) {
-		return ErrRoleAuthoringDenied
+		return nil, ErrRoleAuthoringDenied
 	}
-	return nil
+	hash := contentHash(current)
+	return &hash, nil
 }

--- a/cmd/fleet/internal/agentruntime/scope_conditional_test.go
+++ b/cmd/fleet/internal/agentruntime/scope_conditional_test.go
@@ -1,0 +1,76 @@
+package agentruntime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// goldenHashOfHello pins fleet's contentHash to trip2g's hashContent
+// (internal/case/updatenotes). The same constant is asserted from the trip2g
+// side in that package's tests: the two implementations are independent, and a
+// silent drift would turn every conditional patch into a hash mismatch — a
+// failure that would look like a concurrency problem, not like a bug here.
+const goldenHashOfHello = "LPJNul-wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ="
+
+func TestContentHashGolden(t *testing.T) {
+	require.Equal(t, goldenHashOfHello, contentHash("hello"))
+}
+
+type conditionalKB struct {
+	KB
+	gotHash   string
+	gotCalled bool
+	plainCall bool
+}
+
+func (c *conditionalKB) PatchIfUnchanged(_ context.Context, _, _, _, expectedHash string) error {
+	c.gotCalled = true
+	c.gotHash = expectedHash
+	return nil
+}
+
+func (c *conditionalKB) Patch(context.Context, string, string, string) error {
+	c.plainCall = true
+	return nil
+}
+
+// The hash must be of the exact bytes the guard verified, so trip2g rejects the
+// patch if anything moved in between.
+func TestScopedKB_PatchIsConditionalOnVerifiedBytes(t *testing.T) {
+	const body = "hello world\n"
+	kb := &conditionalKB{KB: newMemKB(map[string]string{"notes/plain.md": body})}
+	scoped := NewScopedKB(kb, nil, []string{"**"})
+
+	require.NoError(t, scoped.Patch(context.Background(), "notes/plain.md", "world", "there"))
+
+	require.True(t, kb.gotCalled, "a hash-capable KB must get the conditional patch")
+	require.False(t, kb.plainCall, "the unconditional path must not be used")
+	require.Equal(t, contentHash(body), kb.gotHash)
+}
+
+// With the guard off there is no verification read, so there is no hash to
+// condition on and the plain path is correct.
+func TestScopedKB_PatchUnconditionalWhenGuardOff(t *testing.T) {
+	kb := &conditionalKB{KB: newMemKB(map[string]string{"notes/plain.md": "hello\n"})}
+	scoped := NewScopedKB(kb, nil, []string{"**"})
+	scoped.allowRoleAuthoring = true
+
+	require.NoError(t, scoped.Patch(context.Background(), "notes/plain.md", "hello", "bye"))
+
+	require.False(t, kb.gotCalled)
+	require.True(t, kb.plainCall)
+}
+
+// A KB that cannot do conditional patches still works.
+func TestScopedKB_PatchFallsBackWithoutConditionalSupport(t *testing.T) {
+	kb := newMemKB(map[string]string{"notes/plain.md": "hello world\n"})
+	scoped := NewScopedKB(kb, nil, []string{"**"})
+
+	require.NoError(t, scoped.Patch(context.Background(), "notes/plain.md", "world", "there"))
+
+	got, err := kb.Read(context.Background(), "notes/plain.md")
+	require.NoError(t, err)
+	require.Equal(t, "hello there\n", got)
+}

--- a/cmd/fleet/internal/fleet/remotekb.go
+++ b/cmd/fleet/internal/fleet/remotekb.go
@@ -14,11 +14,12 @@ import (
 
 // JSON map keys used in the hybrid UpdateNotesScoped variables.
 const (
-	jsonKeyPath    = "path"
-	jsonKeyContent = "content"
-	jsonKeyFind    = "find"
-	jsonKeyReplace = "replace"
-	jsonKeyChanges = "changes"
+	jsonKeyPath         = "path"
+	jsonKeyContent      = "content"
+	jsonKeyFind         = "find"
+	jsonKeyReplace      = "replace"
+	jsonKeyExpectedHash = "expectedHash"
+	jsonKeyChanges      = "changes"
 )
 
 // remoteKB is the fleet's agentruntime.KB over the trip2g API, scoped to a
@@ -91,6 +92,30 @@ func (k *remoteKB) Patch(ctx context.Context, path, find, replace string) error 
 	}
 	// Best-effort overlay sync: keep in-memory view consistent so a subsequent
 	// Read in the same run is served from cache without a remote round-trip.
+	if cur, ok := k.overlay[path]; ok {
+		k.overlay[path] = replaceOnce(cur, find, replace)
+	}
+	return nil
+}
+
+// PatchIfUnchanged applies a patch only if the note still hashes to
+// expectedHash, letting trip2g compare against the live content inside the same
+// atomic mutation (internal/case/updatenotes applies the check and the edit
+// together). That closes the window between the caller verifying a note and the
+// edit landing — including the case where Read was served from the overlay,
+// which is seeded once per delivery and never refreshed: stale bytes now produce
+// a loud hash mismatch instead of an unverified write.
+func (k *remoteKB) PatchIfUnchanged(ctx context.Context, path, find, replace, expectedHash string) error {
+	if err := k.update(ctx, []map[string]any{
+		{"patch": map[string]any{
+			jsonKeyPath:         path,
+			jsonKeyFind:         find,
+			jsonKeyReplace:      replace,
+			jsonKeyExpectedHash: expectedHash,
+		}},
+	}); err != nil {
+		return err
+	}
 	if cur, ok := k.overlay[path]; ok {
 		k.overlay[path] = replaceOnce(cur, find, replace)
 	}

--- a/docs/dev/fleet_write_validation.md
+++ b/docs/dev/fleet_write_validation.md
@@ -155,6 +155,26 @@ forms).
   fleet-wide for operators who do want agents managing roles. It logs a WARN at
   startup when off, because a guard silently disabled is worse than none.
 
+The patch is conditional on the bytes that were verified. `ScopedKB` hashes the
+content it read and `remoteKB.PatchIfUnchanged` sends it as `expectedHash`, so
+trip2g compares against the live note inside the same atomic mutation
+(`internal/case/updatenotes`). Without it the guard verified one version and
+trip2g patched whatever was current — a window that is wider than a race, because
+`remoteKB.Read` is served from an overlay seeded once per delivery and never
+refreshed. Stale bytes now produce a loud hash mismatch instead of an unverified
+write. A concurrent edit therefore fails the run, which is the intended trade.
+
+fleet computes the hash itself rather than asking for it, so no schema or query
+changed; the two implementations are tied together by a golden value asserted from
+both sides (`TestContentHashGolden` / `TestHashContentGolden`), because a silent
+drift would look like a concurrency fault rather than a bug. A KB without the
+optional `conditionalPatcher` interface (`FileKB`, test doubles) is patched
+unconditionally, as before.
+
+Future: the overlay could carry the hash of what fleet last wrote, making a
+write-then-patch of the same note in one run conditional too. Not needed yet — a
+role doing that is better rewritten.
+
 This closes authorship, not the underlying property that a role declares its own
 scope. A human-authored role still does — which is intended: the point is that
 only humans mint roles.

--- a/internal/case/updatenotes/hash_golden_test.go
+++ b/internal/case/updatenotes/hash_golden_test.go
@@ -1,0 +1,17 @@
+package updatenotes
+
+import "testing"
+
+// goldenHashOfHello pins the wire format of expectedHash. fleet computes this
+// value independently (cmd/fleet/internal/agentruntime, contentHash) so it can
+// make a patch conditional on the exact bytes it verified. The two
+// implementations never meet in code, so they are tied together here: changing
+// the algorithm or the encoding on either side breaks this test rather than
+// silently turning every conditional patch into a hash mismatch.
+const goldenHashOfHello = "LPJNul-wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ="
+
+func TestHashContentGolden(t *testing.T) {
+	if got := hashContent([]byte("hello")); got != goldenHashOfHello {
+		t.Fatalf("hashContent drifted from the value fleet computes:\n got %q\nwant %q", got, goldenHashOfHello)
+	}
+}


### PR DESCRIPTION
**Stacked on #316** — base it there, or merge #316 first.

The role guard verifies a note, then trip2g patches whatever is current. Nothing tied
the two together, so the bytes checked and the bytes changed could differ.

This is wider than a race window: `remoteKB.Read` is served from an overlay seeded
once from the delivery payload and never refreshed
(`cmd/fleet/internal/fleet/remotekb.go:61`), shared across every fanned-out item, so
the guard's view can be stale for the whole lifetime of a delivery. And
`remoteKB.Patch` sent no `expectedHash`, so trip2g applied no concurrency check
either.

## The fix

`ScopedKB` now hashes the exact content it verified and passes it down;
`remoteKB.PatchIfUnchanged` sends it as `expectedHash`, and trip2g compares against
the live note **inside the same atomic mutation**
(`internal/case/updatenotes/resolve.go:254`). Either the bytes the guard approved are
the bytes that change, or the patch fails loudly.

Stale overlay content is fixed by the same mechanism without touching the overlay: a
hash of stale bytes simply mismatches.

## Cost

Nothing new was built on either side — both halves already existed and were never
connected. trip2g has accepted `expectedHash` on patches all along, and fleet already
mapped `UpdateNotesHashMismatchPayload` to an error (`remotekb.go:132`). Since
`hashContent` is `base64url(sha256(content))` over the raw note, fleet computes it from
the bytes it already read: **no schema change, no query change, no extra round trip.**

`KB` is not broken either. The capability is an optional interface:

```go
type conditionalPatcher interface {
    PatchIfUnchanged(ctx context.Context, path, find, replace, expectedHash string) error
}
```

`remoteKB` implements it; `FileKB` and test doubles are untouched and keep the
unconditional path. With the guard disabled there is no verification read, hence no
hash to condition on, and the plain path is used.

## Accepted trade

A concurrent edit now fails the run instead of silently patching unverified content.
That is the intended behaviour.

## Keeping the two hashes honest

fleet's `contentHash` and trip2g's `hashContent` are independent implementations that
never meet in code. They are pinned to the same golden value from both sides —
`TestContentHashGolden` in agentruntime and `TestHashContentGolden` in updatenotes — so
changing the algorithm or the encoding on either side breaks a test instead of turning
every conditional patch into a hash mismatch that reads like a concurrency fault.

## Future

The overlay could carry the hash of what fleet last wrote, making a write-then-patch of
the same note within one run conditional as well. Not needed yet.
