### PR TITLE
fix(graph): inLinks drops backlinks the reader cannot read

### DIFF
--- a/internal/graph/note_view_inlinks_acl_test.go
+++ b/internal/graph/note_view_inlinks_acl_test.go
@@ -1,0 +1,107 @@
+package graph
+
+// Regression test for the NoteView.inLinks ACL hole: the resolver resolved the
+// inbound permalinks against the whole corpus (LatestNoteViews) and returned
+// every hit unfiltered. NoteView exposes content and html, so a reader of note
+// A got the full body of every note linking to A, including notes in subgraphs
+// they cannot read. Every returned note must now pass CanReadNote — the same
+// primitive as the note read path — and unreadable ones are dropped silently:
+// this is a graph edge listing, not a search result.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+
+	"trip2g/internal/appreq"
+	appmodel "trip2g/internal/model"
+	"trip2g/internal/usertoken"
+)
+
+// inLinksEnv implements just the Env surface InLinks touches. The embedded nil
+// Env panics on any unexpected call.
+type inLinksEnv struct {
+	Env
+	nvs     *appmodel.NoteViews
+	canRead func(context.Context, *appmodel.NoteView) (bool, error)
+}
+
+func (e *inLinksEnv) LatestNoteViews() *appmodel.NoteViews { return e.nvs }
+
+func (e *inLinksEnv) CanReadNote(ctx context.Context, note *appmodel.NoteView) (bool, error) {
+	return e.canRead(ctx, note)
+}
+
+// inLinksCtx carries env in the appreq the way r.env(ctx) expects to find it.
+func inLinksCtx(env Env) context.Context {
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.SetRequestURI("http://example.com/graphql")
+	req := &appreq.Request{Req: fctx, Env: env}
+	req.SetUserToken(&usertoken.Data{ID: 5, Role: "user"})
+	req.StoreInContext()
+	return fctx
+}
+
+// inLinksFixture: a target in subgraph "a" linked to from a readable note in
+// "a" and from a secret note in "b".
+func inLinksFixture() (*appmodel.NoteView, *appmodel.NoteViews) {
+	target := aclNote(1, "a/target.md", "/a-target", "a")
+	readable := aclNote(2, "a/two.md", "/a-two", "a")
+	secret := aclNote(3, "b/secret.md", "/b-secret", "b")
+	secret.Content = []byte("private body")
+
+	target.InLinks = map[string]struct{}{
+		readable.Permalink: {},
+		secret.Permalink:   {},
+	}
+
+	return target, aclNvs(target, readable, secret)
+}
+
+func inLinksPermalinks(notes []appmodel.NoteView) []string {
+	out := make([]string, 0, len(notes))
+	for _, n := range notes {
+		out = append(out, n.Permalink)
+	}
+	return out
+}
+
+func TestNoteViewInLinks_DropsUnreadableNotes(t *testing.T) {
+	target, nvs := inLinksFixture()
+	env := &inLinksEnv{nvs: nvs, canRead: canReadSubgraphA}
+	r := &noteViewResolver{&Resolver{DefaultEnv: env}}
+
+	got, err := r.InLinks(inLinksCtx(env), target)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"/a-two"}, inLinksPermalinks(got),
+		"a note in subgraph b must not leak through inLinks to a reader of subgraph a")
+}
+
+func TestNoteViewInLinks_ReadableNotesAreKept(t *testing.T) {
+	target, nvs := inLinksFixture()
+	env := &inLinksEnv{nvs: nvs, canRead: func(context.Context, *appmodel.NoteView) (bool, error) {
+		return true, nil
+	}}
+	r := &noteViewResolver{&Resolver{DefaultEnv: env}}
+
+	got, err := r.InLinks(inLinksCtx(env), target)
+
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"/a-two", "/b-secret"}, inLinksPermalinks(got))
+}
+
+func TestNoteViewInLinks_ACLErrorFails(t *testing.T) {
+	target, nvs := inLinksFixture()
+	env := &inLinksEnv{nvs: nvs, canRead: func(context.Context, *appmodel.NoteView) (bool, error) {
+		return true, errors.New("db down")
+	}}
+	r := &noteViewResolver{&Resolver{DefaultEnv: env}}
+
+	_, err := r.InLinks(inLinksCtx(env), target)
+
+	require.Error(t, err, "a failed ACL check must not fall through to returning the note")
+}

--- a/internal/graph/schema.resolvers.go
+++ b/internal/graph/schema.resolvers.go
@@ -2994,16 +2994,32 @@ func (r *noteViewResolver) Warnings(ctx context.Context, obj *appmodel.NoteView)
 }
 
 // InLinks is the resolver for the inLinks field.
