### PR TITLE
feat(fleet): deliver a role's own frontmatter in the input bag

### DIFF
--- a/cmd/codellm/fleetkit/fleetkit.py
+++ b/cmd/codellm/fleetkit/fleetkit.py
@@ -22,7 +22,16 @@ import os
 
 import yaml
 
-__all__ = ["render", "note", "write", "patch", "emit", "bag", "note_frontmatter"]
+__all__ = [
+    "render",
+    "note",
+    "write",
+    "patch",
+    "emit",
+    "bag",
+    "frontmatter",
+    "note_frontmatter",
+]
 
 
 def render(meta, body=""):
@@ -72,6 +81,19 @@ class Frontmatter(dict):
 
     def __getattr__(self, name):
         return self.get(name)
+
+
+def frontmatter():
+    """The role note's OWN frontmatter, as an attribute-access mapping.
+
+    This is the role's configuration — thresholds, target folders, endpoints —
+    read from the note that declares it instead of hardcoded in the body. Values
+    are strings: trip2g stringifies note meta, so `max: 3` arrives as "3".
+
+    Returns an empty mapping outside a delivery, so `frontmatter().whatever`
+    reads as None rather than raising.
+    """
+    return Frontmatter(bag().get("frontmatter") or {})
 
 
 def note_frontmatter(path):

--- a/cmd/codellm/fleetkit/node/index.js
+++ b/cmd/codellm/fleetkit/node/index.js
@@ -77,6 +77,15 @@ function parse_frontmatter(content) {
  * changed_files. A path the bag does not carry is a role misconfiguration, not
  * a finding, so it throws rather than reading as a note with no fields.
  */
+/**
+ * The role note's OWN frontmatter — its configuration, read from the note that
+ * declares it instead of hardcoded in the body. Values are strings: trip2g
+ * stringifies note meta, so `max: 3` arrives as "3". Empty outside a delivery.
+ */
+function frontmatter() {
+  return bag().frontmatter || {};
+}
+
 function note_frontmatter(path) {
   const b = bag();
   for (const key of ['attached_notes', 'changed_files']) {
@@ -89,4 +98,7 @@ function note_frontmatter(path) {
   );
 }
 
-module.exports = { render, note, write, patch, emit, bag, note_frontmatter, parse_frontmatter };
+module.exports = {
+  render, note, write, patch, emit, bag,
+  frontmatter, note_frontmatter, parse_frontmatter,
+};

--- a/cmd/codellm/internal/coderun/fleetkit_behaviour_test.go
+++ b/cmd/codellm/internal/coderun/fleetkit_behaviour_test.go
@@ -257,3 +257,57 @@ func TestFleetkitRuns_ParseFrontmatter(t *testing.T) {
 		})
 	}
 }
+
+// pyRoleFrontmatter / jsRoleFrontmatter exercise frontmatter(): the role's own
+// config, read from the delivery bag. Each probe writes its own bag and points
+// FLEET_INPUT at it, since bag() resolves the env var per call.
+const pyRoleFrontmatter = `
+import json, os, tempfile, fleetkit
+
+path = os.path.join(tempfile.mkdtemp(), "bag.json")
+with open(path, "w") as fh:
+    json.dump({"frontmatter": {"krisp_base_url": "https://api.krisp.ai", "max": "3"}}, fh)
+os.environ["FLEET_INPUT"] = path
+
+fm = fleetkit.frontmatter()
+print(json.dumps({"url": fm.krisp_base_url, "max": fm.max, "missing": fm.nope}))
+`
+
+const jsRoleFrontmatter = `
+const fs = require('fs'), os = require('os'), path = require('path');
+const fleetkit = require('fleetkit');
+
+const p = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'bag')), 'bag.json');
+fs.writeFileSync(p, JSON.stringify({frontmatter: {krisp_base_url: 'https://api.krisp.ai', max: '3'}}));
+process.env.FLEET_INPUT = p;
+
+const fm = fleetkit.frontmatter();
+console.log(JSON.stringify({url: fm.krisp_base_url, max: fm.max, missing: fm.nope ?? null}));
+`
+
+func TestFleetkitRuns_RoleFrontmatter(t *testing.T) {
+	cases := []struct {
+		name string
+		run  func(*testing.T, string) string
+		src  string
+	}{
+		{"python", runPython, pyRoleFrontmatter},
+		{"node", runNode, jsRoleFrontmatter},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got struct {
+				URL     string `json:"url"`
+				Max     string `json:"max"`
+				Missing any    `json:"missing"`
+			}
+			out := tc.run(t, tc.src)
+			require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &got), "stdout: %q", out)
+
+			require.Equal(t, "https://api.krisp.ai", got.URL)
+			require.Equal(t, "3", got.Max, "trip2g stringifies note meta; values arrive as text")
+			require.Nil(t, got.Missing, "a missing key must read as empty, not raise")
+		})
+	}
+}

