### PR TITLE
fix(auth): one rule decides whether a Location can only be this site

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -96,11 +96,12 @@ func (a *app) startServer() { //nolint:gocognit // server startup wiring
 				query.Del("hat")
 				parsedURL.RawQuery = query.Encode()
 
-				// RequestURI, not String: the target is this request's own URL
-				// with one parameter removed, so it has no business carrying a
-				// host. A request line may be absolute-form, and String() would
-				// then hand that host straight back as a redirect.
-				appresp.Redirect(ctx, parsedURL.RequestURI(), http.StatusFound)
+				// The target is this request's own URL with one parameter
+				// removed, so it has no business carrying a host. A request
+				// line may be absolute-form, and then RequestURI() is the path
+				// of that URL — which can be "//evil.com", another origin
+				// written as a path. SamePath is the rule that decides.
+				appresp.Redirect(ctx, appresp.SamePath(parsedURL.RequestURI()), http.StatusFound)
 				return
 			}
 		}

--- a/internal/appresp/samepath.go
+++ b/internal/appresp/samepath.go
@@ -1,0 +1,26 @@
+package appresp
+
+// SamePath answers a Location that can only be this site: target when it is
+// already a path here, "/" when it is anything else.
+//
+// A value that starts with a slash is not yet same-origin. "//evil.com" is a
+// protocol-relative URL and some browsers normalise "/\evil.com" into one, so
+// both are another origin written as a path. Both arrive that way from real
+// sources: url.URL.RequestURI() of an absolute-form request line hands back
+// "//evil.com", and so does the path of an absolute URL that genuinely names
+// this host.
+//
+// One rule in one place, because this was got wrong twice by writing it twice:
+// everything that builds a Location out of something a request carried goes
+// through here, and nothing repeats the reasoning.
+func SamePath(target string) string {
+	if target == "" || target[0] != '/' {
+		return "/"
+	}
+
+	if len(target) > 1 && (target[1] == '/' || target[1] == '\\') {
+		return "/"
+	}
+
+	return target
+}

--- a/internal/appresp/samepath_test.go
+++ b/internal/appresp/samepath_test.go
@@ -1,0 +1,46 @@
+package appresp
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSamePath(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", "/"},
+		{"root", "/", "/"},
+		{"path", "/boards/x", "/boards/x"},
+		{"path with query", "/boards/x?tab=2", "/boards/x?tab=2"},
+		{"path with fragment", "/boards/x#!userspace=open", "/boards/x#!userspace=open"},
+		{"escaped backslash stays ours", "/%5Cevil.com", "/%5Cevil.com"},
+		{"protocol relative", "//evil.com", "/"},
+		{"protocol relative with path", "//evil.com/steal", "/"},
+		{"backslash browsers normalise", "/\\evil.com", "/"},
+		{"absolute", "https://evil.com/steal", "/"},
+		{"no leading slash", "evil.com", "/"},
+		{"scheme relative word", "relative/path", "/"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, SamePath(tc.in))
+		})
+	}
+}
+
+// An absolute-form request line is accepted by the server, and RequestURI()
+// then hands back the path of that URL — which can itself be another origin.
+// This is the shape that reached a Location header twice.
+func TestSamePathRefusesAnAbsoluteFormRequestLine(t *testing.T) {
+	parsed, err := url.Parse("http://ourhost//evil.com")
+	require.NoError(t, err)
+	require.Equal(t, "//evil.com", parsed.RequestURI())
+
+	require.Equal(t, "/", SamePath(parsed.RequestURI()))
+}

--- a/internal/oauthstate/state.go
+++ b/internal/oauthstate/state.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"time"
 
+	"trip2g/internal/appresp"
+
 	"github.com/valyala/fasthttp"
 )
 
