### PR TITLE
fix(federation): a peer's rpc refusal no longer records the key it never took

### DIFF
--- a/docs/dev/federation_key_rotation.md
+++ b/docs/dev/federation_key_rotation.md
@@ -134,6 +134,14 @@ applied it answers the repeat as a no-op, and a peer that never heard the first
 attempt applies it now. Minting a fresh key per attempt would leave nobody
 holding what the peer has.
 
+A refusal is an answer that proves the call never executed, at either layer: a
+JSON-RPC error coded -32700, -32600, -32601 or -32602 (the protocol's
+pre-execution codes) or -32001 (trip2g's auth code), or an HTTP status refused
+before dispatch — 400, 401, 403, 404, 405, 501. Everything ambiguous is
+silence: an internal error (-32603), a timeout, any 5xx may have arrived after
+the peer committed, and recording on ambiguity heals on retry where discarding
+a committed key does not.
+
 The probe is what closes the window rather than a timer. A rotation that
 verifies on the next call clears the old key on the base within milliseconds, so
 the state where two keys are accepted is an exception, not a resting state.

--- a/internal/case/admin/rotatefederationsecret/resolve.go
+++ b/internal/case/admin/rotatefederationsecret/resolve.go
@@ -93,9 +93,8 @@ func Propose(ctx context.Context, env Env, peer model.FederationPeer, secret []b
 	params := model.MCPRotateSecretParams{SecretHex: hex.EncodeToString(secret)}
 
 	result, err := env.FederationPeerClient(peer).RotateSecret(ctx, params)
-	var rpcErr *model.FederationRPCError
-	if errors.As(err, &rpcErr) && answeredWithoutExecuting(rpcErr.Code) {
-		return fmt.Errorf("%w: %w", ErrPeerRefused, rpcErr)
+	if answeredWithoutExecuting(err) {
+		return fmt.Errorf("%w: %w", ErrPeerRefused, err)
 	}
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrPeerSilent, err)
@@ -107,18 +106,35 @@ func Propose(ctx context.Context, env Env, peer model.FederationPeer, secret []b
 	return nil
 }
 
-// answeredWithoutExecuting reports whether a JSON-RPC code proves the peer
-// never ran the call: the request was unparseable, malformed, unauthenticated,
-// or named a method it does not have. Any of them means the peer still holds
-// only the old key. An internal error proves nothing — the peer may have
-// failed after committing — so it stays on the silence path. The values are
-// the protocol's (JSON-RPC 2.0 §5.1), redeclared rather than importing the MCP
-// surface for four integers.
-func answeredWithoutExecuting(code int) bool {
-	switch code {
-	case -32700, -32600, -32601, -32602, model.FederationAuthErrorCode:
-		return true
+// answeredWithoutExecuting reports whether an answer proves the peer never ran
+// the call, which is what makes a refusal: the peer still holds only the old
+// key. Two layers can answer. A JSON-RPC error whose code says the request was
+// unparseable, malformed, unauthenticated or named a method the peer does not
+// have — the first four codes are the protocol's (JSON-RPC 2.0 §5.1), the auth
+// one is trip2g's own. Or an HTTP status refused before any JSON-RPC was
+// dispatched — a proxy that would not route it, an adapter without the
+// endpoint. Everything ambiguous stays silence: an internal error, a timeout
+// or a 5xx may have come AFTER the peer committed, and recording on ambiguity
+// heals on retry where discarding a committed key does not.
+func answeredWithoutExecuting(err error) bool {
+	var rpcErr *model.FederationRPCError
+	if errors.As(err, &rpcErr) {
+		switch rpcErr.Code {
+		case -32700, -32600, -32601, -32602, model.FederationAuthErrorCode:
+			return true
+		}
+		return false
 	}
+
+	var httpErr *model.FederationHTTPError
+	if errors.As(err, &httpErr) {
+		switch httpErr.Status {
+		case 400, 401, 403, 404, 405, 501:
+			return true
+		}
+		return false
+	}
+
 	return false
 }
 

--- a/internal/case/admin/rotatefederationsecret/resolve.go
+++ b/internal/case/admin/rotatefederationsecret/resolve.go
@@ -93,6 +93,10 @@ func Propose(ctx context.Context, env Env, peer model.FederationPeer, secret []b
 	params := model.MCPRotateSecretParams{SecretHex: hex.EncodeToString(secret)}
 
 	result, err := env.FederationPeerClient(peer).RotateSecret(ctx, params)
+	var rpcErr *model.FederationRPCError
+	if errors.As(err, &rpcErr) && answeredWithoutExecuting(rpcErr.Code) {
+		return fmt.Errorf("%w: %w", ErrPeerRefused, rpcErr)
+	}
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrPeerSilent, err)
 	}
@@ -101,6 +105,21 @@ func Propose(ctx context.Context, env Env, peer model.FederationPeer, secret []b
 	}
 
 	return nil
+}
+
+// answeredWithoutExecuting reports whether a JSON-RPC code proves the peer
+// never ran the call: the request was unparseable, malformed, unauthenticated,
+// or named a method it does not have. Any of them means the peer still holds
+// only the old key. An internal error proves nothing — the peer may have
+// failed after committing — so it stays on the silence path. The values are
+// the protocol's (JSON-RPC 2.0 §5.1), redeclared rather than importing the MCP
+// surface for four integers.
+func answeredWithoutExecuting(code int) bool {
+	switch code {
+	case -32700, -32600, -32601, -32602, model.FederationAuthErrorCode:
+		return true
+	}
+	return false
 }
 
 // Resolve rotates a pairing that is already installed.

--- a/internal/case/admin/rotatefederationsecret/resolve_test.go
+++ b/internal/case/admin/rotatefederationsecret/resolve_test.go
@@ -181,6 +181,46 @@ func TestResolveRecordsNothingWhenThePeerRefuses(t *testing.T) {
 	require.Nil(t, env.rotated, "this side moved off a key the peer said it kept")
 }
 
+// The real transport answers a refusal as a typed JSON-RPC error, never as an
+// IsError tool result. A code the peer sends before executing anything proves
+// it still holds only the old key; an internal error proves nothing — the peer
+// may have failed after committing — so it stays on the silence path.
+func TestResolveClassifiesRPCAnswers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		code     int
+		recorded bool
+	}{
+		{"parse error is a refusal", -32700, false},
+		{"invalid request is a refusal", -32600, false},
+		{"method not found is a refusal", -32601, false},
+		{"invalid params is a refusal", -32602, false},
+		{"auth failure is a refusal", model.FederationAuthErrorCode, false},
+		{"internal error is silence", -32603, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			env := &envStub{row: liveRow(), peer: &peerStub{
+				rotateErr: &model.FederationRPCError{Code: tt.code, Message: "answered"},
+			}}
+
+			payload, err := rotatefederationsecret.Resolve(context.Background(), env, "peer")
+
+			require.NoError(t, err)
+			require.IsType(t, &graphmodel.ErrorPayload{}, payload)
+			if tt.recorded {
+				require.NotNil(t, env.rotated, "the peer may have committed before the answer was lost")
+			} else {
+				require.Nil(t, env.rotated, "the peer answered without executing, so it still holds only the old key")
+			}
+		})
+	}
+}
+
 // Silence is the other outcome and needs the opposite treatment: the peer may
 // have committed before the answer was lost, so the proposal is kept and a retry
 // re-proposes it.

