### PR TITLE
infra: search index on disk for every prod instance

### DIFF
--- a/infra/service.j2
+++ b/infra/service.j2
@@ -27,6 +27,10 @@ EnvironmentFile=/etc/{{ item.service_name }}.env
 # See docs/dev/gc_tuning.md.
 Environment=GOGC={{ go_gc | default(100) }}
 Environment=GOMEMLIMIT={{ item.go_mem_limit | default(go_mem_limit_default) }}
+# Full-text index on disk instead of the heap (~350 MB less per 1000 notes,
+# reopen in ms instead of a rebuild at boot). One directory per instance; the
+# app creates <version>/<schema> below it. See docs/dev/search_index_on_disk.md.
+Environment=SEARCH_INDEX_PATH={{ data_dir }}/search/{{ item.service_name }}
 Restart=on-failure
 
 # Zero-downtime drain: SIGTERM makes the app flip /healthz to 503 immediately,

--- a/infra/site.yml
+++ b/infra/site.yml
@@ -56,6 +56,15 @@
         group: "{{ app_user }}"
         mode: '0750'
 
+    - name: Create per-instance search index dirs
+      file:
+        path: "{{ data_dir }}/search/{{ item.service_name }}"
+        state: directory
+        owner: "{{ app_user }}"
+        group: "{{ app_user }}"
+        mode: '0750'
+      loop: "{{ trip2g_services }}"
+
     - name: Download Litestream
       get_url:
         url: https://github.com/benbjohnson/litestream/releases/download/v0.3.13/litestream-v0.3.13-linux-amd64.deb


### PR DESCRIPTION
Production still runs the in-memory bleve index: no `/etc/trip2g_*.env` sets `SEARCH_INDEX_PATH`, and today's profile of `trip2g_landing` (1042 MB RES against GOMEMLIMIT=700MiB on a 2 GB box with 74 MB free) shows ~60% of CPU in GC scanning. `docs/dev/search_index_on_disk.md` measured the in-memory index at +350 MB of heap per ~1000 notes versus +4 MB on disk.

- `infra/service.j2`: `Environment=SEARCH_INDEX_PATH={{ data_dir }}/search/{{ item.service_name }}` next to the GC tuning, so it is authoritative over the hand-managed env files and one directory per instance; the app creates `<version>/<schema>` below it.
- `infra/site.yml`: creates `/opt/trip2g/data/search/<service>` for each instance, owned by the app user.

Takes effect on the next `make build_and_deploy` (the unit template change triggers the service restart). Disk: ~45 MB per 1000 notes steady, budget 2x during merges; `/` has 1.7 GB free. `ansible-playbook --syntax-check site.yml` passes; not applied to the host from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVHnhgCSBUfhAZGKih9pbe