### PR TITLE
fix(codellm): refuse to unseal when an expose-env prefix covers the role's seal key

### DIFF
--- a/cmd/codellm/internal/codellm/server.go
+++ b/cmd/codellm/internal/codellm/server.go
@@ -280,7 +280,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// this process: it is resolved from codellm's OWN environment and the
 	// plaintext goes into the bag, not into the child's env, so a role can only
 	// read the secrets its own note declared.
-	bag, secrets, unsealErr := unsealBag(bag, osEnv{}, s.cfg.ExposeEnv)
+	bag, secrets, unsealErr := unsealBag(bag, osEnv{}, s.cfg.ExposeEnv, s.cfg.ExposeEnvPrefix)
 	if unsealErr != nil {
 		s.cfg.Metrics.RecordExecError(unsealErr)
 		writeError(w, http.StatusUnprocessableEntity, "unseal_error", unsealErr.Error())

--- a/cmd/codellm/internal/codellm/unseal.go
+++ b/cmd/codellm/internal/codellm/unseal.go
@@ -94,9 +94,11 @@ func openSealed(key, blob string) (string, error) {
 // fleet and codellm are deployed separately, so a newer fleet may send fields
 // this build does not model, and a typed round trip would silently drop them.
 //
-// exposedToChild is the env allowlist the code child will receive; naming the
-// seal key there is a deploy mistake that must fail, not be worked around.
-func unsealBag(bag []byte, env envLookup, exposedToChild []string) ([]byte, []string, error) {
+// exposedNames and exposedPrefixes are the operator's env allowlist for the
+// code child; a seal key either one covers is a deploy mistake that must fail,
+// not be worked around. Startup only checks the default key name, so a role
+// naming its own key is checked here against the same predicate.
+func unsealBag(bag []byte, env envLookup, exposedNames, exposedPrefixes []string) ([]byte, []string, error) {
 	if len(bag) == 0 {
 		return bag, nil, nil
 	}
@@ -119,7 +121,7 @@ func unsealBag(bag []byte, env envLookup, exposedToChild []string) ([]byte, []st
 	if v, ok := doc["unseal_env_key"].(string); ok && strings.TrimSpace(v) != "" {
 		envKey = strings.TrimSpace(v)
 	}
-	if nameIsExposed(envKey, exposedToChild) {
+	if matchesAllowlist(envKey, exposedNames, exposedPrefixes) {
 		return nil, nil, fmt.Errorf("%w: %s", errSealKeyExposed, envKey)
 	}
 
@@ -148,18 +150,6 @@ func unsealBag(bag []byte, env envLookup, exposedToChild []string) ([]byte, []st
 		return nil, nil, fmt.Errorf("delivery bag: %w", err)
 	}
 	return out, opened, nil
-}
-
-// nameIsExposed reports whether name is on the child env allowlist. Only exact
-// names are checked here; prefixes are rejected at startup, where the operator
-// can act on them.
-func nameIsExposed(name string, exposed []string) bool {
-	for _, e := range exposed {
-		if e == name {
-			return true
-		}
-	}
-	return false
 }
 
 func stringSlice(v any) []string {
@@ -210,7 +200,7 @@ func (osEnv) get(name string) string { return os.Getenv(name) }
 // the default name can be checked here; a role naming its own key is checked
 // per run, since codellm learns those names only from notes.
 func ValidateSealKeyNotExposed(exposeEnv, exposeEnvPrefix []string) error {
-	if nameIsExposed(defaultSealEnvKey, exposeEnv) {
+	if matchesAllowlist(defaultSealEnvKey, exposeEnv, nil) {
 		return fmt.Errorf("%w: %s is in the expose-env allowlist", errSealKeyExposed, defaultSealEnvKey)
 	}
 	for _, p := range exposeEnvPrefix {

--- a/cmd/codellm/internal/codellm/unseal_test.go
+++ b/cmd/codellm/internal/codellm/unseal_test.go
@@ -64,7 +64,7 @@ func TestUnsealBag_OpensDeclaredFields(t *testing.T) {
 		"depth":  1,
 	})
 
-	out, opened, err := unsealBag(bag, mapEnv{"SEAL_KEY": testKey}, nil)
+	out, opened, err := unsealBag(bag, mapEnv{"SEAL_KEY": testKey}, nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, []string{"krisp-token-value"}, opened)
 
@@ -88,7 +88,7 @@ func TestUnsealBag_PreservesUnknownFields(t *testing.T) {
 		"changed_files": []any{},
 	})
 
-	out, _, err := unsealBag(bag, mapEnv{}, nil)
+	out, _, err := unsealBag(bag, mapEnv{}, nil, nil)
 	require.NoError(t, err)
 
 	var got map[string]any
@@ -99,7 +99,7 @@ func TestUnsealBag_PreservesUnknownFields(t *testing.T) {
 func TestUnsealBag_NoDeclarationIsANoOp(t *testing.T) {
 	bag := bagJSON(t, map[string]any{"frontmatter": map[string]string{"a": "b"}})
 
-	out, opened, err := unsealBag(bag, mapEnv{}, nil)
+	out, opened, err := unsealBag(bag, mapEnv{}, nil, nil)
 	require.NoError(t, err)
 	require.Empty(t, opened)
 
@@ -116,7 +116,7 @@ func TestUnsealBag_CustomEnvKey(t *testing.T) {
 		"unseal_env_key": "SEAL_KEY_V2",
 	})
 
-	_, opened, err := unsealBag(bag, mapEnv{"SEAL_KEY_V2": testKey}, nil)
+	_, opened, err := unsealBag(bag, mapEnv{"SEAL_KEY_V2": testKey}, nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, []string{"v"}, opened)
 }
@@ -130,7 +130,7 @@ func TestUnsealBag_MissingFieldIsAnError(t *testing.T) {
 		"unseal":      []string{"absent"},
 	})
 
-	_, _, err := unsealBag(bag, mapEnv{"SEAL_KEY": testKey}, nil)
+	_, _, err := unsealBag(bag, mapEnv{"SEAL_KEY": testKey}, nil, nil)
 	require.ErrorContains(t, err, "absent")
 }
 
@@ -141,7 +141,7 @@ func TestUnsealBag_UnknownEnvKeyIsAnError(t *testing.T) {
 		"unseal":      []string{"tok"},
 	})
 
-	_, _, err := unsealBag(bag, mapEnv{}, nil)
+	_, _, err := unsealBag(bag, mapEnv{}, nil, nil)
 	require.Error(t, err)
 }
 
@@ -155,7 +155,7 @@ func TestUnsealBag_ErrorDoesNotLeakEnvDetail(t *testing.T) {
 		"unseal":      []string{"tok"},
 	})
 
-	_, _, err := unsealBag(bag, mapEnv{"SEAL_KEY": "short"}, nil)
+	_, _, err := unsealBag(bag, mapEnv{"SEAL_KEY": "short"}, nil, nil)
 
 	require.Error(t, err)
 	require.NotContains(t, err.Error(), "32 bytes")
@@ -172,9 +172,49 @@ func TestUnsealBag_RefusesKeyExposedToChildren(t *testing.T) {
 		"unseal":      []string{"tok"},
 	})
 
-	_, _, err := unsealBag(bag, mapEnv{"SEAL_KEY": testKey}, []string{"SEAL_KEY"})
+	_, _, err := unsealBag(bag, mapEnv{"SEAL_KEY": testKey}, []string{"SEAL_KEY"}, nil)
 
 	require.ErrorIs(t, err, errSealKeyExposed)
+}
+
+// An operator prefix forwards every matching var into the child env, so a key
+// it covers is just as exposed as one listed by name. Startup only checks the
+// default name; a role-named key is only known here.
+func TestUnsealBag_RefusesKeyCoveredByExposedPrefix(t *testing.T) {
+	blob := sealWith(t, "v")
+
+	tests := []struct {
+		name     string
+		envKey   string
+		prefixes []string
+		wantErr  error
+	}{
+		{name: "role key under operator prefix", envKey: "KRISP_SEAL_KEY", prefixes: []string{"KRISP_"}, wantErr: errSealKeyExposed},
+		{name: "default key under operator prefix", envKey: "", prefixes: []string{"SEAL"}, wantErr: errSealKeyExposed},
+		{name: "prefix does not cover the key", envKey: "KRISP_SEAL_KEY", prefixes: []string{"OTHER_"}},
+		{name: "empty prefix covers nothing", envKey: "KRISP_SEAL_KEY", prefixes: []string{""}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := map[string]any{
+				"frontmatter": map[string]string{"tok": blob},
+				"unseal":      []string{"tok"},
+			}
+			if tt.envKey != "" {
+				doc["unseal_env_key"] = tt.envKey
+			}
+			env := mapEnv{"SEAL_KEY": testKey, "KRISP_SEAL_KEY": testKey}
+
+			_, opened, err := unsealBag(bagJSON(t, doc), env, nil, tt.prefixes)
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, []string{"v"}, opened)
+		})
+	}
 }
 
 func TestRedactSecrets(t *testing.T) {
@@ -203,7 +243,7 @@ func TestDataEncryptionCompat(t *testing.T) {
 func TestUnsealBag_NonJSONPassesThrough(t *testing.T) {
 	raw := []byte("hello, not json")
 
-	out, opened, err := unsealBag(raw, mapEnv{}, nil)
+	out, opened, err := unsealBag(raw, mapEnv{}, nil, nil)
 
 	require.NoError(t, err)
 	require.Empty(t, opened)


### PR DESCRIPTION
## What was wrong

The seal-key exposure guard in codellm ignored the operator's `--expose-env-prefix` allowlist.

- `handleChatCompletions` called `unsealBag(bag, osEnv{}, s.cfg.ExposeEnv)` with only the exact-name allowlist.
- `nameIsExposed` compared exact names only; its comment claimed prefixes were "rejected at startup".
- `ValidateSealKeyNotExposed` does check prefixes at startup, but only for the default `SEAL_KEY` name.
- `effectiveEnvNames` forwards every env var matching an operator prefix into the child env.

## Scenario

Operator runs codellm with `--expose-env-prefix=KRISP_`. A role note sets `unseal_env_key: KRISP_SEAL_KEY`. Startup validation passes (`SEAL_KEY` does not start with `KRISP_`), the per-run check passes (the exact-name list does not contain it), and the child env receives `KRISP_SEAL_KEY`. The role's code then holds the decryption key for every sealed blob it can read, which is exactly the escalation `errSealKeyExposed` exists to block.

## What changed

- `unsealBag` now takes both `exposedNames` and `exposedPrefixes`; `server.go` passes `s.cfg.ExposeEnvPrefix` through.
- The check reuses `matchesAllowlist` from `envscope.go`, the same predicate that decides what reaches the child, so name and prefix coverage cannot drift apart again.
- `nameIsExposed` and its stale comment are removed; `ValidateSealKeyNotExposed` behaviour is unchanged (it still reports name and prefix hits with distinct messages).

## Testing

- New `TestUnsealBag_RefusesKeyCoveredByExposedPrefix` (table-driven): role key under an operator prefix and default `SEAL_KEY` under a prefix are refused with `errSealKeyExposed`; a non-matching prefix and an empty prefix still unseal. Confirmed red before the fix (both covered cases returned nil error).
- `go test ./cmd/codellm/...`, `go vet ./cmd/codellm/...`, golangci-lint with `--build-tags dev`: all green. Pre-push hook ran the full suite and lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
