### PR TITLE
fix(auth): OAuth login loses the page it started on, and downgrades https to http

### DIFF
--- a/assets/ui/auth/oauth/buttons/buttons.view.ts
+++ b/assets/ui/auth/oauth/buttons/buttons.view.ts
@@ -1,8 +1,13 @@
 namespace $.$$ {
 	export class $trip2g_auth_oauth_buttons extends $.$trip2g_auth_oauth_buttons {
+		redirect_url() {
+			const here = new URL( this.$.$mol_state_arg.href() )
+			return here.pathname + here.search + here.hash
+		}
+
 		@$mol_mem
 		oauth_urls() {
-			const redirectUrl = this.$.$mol_state_arg.href()
+			const redirectUrl = this.redirect_url()
 			try {
 				return $trip2g_auth_oauth_buttons_urls({ input: { redirectUrl } })
 			} catch {

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -13,6 +13,7 @@ import (
 	"time"
 	"trip2g/internal/acmecache"
 	"trip2g/internal/appreq"
+	"trip2g/internal/appresp"
 	"trip2g/internal/case/signinbyhat"
 	"trip2g/internal/metrics"
 	"trip2g/internal/noteloader"
@@ -95,7 +96,7 @@ func (a *app) startServer() { //nolint:gocognit // server startup wiring
 				query.Del("hat")
 				parsedURL.RawQuery = query.Encode()
 
-				ctx.Redirect(parsedURL.String(), http.StatusFound)
+				appresp.Redirect(ctx, parsedURL.String(), http.StatusFound)
 				return
 			}
 		}

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -96,7 +96,11 @@ func (a *app) startServer() { //nolint:gocognit // server startup wiring
 				query.Del("hat")
 				parsedURL.RawQuery = query.Encode()
 
-				appresp.Redirect(ctx, parsedURL.String(), http.StatusFound)
+				// RequestURI, not String: the target is this request's own URL
+				// with one parameter removed, so it has no business carrying a
+				// host. A request line may be absolute-form, and String() would
+				// then hand that host straight back as a redirect.
+				appresp.Redirect(ctx, parsedURL.RequestURI(), http.StatusFound)
 				return
 			}
 		}

--- a/e2e/oidc.spec.js
+++ b/e2e/oidc.spec.js
@@ -101,6 +101,26 @@ test.describe.serial('OIDC SSO login', () => {
     expect(await sessionCookie(page)).toBeTruthy();
   });
 
+  test('login returns to the page it started on', async ({ page, request, baseURL }) => {
+    await createOidcCred(request, adminToken, idp.issuer, { autoProvision: false });
+    idp.setUser({ email: 'existing-oidc@example.com', email_verified: true });
+
+    const relative = new URL(await login(page, '/some/deep/page?tab=2'));
+    expect(relative.pathname + relative.search).toBe('/some/deep/page?tab=2');
+    expect(await sessionCookie(page)).toBeTruthy();
+
+    // The frontend reads location.href, so the redirect arrives absolute; an
+    // absolute URL on our own origin must keep its path rather than collapse
+    // to the root.
+    const absolute = new URL(await login(page, `${baseURL}/some/deep/page`));
+    expect(absolute.pathname).toBe('/some/deep/page');
+
+    // Anywhere else is still refused, which is what safeRedirect is for.
+    const elsewhere = new URL(await login(page, 'https://evil.example.com/steal'));
+    expect(elsewhere.host).toBe(new URL(baseURL).host);
+    expect(elsewhere.pathname).toBe('/');
+  });
+
   test('missing UserInfo verification falls back to matching signed ID token', async ({ page, request }) => {
     await createOidcCred(request, adminToken, idp.issuer, { autoProvision: false });
     idp.setUser({ email: 'existing-oidc@example.com', email_verified: undefined });

--- a/internal/appresp/redirect.go
+++ b/internal/appresp/redirect.go
@@ -1,0 +1,18 @@
+package appresp
+
+import "github.com/valyala/fasthttp"
+
+// Redirect sends the browser to location, written to the Location header
+// exactly as given.
+//
+// fasthttp's ctx.Redirect resolves a relative target against the request URI
+// and emits the absolute result, so behind a TLS-terminating proxy — where the
+// request always arrives over plain http — every relative redirect downgrades
+// the browser to http. The Secure cookies just set on the https response are
+// then not sent, and a sign-in that succeeded looks like one that failed.
+// A relative Location is resolved by the browser against the page it is
+// actually on, which is the only place the real scheme still exists.
+func Redirect(ctx *fasthttp.RequestCtx, location string, statusCode int) {
+	ctx.Response.Header.Set(fasthttp.HeaderLocation, location)
+	ctx.Response.SetStatusCode(statusCode)
+}

--- a/internal/appresp/redirect_test.go
+++ b/internal/appresp/redirect_test.go
@@ -1,0 +1,47 @@
+package appresp
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+func TestRedirectKeepsTheLocationVerbatim(t *testing.T) {
+	cases := []struct {
+		name     string
+		location string
+	}{
+		{"root", "/"},
+		{"path with query", "/?berror=invalid_state"},
+		{"path with fragment", "/boards/x#!userspace=open"},
+		{"absolute elsewhere", "https://oauth.example.com/auth?client_id=x"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var ctx fasthttp.RequestCtx
+			ctx.Request.SetRequestURI("/_system/auth/oidc/callback")
+			ctx.Request.SetHost("app.example.com")
+
+			Redirect(&ctx, tc.location, http.StatusFound)
+
+			require.Equal(t, http.StatusFound, ctx.Response.StatusCode())
+			require.Equal(t, tc.location, string(ctx.Response.Header.Peek("Location")))
+		})
+	}
+}
+
+// A relative target must not be absolutised against the request, which behind a
+// TLS-terminating proxy always says http — the downgrade that drops every
+// Secure cookie the browser was just given.
+func TestRedirectDoesNotAdoptTheRequestScheme(t *testing.T) {
+	var ctx fasthttp.RequestCtx
+	ctx.Request.SetRequestURI("/_system/auth/oidc/callback")
+	ctx.Request.SetHost("app.example.com")
+
+	Redirect(&ctx, "/", http.StatusFound)
+
+	require.NotContains(t, string(ctx.Response.Header.Peek("Location")), "http://")
+}

--- a/internal/case/handlegithubcallback/endpoint.go
+++ b/internal/case/handlegithubcallback/endpoint.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"trip2g/internal/appreq"
+	"trip2g/internal/appresp"
 	"trip2g/internal/db"
 	"trip2g/internal/githubauth"
 	"trip2g/internal/logger"
@@ -39,7 +40,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 		env.Logger().Info("oauth login failed: oauth not configured",
 			"provider", "github",
 			"ip", clientIP)
-		ctx.Redirect("/?berror=oauth_not_configured", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=oauth_not_configured", http.StatusFound)
 		return nil, nil //nolint:nilerr // error handled via redirect, not returned
 	}
 
@@ -50,7 +51,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 			"provider", "github",
 			"error", err.Error(),
 			"ip", clientIP)
-		ctx.Redirect("/?berror=oauth_failed", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=oauth_failed", http.StatusFound)
 		return nil, nil
 	}
 	clientSecret := string(clientSecretBytes)
@@ -61,7 +62,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 			"provider", "github",
 			"error", errorParam,
 			"ip", clientIP)
-		ctx.Redirect("/?berror=oauth_failed", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=oauth_failed", http.StatusFound)
 		return nil, nil
 	}
 
@@ -72,7 +73,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 		env.Logger().Info("oauth login failed: invalid state",
 			"provider", "github",
 			"ip", clientIP)
-		ctx.Redirect("/?berror=invalid_state", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=invalid_state", http.StatusFound)
 		return nil, nil //nolint:nilerr // redirect response with error logged
 	}
 
@@ -85,7 +86,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 			"provider", "github",
 			"error", err.Error(),
 			"ip", clientIP)
-		ctx.Redirect("/?berror=oauth_failed", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=oauth_failed", http.StatusFound)
 		return nil, nil
 	}
 
@@ -96,7 +97,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 			"provider", "github",
 			"error", err.Error(),
 			"ip", clientIP)
