### PR TITLE
fix(mcp): expand lists a child's preview on its own line so the title is copyable

### DIFF
--- a/e2e/mcp-toc.spec.js
+++ b/e2e/mcp-toc.spec.js
@@ -222,11 +222,16 @@ test.describe('MCP TOC', () => {
       arguments: { path: NOTE_PATH, toc_path: ['Main Section'] },
     });
 
-    // The listing may preview a short child title's opening words; what it
-    // must not carry is the section body itself.
+    // A bullet line is exactly the title an agent copies into toc_path, so a
+    // short child's preview goes on its own indented line underneath instead
+    // of trailing the title. What the listing must never carry is the body.
     const text = result.content?.[0]?.text ?? '';
+    const lines = text.split('\n');
     expect(text).toContain('1 subsection(s)');
-    expect(text).toContain('- Subsection');
+    expect(lines).toContain('- Subsection');
+    expect(lines[lines.indexOf('- Subsection') + 1]).toMatch(
+      /^ {4}preview: Nested subsection content/,
+    );
     expect(text).not.toContain('Main content goes here');
     expect(text).not.toContain('<p>');
 

--- a/internal/case/mcp/resolve.go
+++ b/internal/case/mcp/resolve.go
@@ -913,11 +913,12 @@ func expandSummary(note *model.NoteView, parentPath []string, children []TOCNode
 		if c.HasChildren {
 			marker = " (has subsections)"
 		}
-		preview := ""
+		// The preview goes on its own line so the bullet line is exactly the
+		// title an agent has to copy into toc_path.
+		fmt.Fprintf(&sb, "- %s%s\n", c.Title, marker)
 		if c.Preview != "" {
-			preview = " — " + c.Preview
+			fmt.Fprintf(&sb, "    preview: %s\n", c.Preview)
 		}
-		fmt.Fprintf(&sb, "- %s%s%s\n", c.Title, marker, preview)
 	}
 	return sb.String()
 }

