### PR TITLE
fix(mcp): a gated federation KB-note is invisible to an API key

### DIFF
--- a/internal/case/mcp/federation_acl.go
+++ b/internal/case/mcp/federation_acl.go
@@ -24,7 +24,7 @@ func accessibleKBNotes(ctx context.Context, env federationACLEnv) ([]*model.MCPF
 			continue
 		}
 
-		ok, err := env.CanReadNote(ctx, kb.Note)
+		ok, err := canReadMCPNote(ctx, env, kb.Note)
 		if err != nil {
 			return nil, fmt.Errorf("check federation kb-note access: %w", err)
 		}

--- a/internal/case/mcp/federation_acl_test.go
+++ b/internal/case/mcp/federation_acl_test.go
@@ -44,6 +44,63 @@ func TestAccessibleKBNotes(t *testing.T) {
 	require.Equal(t, allowedNote, got[0].Note)
 }
 
+// An API key is admin everywhere else on the MCP surface (canReadMCPNote), and
+// a KB-note is a note like any other. Before this test accessibleKBNotes called
+// CanReadNote directly, so a KB-note without free: true was invisible to an
+// API-keyed caller and every federated_* call on it answered
+// federation_not_configured — the same "not configured" a kb_id that does not
+// exist gets, which is why it read as a routing problem rather than an ACL one.
+func TestAccessibleKBNotesAPIKeySeesGatedKBNote(t *testing.T) {
+	gated := &model.NoteView{PathID: 1, MCPFederationKBURL: "https://gated.example/_system/mcp"}
+	nvs := model.NewNoteViews()
+	nvs.MCPFederationNotes = []*model.MCPFederationNote{model.NewMCPFederationNote(gated)}
+
+	env := federationACLEnvMock{
+		noteViews: nvs,
+		canReadFunc: func(ctx context.Context, note *model.NoteView) (bool, error) {
+			return false, errors.New("CanReadNote must not decide for an API key")
+		},
+	}
+
+	got, err := accessibleKBNotes(contextWithMCPAPIKeyAuth(context.Background(), false), env)
+
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, gated, got[0].Note)
+}
+
+func TestAccessibleKBNotesFederatedPeerKeepsItsSubgraphScope(t *testing.T) {
+	inScope := &model.NoteView{
+		PathID:             1,
+		SubgraphNames:      []string{"shared"},
+		MCPFederationKBURL: "https://in.example/_system/mcp",
+	}
+	outOfScope := &model.NoteView{
+		PathID:             2,
+		SubgraphNames:      []string{"private"},
+		MCPFederationKBURL: "https://out.example/_system/mcp",
+	}
+	nvs := model.NewNoteViews()
+	nvs.MCPFederationNotes = []*model.MCPFederationNote{
+		model.NewMCPFederationNote(inScope),
+		model.NewMCPFederationNote(outOfScope),
+	}
+
+	env := federationACLEnvMock{
+		noteViews: nvs,
+		canReadFunc: func(ctx context.Context, note *model.NoteView) (bool, error) {
+			return false, errors.New("CanReadNote must not decide for a federated peer")
+		},
+	}
+	ctx := contextWithFederationAuth(context.Background(), "peer", []string{"shared"})
+
+	got, err := accessibleKBNotes(ctx, env)
+
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, inScope, got[0].Note)
+}
+
 func TestAccessibleKBNotesReturnsCanReadError(t *testing.T) {
 	wantErr := errors.New("boom")
 	note := &model.NoteView{PathID: 1, MCPFederationKBURL: "https://allowed.example/_system/mcp"}

--- a/internal/case/mcp/resolve.go
+++ b/internal/case/mcp/resolve.go
@@ -381,7 +381,14 @@ func FederationDepthFromContext(ctx context.Context) int {
 	return depth
 }
 
-func canReadMCPNote(ctx context.Context, env Env, note *model.NoteView) (bool, error) {
+// mcpNoteReader is the only thing canReadMCPNote needs from an env, so every
+// caller on the MCP surface can reach it — including accessibleKBNotes, whose
+// own env is narrower than Env.
+type mcpNoteReader interface {
+	CanReadNote(ctx context.Context, note *model.NoteView) (bool, error)
+}
+
+func canReadMCPNote(ctx context.Context, env mcpNoteReader, note *model.NoteView) (bool, error) {
 	if mcpAPIKeyAuthed(ctx) {
 		return true, nil // API key = admin, sees all notes
 	}


### PR DESCRIPTION
A KB-note that is not `free: true` is invisible to an API-key caller, so every
`federated_*` call routed through it answers `federation_not_configured` — the
same answer a `kb_id` that does not exist gets. That reads as a routing or
registration problem, which is why it took a while to place: the note is there,
the outbound secret is there, and the peer is reachable.

The cause is one call site. `canReadMCPNote` is the MCP surface's note ACL, and
its first branch is `if mcpAPIKeyAuthed(ctx) { return true }` — an API key is
admin and sees every note. Eight call sites in the package go through it.
`accessibleKBNotes` is the ninth and calls `env.CanReadNote` directly, so the
KB-note filter falls back to guest rules while `search` in the same request,
with the same key, returns notes from gated subgraphs.

Reproduced against a running instance: with a valid API key, `search` returns a
note in a private subgraph, while `federated_search` on a KB-note without
`free: true` answers `federation_not_configured`. Adding `free: true` to the
KB-note alone makes it work, which is the workaround this removes the need for.

## The change

- `accessibleKBNotes` calls `canReadMCPNote` instead of `env.CanReadNote`.
- `canReadMCPNote` takes an interface with just `CanReadNote` rather than the
  full `Env`, which is all its body ever used and is what lets federation's
  narrower env reach it.

Federated peers are unaffected by design and by test: `canReadMCPNote`'s second
branch already sends them to `ResolveWithSubgraphs`, so a peer's `kid` still
sees only KB-notes its granted subgraphs cover.

## Tests

Two added, both verified to fail without the one-line change:

- `TestAccessibleKBNotesAPIKeySeesGatedKBNote` — an API-keyed caller reaches a
  KB-note whose `CanReadNote` would refuse.
- `TestAccessibleKBNotesFederatedPeerKeepsItsSubgraphScope` — a peer scoped to
  one subgraph still gets only the KB-note in it.

Both mocks make `CanReadNote` return an error, so a regression that reintroduces
the direct call fails loudly rather than passing by coincidence.

`go test ./...` is green.