-		ctx.Redirect("/?berror=email_not_verified", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=email_not_verified", http.StatusFound)
 		return nil, nil
 	}
 
@@ -108,14 +109,14 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 				"provider", "github",
 				"email", email,
 				"ip", clientIP)
-			ctx.Redirect("/?berror=user_not_found", http.StatusFound)
+			appresp.Redirect(ctx, "/?berror=user_not_found", http.StatusFound)
 			return nil, nil
 		}
 		env.Logger().Info("oauth login failed: oauth error",
 			"provider", "github",
 			"error", err.Error(),
 			"ip", clientIP)
-		ctx.Redirect("/?berror=oauth_failed", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=oauth_failed", http.StatusFound)
 		return nil, nil
 	}
 
@@ -126,7 +127,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 			"provider", "github",
 			"error", err.Error(),
 			"ip", clientIP)
-		ctx.Redirect("/?berror=oauth_failed", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=oauth_failed", http.StatusFound)
 		return nil, nil
 	}
 
@@ -137,7 +138,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 		"ip", clientIP)
 
 	// Redirect to saved URL
-	ctx.Redirect(redirect, http.StatusFound)
+	appresp.Redirect(ctx, redirect, http.StatusFound)
 	return nil, nil
 }
 

--- a/internal/case/handlegithubstart/endpoint.go
+++ b/internal/case/handlegithubstart/endpoint.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"trip2g/internal/appreq"
+	"trip2g/internal/appresp"
 	"trip2g/internal/db"
 	"trip2g/internal/githubauth"
 	"trip2g/internal/oauthstate"
