### PR TITLE
fleet: pause a role with enabled: false

### DIFF
--- a/cmd/fleet/internal/fleet/discovery.go
+++ b/cmd/fleet/internal/fleet/discovery.go
@@ -29,8 +29,8 @@ func NewDiscovery(gql graphql.Client, fleetID, agentsFolder string, offeredTools
 // this fleet's --fleet-id are processed. A role with an empty fleet_id is
 // skipped with a warning (untagged roles are never claimed — belonging to no
 // fleet keeps two fleets from both processing it). A role tagged for another
-// fleet is skipped silently. Invalid roles that match this fleet are excluded
-// and reported. DiscoverParsed stays unpartitioned for cross-fleet introspection.
+// fleet is skipped silently, as is a role paused with `enabled: false`. Invalid
+// roles that match this fleet are excluded and reported. DiscoverParsed stays unpartitioned for cross-fleet introspection.
 func (d *Discovery) DiscoverRoles(ctx context.Context) ([]Role, []error) {
 	parsed, errs := d.DiscoverParsed(ctx)
 	var roles []Role
@@ -43,6 +43,14 @@ func (d *Discovery) DiscoverRoles(ctx context.Context) ([]Role, []error) {
 		}
 		if role.FleetID != d.fleetID {
 			continue // belongs to another fleet
+		}
+		if role.Disabled {
+			// Paused by its own frontmatter. Silent, like a role of another
+			// fleet: a warning here would fire every poll and grade every cycle
+			// partial. What shows the pause is the registry it left — its
+			// webhooks are deleted by the next reconcile, so a cron role stops
+			// firing — and --dry-run, which reports it as DISABLED.
+			continue
 		}
 		if verr := role.Validate(d.offeredTools); verr != nil {
 			errs = append(errs, verr)

--- a/cmd/fleet/internal/fleet/discovery_test.go
+++ b/cmd/fleet/internal/fleet/discovery_test.go
@@ -61,6 +61,52 @@ func roleNote(path, fleetID string) string {
 	]}}`
 }
 
+// TestDiscoverRoles_SkipsDisabledRolesSilently asserts the pause switch: a role
+// with `enabled: false` leaves the registry without an error, so the poll cycle
+// stays OK and the reconciler drops its webhooks on the next pass. Silence is
+// the point — a warning would fire every poll and grade every cycle partial for
+// a state the operator chose.
+func TestDiscoverRoles_SkipsDisabledRolesSilently(t *testing.T) {
+	resp := `{"notePaths":[
+		` + roleNote("roles/running.md", "f1") + `,
+		` + disabledRoleNote("roles/paused.md", "f1", "false") + `
+	]}`
+	gql := fakeAdminGQL(func(_ string, _ json.RawMessage) (string, error) { return resp, nil })
+
+	roles, errs := NewDiscovery(gql, "f1", "roles/", nil).DiscoverRoles(context.Background())
+
+	require.Len(t, roles, 1)
+	require.Equal(t, "roles/running.md", roles[0].NotePath)
+	require.Empty(t, errs, "a paused role is a choice, not a fault")
+}
+
+// TestDiscoverRoles_RefusesAnUnreadableEnabledValue asserts the loud half: a
+// value that is neither true nor false is a parse error, not a role left
+// quietly running.
+func TestDiscoverRoles_RefusesAnUnreadableEnabledValue(t *testing.T) {
+	resp := `{"notePaths":[` + disabledRoleNote("roles/typo.md", "f1", "nope") + `]}`
+	gql := fakeAdminGQL(func(_ string, _ json.RawMessage) (string, error) { return resp, nil })
+
+	roles, errs := NewDiscovery(gql, "f1", "roles/", nil).DiscoverRoles(context.Background())
+
+	require.Empty(t, roles)
+	require.Len(t, errs, 1)
+	require.Contains(t, errs[0].Error(), "roles/typo.md")
+	require.Contains(t, errs[0].Error(), "enabled")
+}
+
+// disabledRoleNote is roleNote plus an explicit `enabled` value, raw enough to
+// carry a malformed one.
+func disabledRoleNote(path, fleetID, enabled string) string {
+	return `{"value":"` + path + `","content":"Body.","latestNoteView":{"meta":[
+		{"key":"fleet_id","raw":"` + fleetID + `"},
+		{"key":"enabled","raw":"` + enabled + `"},
+		{"key":"mode","raw":"change"},
+		{"key":"trigger_include","raw":"[\"boards/**\"]"},
+		{"key":"trigger_on","raw":"[update]"}
+	]}}`
+}
+
 // TestDiscoverRoles_PartitionsByFleetID asserts the fleet_id partition:
 // only matching-fleet_id roles are processed; a mismatched role is skipped
 // silently; an untagged (empty fleet_id) role is skipped WITH an error/warning.

--- a/cmd/fleet/internal/fleet/role.go
+++ b/cmd/fleet/internal/fleet/role.go
@@ -30,6 +30,13 @@ type Role struct {
 	EnvPassthrough []string
 	EnvPrefix      []string
 
+	// Disabled is the role's own pause switch, written `enabled: false` in the
+	// frontmatter: it takes the role out of the registry without deleting the
+	// note. Stored inverted so the zero value is a role that runs — the same
+	// default the frontmatter has when it says nothing, and the one a Role
+	// built in code without ParseRole should get.
+	Disabled bool
+
 	FleetID        string // partition key: only the fleet whose --fleet-id matches processes this role
 	Model          string
 	Tools          []string
@@ -75,7 +82,11 @@ func ParseRole(notePath, body string, m map[string]string) (Role, error) {
 		Concurrency:    strings.TrimSpace(m["concurrency"]),
 		ForEach:        strings.TrimSpace(m["for_each"]),
 	}
-	var err error
+	enabled, err := parseBoolDefaultTrue(m["enabled"])
+	if err != nil {
+		return Role{}, fmt.Errorf("enabled: %w", err)
+	}
+	r.Disabled = !enabled
 	if r.MaxTokens, err = parseIntOpt(m["max_tokens"]); err != nil {
 		return Role{}, fmt.Errorf("max_tokens: %w", err)
 	}
@@ -89,6 +100,24 @@ func ParseRole(notePath, body string, m map[string]string) (Role, error) {
 		return Role{}, fmt.Errorf("timeout_seconds: %w", err)
 	}
 	return r, nil
+}
+
+// parseBoolDefaultTrue reads a frontmatter flag that defaults to on. It accepts
+// what a person writes in YAML (true/false, yes/no, on/off, 1/0) and refuses
+// anything else rather than guessing: a role silently left running because
+// `enabled: nope` did not parse is the failure this switch exists to prevent.
+func parseBoolDefaultTrue(raw string) (bool, error) {
+	v := strings.ToLower(strings.Trim(strings.TrimSpace(raw), `"'`))
+	switch v {
+	case "":
+		return true, nil
+	case "true", "yes", "on", "1", "t", "y":
+		return true, nil
+	case "false", "no", "off", "0", "f", "n":
+		return false, nil
+	default:
+		return false, fmt.Errorf("must be true or false, got %q", raw)
+	}
 }
 
 // copyMeta clones the frontmatter map. Discovery builds one map per note and

