### PR TITLE
Keep the reader on the host they are already on

### DIFF
--- a/internal/case/rendernotepage/domain_self_links_test.go
+++ b/internal/case/rendernotepage/domain_self_links_test.go
@@ -1,0 +1,54 @@
+package rendernotepage_test
+
+import (
+	"net/http"
+	"regexp"
+	"testing"
+
+	"trip2g/internal/mdloader"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A page served on host H must not contain absolute links back to H.
+// The reader is already there: sending them away and back is a wasted round
+// trip at best, and at worst a link to a name they cannot reach -- a staging
+// copy, a preview deployment, a host reachable only from outside.
+//
+// Body and chrome are rendered through different paths, so this asserts the
+// property of the whole response rather than of one element in it.
+func TestServedPage_HasNoAbsoluteLinksToItsOwnHost(t *testing.T) {
+	const host = "docs.example.com"
+
+	views := loadTestVault(t, []mdloader.SourceFile{
+		{
+			Path:    "site-nav.md",
+			Content: []byte("---\nfree: true\n---\n- [[note-b]]\n- [[note-c]]"),
+		},
+		{
+			Path:    "note-a.md",
+			Content: []byte("---\nfree: true\nroute: " + host + "/a\nheader: site-nav.md\n---\nBody: [[note-b]] and [[note-c]]"),
+		},
+		{
+			Path:    "note-b.md",
+			Content: []byte("---\nfree: true\nroute: " + host + "/b\n---\nPage B"),
+		},
+		{
+			Path:    "note-c.md",
+			Content: []byte("---\nfree: true\nroute: " + host + "\n---\nPage C"),
+		},
+	})
+
+	env, _, _ := cacheTestEnv(views, nil)
+
+	ctx := newReqCtx(reqOpts{host: host, path: "/a"})
+	runHandle(t, env, ctx, nil)
+	require.Equal(t, http.StatusOK, ctx.Response.StatusCode())
+
+	page := string(body(t, ctx))
+
+	selfAbsolute := regexp.MustCompile(`href="https?://` + regexp.QuoteMeta(host) + `[/"]`)
+	found := selfAbsolute.FindAllString(page, -1)
+	require.Empty(t, found,
+		"page served on %s links back to %s with an absolute URL: %v", host, host, found)
+}

--- a/internal/case/rendernotepage/domain_self_links_test.go
+++ b/internal/case/rendernotepage/domain_self_links_test.go
@@ -17,6 +17,9 @@ import (
 //
 // Body and chrome are rendered through different paths, so this asserts the
 // property of the whole response rather than of one element in it.
+//
+// Navigation only: rel=canonical, og:url and JSON-LD are absolute by their
+// own specifications and are excluded on purpose.
 func TestServedPage_HasNoAbsoluteLinksToItsOwnHost(t *testing.T) {
 	const host = "docs.example.com"
 
@@ -47,7 +50,7 @@ func TestServedPage_HasNoAbsoluteLinksToItsOwnHost(t *testing.T) {
 
 	page := string(body(t, ctx))
 
-	selfAbsolute := regexp.MustCompile(`href="https?://` + regexp.QuoteMeta(host) + `[/"]`)
+	selfAbsolute := regexp.MustCompile(`<a\b[^>]*href="https?://` + regexp.QuoteMeta(host) + `[/"]`)
 	found := selfAbsolute.FindAllString(page, -1)
 	require.Empty(t, found,
 		"page served on %s links back to %s with an absolute URL: %v", host, host, found)

--- a/internal/case/rendernotepage/endpoint.go
+++ b/internal/case/rendernotepage/endpoint.go
@@ -82,7 +82,16 @@ func (e Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 	}
 
 	// 301 redirect for non-canonical URL variants (alternate transliteration methods).
-	if resp.Note != nil && resp.Note.AlternatePermalinks != nil && request.Path != resp.Note.Permalink {
+	//
+	// Only when the reader actually arrived by one of those variants. A path
+	// that merely differs from the permalink is not a variant: a note reached
+	// through its own route: frontmatter is served at a path of the author's
+	// choosing, and redirecting it away is both surprising and, on a custom
+	// domain, fatal -- the permalink is not routed there, so the redirect
+	// lands on a 404. Before this test the two cases were indistinguishable,
+	// and which one a note got depended on whether its filename happened to
+	// contain characters the transliterator rewrites.
+	if resp.Note != nil && isAlternatePermalink(resp.Note, request.Path) {
 		redirectURL := resp.Note.PermalinkEncoded()
 		if qs := req.Req.URI().QueryString(); len(qs) > 0 {
 			redirectURL += "?" + string(qs)
@@ -396,7 +405,7 @@ func renderLayout(
 
 	vars := make(jet.VarMap)
 	vars["note"] = reflect.ValueOf(resp.NoteView)
-	vars["nvs"] = reflect.ValueOf(templateviews.NewNVS(resp.Notes, resp.DefaultVersion))
+	vars["nvs"] = reflect.ValueOf(templateviews.NewNVSWithDomain(resp.Notes, resp.DefaultVersion, resp.domainHost))
 	vars["title"] = reflect.ValueOf(resp.Title)
 	vars["publicURL"] = reflect.ValueOf(env.PublicURL())
 
@@ -682,7 +691,7 @@ func buildDefaultTemplateCtx(
 
 	dtCtx := &defaulttemplate.Ctx{
 		Note:            resp.NoteView,
-		Notes:           templateviews.NewNVS(resp.Notes, resp.DefaultVersion),
+		Notes:           templateviews.NewNVSWithDomain(resp.Notes, resp.DefaultVersion, resp.domainHost),
 		Title:           layoutParams.Title,
 		JSURLs:          jsURLs,
 		LocaleHashes:    env.UserLocaleHashes(),
@@ -728,4 +737,23 @@ func buildDefaultTemplateCtx(
 	}
 
 	return dtCtx
+}
+
+// isAlternatePermalink reports whether path is one of the note's superseded
+// permalink spellings -- the variants produced by the other transliteration
+// methods -- as opposed to the canonical permalink or any other path the note
+// answers at.
+func isAlternatePermalink(note *model.NoteView, path string) bool {
+	if note.AlternatePermalinks == nil || path == note.Permalink {
+		return false
+	}
+	if path == note.PermalinkOriginal {
+		return true
+	}
+	for _, variant := range note.AlternatePermalinks {
+		if path == variant {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/case/rendernotepage/header_domain_links_test.go
+++ b/internal/case/rendernotepage/header_domain_links_test.go
@@ -1,0 +1,67 @@
+package rendernotepage_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"trip2g/internal/mdloader"
+
+	"github.com/stretchr/testify/require"
+)
+
+func extractBetween(s, from, to string) string {
+	start := strings.Index(s, from)
+	if start == -1 {
+		return ""
+	}
+	rest := s[start+len(from):]
+	end := strings.Index(rest, to)
+	if end == -1 {
+		return ""
+	}
+	return rest[:end]
+}
+
+// The same [[note-b]] wikilink must resolve to the same href whether it
+// stands in the page body or in the header note attached via the header:
+// frontmatter field. Today the body is rendered with the request's domain
+// host (DomainHTML["docs.example.com"], relative "/b") while the header note
+// is looked up through templateviews.NVS, which wraps it without a domain
+// host, so it renders DomainHTML[""] — the main-domain variant with the
+// absolute https://docs.example.com/b.
+func TestHeaderWikilink_ResolvesLikeBodyWikilink_OnCustomDomain(t *testing.T) {
+	views := loadTestVault(t, []mdloader.SourceFile{
+		{
+			Path:    "site-nav.md",
+			Content: []byte("---\nfree: true\n---\n- [[note-b]]"),
+		},
+		{
+			Path:    "note-a.md",
+			Content: []byte("---\nfree: true\nroute: docs.example.com/a\nheader: site-nav.md\n---\nBody link: [[note-b]]"),
+		},
+		{
+			Path:    "note-b.md",
+			Content: []byte("---\nfree: true\nroute: docs.example.com/b\n---\nPage B"),
+		},
+	})
+
+	env, _, _ := cacheTestEnv(views, nil)
+
+	ctx := newReqCtx(reqOpts{host: "docs.example.com", path: "/a"})
+	runHandle(t, env, ctx, nil)
+	require.Equal(t, http.StatusOK, ctx.Response.StatusCode())
+
+	page := string(body(t, ctx))
+
+	content := extractBetween(page, `<div class="content__body`, `</div>`)
+	require.Contains(t, content, `href="/b"`,
+		"body wikilink must use the relative path on the note's own domain")
+
+	nav := extractBetween(page, `<nav class="site-header__nav">`, `</nav>`)
+	require.NotEmpty(t, nav, "site header nav must render from the header note's first list")
+	require.NotContains(t, nav, `href="https://docs.example.com/b"`,
+		"header wikilink must not use an absolute URL for the host the reader is already on")
+	require.Contains(t, nav, `href="/b"`,
+		"header wikilink must resolve exactly like the body wikilink")
+}

--- a/internal/case/rendernotepage/route_alias_redirect_test.go
+++ b/internal/case/rendernotepage/route_alias_redirect_test.go
@@ -1,0 +1,90 @@
+package rendernotepage_test
+
+import (
+	"net/http"
+	"testing"
+
+	"trip2g/internal/logger"
+	"trip2g/internal/mdloader"
+	"trip2g/internal/model"
+
+	"github.com/stretchr/testify/require"
+)
+
+func loadTestVault(t *testing.T, sources []mdloader.SourceFile) *model.NoteViews {
+	t.Helper()
+	log := logger.TestLogger{}
+	views, err := mdloader.Load(mdloader.Options{
+		Sources:   sources,
+		Log:       &log,
+		Version:   "live",
+		PublicURL: "https://example.com",
+	})
+	require.NoError(t, err)
+	return views
+}
+
+// A note with an explicit route must answer 200 at the route path itself,
+// independent of what characters its vault filename happens to contain.
+// Today the alternate-permalink 301 (endpoint.go) fires for any request path
+// that differs from Permalink once AlternatePermalinks is non-nil, so two
+// notes in the same folder with identical route frontmatter behave
+// differently: the ascii one answers 200, the transliterated one redirects.
+func TestRouteAlias_ServedDirectly_RegardlessOfFilename(t *testing.T) {
+	views := loadTestVault(t, []mdloader.SourceFile{
+		{
+			Path:    "docs/note-a.md",
+			Content: []byte("---\nfree: true\nroute: /short-a\n---\nAscii filename note"),
+		},
+		{
+			Path:    "docs/статья.md",
+			Content: []byte("---\nfree: true\nroute: /short-b\n---\nTransliterated filename note"),
+		},
+	})
+
+	env, _, _ := cacheTestEnv(views, nil)
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "ascii filename", path: "/short-a"},
+		{name: "transliterated filename", path: "/short-b"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := newReqCtx(reqOpts{path: tt.path})
+			runHandle(t, env, ctx, nil)
+			require.Equal(t, http.StatusOK, ctx.Response.StatusCode(),
+				"route path %s must be served directly, got redirect to %q",
+				tt.path, string(ctx.Response.Header.Peek("Location")))
+		})
+	}
+}
+
+// Same inconsistency on a custom domain, where it is worse: the 301 points at
+// the note's vault-path permalink, but the custom domain serves only explicit
+// routes, so the redirect target answers 404 on that host.
+func TestRouteOnCustomDomain_ServedAtRoutePath(t *testing.T) {
+	views := loadTestVault(t, []mdloader.SourceFile{
+		{
+			Path:    "docs/статья.md",
+			Content: []byte("---\nfree: true\nroute: docs.example.com/c\n---\nRouted note"),
+		},
+	})
+
+	env, _, _ := cacheTestEnv(views, nil)
+
+	ctx := newReqCtx(reqOpts{host: "docs.example.com", path: "/c"})
+	runHandle(t, env, ctx, nil)
+
+	status := ctx.Response.StatusCode()
+	location := string(ctx.Response.Header.Peek("Location"))
+
+	locationRoutable := location == "" || views.GetByRoute("docs.example.com", location) != nil
+
+	require.Equal(t, http.StatusOK, status,
+		"route path must be served directly on its domain; got %d to %q (routable on this host: %v)",
+		status, location, locationRoutable)
+}

--- a/internal/case/rendernotepage/userspace.go
+++ b/internal/case/rendernotepage/userspace.go
@@ -222,7 +222,7 @@ func buildUserSpaceHelper(
 
 	h := newUserSpaceHelper(jsURLs, localeHashes, uiLang, devMode, resp.UserToken.IsAdmin(), resp.Title, resp.NoteView)
 	h.cssURLs = cssURLs
-	h.nvs = templateviews.NewNVS(resp.Notes, resp.DefaultVersion)
+	h.nvs = templateviews.NewNVSWithDomain(resp.Notes, resp.DefaultVersion, resp.domainHost)
 	if resp.Notes != nil {
 		h.layoutSections = resp.Notes.LayoutSections
 	}

--- a/internal/mdloader/domain_render.go
+++ b/internal/mdloader/domain_render.go
@@ -34,19 +34,28 @@ func (ldr *loader) generateDomainHTMLs() {
 		if p.Ast() == nil {
 			continue
 		}
-		// Pass 1: custom domain re-render for notes with explicit custom domain routes.
-		if hasCustomDomainRoutes(p) {
-			for _, host := range ldr.uniqueHostsForNote(p) {
-				domainLinks, domainNoteIndex := ldr.buildDomainResolvedLinks(p, host)
-				if domainLinks == nil {
-					// No differences from main domain -- skip re-render.
-					continue
-				}
+		// Pass 1: custom domain re-render.
+		//
+		// A note with its own routes is rendered for the hosts it lives on.
+		// A note without any -- a shared header, footer or sidebar -- is
+		// rendered for every configured host, because it is served as part of
+		// pages that do live there, and its links have to resolve the way the
+		// body's do. Without this the chrome keeps the main-domain rendering
+		// and points back at the reader's own host with an absolute URL.
+		hosts := ldr.uniqueHostsForNote(p)
+		if len(hosts) == 0 {
+			hosts = domainHosts
+		}
+		for _, host := range hosts {
+			domainLinks, domainNoteIndex := ldr.buildDomainResolvedLinks(p, host)
+			if domainLinks == nil {
+				// No differences from main domain -- skip re-render.
+				continue
+			}
 
-				if err := ldr.generateDomainHTML(p, host, domainLinks, domainNoteIndex); err != nil {
-					ldr.log.Warn("failed to generate domain HTML",
-						"path", p.Path, "host", host, "error", err)
-				}
+			if err := ldr.generateDomainHTML(p, host, domainLinks, domainNoteIndex); err != nil {
+				ldr.log.Warn("failed to generate domain HTML",
+					"path", p.Path, "host", host, "error", err)
 			}
 		}
 
@@ -218,15 +227,4 @@ func (ldr *loader) generateDomainHTML(
 	// TODO(v2): DomainFreeHTML -- also re-render FreeHTML for custom domain context.
 
 	return nil
-}
-
-// hasCustomDomainRoutes returns true if the note has at least one route
-// with a non-empty Host (custom domain, not a main-domain alias).
-func hasCustomDomainRoutes(n *model.NoteView) bool {
-	for _, r := range n.Routes {
-		if r.Host != "" {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/templateviews/nvs.go
+++ b/internal/templateviews/nvs.go
@@ -11,17 +11,32 @@ import (
 type NVS struct {
 	nvs            *model.NoteViews
 	defaultVersion string
+	domainHost     string
 }
 
-// NewNVS creates a new template NVS wrapper.
+// NewNVS creates a new template NVS wrapper for the main domain.
 func NewNVS(nvs *model.NoteViews, defaultVersion string) *NVS {
+	return NewNVSWithDomain(nvs, defaultVersion, "")
+}
+
+// NewNVSWithDomain creates a template NVS wrapper bound to the host the page
+// is being served on. Notes it returns render that host's HTML, so a header,
+// footer or sidebar resolves its links exactly as the page body does.
+func NewNVSWithDomain(nvs *model.NoteViews, defaultVersion, domainHost string) *NVS {
 	if nvs == nil {
 		return nil
 	}
 	return &NVS{
 		nvs:            nvs,
 		defaultVersion: defaultVersion,
+		domainHost:     domainHost,
 	}
+}
+
+// wrap builds a Note carrying this NVS's host, so every note reached through
+// the wrapper renders for the same domain as the page around it.
+func (n *NVS) wrap(nv *model.NoteView) *Note {
+	return NewNoteWithDomain(nv, n.domainHost)
 }
 
 // ByPath returns a note by its file path (e.g., "/_sidebar.md", "_sidebar.md").
@@ -39,7 +54,7 @@ func (n *NVS) ByPath(path string) *Note {
 		return nil
 	}
 
-	return NewNote(nv)
+	return n.wrap(nv)
 }
 
 // ByPermalink returns a note by its permalink (e.g., "/docs", "/about").
@@ -54,7 +69,7 @@ func (n *NVS) ByPermalink(permalink string) *Note {
 		return nil
 	}
 
-	return NewNote(nv)
+	return n.wrap(nv)
 }
 
 // ByWikilink resolves a wikilink target using Obsidian's algorithm:
@@ -70,11 +85,11 @@ func (n *NVS) ByWikilink(target string) *Note {
 	if strings.Contains(target, "/") {
 		permalink := "/" + strings.ToLower(strings.ReplaceAll(target, " ", "_"))
 		if nv, ok := n.nvs.Map[permalink]; ok {
-			return NewNote(nv)
+			return n.wrap(nv)
 		}
 		pathKey := strings.ReplaceAll(target, " ", "_") + ".md"
 		if nv, ok := n.nvs.PathMap[pathKey]; ok {
-			return NewNote(nv)
+			return n.wrap(nv)
 		}
 		return nil
 	}
@@ -83,7 +98,7 @@ func (n *NVS) ByWikilink(target string) *Note {
 	key := strings.ToLower(strings.ReplaceAll(target, " ", "_"))
 	candidates := n.nvs.BasenameMap[key]
 	if len(candidates) == 1 {
-		return NewNote(candidates[0])
+		return n.wrap(candidates[0])
 	}
 	if len(candidates) > 1 {
 		// Shortest path from root wins (Obsidian priority).
@@ -96,7 +111,7 @@ func (n *NVS) ByWikilink(target string) *Note {
 				shortestDepth = depth
 			}
 		}
-		return NewNote(shortest)
+		return n.wrap(shortest)
 	}
 
 	return nil
@@ -111,7 +126,7 @@ func (n *NVS) Sidebars(note *Note) []*Note {
 	sidebars := n.nvs.Sidebars(note.nv)
 	result := make([]*Note, 0, len(sidebars))
 	for _, s := range sidebars {
-		result = append(result, NewNote(s))
+		result = append(result, n.wrap(s))
 	}
 	return result
 }
@@ -125,7 +140,7 @@ func (n *NVS) HomePages(note *Note) []*Note {
 	homePages := n.nvs.HomePages(note.nv)
 	result := make([]*Note, 0, len(homePages))
 	for _, hp := range homePages {
-		result = append(result, NewNote(hp))
+		result = append(result, n.wrap(hp))
 	}
 	return result
 }
@@ -139,7 +154,7 @@ func (n *NVS) BackLinks(note *Note) []*Note {
 	result := make([]*Note, 0, len(note.nv.InLinks))
 	for path := range note.nv.InLinks {
 		if linked := n.nvs.GetByPath(path); linked != nil && !linked.IsSystem() {
-			result = append(result, NewNote(linked))
+			result = append(result, n.wrap(linked))
 		}
 	}
 	return result
@@ -159,7 +174,7 @@ func (n *NVS) OutLinks(note *Note) []*Note {
 		}
 		seen[permalink] = struct{}{}
 		if linked := n.nvs.GetByPath(permalink); linked != nil {
-			result = append(result, NewNote(linked))
+			result = append(result, n.wrap(linked))
 		}
 	}
 	return result
@@ -182,7 +197,7 @@ func (n *NVS) List() []*Note {
 	visible := n.nvs.VisibleList()
 	result := make([]*Note, 0, len(visible))
 	for _, nv := range visible {
-		result = append(result, NewNote(nv))
+		result = append(result, n.wrap(nv))
 	}
 	return result
 }

--- a/internal/templateviews/query.go
+++ b/internal/templateviews/query.go
@@ -96,7 +96,7 @@ func (q *NoteQuery) All() []*Note {
 		if q.public && !nv.IsPubliclyReadable() {
 			continue
 		}
-		notes = append(notes, NewNote(nv))
+		notes = append(notes, q.nvs.wrap(nv))
 	}
 
 	// Step 2: Sort


### PR DESCRIPTION
A page served on host H points back at H with absolute URLs, and a note does not always answer at the path its `route:` names. Both surface as soon as one vault serves several domains.

## What happens now

A shared header note linked with the `header:` frontmatter field renders `https://docs.example.com/b`, while the page body on that same host renders `/b` for the same `[[wikilink]]`. Clicking it leaves the host the reader is on. On a host reachable only from inside — a staging copy, a preview deployment — the link does not resolve at all.

A note with `route: docs.example.com/b` answers at `/b` only when its vault filename contains nothing the transliterator rewrites. Two notes in one folder with identical route frontmatter behave differently, and the discriminator is invisible from the frontmatter. On a custom domain the redirect lands on a permalink that host does not route, so the alias leads to a 404.

## Why

`generateDomainHTMLs` re-rendered only notes carrying their own custom-domain routes. Shared chrome has none, so it kept the main-domain rendering.

`templateviews.NVS` wrapped notes with `NewNote`, which carries no domain, so `HTMLString()` returned `DomainHTML[""]` even where a per-host rendering existed. `NewNoteWithDomain` already existed and was used for the body only.

The transliteration 301 fired whenever the request path differed from the permalink. That meant "arrived by an old spelling" until `RouteMap` began to be consulted before `nv.Map`; a note reached through its own route matches the same condition. `og:url` and `rel=canonical` already prefer the route URL on a custom domain, so the page declared one URL canonical and redirected away from it.

## What changed

Notes without their own routes are re-rendered for every configured host. The existing "nothing changed, skip re-render" guard still applies, so a vault with no cross-domain links pays one link-map comparison per note per host and no extra render.

`NVS` carries the request host, so header, footer, sidebar, backlinks and queries resolve links the way the body does.

The 301 fires only when the request path is one of the note's alternate permalink spellings.

`rel=canonical`, `og:url` and JSON-LD stay absolute — they are absolute by their own specifications.

## Tests

Four, committed before the fix so they read red first. The last states the property rather than a symptom: a page served on host H contains no `<a href>` back to H.

```
TestServedPage_HasNoAbsoluteLinksToItsOwnHost
TestHeaderWikilink_ResolvesLikeBodyWikilink_OnCustomDomain
TestRouteAlias_ServedDirectly_RegardlessOfFilename
TestRouteOnCustomDomain_ServedAtRoutePath
```

`go test ./internal/...` — 211 packages, no failures. `make lint` — 0 issues.

## Not in this change

Making `route:` the canonical address — permalink redirecting to it, route in sitemaps — would move URLs already indexed for existing users. Mounting a whole vault on a host without a per-note `route:` is a separate design question.