@@ -25,7 +26,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 	// Load credentials from DB
 	creds, err := env.GetActiveGitHubOAuthCredentials(ctx)
 	if err != nil || creds.ClientID == "" {
-		req.Req.Redirect("/?berror=oauth_not_configured", http.StatusFound)
+		appresp.Redirect(req.Req, "/?berror=oauth_not_configured", http.StatusFound)
 		return nil, nil //nolint:nilerr // error handled via redirect, not returned
 	}
 
@@ -47,7 +48,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 
 	// Redirect to GitHub OAuth
 	authURL := githubauth.BuildAuthURL(creds.ClientID, callbackURL, state)
-	req.Req.Redirect(authURL, http.StatusFound)
+	appresp.Redirect(req.Req, authURL, http.StatusFound)
 
 	return nil, nil
 }

--- a/internal/case/handlegooglecallback/endpoint.go
+++ b/internal/case/handlegooglecallback/endpoint.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"trip2g/internal/appreq"
+	"trip2g/internal/appresp"
 	"trip2g/internal/db"
 	"trip2g/internal/googleauth"
 	"trip2g/internal/logger"
@@ -39,7 +40,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 		env.Logger().Info("oauth login failed: oauth not configured",
 			"provider", "google",
 			"ip", clientIP)
-		ctx.Redirect("/?berror=oauth_not_configured", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=oauth_not_configured", http.StatusFound)
 		return nil, nil //nolint:nilerr // error handled via redirect, not returned
 	}
 
@@ -50,7 +51,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 			"provider", "google",
 			"error", err.Error(),
 			"ip", clientIP)
-		ctx.Redirect("/?berror=oauth_failed", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=oauth_failed", http.StatusFound)
 		return nil, nil
 	}
 	clientSecret := string(clientSecretBytes)
@@ -61,7 +62,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 			"provider", "google",
 			"error", errorParam,
 			"ip", clientIP)
-		ctx.Redirect("/?berror=oauth_failed", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=oauth_failed", http.StatusFound)
 		return nil, nil
 	}
 