--- a/internal/case/admin/rotatefederationsecret/resolve_test.go
+++ b/internal/case/admin/rotatefederationsecret/resolve_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -181,41 +182,50 @@ func TestResolveRecordsNothingWhenThePeerRefuses(t *testing.T) {
 	require.Nil(t, env.rotated, "this side moved off a key the peer said it kept")
 }
 
-// The real transport answers a refusal as a typed JSON-RPC error, never as an
-// IsError tool result. A code the peer sends before executing anything proves
-// it still holds only the old key; an internal error proves nothing — the peer
-// may have failed after committing — so it stays on the silence path.
-func TestResolveClassifiesRPCAnswers(t *testing.T) {
+// The real transport answers a refusal as a typed JSON-RPC or HTTP error,
+// never as an IsError tool result. An answer that precedes execution proves
+// the peer still holds only the old key; anything ambiguous — an internal
+// error, a 5xx, an unknown code — may have come after the peer committed, so
+// it stays on the silence path.
+func TestResolveClassifiesAnswers(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		code     int
-		recorded bool
+		name      string
+		rotateErr error
+		recorded  bool
 	}{
-		{"parse error is a refusal", -32700, false},
-		{"invalid request is a refusal", -32600, false},
-		{"method not found is a refusal", -32601, false},
-		{"invalid params is a refusal", -32602, false},
-		{"auth failure is a refusal", model.FederationAuthErrorCode, false},
-		{"internal error is silence", -32603, true},
+		{"parse error is a refusal", &model.FederationRPCError{Code: -32700, Message: "answered"}, false},
+		{"invalid request is a refusal", &model.FederationRPCError{Code: -32600, Message: "answered"}, false},
+		{"method not found is a refusal", &model.FederationRPCError{Code: -32601, Message: "answered"}, false},
+		{"invalid params is a refusal", &model.FederationRPCError{Code: -32602, Message: "answered"}, false},
+		{"auth failure is a refusal", &model.FederationRPCError{Code: model.FederationAuthErrorCode, Message: "answered"}, false},
+		{"a wrapped refusal is still a refusal", fmt.Errorf("call rotate_secret: %w", &model.FederationRPCError{Code: -32601, Message: "answered"}), false},
+		{"internal error is silence", &model.FederationRPCError{Code: -32603, Message: "answered"}, true},
+		{"an unknown code is silence", &model.FederationRPCError{Code: -32000, Message: "answered"}, true},
+		{"http not found is a refusal", &model.FederationHTTPError{Status: 404}, false},
+		{"http method not allowed is a refusal", &model.FederationHTTPError{Status: 405}, false},
+		{"http bad gateway is silence", &model.FederationHTTPError{Status: 502}, true},
+		{"http too many requests is silence", &model.FederationHTTPError{Status: 429}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			env := &envStub{row: liveRow(), peer: &peerStub{
-				rotateErr: &model.FederationRPCError{Code: tt.code, Message: "answered"},
-			}}
+			env := &envStub{row: liveRow(), peer: &peerStub{rotateErr: tt.rotateErr}}
 
 			payload, err := rotatefederationsecret.Resolve(context.Background(), env, "peer")
 
 			require.NoError(t, err)
-			require.IsType(t, &graphmodel.ErrorPayload{}, payload)
+			errPayload, ok := payload.(*graphmodel.ErrorPayload)
+			require.True(t, ok)
+			require.Empty(t, env.cleared, "nothing was confirmed, so nothing may be retired")
 			if tt.recorded {
 				require.NotNil(t, env.rotated, "the peer may have committed before the answer was lost")
 			} else {
 				require.Nil(t, env.rotated, "the peer answered without executing, so it still holds only the old key")
+				require.Contains(t, errPayload.Message, tt.rotateErr.Error(),
+					"the operator acts on WHY the peer said no")
 			}
 		})
 	}

