### PR TITLE
fix(docker): docs image binds its internal listener to loopback

### DIFF
--- a/Dockerfile.docs
+++ b/Dockerfile.docs
@@ -6,7 +6,7 @@ FROM ${TRIP2G_IMAGE}
 RUN apk add --no-cache nodejs unzip
 
 ENV LISTEN_ADDR=0.0.0.0:8080 \
-    INTERNAL_LISTEN_ADDR=:8081 \
+    INTERNAL_LISTEN_ADDR=127.0.0.1:8081 \
     PUBLIC_URL=http://127.0.0.1:8080 \
     DB_FILE=/data/data.sqlite3 \
     STORAGE_BACKEND=local \

--- a/scripts/docs-image-entrypoint.sh
+++ b/scripts/docs-image-entrypoint.sh
@@ -23,7 +23,7 @@ mkdir -p "$(dirname "$DB_FILE")" "$STORAGE_LOCAL_DIR"
 server=$!
 
 i=0
-until wget -q -O /dev/null "http://127.0.0.1${INTERNAL_LISTEN_ADDR}/readyz"; do
+until wget -q -O /dev/null "http://${INTERNAL_LISTEN_ADDR}/readyz"; do
     i=$((i + 1))
     if [ "$i" -gt 150 ]; then
         echo "trip2g-docs: trip2g did not come up" >&2


### PR DESCRIPTION
`INTERNAL_LISTEN_ADDR` defaulted to `:8081`, so `/readyz`, `/metrics` and pprof were bound on every interface of the container. Only the site on 8080 is meant to be reached from outside; the internal listener now defaults to `127.0.0.1:8081`, and the entrypoint waits on the address as given instead of prefixing a host to it.

Verified: rebuilt, `Pushed: 250`; inside the container `127.0.0.1:8081` and `0.0.0.0:8080` listen; `/readyz` published on the host is unreachable (curl 000) while `/en/user` on 8080 answers 200.