### PR TITLE
feat(admin): the outbound form carries the rotation switch, on by default

### DIFF
--- a/assets/ui/admin/federation/federation.view.tree.locale=ru.json
+++ b/assets/ui/admin/federation/federation.view.tree.locale=ru.json
@@ -34,5 +34,7 @@
 	"$trip2g_admin_federation_show_OutboundScopeNote_title": "Выдано пиром",
 	"$trip2g_admin_federation_button_rotate_title": "Ротировать ключ",
 	"$trip2g_admin_federation_show_OutboundScopeName_title": "Подграф",
-	"$trip2g_admin_federation_show_OutboundScopeAbout_title": "Что это"
+	"$trip2g_admin_federation_show_OutboundScopeAbout_title": "Что это",
+	"$trip2g_admin_federation_outbound_Rotate_field_name": "Заменить ключ перед сохранением",
+	"$trip2g_admin_federation_outbound_Rotate_field_hint": "По умолчанию включено. Присланный ключ уже прошёл через чат, поэтому хаб просит пира принять свежий и сохраняет именно его. Выключайте только для пира, который ротацию не умеет: публичной базы или адаптера."
 }

--- a/assets/ui/admin/federation/outbound/outbound.view.tree
+++ b/assets/ui/admin/federation/outbound/outbound.view.tree
@@ -23,6 +23,12 @@ $trip2g_admin_federation_outbound $mol_page
 					bid <= kb_url_bid \
 					Content <= kb_url_control $mol_string
 						value? <=> kb_url? \
+				<= Rotate_field $mol_form_field
+					name @ \Replace the key before storing it
+					hint @ \On by default. The key you were sent has been through a chat, so this asks the peer to adopt a fresh one and stores that instead. Turn it off only for a peer that cannot rotate: a public base, or an adapter.
+					bid <= rotate_bid \
+					Content <= rotate_control $mol_check_box
+						checked? <=> rotate? true
 				<= Description_field $mol_form_field
 					name @ \Description
 					bid <= description_bid \

--- a/assets/ui/admin/federation/outbound/outbound.view.ts
+++ b/assets/ui/admin/federation/outbound/outbound.view.ts
@@ -10,11 +10,13 @@ namespace $.$$ {
 			const res = $trip2g_admin_federation_outbound_create({
 				input: key ? {
 					key,
+					rotate: this.rotate(),
 					description: this.description() || null,
 				} : {
 					kid: this.kid(),
 					secretHex: this.secret_hex(),
 					kbURL: this.kb_url(),
+					rotate: this.rotate(),
 					description: this.description() || null,
 				},
 			})


### PR DESCRIPTION
Closes the gap the user documentation already admits: `rotate` exists on
`createOutboundFederationSecret`, but the admin form had no control for it, so a
peer that cannot rotate could only be installed through the API.

That case is real, not hypothetical. A public base holds no secret at all, and an
adapter speaks the same auth without implementing rotation; both answer the
rotation call with a refusal, and with rotation forced on, the form refuses to
store anything for them.

On by default, because the default is the safe one: the key an operator was sent
has been through a chat window, and storing it as the live credential is the
thing rotation exists to prevent. The hint under the field says when to turn it
off rather than leaving the reader to infer it from a failure.

Also removes the last reason the documentation had to send an operator to the
API for an ordinary install.