--- a/cmd/codellm/internal/coderun/fleetkit_test.go
+++ b/cmd/codellm/internal/coderun/fleetkit_test.go
@@ -24,7 +24,7 @@ const (
 func fleetkitAPI() []string {
 	return []string{
 		"render", "note", "write", "patch", "emit", "bag",
-		"note_frontmatter", "parse_frontmatter",
+		"frontmatter", "note_frontmatter", "parse_frontmatter",
 	}
 }
 

--- a/cmd/fleet/internal/fleet/handler.go
+++ b/cmd/fleet/internal/fleet/handler.go
@@ -170,7 +170,7 @@ func (f *Fleet) serveChangeDelivery(w http.ResponseWriter, r *http.Request, role
 			Instr:    instruction,
 			GQL:      NewScopedGraphQLClient(f.cfg.Trip2gBaseURL, payload.APIToken, f.hc),
 			Overlay:  overlay,
-			InputBag: buildInputBag(rc),
+			InputBag: buildInputBag(role, rc),
 			Item:     fanOutItem(len(items), i),
 		})
 		if runErr != nil {
@@ -234,8 +234,14 @@ func (f *Fleet) serveChangeDelivery(w http.ResponseWriter, r *http.Request, role
 // to code programs via $FLEET_INPUT. It carries only non-secret trigger data
 // (the same fields exposed to Jet templates). The scoped write token is never
 // included.
-func buildInputBag(rc renderCtx) []byte {
-	bag := fleetinput.Input{ChangedFiles: rc.ChangedFiles, ChangeFile: rc.ChangeFile, AttachedNotes: rc.AttachedNotes, Depth: rc.Depth}
+func buildInputBag(role Role, rc renderCtx) []byte {
+	bag := fleetinput.Input{
+		Frontmatter:   role.Frontmatter,
+		ChangedFiles:  rc.ChangedFiles,
+		ChangeFile:    rc.ChangeFile,
+		AttachedNotes: rc.AttachedNotes,
+		Depth:         rc.Depth,
+	}
 	data, _ := json.Marshal(bag)
 	return data
 }
@@ -333,7 +339,7 @@ func (f *Fleet) serveCronDelivery(w http.ResponseWriter, r *http.Request, role R
 		Instr:    instruction,
 		GQL:      NewScopedGraphQLClient(f.cfg.Trip2gBaseURL, payload.APIToken, f.hc),
 		Overlay:  overlay,
-		InputBag: buildCronInputBag(rc),
+		InputBag: buildCronInputBag(role, rc),
 	})
 	if runErr != nil {
 		//nolint:sloglint // Fleet has no logger instance; global slog is intentional here
@@ -357,9 +363,14 @@ func (f *Fleet) serveCronDelivery(w http.ResponseWriter, r *http.Request, role R
 
 // buildCronInputBag marshals the cron render context into the JSON bag delivered
 // to code programs via $FLEET_INPUT. Exposes now as an RFC3339 string.
-func buildCronInputBag(rc renderCtx) []byte {
+func buildCronInputBag(role Role, rc renderCtx) []byte {
 	now := rc.Now.Format(time.RFC3339)
-	bag := fleetinput.Input{AttachedNotes: rc.AttachedNotes, Depth: rc.Depth, Now: &now}
+	bag := fleetinput.Input{
+		Frontmatter:   role.Frontmatter,
+		AttachedNotes: rc.AttachedNotes,
+		Depth:         rc.Depth,
+		Now:           &now,
+	}
 	data, _ := json.Marshal(bag)
 	return data
 }

--- a/cmd/fleet/internal/fleet/inputbag_test.go
+++ b/cmd/fleet/internal/fleet/inputbag_test.go
@@ -1,0 +1,73 @@
+package fleet
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trip2g/internal/fleetinput"
+)
+
+func decodeBag(t *testing.T, raw []byte) fleetinput.Input {
+	t.Helper()
+	var bag fleetinput.Input
+	require.NoError(t, json.Unmarshal(raw, &bag))
+	return bag
+}
+
+// A role's own frontmatter travels in the bag, so code can read its
+// configuration from the note that declares it instead of hardcoding it in the
+// body.
+func TestBuildInputBag_CarriesRoleFrontmatter(t *testing.T) {
+	role, err := ParseRole("roles/ingest.md", "body", map[string]string{
+		"fleet_id":       "codellm",
+		"mode":           "cron",
+		"cron_schedule":  "* * * * *",
+		"krisp_base_url": "https://api.krisp.ai",
+	})
+	require.NoError(t, err)
+
+	bag := decodeBag(t, buildInputBag(role, renderCtx{Depth: 1}))
+
+	require.Equal(t, "https://api.krisp.ai", bag.Frontmatter["krisp_base_url"])
+	require.Equal(t, "codellm", bag.Frontmatter["fleet_id"])
+	require.Equal(t, 1, bag.Depth)
+}
+
+func TestBuildCronInputBag_CarriesRoleFrontmatter(t *testing.T) {
+	role, err := ParseRole("roles/ingest.md", "body", map[string]string{
+		"fleet_id":       "codellm",
+		"krisp_base_url": "https://api.krisp.ai",
+	})
+	require.NoError(t, err)
+
+	bag := decodeBag(t, buildCronInputBag(role, renderCtx{}))
+
+	require.Equal(t, "https://api.krisp.ai", bag.Frontmatter["krisp_base_url"])
+}
+
+// A role with no frontmatter must not produce a null map the other side has to
+// special-case.
+func TestBuildInputBag_EmptyFrontmatterIsAnEmptyMap(t *testing.T) {
+	role, err := ParseRole("roles/x.md", "body", map[string]string{})
+	require.NoError(t, err)
+
+	bag := decodeBag(t, buildInputBag(role, renderCtx{}))
+
+	require.NotNil(t, bag.Frontmatter)
+	require.Empty(t, bag.Frontmatter)
+}
+
+// ParseRole keeps the raw frontmatter, and keeps its OWN copy: discovery reuses
+// the map it builds per note, and a later mutation there must not reach into a
+// parsed Role.
+func TestParseRole_RetainsFrontmatterCopy(t *testing.T) {
+	meta := map[string]string{"fleet_id": "codellm", "custom": "one"}
+
+	role, err := ParseRole("roles/x.md", "body", meta)
+	require.NoError(t, err)
+
+	meta["custom"] = "two"
+	require.Equal(t, "one", role.Frontmatter["custom"])
+}

--- a/cmd/fleet/internal/fleet/role.go
+++ b/cmd/fleet/internal/fleet/role.go
@@ -11,8 +11,13 @@ import (
 
 // Role is a parsed role note: flat frontmatter (config) + body (instruction).
 type Role struct {
-	NotePath       string
-	Body           string
+	NotePath string
+	Body     string
+
+	// Frontmatter is the note's raw flat meta, kept whole so fields this struct
+	// does not model still reach the role's own code through the delivery bag.
+	Frontmatter map[string]string
+
 	FleetID        string // partition key: only the fleet whose --fleet-id matches processes this role
 	Model          string
 	Tools          []string
@@ -39,6 +44,7 @@ func ParseRole(notePath, body string, m map[string]string) (Role, error) {
 	r := Role{
 		NotePath:       notePath,
 		Body:           body,
+		Frontmatter:    copyMeta(m),
 		FleetID:        strings.TrimSpace(m["fleet_id"]),
 		Model:          strings.TrimSpace(m["model"]),
 		Tools:          parseList(m["tools"]),
@@ -67,6 +73,17 @@ func ParseRole(notePath, body string, m map[string]string) (Role, error) {
 		return Role{}, fmt.Errorf("timeout_seconds: %w", err)
 	}
 	return r, nil
+}
+
+// copyMeta clones the frontmatter map. Discovery builds one map per note and
+// the Role outlives that loop, so sharing it would let a later write reach into
+// an already-parsed Role.
+func copyMeta(m map[string]string) map[string]string {
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
 }
 
 // defaultTimeoutSeconds is the agent-run timeout applied when a role omits

--- a/docs/dev/unseal_codellm_secrets.md
+++ b/docs/dev/unseal_codellm_secrets.md
@@ -33,13 +33,27 @@ krisp_base_url: https://api.krisp.ai
 ```
 
 ```python
-fm = fleetkit.bag().frontmatter
-base_url = fm.krisp_base_url.rstrip('/')
-token = fm.krisp_token          # decrypted by codellm; ciphertext never reaches here
+cfg = fleetkit.frontmatter()      # the role's own frontmatter, ciphertext included
+sec = fleetkit.secrets()          # what codellm unsealed for this run
+
+base_url = cfg.krisp_base_url.rstrip('/')
+token = sec.krisp_token
 ```
 
-Secret and non-secret config read identically. There is no `unseal()` call in the role, no env
-var mapping, and no master key inside the sandbox.
+There is no `unseal()` call in the role, no env var mapping, and no master key inside the
+sandbox.
+
+**Decided: unsealed values go in their own `secrets` section, not inline in the frontmatter.**
+Inline would read more uniformly — `cfg.krisp_token` beside `cfg.krisp_base_url` — and that
+uniformity is why this design beat the alternatives in the first place. It loses to one thing:
+the bag is what a role dumps while debugging, and `print(cfg)` or `emit(answer=json.dumps(bag))`
+would publish the token into vault content, which is the store this whole feature exists to keep
+clean. A separate section costs one asymmetry in the role's source and takes the secret out of
+the object most likely to be dumped whole. The asymmetry is also honest: those two values are not
+the same kind of thing.
+
+Note what it does not buy: dumping the *whole bag* still carries the secrets. This narrows the
+accident, it does not remove it.
 
 ## The pivotal fact
 
@@ -209,7 +223,13 @@ blobs.
 2. **codellm** reads `unseal` from the bag, resolves `unseal_env_key` against **its own**
    environment, decrypts those fields, and replaces the ciphertext with plaintext in the bag it
    writes to `$FLEET_INPUT`.
-3. **The role's code** reads them as ordinary frontmatter through `fleetkit.bag().frontmatter`.
+3. **The role's code** reads config through `fleetkit.frontmatter()` and unsealed values through
+   `fleetkit.secrets()`. Both return the attribute-access mapping `fleetkit` already uses for
+   frontmatter, so a missing key reads as `None` instead of raising.
+
+The ciphertext stays in the frontmatter as it was written. codellm adds the plaintext alongside
+rather than substituting it, so a role can still tell that a value was sealed, and the bag's
+frontmatter section is a faithful view of the note.
 
 trip2g needs no change: it stores and serves the note like any other, ciphertext included.
 
@@ -460,9 +480,7 @@ which is exactly the provisioning ergonomics sealing exists to provide.
 
 ## Open questions
 
-- Whether the unsealed values should sit inline in the bag's frontmatter (chosen, for a uniform
-  read) or in a separate `bag.secrets` section that a wholesale dump is less likely to catch.
-  This is the debug-leak footgun above; the two goals are in direct tension.
+
 - Whether `unseal` should also be honoured on **attached** notes. **Answer: no, and the code
   already enforces it.** `buildAttachedNotes` (`internal/webhookutil/attached_notes.go`) constructs
   `Meta` explicitly from `tags` and `layout` only — arbitrary frontmatter never travels that path —
@@ -485,7 +503,7 @@ which is exactly the provisioning ergonomics sealing exists to provide.
   values. If anyone later adds the bag to `exec` calls, plaintext flows into a real model
   conversation and out to the provider.
 
-- Whether to bind the ciphertext to its location with AAD. `dataencryption` passes `nil` additional
+- ~~Whether to bind the ciphertext to its location with AAD.~~ **Decided: no AAD.** `dataencryption` passes `nil` additional
   data, so nothing ties a blob to the note and field it belongs to: anyone who can read a blob can
   paste it into their own role under the same key and have it decrypt — relocation, not a crypto
   break. The obvious binding is the note path, and it has a real cost: **renaming or moving a role
@@ -494,5 +512,12 @@ which is exactly the provisioning ergonomics sealing exists to provide.
   half-measure buys nothing. Note also that `EncryptData`/`DecryptData` take no AAD parameter and
   are shared with the `secrets` table and `cmd/tge2e`, so this means a new method beside them, not
   a change to them.
+
+  Rejected because the cost lands on an everyday operation and the benefit does not. Moving a note
+  between folders is routine in Obsidian, and binding to the path would break every blob in it
+  silently, at the next tick. What binding buys is preventing one role from copying another's
+  ciphertext — and under the pivotal fact the roles are written by the same person who owns the
+  secrets, so that is not an adversary. Revisit only if role authorship ever spreads beyond one
+  trusted party, which is the same condition that reopens the rest of this design.
 - What the `--dry-run` reconcile report should say about a role whose `unseal` field cannot be
   opened — a startup-time validation would catch a bad blob before its first cron tick.

--- a/internal/fleetinput/input.go
+++ b/internal/fleetinput/input.go
@@ -21,6 +21,13 @@ type AttachedNote struct {
 }
 
 type Input struct {
+	// Frontmatter is the role note's OWN frontmatter, as flat strings — trip2g
+	// stringifies note meta, so a numeric or boolean field arrives as its text
+	// form and nothing downstream should expect typed values. It lets a role read
+	// its configuration from the note that declares it instead of hardcoding it
+	// in the body.
+	Frontmatter map[string]string `json:"frontmatter"`
+
 	ChangedFiles  []ChangeInfo   `json:"changed_files"`
 	ChangeFile    *ChangeInfo    `json:"change_file,omitempty"`
 	AttachedNotes []AttachedNote `json:"attached_notes"`


### PR DESCRIPTION
First of two steps toward sealed secrets in role frontmatter
(`docs/dev/unseal_codellm_secrets.md`). This one carries no secrets and is useful on
its own: **a role can read its configuration from the note that declares it**, instead
of hardcoding it in the body.

```yaml
---
fleet_id: codellm
mode: cron
cron_schedule: "* * * * *"
krisp_base_url: https://api.krisp.ai
---
```

```python
cfg = fleetkit.frontmatter()
base_url = cfg.krisp_base_url.rstrip('/')
```

## What changed

- `fleetinput.Input` gains `frontmatter` — the shared bag contract between fleet and
  codellm, so it belongs in the package both already import.
- `Role` keeps the raw flat meta. `ParseRole` previously read the fields it models and
  dropped the map; fields it does not model now still reach the role's own code. The
  map is **copied**: discovery builds one per note in a loop, and a Role outlives that
  loop.
- `buildInputBag` / `buildCronInputBag` take the role and populate it.
- `fleetkit.frontmatter()` in both twins, python and node, returning the same
  attribute-access mapping the kit already uses — a missing key reads as `None`/`null`
  rather than raising.

## Values are strings

trip2g stringifies note meta (`noteViewResolver.Meta` renders each value with
`fmt.Sprintf("%v", …)`), so `max: 3` arrives as `"3"` and a YAML list arrives in its
bracketed text form. Documented on the field and asserted in the behaviour test, so
nothing downstream expects typed values.

## Not in this PR

Nothing about secrets: no `unseal`, no `unseal_env_key`, no `secrets` section, no
master key. The Jet render context is untouched too — `renderInstruction` still exposes
exactly four vars, so a role body cannot interpolate its own frontmatter, which keeps
the "no credential can leak into the instruction" property intact for the next step.

## Tests

Bag builders carry the frontmatter on both the change and cron paths; an empty
frontmatter serializes as `{}` rather than `null`, so the other side has no special
case; `ParseRole` keeps its own copy (mutating the caller's map afterwards does not
reach the Role). The fleetkit helper is exercised through its **real interpreter** in
both languages, not just pinned in source, and the API list both twins must keep
exporting is updated.