+// NoteView exposes content and html, so every backlink must pass CanReadNote —
+// otherwise a reader of this note sees the body of notes in subgraphs they have
+// no access to. Unreadable ones are dropped silently: this is an edge listing,
+// not a search result.
 func (r *noteViewResolver) InLinks(ctx context.Context, obj *appmodel.NoteView) ([]appmodel.NoteView, error) {
 	res := []appmodel.NoteView{}
 
-	nvs := r.env(ctx).LatestNoteViews()
+	env := r.env(ctx)
+	nvs := env.LatestNoteViews()
 
 	for permalink := range obj.InLinks {
 		note := nvs.GetByPath(permalink)
-		if note != nil {
-			res = append(res, *note)
+		if note == nil {
+			continue
 		}
+
+		canRead, err := env.CanReadNote(ctx, note)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check CanReadNote: %w", err)
+		}
+
+		if !canRead {
+			continue
+		}
+
+		res = append(res, *note)
 	}
 
 	return res, nil


### PR DESCRIPTION
## What leaked

`NoteView.inLinks` (`internal/graph/schema.resolvers.go`) resolved the inbound permalinks in `obj.InLinks` against `LatestNoteViews()` — the whole global corpus — and returned every hit with no permission check.

`NoteView` exposes `content` and `html` in the schema, so anyone who could read note A received the **full body** of every note that links to A. A single link from a note in a restricted subgraph into a public note was enough to publish that restricted note's text to every reader of the public one. Anonymous readers included: nothing in the resolver looked at the requester at all.

## The fix

Every backlink now goes through `env.CanReadNote(ctx, note)` — `canreadnote.Resolve`, the repo's single access primitive, reached the same way `sitesearch` and `similarnotes` reach it. Unreadable notes are dropped from the list; an error from the check fails the field rather than falling through to returning the note.

**Silently dropping, not a placeholder.** `inLinks` is a graph edge listing, not a search result: the caller asked which notes link here, and the honest answer is the subset they are allowed to see. The `sitesearch` "Закрытый материал." teaser exists to tell a searcher that a paywalled hit exists and is worth buying; a backlink list has no such job, and a placeholder there would leak the existence and title of restricted notes for nothing.

**On N+1:** the check is per note, matching `similarnotes.filterByPermissions` and the `sitesearch` result loop, which both call `CanReadNote` per item. `inLinks` is bounded by a note's actual inbound link count, so this stays in the same shape as the neighbours rather than introducing a batching path they do not have.

There is no `outLinks` resolver on `NoteView` — the field does not exist in `schema.graphqls`, so nothing else in this file carries the same hole.

## What the test proves

`internal/graph/note_view_inlinks_acl_test.go` drives the real resolver through an `appreq`-carrying context, reusing the `aclNote` / `aclNvs` / `canReadSubgraphA` helpers already in the package from the `noteChanges` ACL work:

- a target in subgraph `a` with backlinks from a readable note in `a` and a secret note in `b`; a reader of `a` gets only the `a` backlink (red before the fix: it got both);
- a reader who can read everything still gets both backlinks — the fix filters, it does not truncate;
- a failing `CanReadNote` returns an error instead of leaking the note (red before the fix: it returned nil error and the note).

Red before the fix:

```
--- FAIL: TestNoteViewInLinks_DropsUnreadableNotes (0.00s)
        Error:      Not equal:
                    expected: []string{"/a-two"}
                    actual  : []string{"/a-two", "/b-secret"}
        Messages:   a note in subgraph b must not leak through inLinks to a reader of subgraph a
--- FAIL: TestNoteViewInLinks_ACLErrorFails (0.00s)
        Error:      An error is expected but got nil.
        Messages:   a failed ACL check must not fall through to returning the note
```

## What I ran

- `go test ./internal/graph/ -run TestNoteViewInLinks -v` — 3/3 pass.
- `go build ./...` — clean.
- `go tool golangci-lint run internal/graph/...` — 0 issues.
- `go test -count=1 ./...` — full suite green.

One flake, unrelated to this change: `internal/movebus` `TestSessionKeyStableWithinHourAndAnonymous` failed once out of three full runs, because the hex session token it generated (`ff017e2842025312`) happened to contain the digits of the viewer id it asserts are absent. Pre-existing, and it reproduces on `main` by construction.

## Not in this PR

The rendered backlinks widget takes the same unfiltered path — `internal/templateviews/nvs.go` (`BackLinks`, `OutLinks`) and the widget in `internal/defaulttemplate` build their lists from the global corpus without an ACL check — but what a page should *show* where a restricted backlink would be is a product decision for the repo owner, not something to settle inside a security fix, so that code is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ke6BAhy3HduAt1wkeRimjU