--- a/internal/case/mcp/testdata/endpoint_golden.txt
+++ b/internal/case/mcp/testdata/endpoint_golden.txt
@@ -1368,7 +1368,7 @@ HTTP 200 application/json
     "content": [
       {
         "type": "text",
-        "text": "Doc — \"top level\", 2 subsection(s):\n- Alpha — alpha body\n- Beta — beta body\n"
+        "text": "Doc — \"top level\", 2 subsection(s):\n- Alpha\n    preview: alpha body\n- Beta\n    preview: beta body\n"
       }
     ],
     "structuredContent": {
@@ -1442,7 +1442,7 @@ HTTP 200 application/json
     "content": [
       {
         "type": "text",
-        "text": "Книга 10 — \"top level\", 2 subsection(s):\n- 1 — Душа моя, ужели ты никогда не будешь доброй и простой?\n- 2 — Замечай, чего требует твоя природа.\n"
+        "text": "Книга 10 — \"top level\", 2 subsection(s):\n- 1\n    preview: Душа моя, ужели ты никогда не будешь доброй и простой?\n- 2\n    preview: Замечай, чего требует твоя природа.\n"
       }
     ],
     "structuredContent": {

--- a/internal/case/mcp/toc_expand_test.go
+++ b/internal/case/mcp/toc_expand_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"html/template"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -150,4 +151,71 @@ func TestSnippetBreadcrumbDropsTheTitleH1(t *testing.T) {
 		snippetTocPath(note, "maxims body", ""))
 	require.Equal(t, []string{"Reflections"},
 		snippetTocPath(note, "reflections body", ""))
+}
+
+// A one-line "- Title — preview" listing made the whole line look like the
+// title: a model copied "Prerequisites — Docker running locally Node.js …"
+// into toc_path and got "section not found". The bullet line now carries
+// nothing but the title, so copying it verbatim resolves.
+func TestExpandSummaryPutsThePreviewOnItsOwnLine(t *testing.T) {
+	note := &model.NoteView{Title: "Guide"}
+	tests := []struct {
+		name      string
+		children  []TOCNode
+		wantLines []string
+	}{
+		{
+			name:     "a child with a preview takes two lines",
+			children: []TOCNode{{Title: "Prerequisites", Preview: "Docker running locally Node.js 20+"}},
+			wantLines: []string{
+				"- Prerequisites",
+				"    preview: Docker running locally Node.js 20+",
+			},
+		},
+		{
+			name:      "a child without a preview takes one",
+			children:  []TOCNode{{Title: "A heading long enough to stand on its own"}},
+			wantLines: []string{"- A heading long enough to stand on its own"},
+		},
+		{
+			name:     "the has_children marker stays on the title line",
+			children: []TOCNode{{Title: "Setup", HasChildren: true, Preview: "pick a package manager"}},
+			wantLines: []string{
+				"- Setup (has subsections)",
+				"    preview: pick a package manager",
+			},
+		},
+		{
+			name: "children keep their own lines",
+			children: []TOCNode{
+				{Title: "1", Preview: "Душа моя, ужели ты никогда не будешь доброй?"},
+				{Title: "2", HasChildren: true},
+			},
+			wantLines: []string{
+				"- 1",
+				"    preview: Душа моя, ужели ты никогда не будешь доброй?",
+				"- 2 (has subsections)",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines := strings.Split(strings.TrimRight(expandSummary(note, nil, tt.children), "\n"), "\n")
+			require.Equal(t, `Guide — "top level", `+strconv.Itoa(len(tt.children))+" subsection(s):", lines[0])
+			require.Equal(t, tt.wantLines, lines[1:])
+
+			// A bullet line is exactly the string an agent copies into toc_path,
+			// so no preview text may leak onto one.
+			for _, line := range lines[1:] {
+				if !strings.HasPrefix(line, "- ") {
+					continue
+				}
+				for _, c := range tt.children {
+					if c.Preview != "" {
+						require.NotContains(t, line, c.Preview)
+					}
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Why

With the old one-line listing `- Title (has subsections) — preview words`, the whole line reads as the title: gpt-5.4-mini copied `Prerequisites — Docker running locally Node.js …` into `toc_path` and got `section not found` in 2 of 3 recorded runs.

With the title alone on the bullet line and the preview indented underneath, the same client-side test against production had zero `toc_path` errors in 3 of 3 runs and copied titles exactly.

## What changed

- `expandSummary` in `internal/case/mcp/resolve.go` prints `- Title (has subsections)` on the bullet line and, only when a preview exists, a second line `    preview: …`. The `has_children` marker stays on the title line.
- Table-driven unit test in `internal/case/mcp/toc_expand_test.go`: child with a preview takes two lines, child without takes one, the marker stays put, and no preview text ever leaks onto a bullet line.
- Golden file `internal/case/mcp/testdata/endpoint_golden.txt` regenerated with `-update-golden`. Only the two expand listing texts changed; the structured payloads are untouched.
- `e2e/mcp-toc.spec.js` asserts the new shape: `- Subsection` is its own line and the next line matches `    preview: Nested subsection content`.

`federated_expand` forwards the peer's response verbatim, so it inherits the new text with no change. `expandSummary` is the only place that formats a child listing.

## Verified

- `go build ./...`, `go vet ./internal/case/mcp/...`, `go test -count=1 ./internal/case/mcp/...` all pass.
- `golangci-lint run --build-tags dev ./internal/case/mcp/...`: 0 issues.
- Red/green confirmed: the new unit test fails against the previous one-line format and passes after.
- The pre-push hook ran the full repo test and lint suite: all checks passed.

## Not verified

The e2e mesh was not executed. Disk on this machine is at 93% with under 10 GB free, and the mcp-toc spec needs the full Docker stack plus a synced vault, so there is no cheaper subset that boots it. The spec was checked to parse and enumerate with `playwright test --list e2e/mcp-toc.spec.js` (16 tests).

## Note

The repo's CLAUDE.md asks for a one-line commit subject with no trailers. The trailers below were required by the session's attribution instruction, so the commit carries them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVHnhgCSBUfhAZGKih9pbe