### PR TITLE
fix(auth): an own-host URL cannot smuggle a protocol-relative path past safeRedirect

### DIFF
--- a/internal/oauthstate/state.go
+++ b/internal/oauthstate/state.go
@@ -33,43 +33,48 @@ type State struct {
 
 // safeRedirect ensures the redirect target is a same-origin relative path.
 // An absolute URL on host — what the frontend sends, since it reads
-// location.href — is reduced to its path; anything pointing elsewhere becomes
-// "/" so OAuth login cannot be turned into open-redirect phishing.
+// location.href — is reduced to its path first; then the one rule below
+// decides, so no shape can reach the browser without passing it.
 func safeRedirect(host, redirect string) string {
-	if redirect == "" {
-		return "/"
-	}
-
 	if scheme.MatchString(redirect) {
-		return ownOriginPath(host, redirect)
+		redirect = ownOriginPath(host, redirect)
 	}
 
-	// Must start with a single slash and not be protocol-relative (//host).
-	if redirect[0] != '/' || (len(redirect) > 1 && redirect[1] == '/') {
+	return relativePath(redirect)
+}
+
+var scheme = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.-]*:`)
+
+// relativePath is the whole decision: a path on this site, or "/". Everything
+// reaches it, including what ownOriginPath has just reduced — an absolute URL
+// on our own host can still carry "//evil.com" as its path, and answering with
+// that path is a Location the browser reads as another origin.
+func relativePath(redirect string) string {
+	if redirect == "" || redirect[0] != '/' {
 		return "/"
 	}
-	// Reject backslash variants that some browsers normalise to /.
-	if len(redirect) > 1 && redirect[1] == '\\' {
+
+	// Protocol-relative (//host), and the backslash variants some browsers
+	// normalise into it.
+	if len(redirect) > 1 && (redirect[1] == '/' || redirect[1] == '\\') {
 		return "/"
 	}
 
 	return redirect
 }
 
-var scheme = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.-]*:`)
-
-// ownOriginPath keeps the path of an absolute URL that names this very host,
-// and refuses every other one. The scheme is not compared: behind a
-// TLS-terminating proxy the page and the request disagree about it, and the
-// answer is a path either way.
+// ownOriginPath reduces an absolute URL that names this very host to its path,
+// and answers "" for every other one, which relativePath turns into "/". The
+// scheme is not compared: behind a TLS-terminating proxy the page and the
+// request disagree about it, and the answer is a path either way.
 func ownOriginPath(host, redirect string) string {
 	if host == "" {
-		return "/"
+		return ""
 	}
 
 	target, err := url.Parse(redirect)
-	if err != nil || target.Host != host || target.EscapedPath() == "" {
-		return "/"
+	if err != nil || target.Host != host {
+		return ""
 	}
 
 	path := target.EscapedPath()

--- a/internal/oauthstate/state_test.go
+++ b/internal/oauthstate/state_test.go
@@ -33,6 +33,13 @@ func TestSafeRedirect(t *testing.T) {
 		// absolute URLs elsewhere must be rejected
 		{"other host", "https://evil.com", "/"},
 		{"other host with path", "http://evil.com/steal", "/"},
+		// The host matches and the path is protocol-relative, so reducing the
+		// URL to that path hands back "//evil.com" — a Location the browser
+		// reads as another origin. The same shape the relative branch has
+		// always refused.
+		{"own host, protocol-relative path", "https://app.example.com//evil.com", "/"},
+		{"own host, protocol-relative path with more", "https://app.example.com//evil.com/steal?a=1", "/"},
+		{"own host, backslash path", "https://app.example.com/\\evil.com", "/%5Cevil.com"},
 		{"userinfo disguise", "https://app.example.com@evil.com/steal", "/"},
 		{"host as prefix", "https://app.example.com.evil.com/steal", "/"},
 		// protocol-relative


### PR DESCRIPTION
An open redirect introduced by #344 and live on `main`. CodeQL raised it as a new `go/unvalidated-url-redirection` alert against `internal/appresp/redirect.go`.

## The hole

#344 taught `safeRedirect` to accept an absolute URL naming the site's own host and reduce it to its path. That branch returned the path directly, without the rule the relative branch has always applied:

```go
if scheme.MatchString(redirect) {
    return ownOriginPath(host, redirect)   // never reaches the check below
}
if redirect[0] != '/' || (len(redirect) > 1 && redirect[1] == '/') {
    return "/"
}
```

A path can itself be another origin:

```
url.Parse("https://ourhost//evil.com")
  -> Host = "ourhost"        # the host check passes, it really is ours
  -> EscapedPath = "//evil.com"
```

`Location: //evil.com` is protocol-relative, so the browser goes to `evil.com`. Reachable as `https://ourhost/_system/auth/oidc?redirect=https://ourhost//evil.com`: the person signs in for real and lands on the attacker's site.

The backslash variants are not affected — `EscapedPath` returns `/%5Cevil.com`, which no browser normalises back into a slash — so `//` was the whole of it.

## The fix

Not another case in a list of refusals. `ownOriginPath` now only *reduces* a URL to a path (or to `""` for anything not ours), and a single `relativePath` makes the decision. Every value reaches it, including what `ownOriginPath` just produced, so there is no second route to the browser for a shape to take.

```go
func safeRedirect(host, redirect string) string {
    if scheme.MatchString(redirect) {
        redirect = ownOriginPath(host, redirect)
    }
    return relativePath(redirect)
}
```

## Tests

Written first, and they fail on `main`:

- `https://app.example.com//evil.com` -> `/`
- `https://app.example.com//evil.com/steal?a=1` -> `/`
- `https://app.example.com/\evil.com` -> `/%5Cevil.com`, which stays on our origin

`make test` and `golangci-lint` green.