--- a/internal/federation/client.go
+++ b/internal/federation/client.go
@@ -222,7 +222,7 @@ func (c *Client) do(
 		return nil, fmt.Errorf("post json: %w", err)
 	}
 	if resp.StatusCode() < 200 || resp.StatusCode() >= 300 {
-		return nil, fmt.Errorf("post json: status %d", resp.StatusCode())
+		return nil, &model.FederationHTTPError{Status: resp.StatusCode()}
 	}
 
 	return append([]byte(nil), resp.Body()...), nil

--- a/internal/federation/client.go
+++ b/internal/federation/client.go
@@ -129,7 +129,7 @@ func (c *Client) callTool(ctx context.Context, name string, args any) (model.Fed
 	}
 
 	if resp.Error != nil {
-		return model.FederationResult{}, fmt.Errorf("federation rpc error %d: %s", resp.Error.Code, resp.Error.Message)
+		return model.FederationResult{}, &model.FederationRPCError{Code: resp.Error.Code, Message: resp.Error.Message}
 	}
 	content := make([]model.FederationContent, len(resp.Result.Content))
 	for i, c := range resp.Result.Content {

--- a/internal/federation/client_test.go
+++ b/internal/federation/client_test.go
@@ -180,6 +180,24 @@ func TestClientTypesAJSONRPCErrorAnswer(t *testing.T) {
 	require.Contains(t, rpcErr.Message, "rotate_secret")
 }
 
+// An HTTP status is the other layer that can answer — an adapter without the
+// endpoint says 404 where a trip2g peer says -32601 — so it is typed too.
+func TestClientTypesAnHTTPErrorAnswer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	peer := model.FederationPeer{KBURL: server.URL, KID: "kid-1", Secret: []byte("secret")}
+
+	_, err := federation.NewClient(peer, &fasthttp.Client{}, true).
+		RotateSecret(context.Background(), model.MCPRotateSecretParams{SecretHex: "00"})
+
+	var httpErr *model.FederationHTTPError
+	require.ErrorAs(t, err, &httpErr)
+	require.Equal(t, 404, httpErr.Status)
+}
+
 // The signature covers the body, so the arguments a peer verifies are the ones
 // that were sent — the property a call carrying a key depends on.
 func TestClientSignsTheBody(t *testing.T) {

--- a/internal/federation/client_test.go
+++ b/internal/federation/client_test.go
@@ -159,6 +159,27 @@ func TestClientDoesNotRetryWithoutAPreviousKey(t *testing.T) {
 	require.Equal(t, 1, calls)
 }
 
+// A JSON-RPC error is an answer — the peer heard the call and named a reason —
+// where a transport failure proves nothing reached it. Callers that record
+// opposite outcomes for the two (key rotation) need the code and message typed.
+func TestClientTypesAJSONRPCErrorAnswer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"1","error":{"code":-32601,"message":"Method not found: rotate_secret"}}`))
+	}))
+	defer server.Close()
+
+	peer := model.FederationPeer{KBURL: server.URL, KID: "kid-1", Secret: []byte("secret")}
+
+	_, err := federation.NewClient(peer, &fasthttp.Client{}, true).
+		RotateSecret(context.Background(), model.MCPRotateSecretParams{SecretHex: "00"})
+
+	var rpcErr *model.FederationRPCError
+	require.ErrorAs(t, err, &rpcErr)
+	require.Equal(t, -32601, rpcErr.Code)
+	require.Contains(t, rpcErr.Message, "rotate_secret")
+}
+
 // The signature covers the body, so the arguments a peer verifies are the ones
 // that were sent — the property a call carrying a key depends on.
 func TestClientSignsTheBody(t *testing.T) {

--- a/internal/model/federation_errors.go
+++ b/internal/model/federation_errors.go
@@ -15,3 +15,15 @@ type FederationRPCError struct {
 func (e *FederationRPCError) Error() string {
 	return fmt.Sprintf("federation rpc error %d: %s", e.Code, e.Message)
 }
+
+// FederationHTTPError is a non-2xx HTTP answer from a peer's endpoint. Like
+// FederationRPCError it proves something answered; unlike it, the answer came
+// from the HTTP layer — a proxy, an adapter without the endpoint — before any
+// JSON-RPC was dispatched.
+type FederationHTTPError struct {
+	Status int
+}
+
+func (e *FederationHTTPError) Error() string {
+	return fmt.Sprintf("post json: status %d", e.Status)
+}

--- a/internal/model/federation_rpc_error.go
+++ b/internal/model/federation_rpc_error.go
@@ -1,0 +1,17 @@
+package model
+
+import "fmt"
+
+// FederationRPCError is a JSON-RPC error response from a peer. It is an answer
+// — the peer heard the call and named a reason — where a transport failure
+// proves nothing reached it. Callers that record opposite outcomes for the two
+// (key rotation does) branch on the code; everyone else treats it as any other
+// error. Kept out of federation.go so easyjson does not generate for it.
+type FederationRPCError struct {
+	Code    int
+	Message string
+}
+
+func (e *FederationRPCError) Error() string {
+	return fmt.Sprintf("federation rpc error %d: %s", e.Code, e.Message)
+}


### PR DESCRIPTION
Weekly review (#328) finding 1. `Propose` mapped every Go error from `RotateSecret` to `ErrPeerSilent` and reserved `ErrPeerRefused` for `result.IsError` — but the real client converts every JSON-RPC error response (including `-32601 Method not found` from an older instance or an adapter) into a Go error, and no server path answers a refused rotation as an `IsError` tool result. So a definite refusal took the silence path: the never-accepted key was recorded as current, the pairing degraded to the prev-key fallback, and a post-grace retry would mint a fresh key and drop the only key the peer actually holds — killing the link in both directions. The refusal unit test passed only because its stub fabricated `IsError: true`, a shape the transport never produces.

Fix, in two commits:

1. The client returns a typed `model.FederationRPCError` for JSON-RPC error responses (transport failures stay untyped), and `Propose` classifies codes that prove the call never executed (`-32700`, `-32600`, `-32601`, `-32602`, auth `-32001`) as refusal. An internal error (`-32603`) proves nothing — the peer may have failed after committing — so it stays on the silence path. The `IsError` branch is kept for adapters that answer refusals as tool results.

2. A reviewer pass on the diff found the same bug one layer down: a peer answering at the HTTP level (an adapter without the endpoint says 404 where a trip2g peer says -32601) still took the silence path. Non-2xx now surfaces as a typed `model.FederationHTTPError`, and pre-dispatch statuses (400/401/403/404/405/501) classify as refusal; 408/429/5xx stay silence since a proxy can answer them after the peer committed. Error message texts are byte-identical to the old `fmt.Errorf` strings, so string-rendering consumers see no change.

Both error types live in their own file so `easyjson -all` on `federation.go` does not pick them up. The design doc's decision table now names the concrete refusal definition. Tests first (TDD): client tests pinning both typed answers over a real `httptest` server, and a 12-row table over codes, statuses, an unknown code, and a wrapped error, asserting what gets recorded, that nothing is retired, and that the refusal reason reaches the operator. The install path is unaffected — both outcomes store nothing there; it just reports the real refusal message now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VP3Z8whPxpMtKxqNRnwdQL