--- a/cmd/fleet/internal/fleet/role_test.go
+++ b/cmd/fleet/internal/fleet/role_test.go
@@ -57,6 +57,33 @@ func TestRoleValidate_TimeoutSecondsNonNegative(t *testing.T) {
 	require.Contains(t, err.Error(), "timeout_seconds")
 }
 
+// A role note that says nothing about `enabled` runs: the default is on, and
+// the field is stored inverted so a Role built in code inherits that default
+// rather than a silent pause.
+func TestParseRole_EnabledDefaultsToOn(t *testing.T) {
+	for _, tc := range []struct {
+		raw      string
+		disabled bool
+	}{
+		{"", false},
+		{"true", false},
+		{"yes", false},
+		{"false", true},
+		{"no", true},
+		{"off", true},
+		{"False", true},
+		{`"false"`, true},
+	} {
+		r, err := ParseRole("roles/x.md", "body", map[string]string{"enabled": tc.raw, "mode": "change"})
+		require.NoError(t, err, tc.raw)
+		require.Equal(t, tc.disabled, r.Disabled, "enabled: %q", tc.raw)
+	}
+
+	_, err := ParseRole("roles/x.md", "body", map[string]string{"enabled": "maybe"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "enabled")
+}
+
 func TestParseRole_FlatFrontmatter(t *testing.T) {
 	r, err := ParseRole("roles/triage.md", "Triage the board.", meta(
 		"model", "gpt-4o-mini",

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -682,6 +682,7 @@ func reportRoles(roles []fleet.Role, offered []string, defaultModel string) stri
 		}
 
 		fmt.Fprintf(&b, "%s\n", r.NotePath)
+		fmt.Fprintf(&b, "  enabled:         %t\n", !r.Disabled)
 		fmt.Fprintf(&b, "  mode:            %s\n", r.Mode)
 		fmt.Fprintf(&b, "  trigger_on:      %v -> onCreate=%t onUpdate=%t onRemove=%t\n",
 			r.TriggerOn,
@@ -696,10 +697,17 @@ func reportRoles(roles []fleet.Role, offered []string, defaultModel string) stri
 		fmt.Fprintf(&b, "  tools:           %v\n", r.Tools)
 		fmt.Fprintf(&b, "  for_each:        %s\n", forEach)
 		fmt.Fprintf(&b, "  timeout_seconds: %d%s\n", r.EffectiveTimeoutSeconds(), timeoutNote)
-		if verr := r.Validate(offered); verr != nil {
-			fmt.Fprintf(&b, "  STATUS: FLAGGED: %v\n", verr)
-		} else {
-			fmt.Fprint(&b, "  STATUS: OK\n")
+		switch {
+		case r.Disabled:
+			// Reported before Validate: a paused role registers nothing, so
+			// flagging its config would name a problem that cannot fire.
+			fmt.Fprint(&b, "  STATUS: DISABLED (enabled: false)\n")
+		default:
+			if verr := r.Validate(offered); verr != nil {
+				fmt.Fprintf(&b, "  STATUS: FLAGGED: %v\n", verr)
+			} else {
+				fmt.Fprint(&b, "  STATUS: OK\n")
+			}
 		}
 		b.WriteByte('\n')
 	}

--- a/docs/en/user/fleet.md
+++ b/docs/en/user/fleet.md
@@ -58,6 +58,7 @@ The keys, verified against the runtime:
 
 | Key | Meaning |
 |-----|---------|
+| `enabled` | `false` pauses the role: it leaves the registry, its webhooks are dropped on the next poll, and the note stays where it is. Absent means on. Anything but true/false is a parse error rather than a role left running |
 | `fleet_id` | which fleet claims this role. It also picks the kind of run: a fleet pointed at codellm executes the body as code, one pointed at a model runs it as prose. A role with no `fleet_id` is claimed by nobody and never runs |
 | `model`, `tools` | which model, which tools this role may call |
 | `read_patterns`, `write_patterns` | glob scopes the runtime enforces on every read and write |
@@ -81,6 +82,13 @@ Fleet validates every role at discovery time and refuses bad ones out loud: a ro
 **Cron triggers** run roles on a schedule via [[en/user/webhooks|cron webhooks]]: a nightly digest, a weekly link-checker, a poller that ingests an external source. `mode: both` combines the two in one role.
 
 You never register a webhook by hand. Fleet's reconcile loop creates, updates, and removes them on the hub to match the role notes it finds.
+
+**Pausing a role** is `enabled: false` in its frontmatter. The role leaves the
+registry on the next poll and the reconcile loop drops the webhooks it owned, so
+a cron role stops firing — the note, its history and its config stay where they
+are, and removing the line starts it again. Do not try to pause a cron role by
+writing a schedule that never comes due: an expression the runtime cannot place
+is not a promise that it never fires.
 
 ## Tools and scope
 


### PR DESCRIPTION
A role note has no way to stop short of deleting it. The reach for a pause is a cron expression that never comes due — and that is not a pause: an expression the runtime cannot place is not a promise that it never fires. A role paused that way kept running about once a minute.

`enabled: false` in the role's frontmatter takes it out of the registry on the next poll, and the reconcile loop drops the webhooks it owned, so a cron role stops firing. The note, its history and its config stay where they are; removing the line starts it again.

Details worth reviewing:

- **Silent, like a role of another fleet.** A warning would fire every poll and grade every cycle partial for a state the operator chose. What shows the pause is the registry it left (`fleet_roles_registered` drops, the webhook disappears) and `--dry-run`, which now prints `enabled:` per role and `STATUS: DISABLED (enabled: false)`.
- **Loud on a typo.** `enabled: nope` is a parse error, not a role left quietly running. Accepts what a person writes in YAML: true/false, yes/no, on/off, 1/0.
- **Stored inverted** (`Disabled bool`) so the zero value is a role that runs — the same default the frontmatter has when it says nothing, and the one a `Role` built in code without `ParseRole` gets. The first draft used `Enabled bool` and an existing test caught the trap immediately.

Tests: parse defaults and refusals, discovery skipping silently, discovery refusing an unreadable value. Docs: the key in the frontmatter table and a "Pausing a role" paragraph that also says why the never-due cron trick is not one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ke6BAhy3HduAt1wkeRimjU