### PR TITLE
fix(editor): content textarea class no longer shadows the gql query

### DIFF
--- a/assets/ui/editor/pane/pane.view.tree
+++ b/assets/ui/editor/pane/pane.view.tree
@@ -46,7 +46,7 @@ $trip2g_editor_pane $mol_view
 						<= save_text @ \Save {0} files
 			body <= editor_body /
 		<= right_sidebar_widget null $mol_view
-	ContentTextarea $trip2g_editor_pane_content
+	ContentTextarea $trip2g_editor_pane_textarea
 		value? <=> content?
 		hover? <=> handle_content_hover? null
 		click? <=> handle_content_click? null
@@ -100,7 +100,7 @@ $trip2g_editor_pane $mol_view
 	newfile_msg_exists @ \A file with this name already exists
 	newfile_msg_exists_remote @ \This file was just created elsewhere
 
-$trip2g_editor_pane_content $mol_textarea
+$trip2g_editor_pane_textarea $mol_textarea
 	click? null
 	event *
 		^


### PR DESCRIPTION
## Problem

Opening the editor on any page (`#!editor=open`) shows `[object Object]` where the note body should be. The file tree and toolbar render fine.

## Cause

`assets/ui/editor/pane/` had two things named `$trip2g_editor_pane_content`:

- the view subclass `$trip2g_editor_pane_content $mol_textarea` in `pane.view.tree`, from which `ContentTextarea` is built (introduced in #297 while extracting the `click?` binding);
- the GraphQL query function generated from `content.graphql` (name derived from the file path, since #256).

In the bundle the function is declared after the class and overwrites it in the `$` namespace. `ContentTextarea()` then does `new this.$.$trip2g_editor_pane_content()`, gets the query result object back instead of a textarea, and `$mol_page` renders that non-view as text.

TypeScript does not catch it: the class lives in the generated `.d.ts`, the function in `.graphql.ts`, so they look like separate declarations.

## Fix

Rename the view class to `$trip2g_editor_pane_textarea`. Two lines in `pane.view.tree`; no CSS or TS references the class name. The query name stays as is.

Checked that this is the only view.tree class name that coincides with a generated gql function name across `assets/ui`.

## Verification

Rebuilt `trip2g/user`, opened `/ru/user/nachalo_rabotyi#!editor=open` as admin: the note body renders in the textarea, no `[object Object]` in the iframe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8DwDxiVpmNvGWQpUPHiD5