### PR TITLE
fix(e2e): re-apply the krisp fleet_id alignment reverted by ceec53ec

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -558,8 +558,9 @@ services:
   # Second fleet, dedicated to executor:code roles, pointed at codellm. Per the
   # per-provider-fleet model (docs/dev/codellm_extraction.md P3): one fleet serves
   # one LLM endpoint, and codellm is "just a fleet whose --llm-base-url points at
-  # the codellm service". Its FLEET_ID (e2ec) partitions role discovery — it only
-  # processes roles tagged `fleet_id: e2ec` (the krisp ingest role), while the
+  # the codellm service". Its FLEET_ID (codellm) partitions role discovery — it
+  # only processes roles tagged `fleet_id: codellm` (the krisp ingest role, as
+  # shipped in docs/fleet/krisp/roles/transcript-ingest.md), while the
   # llm-mock `fleet` (e2e) owns the transcript-agent LLM role.
   #
   # This fleet holds NO secret values and sends nothing about env. codellm (which
@@ -580,7 +581,7 @@ services:
     ports:
       - "29094:9090"
     environment:
-      - TRIP2G_FLEET_FLEET_ID=llmcode
+      - TRIP2G_FLEET_FLEET_ID=codellm
       - TRIP2G_FLEET_LISTEN=:9090
       - TRIP2G_FLEET_CALLBACK_URL=http://fleet-code:9090
       - TRIP2G_FLEET_TRIP2G_URL=http://app:20081

--- a/e2e/krisp-ingest.spec.js
+++ b/e2e/krisp-ingest.spec.js
@@ -136,7 +136,7 @@ test.describe.serial('Krisp cron ingest (dockerized)', () => {
             query { admin { allCronWebhooks { nodes { description } } } }
           `);
           return d.admin.allCronWebhooks.nodes.some(n =>
-            n.description.startsWith('fleetcron:e2ec:' + ROLE_PATH + '#'),
+            n.description.startsWith('fleetcron:codellm:' + ROLE_PATH + '#'),
           );
         },
         { timeout: 30000, intervals: [1000] },
@@ -150,7 +150,7 @@ test.describe.serial('Krisp cron ingest (dockerized)', () => {
       query { admin { allCronWebhooks { nodes { id description } } } }
     `);
     const cronWebhook = wh.admin.allCronWebhooks.nodes.find(n =>
-      n.description.startsWith('fleetcron:e2ec:' + ROLE_PATH + '#'),
+      n.description.startsWith('fleetcron:codellm:' + ROLE_PATH + '#'),
     );
     expect(cronWebhook, 'fleet cron webhook must be registered').toBeTruthy();
 


### PR DESCRIPTION
ceec53ec (screenshot-target guard) accidentally reverted its direct parent 9d214ae9 — its hunks are the byte-exact inverse, likely a stale-tree mishap. Since then the krisp ingest chain disagrees three ways: role note `fleet_id: codellm`, compose `TRIP2G_FLEET_FLEET_ID=llmcode`, spec polling `fleetcron:e2ec:`. Fleet discovery filters by exact id, so the seeded role is never picked up and the krisp-ingest e2e (no skip guard) cannot pass — the e2e suite has not been green since 2026-08-20.

This re-applies 9d214ae9 verbatim (clean cherry-pick). Found in the weekly review (#328), finding 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VP3Z8whPxpMtKxqNRnwdQL