@@ -72,7 +73,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 		env.Logger().Info("oauth login failed: invalid state",
 			"provider", "google",
 			"ip", clientIP)
-		ctx.Redirect("/?berror=invalid_state", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=invalid_state", http.StatusFound)
 		return nil, nil //nolint:nilerr // redirect response with error logged
 	}
 
@@ -86,7 +87,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 			"provider", "google",
 			"error", err.Error(),
 			"ip", clientIP)
-		ctx.Redirect("/?berror=oauth_failed", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=oauth_failed", http.StatusFound)
 		return nil, nil
 	}
 
@@ -97,7 +98,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 			"provider", "google",
 			"error", err.Error(),
 			"ip", clientIP)
-		ctx.Redirect("/?berror=oauth_failed", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=oauth_failed", http.StatusFound)
 		return nil, nil
 	}
 
@@ -109,14 +110,14 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 				"provider", "google",
 				"email", userInfo.Email,
 				"ip", clientIP)
-			ctx.Redirect("/?berror=user_not_found", http.StatusFound)
+			appresp.Redirect(ctx, "/?berror=user_not_found", http.StatusFound)
 			return nil, nil
 		}
 		env.Logger().Info("oauth login failed: oauth error",
 			"provider", "google",
 			"error", err.Error(),
 			"ip", clientIP)
-		ctx.Redirect("/?berror=oauth_failed", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=oauth_failed", http.StatusFound)
 		return nil, nil
 	}
 
@@ -127,7 +128,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 			"provider", "google",
 			"error", err.Error(),
 			"ip", clientIP)
-		ctx.Redirect("/?berror=oauth_failed", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=oauth_failed", http.StatusFound)
 		return nil, nil
 	}
 
@@ -138,7 +139,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 		"ip", clientIP)
 
 	// Redirect to saved URL
-	ctx.Redirect(redirect, http.StatusFound)
+	appresp.Redirect(ctx, redirect, http.StatusFound)
 	return nil, nil
 }
 

--- a/internal/case/handlegooglestart/endpoint.go
+++ b/internal/case/handlegooglestart/endpoint.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"trip2g/internal/appreq"
+	"trip2g/internal/appresp"
 	"trip2g/internal/db"
 	"trip2g/internal/googleauth"
 	"trip2g/internal/oauthstate"
@@ -25,7 +26,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 	// Load credentials from DB
 	creds, err := env.GetActiveGoogleOAuthCredentials(ctx)
 	if err != nil || creds.ClientID == "" {
-		req.Req.Redirect("/?berror=oauth_not_configured", http.StatusFound)
+		appresp.Redirect(req.Req, "/?berror=oauth_not_configured", http.StatusFound)
 		return nil, nil //nolint:nilerr // error handled via redirect, not returned
 	}
 
@@ -47,7 +48,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 
 	// Redirect to Google OAuth
 	authURL := googleauth.BuildAuthURL(creds.ClientID, callbackURL, state)
-	req.Req.Redirect(authURL, http.StatusFound)
+	appresp.Redirect(req.Req, authURL, http.StatusFound)
 
 	return nil, nil
 }

--- a/internal/case/handleoidccallback/endpoint.go
+++ b/internal/case/handleoidccallback/endpoint.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"trip2g/internal/appreq"
+	"trip2g/internal/appresp"
 	"trip2g/internal/db"
 	"trip2g/internal/logger"
 	"trip2g/internal/oauthstate"
@@ -44,7 +45,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 		env.Logger().Info("oauth login failed: oauth not configured",
 			"provider", "oidc",
 			"ip", clientIP)
-		ctx.Redirect("/?berror=oauth_not_configured", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=oauth_not_configured", http.StatusFound)
 		return nil, nil //nolint:nilerr // error handled via redirect, not returned
 	}
 
@@ -55,7 +56,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 			"provider", "oidc",
 			"error", err.Error(),
 			"ip", clientIP)
