### PR TITLE
fix(auth): parse and rebuild a Location instead of enumerating what may not be in it

### DIFF
--- a/internal/appresp/samepath.go
+++ b/internal/appresp/samepath.go
@@ -26,7 +26,7 @@ func SamePath(target string) string {
 	}
 
 	path := parsed.EscapedPath()
-	if !strings.HasPrefix(path, "/") || strings.HasPrefix(path, "//") {
+	if !strings.HasPrefix(path, "/") || strings.HasPrefix(path, "//") || strings.HasPrefix(path, "/\\") {
 		return "/"
 	}
 

--- a/internal/appresp/samepath.go
+++ b/internal/appresp/samepath.go
@@ -1,26 +1,42 @@
 package appresp
 
-// SamePath answers a Location that can only be this site: target when it is
-// already a path here, "/" when it is anything else.
+import (
+	"net/url"
+	"strings"
+)
+
+// SamePath answers a Location that can only be this site: target reduced to its
+// path, query and fragment, or "/" when it names anywhere else.
 //
-// A value that starts with a slash is not yet same-origin. "//evil.com" is a
-// protocol-relative URL and some browsers normalise "/\evil.com" into one, so
-// both are another origin written as a path. Both arrive that way from real
-// sources: url.URL.RequestURI() of an absolute-form request line hands back
-// "//evil.com", and so does the path of an absolute URL that genuinely names
-// this host.
+// The value is parsed and rebuilt rather than inspected and passed on, because
+// a target that merely starts with a slash is not yet same-origin and the ways
+// it can stop being one do not enumerate. "//evil.com" is protocol-relative. A
+// browser strips ASCII tab, LF and CR from a URL before parsing it, so
+// "/\t/evil.com" becomes "//evil.com" in the only place that matters, and CR LF
+// in a header value is worse than a redirect. url.Parse refuses control
+// characters as a class, EscapedPath re-encodes everything else that could be
+// read a second way, and a host anywhere in the target is refused outright.
 //
-// One rule in one place, because this was got wrong twice by writing it twice:
-// everything that builds a Location out of something a request carried goes
-// through here, and nothing repeats the reasoning.
+// One rule in one place: everything that builds a Location out of something a
+// request carried goes through here.
 func SamePath(target string) string {
-	if target == "" || target[0] != '/' {
+	parsed, err := url.Parse(target)
+	if err != nil || parsed.Scheme != "" || parsed.Opaque != "" || parsed.Host != "" {
 		return "/"
 	}
 
-	if len(target) > 1 && (target[1] == '/' || target[1] == '\\') {
+	path := parsed.EscapedPath()
+	if !strings.HasPrefix(path, "/") || strings.HasPrefix(path, "//") {
 		return "/"
 	}
 
-	return target
+	if parsed.RawQuery != "" {
+		path += "?" + parsed.RawQuery
+	}
+
+	if parsed.Fragment != "" {
+		path += "#" + parsed.EscapedFragment()
+	}
+
+	return path
 }

--- a/internal/appresp/samepath_test.go
+++ b/internal/appresp/samepath_test.go
@@ -19,12 +19,24 @@ func TestSamePath(t *testing.T) {
 		{"path with query", "/boards/x?tab=2", "/boards/x?tab=2"},
 		{"path with fragment", "/boards/x#!userspace=open", "/boards/x#!userspace=open"},
 		{"escaped backslash stays ours", "/%5Cevil.com", "/%5Cevil.com"},
+		{"escaped slash stays ours", "/%2F/evil.com", "/%2F/evil.com"},
 		{"protocol relative", "//evil.com", "/"},
 		{"protocol relative with path", "//evil.com/steal", "/"},
-		{"backslash browsers normalise", "/\\evil.com", "/"},
+		{"three slashes", "///evil.com", "/"},
+		{"backslash is escaped, not passed on", "/\\evil.com", "/%5Cevil.com"},
+		{"space is escaped", "/ /evil.com", "/%20/evil.com"},
 		{"absolute", "https://evil.com/steal", "/"},
+		{"opaque scheme", "javascript:alert(1)", "/"},
 		{"no leading slash", "evil.com", "/"},
 		{"scheme relative word", "relative/path", "/"},
+		// A browser strips ASCII tab, LF and CR from a URL before it parses it,
+		// so any of them beside the leading slash turns the value back into
+		// "//evil.com" in the one place it matters. CR LF in a header value is
+		// worse than a redirect. Refused as a class by parsing, rather than
+		// enumerated one character at a time.
+		{"tab the browser would strip", "/\t/evil.com", "/"},
+		{"newline the browser would strip", "/\n/evil.com", "/"},
+		{"header injection", "/\r\nSet-Cookie: a=1", "/"},
 	}
 
 	for _, tc := range cases {

--- a/internal/oauthstate/state_test.go
+++ b/internal/oauthstate/state_test.go
@@ -45,8 +45,9 @@ func TestSafeRedirect(t *testing.T) {
 		// protocol-relative
 		{"protocol relative", "//evil.com", "/"},
 		{"protocol relative with path", "//evil.com/path", "/"},
-		// backslash variants some browsers normalise
-		{"backslash", "/\\evil.com", "/"},
+		// A backslash is escaped rather than refused: %5C is not normalised
+		// back into a slash by any browser, so the path stays ours.
+		{"backslash", "/\\evil.com", "/%5Cevil.com"},
 		// no leading slash
 		{"bare host", "evil.com", "/"},
 		{"relative", "relative/path", "/"},


### PR DESCRIPTION
CodeQL alert 76 stayed open after #346. The SARIF for the analysis of `ab2aede7` shows the flow going *through* `SamePath` — lines 16, 17, 21, 25 and out — so the check is not read as a barrier. Chasing why turned up a real bypass, not a modelling gap.

## The bypass

`SamePath` admitted `/` followed by anything that was not `/` or `\`. A browser strips ASCII tab, LF and CR from a URL **before** it parses it, so the character after the leading slash need not survive to the origin decision:

```
SamePath("/\t/evil.com")  ->  "/\t/evil.com"      # admitted
browser strips the tab    ->  "//evil.com"        # another origin
```

Worse, `"/\r\nSet-Cookie: a=1"` came back verbatim, which is header injection rather than a redirect. Both are covered by tests here and both fail on `main`.

## Why this is a fourth PR

The same mistake three times, each time the same shape: a list of characters that may not appear. First `/`, then `/` and `\` in one place instead of two — but a list is still a list, and "characters a browser removes" was never on it. Enumeration does not terminate.

So this stops enumerating. The value is **parsed and rebuilt** rather than inspected and passed on:

- `url.Parse` refuses control characters as a class, so tab, LF and CR are gone without being named as cases.
- A `Scheme`, `Opaque` or `Host` anywhere in the target is refused outright — that covers `https://evil.com`, `javascript:`, `//evil.com` and `///evil.com` at the parse level rather than by prefix.
- `EscapedPath` re-encodes whatever else could be read a second way, so a backslash becomes `%5C` and a space `%20`, neither of which any browser turns back into a slash.
- What is returned is built from the parsed parts. The attacker's string is not the output.

`strings.HasPrefix` in place of byte indexing is the shape CodeQL reads as a barrier; that is a consequence of parsing properly, not the reason for it.

## Behaviour change worth noting

`/\evil.com` used to be refused and is now escaped to `/%5Cevil.com`. Both are safe; escaping keeps a legitimate path containing a backslash working, and it is what falls out of rebuilding rather than judging. `internal/oauthstate`'s table is updated to say so.

## Tests

Written first, and the three new refusals fail on `main`:

- `//evil.com`, `//evil.com/steal`, `///evil.com`, `https://evil.com/steal`, `javascript:alert(1)` -> `/`
- `/\t/evil.com`, `/\n/evil.com`, `/\r\nSet-Cookie: a=1` -> `/`
- `/\evil.com` -> `/%5Cevil.com`, `/ /evil.com` -> `/%20/evil.com`, `/%2F/evil.com` unchanged — all provably this origin
- paths, queries and fragments survive untouched

`go test ./...` and `golangci-lint` green.