@@ -33,38 +35,21 @@ type State struct {
 
 // safeRedirect ensures the redirect target is a same-origin relative path.
 // An absolute URL on host — what the frontend sends, since it reads
-// location.href — is reduced to its path first; then the one rule below
-// decides, so no shape can reach the browser without passing it.
+// location.href — is reduced to its path first, and appresp.SamePath then
+// decides. A path can itself be another origin, so that rule is the one every
+// shape passes and this package does not keep a second copy of it.
 func safeRedirect(host, redirect string) string {
 	if scheme.MatchString(redirect) {
 		redirect = ownOriginPath(host, redirect)
 	}
 
-	return relativePath(redirect)
+	return appresp.SamePath(redirect)
 }
 
 var scheme = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.-]*:`)
 
-// relativePath is the whole decision: a path on this site, or "/". Everything
-// reaches it, including what ownOriginPath has just reduced — an absolute URL
-// on our own host can still carry "//evil.com" as its path, and answering with
-// that path is a Location the browser reads as another origin.
-func relativePath(redirect string) string {
-	if redirect == "" || redirect[0] != '/' {
-		return "/"
-	}
-
-	// Protocol-relative (//host), and the backslash variants some browsers
-	// normalise into it.
-	if len(redirect) > 1 && (redirect[1] == '/' || redirect[1] == '\\') {
-		return "/"
-	}
-
-	return redirect
-}
-
 // ownOriginPath reduces an absolute URL that names this very host to its path,
-// and answers "" for every other one, which relativePath turns into "/". The
+// and answers "" for every other one, which SamePath turns into "/". The
 // scheme is not compared: behind a TLS-terminating proxy the page and the
 // request disagree about it, and the answer is a path either way.
 func ownOriginPath(host, redirect string) string {


### PR DESCRIPTION
CodeQL alert 76 (`go/unvalidated-url-redirection`) stayed open after #345. The SARIF for the analysis of `da615c96` names the remaining flow, and it is the hat sign-in:

```
cmd/server/server.go 92  | call to RequestURI
cmd/server/server.go 103 | call to RequestURI
internal/appresp/redirect.go 16 | location
```

## What was still open

#344 narrowed that redirect from `parsedURL.String()` to `parsedURL.RequestURI()`, which drops the host. It does not drop a path that is *itself* another origin — the same shape #345 fixed in `safeRedirect`, missed here.

An absolute-form request line is accepted, and measured against real fasthttp:

```
GET http://ourhost//evil.com?hat=t HTTP/1.1
  Header.RequestURI() -> "http://ourhost//evil.com?hat=t"
  url.Parse           -> Host "ourhost", RequestURI() "//evil.com?hat=t"
```

Strip `hat` and the Location is `//evil.com`, which the browser reads as another origin. A browser sends origin-form, so reaching this through one is not straightforward; the server accepts absolute-form from any client, and the behaviour of whatever proxy sits in front is not something to bet on.

## Why this is a third PR and not a third patch

The same mistake was made twice because the rule was written twice: once in `safeRedirect`'s relative branch, once — not at all — beside `RequestURI()`. Each place reasoned about a target on its own, and each got a different subset right.

`appresp.SamePath` is now that rule, in one place, and it is where every value that becomes a Location out of something a request carried goes. `oauthstate` no longer keeps a copy; the hat sign-in calls the same function. `grep` for the check finds exactly one implementation.

Anything genuinely absolute and intended — the provider's authorize URL, and `signinbytgauthtoken`, which may legitimately send a person to another host it has checked against `TrustedDomains()` — does not go through `SamePath` and keeps working.

## Tests

- `appresp.SamePath`: table over paths, protocol-relative, backslash, absolute and non-slash targets, plus `/%5Cevil.com` which stays ours because no browser normalises an escaped backslash.
- A regression test that spells out the shape which reached a Location twice: `url.Parse("http://ourhost//evil.com").RequestURI()` is `//evil.com`, and `SamePath` answers `/`.
- `oauthstate`'s existing table passes unchanged through the delegation.

`make test` and `golangci-lint` green.

## Unrelated, noticed while running the suite

`internal/movebus.TestSessionKeyStableWithinHourAndAnonymous` is flaky, on `main` and independent of this branch. It asserts `NotContains(k1, "42")` where `k1` is a 16-hex-char digest under a key from `rand.Read`, so it fails whenever the digest happens to contain those two characters — about 6% of runs. A substring check does not test what the assertion's message says it tests. Left alone here; say the word and it gets its own PR.