-		ctx.Redirect("/?berror=oauth_failed", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=oauth_failed", http.StatusFound)
 		return nil, nil
 	}
 	clientSecret := string(clientSecretBytes)
@@ -66,7 +67,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 			"provider", "oidc",
 			"error", errorParam,
 			"ip", clientIP)
-		ctx.Redirect("/?berror=oauth_failed", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=oauth_failed", http.StatusFound)
 		return nil, nil
 	}
 
@@ -78,7 +79,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 		env.Logger().Info("oauth login failed: invalid state",
 			"provider", "oidc",
 			"ip", clientIP)
-		ctx.Redirect("/?berror=invalid_state", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=invalid_state", http.StatusFound)
 		return nil, nil //nolint:nilerr // redirect response with error logged
 	}
 
@@ -89,7 +90,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 			"provider", "oidc",
 			"error", err.Error(),
 			"ip", clientIP)
-		ctx.Redirect("/?berror=oauth_failed", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=oauth_failed", http.StatusFound)
 		return nil, nil
 	}
 
@@ -103,7 +104,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 			"provider", "oidc",
 			"error", err.Error(),
 			"ip", clientIP)
-		ctx.Redirect("/?berror=oauth_failed", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=oauth_failed", http.StatusFound)
 		return nil, nil
 	}
 
@@ -123,7 +124,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 			"provider", "oidc",
 			"error", err.Error(),
 			"ip", clientIP)
-		ctx.Redirect("/?berror=oauth_failed", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=oauth_failed", http.StatusFound)
 		return nil, nil
 	}
 
@@ -132,7 +133,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 		env.Logger().Info("oauth login failed: id_token/userinfo sub mismatch",
 			"provider", "oidc",
 			"ip", clientIP)
-		ctx.Redirect("/?berror=oauth_failed", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=oauth_failed", http.StatusFound)
 		return nil, nil
 	}
 
@@ -153,7 +154,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 			"berror", berr,
 			"reason", reason,
 			"ip", clientIP)
-		ctx.Redirect("/?berror="+berr, http.StatusFound)
+		appresp.Redirect(ctx, "/?berror="+berr, http.StatusFound)
 		return nil, nil
 	}
 
@@ -162,7 +163,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 			"provider", "oidc",
 			"error", err.Error(),
 			"ip", clientIP)
-		ctx.Redirect("/?berror=oauth_failed", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=oauth_failed", http.StatusFound)
 		return nil, nil
 	}
 	exists := err == nil
@@ -178,7 +179,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 				"provider", "oidc",
 				"email", userInfo.Email,
 				"ip", clientIP)
-			ctx.Redirect("/?berror="+pberr, http.StatusFound)
+			appresp.Redirect(ctx, "/?berror="+pberr, http.StatusFound)
 			return nil, nil
 		}
 
@@ -192,7 +193,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 				"provider", "oidc",
 				"error", err.Error(),
 				"ip", clientIP)
-			ctx.Redirect("/?berror=oauth_failed", http.StatusFound)
+			appresp.Redirect(ctx, "/?berror=oauth_failed", http.StatusFound)
 			return nil, nil
 		}
 
@@ -210,7 +211,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 			"provider", "oidc",
 			"error", err.Error(),
 			"ip", clientIP)
-		ctx.Redirect("/?berror=oauth_failed", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=oauth_failed", http.StatusFound)
 		return nil, nil
 	}
 
@@ -222,7 +223,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 		"ip", clientIP)
 
 	// Redirect to saved URL
-	ctx.Redirect(redirect, http.StatusFound)
+	appresp.Redirect(ctx, redirect, http.StatusFound)
 	return nil, nil
 }
 
@@ -247,7 +248,7 @@ func verifyIDToken(
 			"provider", "oidc",
 			"error", err.Error(),
 			"ip", clientIP)
