### PR TITLE
perf(assets): uploadNoteAsset no longer reloads the whole vault

### DIFF
--- a/cmd/server/note_loader_envs.go
+++ b/cmd/server/note_loader_envs.go
@@ -210,8 +210,6 @@ func makeLatestNoteLoaderWrapper(a *app) *latestNoteLoaderEnv {
 type singleNoteLoaderEnv struct {
 	*app
 	versionID int64
-
-	latestLoader *latestNoteLoaderEnv
 }
 
 func (e *singleNoteLoaderEnv) env(ctx context.Context) *app {
@@ -232,9 +230,12 @@ func (e *singleNoteLoaderEnv) RawNotes(ctx context.Context) ([]noteloader.RawNot
 		return nil, fmt.Errorf("failed to get note by version ID %d: %w", e.versionID, err)
 	}
 
-	// TODO: fix it. the layout can have dependency on multiple layout files. So we need to load all of them.
+	// A layout may import or yield blocks from other layout files, and its
+	// asset() calls are scanned through those imports, so load the layout
+	// files together — but never the notes, which cost a markdown parse and a
+	// frontmatter-patch run each.
 	if strings.HasPrefix(note.Path, "_layouts/") {
-		return e.latestLoader.RawNotes(ctx)
+		return e.rawLayoutNotes(ctx)
 	}
 
 	return []noteloader.RawNote{
@@ -246,6 +247,26 @@ func (e *singleNoteLoaderEnv) RawNotes(ctx context.Context) ([]noteloader.RawNot
 			CreatedAt: note.CreatedAt,
 		},
 	}, nil
+}
+
+func (e *singleNoteLoaderEnv) rawLayoutNotes(ctx context.Context) ([]noteloader.RawNote, error) {
+	notes, err := e.env(ctx).AllLatestLayoutNotes(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get layout notes: %w", err)
+	}
+
+	res := make([]noteloader.RawNote, len(notes))
+	for i, note := range notes {
+		res[i] = noteloader.RawNote{
+			Path:      note.Path,
+			PathID:    note.PathID,
+			VersionID: note.VersionID,
+			Content:   note.Content,
+			CreatedAt: note.CreatedAt,
+		}
+	}
+
+	return res, nil
 }
 
 func (e *singleNoteLoaderEnv) RawAssets(ctx context.Context) ([]noteloader.RawAsset, error) {
@@ -273,8 +294,7 @@ func (e *singleNoteLoaderEnv) RawNoteChunks(_ context.Context) ([]noteloader.Raw
 
 func makeSingleNoteLoaderWrapper(a *app, versionID int64) *singleNoteLoaderEnv {
 	return &singleNoteLoaderEnv{
-		app:          a,
-		versionID:    versionID,
-		latestLoader: makeLatestNoteLoaderWrapper(a),
+		app:       a,
+		versionID: versionID,
 	}
 }

--- a/cmd/server/note_version_assets_test.go
+++ b/cmd/server/note_version_assets_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"testing"
+	"trip2g/internal/appconfig"
+	"trip2g/internal/configregistry"
+	"trip2g/internal/db"
+	"trip2g/internal/frontmatterpatch"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newSingleLoaderTestApp extends newTxTestApp with the pieces the single-note
+// loader reads through the app: config, site config and frontmatter patches.
+func newSingleLoaderTestApp(t *testing.T) *app {
+	t.Helper()
+
+	a := newTxTestApp(t)
+	a.config = &appconfig.Config{PublicURL: "https://example.com"}
+	a.SiteConfigBuilder = configregistry.NewSiteConfigBuilder(a)
+	a.frontmatterPatchLoader = frontmatterpatch.NewLoader(a)
+	return a
+}
+
+func sha256Hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+// insertLatestNote stores content as the latest version of path and returns
+// the version id, the same three writes insertnote performs.
+func insertLatestNote(t *testing.T, a *app, path, content string) int64 {
+	t.Helper()
+	ctx := context.Background()
+
+	notePath, err := a.WriteQueries.InsertNotePath(ctx, db.InsertNotePathParams{
+		Value:             path,
+		ValueHash:         sha256Hex(path),
+		LatestContentHash: sha256Hex(content),
+	})
+	require.NoError(t, err)
+
+	version, err := a.WriteQueries.IncrementNoteVersionCount(ctx, db.IncrementNoteVersionCountParams{
+		LatestContentHash: sha256Hex(content),
+		ID:                notePath.ID,
+	})
+	require.NoError(t, err)
+
+	versionID, err := a.WriteQueries.InsertNoteVersion(ctx, db.InsertNoteVersionParams{
+		PathID:  notePath.ID,
+		Version: version,
+		Content: content,
+	})
+	require.NoError(t, err)
+	return versionID
+}
+
+type vaultFixture struct {
+	mdID, otherMDID, pageID, blocksID int64
+}
+
+// seedVault stores two markdown notes and a two-file layout where the page
+// imports a component that references its own asset.
+func seedVault(t *testing.T, a *app) vaultFixture {
+	t.Helper()
+	return vaultFixture{
+		mdID:      insertLatestNote(t, a, "notes/a.md", "![[a.png]]\n\n![b](images/b.jpg)\n"),
+		otherMDID: insertLatestNote(t, a, "notes/other.md", "![[other.png]]\n"),
+		pageID: insertLatestNote(t, a, "_layouts/mesh/index.html",
+			`{{ import "_blocks" }}<img src="{{ asset("hero.png") }}">{{ yield shell() content }}x{{ end }}`),
+		blocksID: insertLatestNote(t, a, "_layouts/mesh/_blocks.html",
+			`{{block shell()}}<img src="{{ asset("logo.svg") }}">{{yield content}}{{end}}`),
+	}
+}
+
+// TestNoteVersionAssetPaths_SingleVersion pins what uploadNoteAsset validates
+// against: the assets of exactly the requested version, for a markdown note and
+// for a layout file (whose asset() literals include those of the components it
+// imports).
+func TestNoteVersionAssetPaths_SingleVersion(t *testing.T) {
+	a := newSingleLoaderTestApp(t)
+	f := seedVault(t, a)
+
+	tests := []struct {
+		name      string
+		versionID int64
+		want      []string
+	}{
+		{
+			name:      "markdown note lists its own embeds only",
+			versionID: f.mdID,
+			want:      []string{"a.png", "images/b.jpg"},
+		},
+		{
+			name:      "layout page lists its assets and those of imported components",
+			versionID: f.pageID,
+			want:      []string{"_layouts/mesh/hero.png", "_layouts/mesh/logo.svg"},
+		},
+		{
+			name:      "layout component lists its own assets",
+			versionID: f.blocksID,
+			want:      []string{"_layouts/mesh/logo.svg"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			paths, err := a.NoteVersionAssetPaths(context.Background(), tt.versionID)
+			require.NoError(t, err)
+
+			got := make([]string, 0, len(paths))
+			for p := range paths {
+				got = append(got, p)
+			}
+			sort.Strings(got)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestSingleNoteLoaderEnv_RawNotes pins how much of the vault the single-note
+// loader pulls: one note for a markdown version, and only the _layouts/ files
+// for a layout version (a layout may import other layout files, never notes).
+func TestSingleNoteLoaderEnv_RawNotes(t *testing.T) {
+	a := newSingleLoaderTestApp(t)
+	f := seedVault(t, a)
+
+	tests := []struct {
+		name      string
+		versionID int64
+		wantPaths []string
+	}{
+		{
+			name:      "markdown version loads that note alone",
+			versionID: f.mdID,
+			wantPaths: []string{"notes/a.md"},
+		},
+		{
+			name:      "layout version loads the layout files alone",
+			versionID: f.pageID,
+			wantPaths: []string{"_layouts/mesh/_blocks.html", "_layouts/mesh/index.html"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			notes, err := makeSingleNoteLoaderWrapper(a, tt.versionID).RawNotes(context.Background())
+			require.NoError(t, err)
+
+			got := make([]string, 0, len(notes))
+			for _, n := range notes {
+				got = append(got, n.Path)
+			}
+			sort.Strings(got)
+			require.Equal(t, tt.wantPaths, got)
+		})
+	}
+}

--- a/cmd/server/notes.go
+++ b/cmd/server/notes.go
@@ -190,32 +190,26 @@ func (a *app) NoteVersionAssetPaths(ctx context.Context, id int64) (map[string]s
 		return nil, fmt.Errorf("failed to load note version %d: %w", id, err)
 	}
 
-	nvs := loader.NoteViews()
-	layouts := loader.Layouts()
+	for _, layout := range loader.Layouts().Map {
+		if layout.VersionID != id {
+			continue
+		}
 
-	res := map[string]struct{}{}
-
-	if len(layouts.Map) > 0 {
-		for _, layout := range layouts.Map {
-			// TODO: fix it. the singleNoteLoaderEnv loads all notes for _layouts
-			if layout.VersionID != id {
-				continue
-			}
-
-			for _, asset := range layout.Assets {
-				res[asset.Path] = struct{}{}
-			}
+		res := make(map[string]struct{}, len(layout.Assets))
+		for _, asset := range layout.Assets {
+			res[asset.Path] = struct{}{}
 		}
 
 		return res, nil
 	}
 
-	if len(res) == 0 && len(nvs.List) > 0 {
-		return nvs.List[0].Assets, nil
+	for _, nv := range loader.NoteViews().List {
+		if nv.VersionID == id {
+			return nv.Assets, nil
+		}
 	}
 
-	// something strange happened
-	return nil, fmt.Errorf("unknown source type #%d not found", id)
+	return nil, fmt.Errorf("note version %d is not among the loaded notes", id)
 }
 
 func (a *app) AllNotePaths(ctx context.Context) ([]db.NotePath, error) {

--- a/internal/case/uploadnoteasset/resolve.go
+++ b/internal/case/uploadnoteasset/resolve.go
@@ -69,34 +69,14 @@ func Resolve(ctx context.Context, env Env, input Input) (Payload, error) {
 		return denied, nil
 	}
 
-	// Step 1: Validation
-	assetPaths, err := env.NoteVersionAssetPaths(ctx, input.NoteID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get note version asset paths: %w", err)
-	}
-
-	_, exists := assetPaths[input.Path]
-	if !exists {
-		names := []string{}
-
-		for name := range assetPaths {
-			names = append(names, name)
-		}
-
-		assets := strings.Join(names, ", ")
-
-		return &model.ErrorPayload{Message: fmt.Sprintf("unknown asset path %q for noteId=%d. Valid assets: %s", input.Path, input.NoteID, assets)}, nil
-	}
-
 	findAssetParams := db.NoteAssetByPathAndHashParams{
 		AbsolutePath: input.AbsolutePath,
 		Sha256Hash:   input.Sha256Hash,
 	}
 
-	fileName := translit.ToASCII(filepath.Base(input.Path))
-	fileName = reUnsafeChars.ReplaceAllString(fileName, "_")
-
-	// Step 2: Check if asset already exists
+	// The existence check comes first: it is one indexed row, while
+	// NoteVersionAssetPaths parses the note. The sync client resends every
+	// (note, asset) pair, so most calls end in the reuse branch below.
 	existingAsset, err := env.NoteAssetByPathAndHash(ctx, findAssetParams)
 	if err != nil && !db.IsNoFound(err) {
 		return nil, fmt.Errorf("failed to find note asset: %w", err)
@@ -110,6 +90,14 @@ func Resolve(ctx context.Context, env Env, input Input) (Payload, error) {
 	// v3: uploads asset A again -> asset already exists, just create new link to v3
 	// This allows the same asset (by path+hash) to be used in multiple note versions
 	if !alreadyUploaded { //nolint:nestif // two logical paths: new upload vs asset reuse
+		unknown, pathsErr := unknownAssetPath(ctx, env, input)
+		if pathsErr != nil {
+			return nil, pathsErr
+		}
+		if unknown != nil {
+			return unknown, nil
+		}
+
 		limitMsg, limitErr := env.CheckStorageLimits(ctx, input.File.Size)
 		if limitErr != nil {
 			return nil, limitErr
@@ -118,6 +106,9 @@ func Resolve(ctx context.Context, env Env, input Input) (Payload, error) {
 		if limitMsg != "" {
 			return &model.ErrorPayload{Message: limitMsg}, nil
 		}
+
+		fileName := translit.ToASCII(filepath.Base(input.Path))
+		fileName = reUnsafeChars.ReplaceAllString(fileName, "_")
 
 		if uploadErr := uploadAndCreateAsset(ctx, env, input, fileName); uploadErr != nil {
 			return nil, uploadErr
@@ -165,6 +156,27 @@ func Resolve(ctx context.Context, env Env, input Input) (Payload, error) {
 	}
 
 	return &response, nil
+}
+
+// unknownAssetPath rejects an upload whose path the note version does not
+// reference. It parses the note, so it runs only for assets not stored yet.
+func unknownAssetPath(ctx context.Context, env Env, input Input) (*model.ErrorPayload, error) {
+	assetPaths, err := env.NoteVersionAssetPaths(ctx, input.NoteID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get note version asset paths: %w", err)
+	}
+
+	if _, exists := assetPaths[input.Path]; exists {
+		return nil, nil
+	}
+
+	names := make([]string, 0, len(assetPaths))
+	for name := range assetPaths {
+		names = append(names, name)
+	}
+
+	msg := fmt.Sprintf("unknown asset path %q for noteId=%d. Valid assets: %s", input.Path, input.NoteID, strings.Join(names, ", "))
+	return &model.ErrorPayload{Message: msg}, nil
 }
 
 func uploadAndCreateAsset(ctx context.Context, env Env, input Input, fileName string) error {

--- a/internal/case/uploadnoteasset/resolve_test.go
+++ b/internal/case/uploadnoteasset/resolve_test.go
@@ -539,3 +539,91 @@ func TestResolve_ScopedToken(t *testing.T) {
 		})
 	}
 }
+
+// TestResolve_ExistingAssetSkipsLoader pins the early-skip order: an asset
+// already stored under the same absolute path + hash is linked to the version
+// without consulting NoteVersionAssetPaths (which parses the note), while a new
+// asset still goes through it exactly once.
+func TestResolve_ExistingAssetSkipsLoader(t *testing.T) {
+	testContent := []byte("asset bytes")
+	testHash := calcHash(testContent)
+
+	input := model.UploadNoteAssetInput{
+		NoteID:       42,
+		Path:         "images/pic.png",
+		AbsolutePath: "/abs/images/pic.png",
+		Sha256Hash:   testHash,
+		File: graphql.Upload{
+			File:     bytes.NewReader(testContent),
+			Filename: "pic.png",
+			Size:     int64(len(testContent)),
+		},
+	}
+
+	tests := []struct {
+		name          string
+		existing      bool
+		wantLoader    int
+		wantSkipped   bool
+		wantLinked    int
+		wantErrorText string
+	}{
+		{
+			name:        "existing asset links without loading the note",
+			existing:    true,
+			wantLoader:  0,
+			wantSkipped: true,
+			wantLinked:  1,
+		},
+		{
+			name:          "new asset is validated against the note exactly once",
+			existing:      false,
+			wantLoader:    1,
+			wantErrorText: "unknown asset path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := &EnvMock{
+				LoggerFunc: func() logger.Logger { return &logger.TestLogger{} },
+				NoteVersionAssetPathsFunc: func(_ context.Context, _ int64) (map[string]struct{}, error) {
+					return map[string]struct{}{"images/other.png": {}}, nil
+				},
+				NoteAssetByPathAndHashFunc: func(_ context.Context, arg db.NoteAssetByPathAndHashParams) (db.NoteAsset, error) {
+					require.Equal(t, input.AbsolutePath, arg.AbsolutePath)
+					require.Equal(t, testHash, arg.Sha256Hash)
+					if tt.existing {
+						return db.NoteAsset{ID: 7}, nil
+					}
+					return db.NoteAsset{}, sql.ErrNoRows
+				},
+				NoteAssetExistsFunc: func(_ context.Context, _ db.NoteAsset) (bool, error) { return true, nil },
+				UpsertNoteVersionAssetFunc: func(_ context.Context, arg db.UpsertNoteVersionAssetParams) error {
+					require.Equal(t, db.UpsertNoteVersionAssetParams{AssetID: 7, VersionID: 42, Path: "images/pic.png"}, arg)
+					return nil
+				},
+				PrepareLatestNotesFunc: func(_ context.Context, _ bool) (*appmodel.NoteViews, error) {
+					return &appmodel.NoteViews{}, nil
+				},
+			}
+
+			result, err := uploadnoteasset.Resolve(context.Background(), env, input)
+			require.NoError(t, err)
+
+			require.Len(t, env.NoteVersionAssetPathsCalls(), tt.wantLoader)
+			require.Len(t, env.UpsertNoteVersionAssetCalls(), tt.wantLinked)
+
+			if tt.wantErrorText != "" {
+				ep, ok := result.(*model.ErrorPayload)
+				require.True(t, ok, "expected *ErrorPayload, got %T", result)
+				require.Contains(t, ep.Message, tt.wantErrorText)
+				require.Empty(t, env.CreateNoteAssetCalls())
+				return
+			}
+			p, ok := result.(*model.UploadNoteAssetPayload)
+			require.True(t, ok, "expected *UploadNoteAssetPayload, got %T", result)
+			require.Equal(t, tt.wantSkipped, p.UploadSkipped)
+		})
+	}
+}

--- a/internal/db/queries.read.sql.go
+++ b/internal/db/queries.read.sql.go
@@ -413,6 +413,51 @@ func (q *Queries) AllLatestConfigStrings(ctx context.Context) ([]AllLatestConfig
 	return items, nil
 }
 
+const allLatestLayoutNotes = `-- name: AllLatestLayoutNotes :many
+select value as path, p.id as path_id, v.id as version_id, content, v.created_at
+  from note_paths p
+  join note_versions v on p.id = v.path_id and p.version_count = v.version
+ where p.hidden_by is null and p.value glob '_layouts/*'
+`
+
+type AllLatestLayoutNotesRow struct {
+	Path      string    `json:"path"`
+	PathID    int64     `json:"path_id"`
+	VersionID int64     `json:"version_id"`
+	Content   string    `json:"content"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// glob rather than like: like would read the leading underscore as a wildcard.
+func (q *Queries) AllLatestLayoutNotes(ctx context.Context) ([]AllLatestLayoutNotesRow, error) {
+	rows, err := q.db.QueryContext(ctx, allLatestLayoutNotes)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []AllLatestLayoutNotesRow
+	for rows.Next() {
+		var i AllLatestLayoutNotesRow
+		if err := rows.Scan(
+			&i.Path,
+			&i.PathID,
+			&i.VersionID,
+			&i.Content,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const allLatestNoteAssets = `-- name: AllLatestNoteAssets :many
 with latest_versions as (
   select 

--- a/queries.read.sql
+++ b/queries.read.sql
@@ -36,6 +36,13 @@ select value as path, p.id as path_id, v.id as version_id, content, v.created_at
   left join note_version_embeddings e on v.id = e.version_id
  where p.hidden_by is null;
 
+-- name: AllLatestLayoutNotes :many
+-- glob rather than like: like would read the leading underscore as a wildcard.
+select value as path, p.id as path_id, v.id as version_id, content, v.created_at
+  from note_paths p
+  join note_versions v on p.id = v.path_id and p.version_count = v.version
+ where p.hidden_by is null and p.value glob '_layouts/*';
+
 -- name: AllLatestNoteAssets :many
 with latest_versions as (
   select 


### PR DESCRIPTION
## Problem

A 30 s CPU profile of the production process during `scripts/sync-docs-prod.sh` had 66% of CPU under `UploadNoteAsset → uploadnoteasset.Resolve → app.NoteVersionAssetPaths → noteloader.Load → mdloader.Load → frontmatterpatch.ApplyPatches` (jsonnet). Every `uploadNoteAsset` call built a "single" note loader, and for a layout file under `_layouts/` that loader pulled and patched every note of the vault (the `TODO` at `cmd/server/notes.go`). The sync CLI sends one `uploadNoteAsset` per (note, asset) pair, so `_layouts/mesh/logo.svg`, referenced from 11 layout files, cost 11 full vault loads for a file the server already had (each answered `uploadSkipped`). Roughly 60% of flat CPU was GC scanning under `GOMEMLIMIT`, driven by those allocations.

## What changed

**Commit 1 — early skip in the resolver** (`internal/case/uploadnoteasset/resolve.go`). The `NoteAssetByPathAndHash` lookup (one indexed row) now runs before `NoteVersionAssetPaths` (a note parse). An asset already stored under the same absolute path + sha256 goes straight to the reuse branch: self-heal of a missing object, then the `note_version ↔ asset` link upsert, exactly as before. `scopedWriteDenied` still runs first; storage limits still gate a new upload. Behaviour change: for an asset that already exists, the "path is referenced by the note" check no longer runs, so a client that links an existing asset under a path the note does not reference gets a link row instead of an error. The sync clients derive paths from the note's references, so they never hit this; the check still runs for every new asset.

**Commit 2 — the single-note loader loads only layout files for a layout version** (`cmd/server/note_loader_envs.go`, `queries.read.sql`). A layout's `asset()` calls are scanned through the templates it imports, so a layout file cannot be parsed alone, but it never depends on a markdown note. The layout branch now reads `AllLatestLayoutNotes` (latest versions whose path `glob '_layouts/*'`; `glob` because `like` would read the underscore as a wildcard) instead of `AllLatestNotes`. mdloader then runs with zero sources and no patch evaluation. `NoteVersionAssetPaths` now looks the version up in layouts, then in note views, and drops the `TODO`. Markdown notes are unchanged: one note through mdloader with the frontmatter patches still applied, because a patch can add a `datachart` frontmatter source whose wikilink is marked as an asset (`markChartAssets`).

Why this rather than a dedicated asset scanner: reusing `layoutloader.Load` keeps import-following, `.html.json` conversion and the `{{ yield }}` wiring in one place; a second scanner would have to reimplement the walk over imported templates. The remaining per-call cost is parsing the layout set (34 files on the dev vault), and only for a new asset.

## Tests

- `internal/case/uploadnoteasset`: `TestResolve_ExistingAssetSkipsLoader` asserts `NoteVersionAssetPaths` is called 0 times for an existing asset (link still upserted, `uploadSkipped=true`) and exactly once for a new asset.
- `cmd/server/note_version_assets_test.go` (real SQLite via the existing `newTxTestApp` harness): `TestNoteVersionAssetPaths_SingleVersion` pins the asset set for a markdown note, a layout page (its own `asset()` plus the imported component's), and the component alone; `TestSingleNoteLoaderEnv_RawNotes` pins that a markdown version loads one note and a layout version loads only the `_layouts/` files.
- `go build ./... && go vet ./...`, `go test -count=1 ./internal/case/uploadnoteasset/... ./internal/noteloader/... ./internal/layoutloader/... ./cmd/server/...` and `golangci-lint run --build-tags dev` (CI invocation): all green.

## Measurement

Local reproduction on a copy of the dev DB (1759 note paths, 34 layout files), server on a spare port with local storage, Telegram bots and webhooks disabled in the copy. Before each run the 74 notes that reference assets (plus all layouts) are marked changed on the server and the sync state is reset, so `trip2g-sync` pushes them and sends 162 `uploadNoteAsset` calls. Run 1: every stored asset hash is stale, so the first call per file creates the asset (validation path) and the rest reuse it. Run 2: all 162 calls hit an existing asset. A 20 s CPU profile was taken during each run.

| | before | after |
|---|---|---|
| run 1 wall (73 notes, 162 uploads, new assets) | 74.1 s | 7.2 s |
| run 2 wall (75 notes, 162 uploads, all existing) | 75.9 s | 1.4 s |
| run 1 profile: samples in 20 s | 42.3 s (211% CPU) | 13.9 s (70% CPU) |
| run 1 profile: `NoteVersionAssetPaths` cum | 18.5 s (43.7%) | 4.2 s (30.3%) |
| run 1 profile: `mdloader.Load` cum | 13.5 s (31.9%) | 0.4 s (2.8%) |
| run 1 profile: `frontmatterpatch.ApplyPatches` cum | 6.8 s (16.1%) | not in top |
| run 2 profile: samples in 20 s | 43.2 s (216% CPU) | 3.7 s (19% CPU) |
| run 2 profile: `UploadNoteAsset` cum | 18.8 s (43.5%) | 0.05 s (1.3%) |

Before, `runtime.gcBgMarkWorker` sat at 43–44% of both profiles; after, GC is 5.0 s and 1.8 s absolute. In the after run 1 profile the top remaining item under the upload path is `layoutloader.Load` (4.7 s): a new layout asset still parses the whole layout set once. The after run 2 profile is dominated by `PrepareLatestNotes` from the note pushes, not by asset uploads.

## Not verified

- Not measured on production; the local vault differs from the production one (758 notes there).
- The temporary DB copy, storage dir and binaries were deleted after the runs; the profiles are not attached.
- No test covers the `.html.json` layout variant through the single loader (it goes through the same `AllLatestLayoutNotes` path as `.html`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVHnhgCSBUfhAZGKih9pbe
