### PR TITLE
perf(fleet): make the agent system prompt cacheable and measure cache hits

### DIFF
--- a/cmd/fleet/internal/agentruntime/llm.go
+++ b/cmd/fleet/internal/agentruntime/llm.go
@@ -41,6 +41,12 @@ type ChatResult struct {
 	ToolCalls        []ToolCall
 	PromptTokens     int
 	CompletionTokens int
+
+	// CachedPromptTokens is the share of PromptTokens the provider served from
+	// its prompt cache — a subset of PromptTokens, never spend on top of it.
+	// Zero when the provider reports no breakdown, which is not evidence of a
+	// miss: most local runtimes cache and say nothing.
+	CachedPromptTokens int
 }
 
 // LLM is the provider-independent chat surface the executor depends on. The

--- a/cmd/fleet/internal/agentruntime/metrics_test.go
+++ b/cmd/fleet/internal/agentruntime/metrics_test.go
@@ -49,10 +49,26 @@ func (f *fakeMetrics) RecordDenial(kind string) { f.denials = append(f.denials, 
 func (f *fakeMetrics) RecordApplyFailure(_, tool string) { f.applies = append(f.applies, tool) }
 
 // totalTokens sums the recorded spend, mirroring what Result.TokensUsed counts.
+// The cached kind is deliberately excluded: it is a share of the prompt tokens
+// already counted, not spend on top of them.
 func (f *fakeMetrics) totalTokens() int {
 	sum := 0
 	for _, t := range f.tokens {
+		if t.kind == tokenKindCached {
+			continue
+		}
 		sum += t.n
+	}
+	return sum
+}
+
+// tokensOfKind sums the recorded tokens of one kind.
+func (f *fakeMetrics) tokensOfKind(kind string) int {
+	sum := 0
+	for _, t := range f.tokens {
+		if t.kind == kind {
+			sum += t.n
+		}
 	}
 	return sum
 }
@@ -316,4 +332,29 @@ func TestOpenAILLM_EmptyCompletionIsNotSuccess(t *testing.T) {
 	_, err := llm.Chat(context.Background(), "test-model", []Message{{Role: RoleUser, Content: "x"}}, nil)
 	require.ErrorIs(t, err, ErrEmptyCompletion)
 	require.Equal(t, []string{"llm|test-model|empty_completion"}, rec.requests)
+}
+
+// TestRun_RecordsCachedPromptTokens: the cache-hit share is reported as its own
+// kind and must NOT inflate the run's spend — it is part of the prompt tokens
+// already counted, so double-counting it would make the budget bind early.
+func TestRun_RecordsCachedPromptTokens(t *testing.T) {
+	llm := &stubLLM{script: []ChatResult{
+		{
+			ToolCalls:          []ToolCall{toolCall("1", toolFinish, map[string]any{"answer": "ok"})},
+			PromptTokens:       100,
+			CompletionTokens:   10,
+			CachedPromptTokens: 80,
+		},
+	}}
+	m := newFakeMetrics()
+
+	res, err := Run(context.Background(), Input{
+		Instruction: "go", Model: "m", Role: "roles/r.md",
+		MaxTokens: 1000, MaxSteps: 5,
+		Metrics: m, LLM: llm, KB: newMemKB(nil),
+	})
+	require.NoError(t, err)
+	require.Equal(t, 110, res.TokensUsed)
+	require.Equal(t, 80, m.tokensOfKind(tokenKindCached))
+	require.Equal(t, res.TokensUsed, m.totalTokens())
 }

--- a/cmd/fleet/internal/agentruntime/openai_llm.go
+++ b/cmd/fleet/internal/agentruntime/openai_llm.go
@@ -104,6 +104,9 @@ func (l *OpenAILLM) chat(ctx context.Context, model string, messages []Message, 
 		PromptTokens:     resp.Usage.PromptTokens,
 		CompletionTokens: resp.Usage.CompletionTokens,
 	}
+	if d := resp.Usage.PromptTokensDetails; d != nil {
+		out.CachedPromptTokens = d.CachedTokens
+	}
 	if len(resp.Choices) == 0 {
 		// A 200 with no choices is a provider-side failure, not a success: record
 		// it as one before handing ErrEmptyCompletion back.

--- a/cmd/fleet/internal/agentruntime/openai_llm_test.go
+++ b/cmd/fleet/internal/agentruntime/openai_llm_test.go
@@ -120,3 +120,34 @@ func TestOpenAILLM_PlainChatOmitsBudget(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, hasBudget)
 }
+
+// cachedCompletion carries the usage breakdown every OpenAI-compatible
+// provider with prefix caching reports: cached_tokens is the share of
+// prompt_tokens that was served from cache, not spend on top of it.
+const cachedCompletion = `{"id":"1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":2048,"completion_tokens":3,"total_tokens":2051,"prompt_tokens_details":{"cached_tokens":1920}}}`
+
+// TestOpenAILLM_ReportsCachedPromptTokens: the cache-hit share is read off the
+// usage breakdown so cache effectiveness is measurable on any provider that
+// reports it, with no provider-specific request field.
+func TestOpenAILLM_ReportsCachedPromptTokens(t *testing.T) {
+	llm, _ := llmStubServer(t, func(int, map[string]any) (int, string) {
+		return http.StatusOK, cachedCompletion
+	})
+
+	res, err := llm.Chat(context.Background(), "test-model", []Message{{Role: RoleUser, Content: "x"}}, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2048, res.PromptTokens)
+	require.Equal(t, 1920, res.CachedPromptTokens)
+}
+
+// TestOpenAILLM_CachedPromptTokensAbsentIsZero: a provider that omits the
+// breakdown (most local runtimes) must not crash the call.
+func TestOpenAILLM_CachedPromptTokensAbsentIsZero(t *testing.T) {
+	llm, _ := llmStubServer(t, func(int, map[string]any) (int, string) {
+		return http.StatusOK, okCompletion
+	})
+
+	res, err := llm.Chat(context.Background(), "test-model", []Message{{Role: RoleUser, Content: "x"}}, nil)
+	require.NoError(t, err)
+	require.Zero(t, res.CachedPromptTokens)
+}

--- a/cmd/fleet/internal/agentruntime/runtime.go
+++ b/cmd/fleet/internal/agentruntime/runtime.go
@@ -63,6 +63,10 @@ const (
 	statusErrorForRun   = "error"
 	tokenKindPrompt     = "prompt"
 	tokenKindCompletion = "completion"
+	// tokenKindCached is the share of tokenKindPrompt the provider served from
+	// its prompt cache. It is a subset of the prompt tokens, so it is reported
+	// but never added to the run's spend.
+	tokenKindCached = "cached"
 	// unknownTool is the label stand-in for a tool name the model invented. The
 	// name is attacker-controllable, so it must never reach a metric label.
 	unknownTool = "unknown"
@@ -160,25 +164,27 @@ type Result struct {
 	Logs []webhookutil.AgentLog `json:"logs,omitempty"`
 }
 
-const systemPromptTemplate = `You are a scoped trip2g micro-agent. Follow the instruction below.
+// systemPromptTemplate is ordered most-stable-first so a provider with prefix
+// caching can reuse it: the static preamble is identical for every run, the
+// scope is fixed per role, and the per-delivery instruction comes last. Leading
+// with the instruction — as this once did — leaves no shared prefix at all.
+//
+// The tools are deliberately NOT restated here: they already reach the model as
+// the request's tool schemas, and a second prose copy both costs tokens on every
+// step and drifts from the role's actual allowlist, inviting calls the runtime
+// will only refuse.
+const systemPromptTemplate = `You are a scoped trip2g micro-agent. The tools you were given are the only ones you have.
 
-Instruction:
-%s
+Rules:
+- Reads or writes outside scope are rejected by the runtime; do not retry them.
+- When done, call finish with a concise answer. Do not invent paths you have not seen.
 
 Access scope (enforced by the runtime, not negotiable):
 - You may read paths matching: %s
 - You may write paths matching: %s
 
-Tools:
-- search(query): find documents within your read scope.
-- read_note(path): read a document's content (read scope only).
-- write_note(path, content): create or replace a document (write scope only).
-- patch_note(path, find, replace): surgically edit a document (write scope only). Fails if find is absent or occurs more than once; include enough surrounding context to make the match unique.
-- finish(answer): end the run with your final answer/summary.
-
-Rules:
-- Reads or writes outside scope are rejected by the runtime; do not retry them.
-- When done, call finish with a concise answer. Do not invent paths you have not seen.`
+Instruction:
+%s`
 
 // Run executes the instruction through the LLM tool-call loop, enforcing scope
 // and the token hard-cap, and returns the answer plus any in-scope changes. It
@@ -242,9 +248,9 @@ func run(ctx context.Context, in Input, res *Result) error {
 			Role: RoleSystem,
 			Content: fmt.Sprintf(
 				systemPromptTemplate,
-				in.Instruction,
 				formatPatterns(in.ReadPatterns),
 				formatPatterns(in.WritePatterns),
+				in.Instruction,
 			),
 		},
 	}
@@ -275,6 +281,7 @@ func run(ctx context.Context, in Input, res *Result) error {
 		if in.Metrics != nil {
 			in.Metrics.RecordTokens(in.Model, in.Role, tokenKindPrompt, chat.PromptTokens)
 			in.Metrics.RecordTokens(in.Model, in.Role, tokenKindCompletion, chat.CompletionTokens)
+			in.Metrics.RecordTokens(in.Model, in.Role, tokenKindCached, chat.CachedPromptTokens)
 		}
 
 		// No tool calls means the model returned a final answer.
@@ -874,7 +881,7 @@ func toolDefs(execEnabled bool) []ToolDef {
 		},
 		{
 			Name:        toolPatchNote,
-			Description: "Apply a surgical find→replace edit to a document (write scope only). Preserves surrounding content.",
+			Description: "Apply a surgical find→replace edit to a document (write scope only). Preserves surrounding content. Fails if find is absent or occurs more than once, so include enough surrounding context to make the match unique.",
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{

--- a/cmd/fleet/internal/agentruntime/runtime_test.go
+++ b/cmd/fleet/internal/agentruntime/runtime_test.go
@@ -726,3 +726,67 @@ func TestRun_LogsUnpermittedTool(t *testing.T) {
 	require.NotEmpty(t, got["reason"])
 	require.Equal(t, "warn", res.Logs[0].Level)
 }
+
+// systemPromptFor runs a one-step agent and returns the system prompt it built.
+func systemPromptFor(t *testing.T, in Input) string {
+	t.Helper()
+	llm := &stubLLM{script: []ChatResult{
+		{ToolCalls: []ToolCall{toolCall("1", toolFinish, map[string]any{"answer": "ok"})}},
+	}}
+	in.LLM, in.KB = llm, newMemKB(nil)
+	in.Model, in.MaxTokens, in.MaxSteps = "m", 1000, 5
+	_, err := Run(context.Background(), in)
+	require.NoError(t, err)
+	require.NotEmpty(t, llm.seen)
+	require.Equal(t, RoleSystem, llm.seen[0].Role)
+	return llm.seen[0].Content
+}
+
+// TestRun_SystemPromptPutsInstructionLast pins the prompt-cache layout: the
+// per-delivery instruction is the LAST thing in the system prompt, so two
+// deliveries of the same role share every byte before it. A provider with
+// automatic prefix caching can only reuse a prefix that is actually shared;
+// leading with the instruction would leave nothing to reuse.
+func TestRun_SystemPromptPutsInstructionLast(t *testing.T) {
+	base := Input{ReadPatterns: []string{"boards/**"}, WritePatterns: []string{"boards/**"}}
+
+	a := base
+	a.Instruction = "FIRST-DELIVERY-INSTRUCTION"
+	b := base
+	b.Instruction = "SECOND-DELIVERY-INSTRUCTION"
+
+	promptA := systemPromptFor(t, a)
+	promptB := systemPromptFor(t, b)
+
+	require.True(t, strings.HasSuffix(promptA, "FIRST-DELIVERY-INSTRUCTION"),
+		"instruction must be last in the prompt, got:\n%s", promptA)
+
+	shared := commonPrefix(promptA, promptB)
+	require.Contains(t, shared, "boards/**", "the role's scope must sit inside the shared prefix")
+	require.Contains(t, shared, "Rules:", "the static rules must sit inside the shared prefix")
+	require.Len(t, shared, len(promptA)-len("FIRST-DELIVERY-INSTRUCTION"),
+		"everything except the instruction must be shared between deliveries")
+}
+
+// commonPrefix returns the longest prefix a and b share.
+func commonPrefix(a, b string) string {
+	n := min(len(a), len(b))
+	i := 0
+	for i < n && a[i] == b[i] {
+		i++
+	}
+	return a[:i]
+}
+
+// TestRun_SystemPromptDoesNotNameUnofferedTools: a role whose allowlist omits
+// the write tools must not read about them in its prompt. Advertising a tool
+// the runtime will refuse buys nothing but tokens and not_permitted denials.
+func TestRun_SystemPromptDoesNotNameUnofferedTools(t *testing.T) {
+	prompt := systemPromptFor(t, Input{
+		Instruction:  "summarize",
+		ReadPatterns: []string{"boards/**"},
+		Tools:        []string{toolSearch, toolFinish},
+	})
+	require.NotContains(t, prompt, toolWriteNote)
+	require.NotContains(t, prompt, toolPatchNote)
+}

--- a/cmd/fleet/internal/fleetmetrics/metrics.go
+++ b/cmd/fleet/internal/fleetmetrics/metrics.go
@@ -145,7 +145,7 @@ func (m *Metrics) initRun() {
 	}, []string{roleLabel})
 	m.tokens = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "fleet_llm_tokens_total",
-		Help: "LLM tokens spent, by model, role and kind (prompt|completion). A codellm-backed fleet reports zero: it executes code, it does not infer",
+		Help: "LLM tokens spent, by model, role and kind (prompt|completion|cached). cached is the share of prompt served from the provider's prompt cache — a subset of prompt, not spend on top of it, so do not sum the kinds. A codellm-backed fleet reports zero: it executes code, it does not infer",
 	}, []string{modelLabel, roleLabel, "kind"})
 	m.toolCalls = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "fleet_tool_calls_total",

--- a/docs/dev/fleet_codellm_metrics.md
+++ b/docs/dev/fleet_codellm_metrics.md
@@ -84,7 +84,7 @@ count. That keeps the execution core free of a metrics dependency.
 |---|---|
 | `fleet_runs_total{role,status}` | `completed` \| `capped` \| `max_steps` \| `error` |
 | `fleet_run_steps{role}` / `fleet_run_duration_seconds{role}` | drift toward the step ceiling precedes hitting it |
-| `fleet_llm_tokens_total{model,role,kind}` | one series answers both cost-per-model and cost-per-role |
+| `fleet_llm_tokens_total{model,role,kind}` | kind = `prompt` \| `completion` \| `cached`; one series answers both cost-per-model and cost-per-role. `cached` is the share of `prompt` the provider served from its prompt cache — a subset, not spend on top, so never sum the kinds |
 | `fleet_tool_calls_total{tool,outcome}` | `ok` \| `denied` \| `invalid_args` \| `error` \| `apply_failed` \| `not_permitted` |
 | `fleet_denials_total{kind}` | `read` \| `write` \| `not_permitted`; a steady rate usually means misconfigured patterns |
 | `fleet_apply_failures_total{role,tool}` | under `HardFailApply` each one kills its run |


### PR DESCRIPTION
`cmd/fleet` sent no prompt-cache signal of any kind, and its system prompt was laid out so that even automatic prefix caching had nothing to reuse.

## What was wrong

**The static part sat behind the volatile part.** `systemPromptTemplate` led with the per-delivery instruction (Jet-rendered per delivery, and it can carry a whole `change_file.Content`), then the role scope, then the tool prose, then the rules. Everything stable was *after* the one thing that changes every time, so two deliveries of the same role shared a single line of prefix. Every provider with prefix caching — OpenAI, DeepSeek, vLLM, SGLang, Ollama — can only reuse a prefix that is actually shared.

**The tools were described twice.** The prompt restated all five tools in prose while the same tools already reach the model as request tool schemas. The prose copy also never tracked `Role.Tools`: a role allowlisted to `search`+`finish` still read about `write_note` and `patch_note`, and a role with `exec` enabled never read about `exec`. That is tokens on every step plus an invitation to call tools the runtime will only refuse with `not_permitted`.

**Cache effectiveness was invisible.** Nothing read `usage.prompt_tokens_details.cached_tokens`, so there was no way to tell whether any of this worked against whatever endpoint `--llm-base-url` points at.

## What this changes

- **Reorder `systemPromptTemplate` most-stable-first**: static preamble + rules → role scope → instruction last. The shared prefix across deliveries of one role is now the entire prompt minus the instruction. Pinned by `TestRun_SystemPromptPutsInstructionLast`, which asserts the two prompts differ only in their trailing instruction.
- **Drop the prose tool list.** The uniqueness guidance that only lived in the prose (`patch_note` fails on an absent or ambiguous `find`) moves into that tool's `ToolDef.Description`, so no information is lost and the schema stays the single source of truth. `TestRun_SystemPromptDoesNotNameUnofferedTools` pins that a restricted role no longer reads about tools it does not have.
- **Report cache hits**: `ChatResult.CachedPromptTokens` is read off `Usage.PromptTokensDetails` (nil-safe — most local runtimes omit it) and recorded as `fleet_llm_tokens_total{kind="cached"}`. It is a *subset* of the prompt tokens, so it is deliberately not added to `Result.TokensUsed`; double-counting it would make the token budget bind early. The metric help and `docs/dev/fleet_codellm_metrics.md` both say so.

The in-run message history was already cache-friendly and is untouched: `messages` only ever grows, nothing is truncated or reordered, and `tools` is built once from a deterministic slice.

## What this deliberately does not do

Explicit `cache_control` breakpoints for Anthropic-style providers, where caching is opt-in rather than automatic and this PR therefore buys nothing. `go-openai`'s `ChatMessagePart` has no such field, so it needs either custom marshalling or a second `LLM` implementation behind the existing seam — a design call, left out of this PR.

## Testing

`go test ./cmd/fleet/...` and `make lint` — green, 5 new tests.