-		ctx.Redirect("/?berror=oauth_failed", http.StatusFound)
+		appresp.Redirect(ctx, "/?berror=oauth_failed", http.StatusFound)
 		return nil, false
 	}
 	return claims, true

--- a/internal/case/handleoidcstart/endpoint.go
+++ b/internal/case/handleoidcstart/endpoint.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"trip2g/internal/appreq"
+	"trip2g/internal/appresp"
 	"trip2g/internal/db"
 	"trip2g/internal/oauthstate"
 	"trip2g/internal/oidcauth"
@@ -27,7 +28,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 	// Load credentials from DB
 	creds, err := env.GetActiveOIDCCredentials(ctx)
 	if err != nil || creds.ClientID == "" {
-		req.Req.Redirect("/?berror=oauth_not_configured", http.StatusFound)
+		appresp.Redirect(req.Req, "/?berror=oauth_not_configured", http.StatusFound)
 		return nil, nil //nolint:nilerr // error handled via redirect, not returned
 	}
 
@@ -57,7 +58,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 	// Discover OIDC endpoints from issuer
 	endpoints, err := oidcauth.Discover(creds.Issuer)
 	if err != nil {
-		req.Req.Redirect("/?berror=oauth_not_configured", http.StatusFound)
+		appresp.Redirect(req.Req, "/?berror=oauth_not_configured", http.StatusFound)
 		return nil, nil //nolint:nilerr // error handled via redirect, not returned
 	}
 
@@ -66,7 +67,7 @@ func (*Endpoint) Handle(req *appreq.Request) (interface{}, error) {
 
 	// Redirect to OIDC provider
 	authURL := oidcauth.BuildAuthURL(endpoints.AuthorizationEndpoint, creds.ClientID, callbackURL, state, creds.Scopes, nonce)
-	req.Req.Redirect(authURL, http.StatusFound)
+	appresp.Redirect(req.Req, authURL, http.StatusFound)
 
 	return nil, nil
 }

--- a/internal/case/signinbytgauthtoken/middleware.go
+++ b/internal/case/signinbytgauthtoken/middleware.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"net/url"
 
+	"trip2g/internal/appresp"
+
 	"github.com/valyala/fasthttp"
 )
 
@@ -39,7 +41,7 @@ func Process(ctx *fasthttp.RequestCtx, env Env) bool {
 	query.Del(QueryParam)
 	parsedURL.RawQuery = query.Encode()
 
-	ctx.Redirect(parsedURL.String(), http.StatusFound)
+	appresp.Redirect(ctx, parsedURL.String(), http.StatusFound)
 
 	return true
 }

--- a/internal/oauthstate/state.go
+++ b/internal/oauthstate/state.go
@@ -6,6 +6,8 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"net/url"
+	"regexp"
 	"time"
 
 	"github.com/valyala/fasthttp"
@@ -30,21 +32,56 @@ type State struct {
 }
 
 // safeRedirect ensures the redirect target is a same-origin relative path.
-// It rejects absolute URLs (http://, https://) and protocol-relative URLs (//)
-// to prevent open-redirect phishing after OAuth login.
-func safeRedirect(redirect string) string {
+// An absolute URL on host — what the frontend sends, since it reads
+// location.href — is reduced to its path; anything pointing elsewhere becomes
+// "/" so OAuth login cannot be turned into open-redirect phishing.
+func safeRedirect(host, redirect string) string {
 	if redirect == "" {
 		return "/"
 	}
+
+	if scheme.MatchString(redirect) {
+		return ownOriginPath(host, redirect)
+	}
+
 	// Must start with a single slash and not be protocol-relative (//host).
-	if len(redirect) < 1 || redirect[0] != '/' || (len(redirect) > 1 && redirect[1] == '/') {
+	if redirect[0] != '/' || (len(redirect) > 1 && redirect[1] == '/') {
 		return "/"
 	}
 	// Reject backslash variants that some browsers normalise to /.
 	if len(redirect) > 1 && redirect[1] == '\\' {
 		return "/"
 	}
+
 	return redirect
+}
+
+var scheme = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.-]*:`)
+
+// ownOriginPath keeps the path of an absolute URL that names this very host,
+// and refuses every other one. The scheme is not compared: behind a
+// TLS-terminating proxy the page and the request disagree about it, and the
+// answer is a path either way.
+func ownOriginPath(host, redirect string) string {
+	if host == "" {
+		return "/"
+	}
+
+	target, err := url.Parse(redirect)
+	if err != nil || target.Host != host || target.EscapedPath() == "" {
+		return "/"
+	}
+
+	path := target.EscapedPath()
+	if target.RawQuery != "" {
+		path += "?" + target.RawQuery
+	}
+
+	if target.Fragment != "" {
+		path += "#" + target.EscapedFragment()
+	}
+
+	return path
 }
 
 // Generate creates new state, sets cookie, returns encoded state for OAuth URL.
@@ -60,7 +97,7 @@ func GenerateWithOIDCNonce(ctx *fasthttp.RequestCtx, redirect, oidcNonce string,
 }
 
 func generate(ctx *fasthttp.RequestCtx, redirect, oidcNonce string, insecure bool) (string, error) {
-	redirect = safeRedirect(redirect)
+	redirect = safeRedirect(string(ctx.Host()), redirect)
 	// Generate random nonce (16 bytes, hex encoded = 32 chars)
 	nonceBytes := make([]byte, 16)
 	_, err := rand.Read(nonceBytes)

--- a/internal/oauthstate/state_test.go
+++ b/internal/oauthstate/state_test.go
@@ -10,32 +10,65 @@ import (
 )
 
 func TestSafeRedirect(t *testing.T) {
+	const host = "app.example.com"
+
 	cases := []struct {
+		name string
 		in   string
 		want string
 	}{
-		{"", "/"},
-		{"/", "/"},
-		{"/dashboard", "/dashboard"},
-		{"/settings/profile", "/settings/profile"},
-		// absolute URLs must be rejected
-		{"https://evil.com", "/"},
-		{"http://evil.com/steal", "/"},
+		{"empty", "", "/"},
+		{"root", "/", "/"},
+		{"path", "/dashboard", "/dashboard"},
+		{"nested path", "/settings/profile", "/settings/profile"},
+		// an absolute URL on our own host is reduced to its path: the frontend
+		// sends location.href, and losing the path there sends every sign-in
+		// back to the root instead of the page it started on
+		{"own host", "https://app.example.com/boards/x", "/boards/x"},
+		{"own host over http", "http://app.example.com/boards/x", "/boards/x"},
+		{"own host with query", "https://app.example.com/boards/x?tab=2", "/boards/x?tab=2"},
+		{"own host with fragment", "https://app.example.com/boards/x#!userspace=open", "/boards/x#!userspace=open"},
+		{"own host bare", "https://app.example.com", "/"},
+		{"own host with port", "https://app.example.com:8443/boards/x", "/"},
+		// absolute URLs elsewhere must be rejected
+		{"other host", "https://evil.com", "/"},
+		{"other host with path", "http://evil.com/steal", "/"},
+		{"userinfo disguise", "https://app.example.com@evil.com/steal", "/"},
+		{"host as prefix", "https://app.example.com.evil.com/steal", "/"},
 		// protocol-relative
-		{"//evil.com", "/"},
-		{"//evil.com/path", "/"},
+		{"protocol relative", "//evil.com", "/"},
+		{"protocol relative with path", "//evil.com/path", "/"},
 		// backslash variants some browsers normalise
-		{"/\\evil.com", "/"},
+		{"backslash", "/\\evil.com", "/"},
 		// no leading slash
-		{"evil.com", "/"},
-		{"relative/path", "/"},
+		{"bare host", "evil.com", "/"},
+		{"relative", "relative/path", "/"},
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.in, func(t *testing.T) {
-			require.Equal(t, tc.want, safeRedirect(tc.in))
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, safeRedirect(host, tc.in))
 		})
 	}
+}
+
+func TestSafeRedirectWithoutHostRejectsAbsolute(t *testing.T) {
+	require.Equal(t, "/", safeRedirect("", "https://app.example.com/boards/x"))
+}
+
+func TestGenerateKeepsOwnOriginPath(t *testing.T) {
+	var ctx fasthttp.RequestCtx
+	ctx.Request.SetHost("app.example.com")
+
+	encoded, err := Generate(&ctx, "https://app.example.com/boards/x#!userspace=open", true)
+	require.NoError(t, err)
+
+	raw, err := base64.URLEncoding.DecodeString(encoded)
+	require.NoError(t, err)
+
+	var s State
+	require.NoError(t, json.Unmarshal(raw, &s))
+	require.Equal(t, "/boards/x#!userspace=open", s.Redirect)
 }
 
 // csrfNonceFromState pulls the CSRF nonce out of an encoded state blob so the


### PR DESCRIPTION
Two independent bugs in the OAuth/OIDC sign-in path. They stack, and together they look like "SSO does not work in a mobile in-app browser": the login round trip completes, the browser lands on the site root, and it is still signed out.

## 1. The login always returns to `/`

`assets/ui/auth/oauth/buttons/buttons.view.ts` sends `$mol_state_arg.href()`, which is `location.href` — an absolute URL. `oauthstate.safeRedirect` accepts only a relative path and rewrites anything else to `/`, so the state blob always carries `{"r":"/"}` and the page the person was on is gone before the provider is ever reached.

Visible on the wire:

```
GET /_system/auth/oidc?redirect=https%3A%2F%2Fexample.com%2Fboards%2Fdemo
  -> state = {"r":"/", ...}

GET /_system/auth/oidc?redirect=/boards/demo
  -> state = {"r":"/boards/demo", ...}      # the mechanism is fine
```

Affects Google and GitHub too — one view builds all three buttons.

Fixed on both sides, since the request said to:

- the frontend sends `pathname + search + hash`, so the `#!` route survives;
- `safeRedirect` accepts an absolute URL whose host is the request's own host and reduces it to a path. Every other absolute URL is still `/`, including the userinfo (`https://ourhost@evil/`) and prefix (`https://ourhost.evil/`) disguises, which are covered by tests.

## 2. Every redirect downgrades https to http behind a TLS-terminating proxy

`ctx.Redirect` copies the request URI and emits an absolute Location built from it. Where TLS is terminated upstream and the proxy forwards plain HTTP, that scheme is always `http` — the browser's real scheme survives only in `X-Forwarded-Proto`, which this path does not read.

```
$ curl -D - "https://example.com/_system/auth/oidc/callback?code=x&state=bogus"
HTTP/2 302
location: http://example.com/?berror=invalid_state
```

Session and `oauth_state` cookies are `Secure`, so the browser sends none of them on the page it just landed on. A login that fully succeeded renders as a guest — and pressing the SSO button again completes instantly (the provider still holds a session) and lands on the same http page, so it looks like a button that does nothing. A desktop browser hides this by upgrading the http navigation itself; a WebView does not.

`appresp.Redirect` writes the Location verbatim instead. A relative target is resolved by the browser against the page it is actually on, which is the one place the real scheme still exists — no header to trust, no configuration to get wrong. Absolute targets (the provider's authorize URL) pass through unchanged.

## Tests

- `internal/oauthstate`: `safeRedirect` table extended with same-origin absolute URLs, query, fragment, port mismatch and the two host-disguise attacks; a round-trip test asserting `Generate` keeps the path of an absolute own-origin URL.
- `internal/appresp`: Location is emitted verbatim and never adopts the request scheme.
- `e2e/oidc.spec.js`: a login started at `/some/deep/page?tab=2` ends there; the same as an absolute own-origin URL keeps its path; an absolute URL elsewhere still lands on `/`.

`make test` and `golangci-lint` green.